### PR TITLE
jython check to ignore multiprocessing in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ install_requires.extend([
 ])
 
 py_version = sys.version_info
-if sys.version_info < (2, 6):
+if sys.version_info < (2, 6) and not sys.platform.startswith("java"):
     install_requires.append("multiprocessing")
 if sys.version_info < (2, 5):
     install_requires.append("uuid")


### PR DESCRIPTION
I added a sys.platform.startswith("java") to check if jython is being used. This method is used by pip and IMHO is good enough as check for jython environments. It can be actually used in any celery module if needed.
