### PR TITLE
Remove empty AMQP result queues

### DIFF
--- a/celery/backends/amqp.py
+++ b/celery/backends/amqp.py
@@ -123,6 +123,9 @@ class AMQPBackend(BaseDictBackend):
         return result
 
     def get_task_meta(self, task_id, cache=True):
+        if cache and task_id in self._cache:
+            return self._cache[task_id]
+
         return self.poll(task_id)
 
     def wait_for(self, task_id, timeout=None, cache=True):
@@ -148,6 +151,7 @@ class AMQPBackend(BaseDictBackend):
         result = consumer.fetch()
         try:
             if result:
+                consumer.queue_delete(True, True)
                 payload = self._cache[task_id] = result.payload
                 return payload
             else:


### PR DESCRIPTION
When `AMQPBackend` and `ResultConsumer` are used to consume results, then one-time result queues aren't removed even though `auto_delete` is set.

According to [this post](http://lists.rabbitmq.com/pipermail/rabbitmq-discuss/2009-November/005344.html), RabbitMQ doesn't remove queues that didn't have any consumers (only "basic.consume" counts). This information seems to be correct, because when I dispatch task:

```
>>> r = tasks.add.delay(1,1)
```

...and `wait()` for the result:

```
>>> r.wait() -> AMQPBackend.wait_for() -> AMQPBackend.consume() -> carrot.messaging.Consumer.consume() ("basic.consume")
```

....then queue is removed from the RabbitMQ.

However, when I go asynchronous way:

```
>>> r.result -> BaseBackend.get_result() -> AMQPBackend.get_task_meta() -> AMQPBackend.poll() -> carrot.messaging.Consumer.fetch() ("basic.get")
```

...then queue isn't removed from RabbitMQ, even after result is consumed.
