### PR TITLE
UnboundLocalError when using celerybeat and signal-style logging configuration

### DIFF
--- a/celery/apps/beat.py
+++ b/celery/apps/beat.py
@@ -60,11 +60,10 @@ class Beat(object):
         from celery import log
         handled = log.setup_logging_subsystem(loglevel=self.loglevel,
                                               logfile=self.logfile)
-        if not handled:
-            logger = log.get_default_logger(name="celery.beat")
-            if self.redirect_stdouts:
-                log.redirect_stdouts_to_logger(logger,
-                        loglevel=self.redirect_stdouts_level)
+        logger = log.get_default_logger(name="celery.beat")
+        if self.redirect_stdouts and not handled:
+            log.redirect_stdouts_to_logger(logger,
+                    loglevel=self.redirect_stdouts_level)
         return logger
 
     def start_scheduler(self, logger=None):


### PR DESCRIPTION
Hi!

Found a small bug in celerybeat.  Thanks for implementing this functionality, it's really useful for the project where I'm using celery.

And -- thanks for all of your hard work on this project!  It's truly amazing.  I'm consistently amazed by how much new, amazing, useful stuff gets committed every time I look at the changelogs!

If you'd like me to file an issue or anything to help get this committed, or you'd like me to fix this another way, please just let me know.

-Bryan
