### PR TITLE
Add exc_info to TaskRequest.on_failure

### DIFF
--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -493,6 +493,7 @@ class TaskRequest(object):
 
         log_with_extra(self.logger, logging.ERROR,
                        self.error_msg.strip() % context,
+                       exc_info=exc_info,
                        extra={"data": {"hostname": self.hostname,
                                        "id": self.task_id,
                                        "name": self.task_name}})


### PR DESCRIPTION
This patch adds exc_info into the logging request on TaskRequest.on_failure.

I didn't add it before because of an odd behavior which I couldn't explain in a third party app, it turned out this odd behavior was unrelated to the change in celery: http://github.com/dcramer/django-sentry/pull/33
