### PR TITLE
Fix for race condition in Timer.enter

### DIFF
--- a/celery/utils/timer2.py
+++ b/celery/utils/timer2.py
@@ -180,7 +180,7 @@ class Timer(Thread):
             self.running = False
 
     def enter(self, entry, eta, priority=None):
-        if not self.running:
+        if not self.running and not self.is_alive():
             self.start()
         return self.schedule.enter(entry, eta, priority)
 


### PR DESCRIPTION
If Timer.enter is called twice before the timer thread gets a chance to run it will raise a RuntimeError. This makes sure .start() is only called once as expected.
