### PR TITLE
Docs change:

### DIFF
--- a/docs/userguide/executing.rst
+++ b/docs/userguide/executing.rst
@@ -66,18 +66,17 @@ specified date and time has passed, but not necessarily at that exact time.
 
 While ``countdown`` is an integer, ``eta`` must be a :class:`~datetime.datetime` object,
 specifying an exact date and time in the future. This is good if you already
-have a :class:`~datetime.datetime`` object and need to modify it with a
+have a :class:`~datetime.datetime` object and need to modify it with a
 :class:`~datetime.timedelta`, or when using time in seconds is not very readable.
 
 .. code-block:: python
 
     from datetime import datetime, timedelta
 
-    def quickban(username):
-        """Ban user for 24 hours."""
-        ban(username)
+    def add_tomorrow(username):
+        """Add this tomorrow."""
         tomorrow = datetime.now() + timedelta(days=1)
-        UnbanTask.apply_async(args=[username], eta=tomorrow)
+        add.apply_async(args=[10, 10], eta=tomorrow)
 
 
 Serializers
@@ -198,15 +197,15 @@ listen to different queues:
 
 .. code-block:: python
 
-    >>> CompressVideoTask.apply_async(args=[filename],
+    >>> add.apply_async(args=[filename],
     ...                               routing_key="video.compress")
 
-    >>> ImageRotateTask.apply_async(args=[filename, 360],
+    >>> add.apply_async(args=[filename, 360],
     ...                             routing_key="image.rotate")
 
-    >>> ImageCropTask.apply_async(args=[filename, selection],
+    >>> add.apply_async(args=[filename, selection],
     ...                           routing_key="image.crop")
-    >>> UpdateReccomendationsTask.apply_async(routing_key="misc.recommend")
+    >>> add.apply_async(routing_key="misc.recommend")
 
 
 Later, if the crop task is consuming a lot of resources,


### PR DESCRIPTION
In the [Executing Tasks](http://ask.github.com/celery/userguide/executing.html) section of the userguide, the doc starts by saying that all of the following examples use the simple add task, but then changes between add and UnbanTask / VariousTasks for the routing example.

When I was reading this for the first time this morning, obviously I figured out what was intended, but the change of reference frame caused a brief moment of 'huh?' :) 

Personally I like the separation of functionality from context that using a trivial example task provides...

If you wanted to show the functionality in a more real-world example, then you could either link to an example project in examples that uses the functionality/ or have the code for a more complete app with routing, looping etc, at the end of that page. 

Thoughts welcome etc.
