### PR TITLE
CELERYD_FORCE_HIJACK_ROOT_LOGGER

### DIFF
--- a/celery/conf.py
+++ b/celery/conf.py
@@ -66,6 +66,7 @@ _DEFAULTS = {
     "CELERYD_LOG_COLOR": False,
     "CELERYD_LOG_LEVEL": "WARN",
     "CELERYD_LOG_FILE": None,                       # stderr
+    "CELERYD_FORCE_HIJACK_ROOT_LOGGER": False,
     "CELERYBEAT_SCHEDULER": "celery.beat.PersistentScheduler",
     "CELERYBEAT_SCHEDULE": {},
     "CELERYD_STATE_DB": None,
@@ -185,6 +186,7 @@ def prepare(m, source=settings, defaults=_DEFAULTS):
                             compat=["CELERYD_DAEMON_LOG_LEVEL"])
     if not isinstance(m.CELERYD_LOG_LEVEL, int):
         m.CELERYD_LOG_LEVEL = LOG_LEVELS[m.CELERYD_LOG_LEVEL.upper()]
+    m.CELERYD_FORCE_HIJACK_ROOT_LOGGER = _get("CELERYD_FORCE_HIJACK_ROOT_LOGGER")
     m.CELERYD_STATE_DB = _get("CELERYD_STATE_DB")
     m.CELERYD_CONCURRENCY = _get("CELERYD_CONCURRENCY")
     m.CELERYD_PREFETCH_MULTIPLIER = _get("CELERYD_PREFETCH_MULTIPLIER")

--- a/celery/log.py
+++ b/celery/log.py
@@ -83,6 +83,10 @@ def setup_logging_subsystem(loglevel=conf.CELERYD_LOG_LEVEL, logfile=None,
                                                colorize=colorize)
         if not receivers:
             root = logging.getLogger()
+
+            if conf.CELERYD_FORCE_HIJACK_ROOT_LOGGER:
+                root.handlers = []
+
             mp = mputil.get_logger()
             for logger in (root, mp):
                 _setup_logger(logger, logfile, format, colorize, **kwargs)
@@ -122,7 +126,7 @@ def setup_logger(loglevel=conf.CELERYD_LOG_LEVEL, logfile=None,
     Returns logger object.
 
     """
-    if not root:
+    if not root or conf.CELERYD_FORCE_HIJACK_ROOT_LOGGER:
         return _setup_logger(get_default_logger(loglevel, name),
                              logfile, format, colorize, **kwargs)
     setup_logging_subsystem(loglevel, logfile, format, colorize, **kwargs)


### PR DESCRIPTION
Take over logging even if logging has been setup by a third party before celery.
