### PR TITLE
Debian init.d celery within virtualenv

### DIFF
--- a/contrib/debian/init.d/celerybeat
+++ b/contrib/debian/init.d/celerybeat
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # =========================================================
 #  celerybeat - Starts the Celery periodic task scheduler.
 # =========================================================
@@ -69,7 +69,9 @@
 #
 #   * CELERYBEAT_GROUP
 #       Group to run celeryd as. Default is current user.
-
+#
+#   * VIRTUALENV
+#       Full path to the virtualenv environment to activate. Default is none.
 
 ### BEGIN INIT INFO
 # Provides:          celerybeat
@@ -165,6 +167,9 @@ start_worker () {
                            $* \
                            --pidfile $CELERYBEAT_PID_FILE
                            --exec $CELERYBEAT -- $CELERYBEAT_OPTS"
+    if [ -n "$VIRTUALENV" ]; then
+        cmd="source $VIRTUALENV/bin/activate && $cmd"
+    fi
     if $cmd; then
         log_end_msg 0
     else

--- a/contrib/debian/init.d/celeryd
+++ b/contrib/debian/init.d/celeryd
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # ============================================
 #  celeryd - Starts the Celery worker daemon.
 # ============================================
@@ -64,7 +64,9 @@
 #
 #   * CELERYD_GROUP
 #       Group to run celeryd as. Default is current user.
-
+#
+#   * VIRTUALENV
+#       Full path to the virtualenv environment to activate. Default is none.
 
 ### BEGIN INIT INFO
 # Provides:          celeryd
@@ -108,7 +110,6 @@ fi
 if [ -n "$CELERYD_GROUP" ]; then
     DAEMON_OPTS="$DAEMON_OPTS --group $CELERYD_GROUP"
 fi
-
 if [ -n "$CELERYD_CHDIR" ]; then
     DAEMON_OPTS="$DAEMON_OPTS --chdir $CELERYD_CHDIR"
 fi
@@ -157,6 +158,9 @@ start_worker () {
                            $* \
                            --pidfile $CELERYD_PID_FILE
                            --exec $CELERYD -- $CELERYD_OPTS"
+    if [ -n "$VIRTUALENV" ]; then
+        cmd="source $VIRTUALENV/bin/activate && $cmd"
+    fi
     if $cmd; then
         log_end_msg 0
     else

--- a/contrib/debian/init.d/celeryd-multi
+++ b/contrib/debian/init.d/celeryd-multi
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 ### BEGIN INIT INFO
 # Provides:          celeryd-multi
@@ -111,6 +111,9 @@ start_worker () {
                                     --make-pidfile $* \
                                     --pidfile $CELERYD_PID_FILE \
                                     --exec $CELERYD --"
+    if [ -n "$VIRTUALENV" ]; then
+        cmd="source $VIRTUALENV/bin/activate && $cmd"
+    fi
     for wname in `celeryd-multi names $WORKERS $CELERYD_OPTS`; do
         log_daemon_msg "Starting celery task worker" "$wname"
         startcmd=`celeryd-multi get "$wname" $WORKERS --cmd="$cmd" $CELERYD_OPTS`

--- a/contrib/debian/init.d/celeryevcam
+++ b/contrib/debian/init.d/celeryevcam
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # ============================================
 #  celeryd - Starts the Celery worker daemon.
 # ============================================
@@ -70,7 +70,9 @@
 #
 #   * CELERYEV_GROUP
 #       Group to run celeryev as. Default is current user.
-
+#
+#   * VIRTUALENV
+#       Full path to the virtualenv environment to activate. Default is none.
 
 ### BEGIN INIT INFO
 # Provides:          celeryev
@@ -176,6 +178,9 @@ start_evcam () {
                            $* \
                            --pidfile $CELERYEV_PID_FILE
                            --exec $CELERYEV -- $CELERYEV_OPTS"
+    if [ -n "$VIRTUALENV" ]; then
+        cmd="source $VIRTUALENV/bin/activate && $cmd"
+    fi
     if $cmd; then
         log_end_msg 0
     else


### PR DESCRIPTION
The following pull introduces a $VIRTUALENV configuration option to the debian init.d (contrib/debian/init.d/) scripts that starts celeryd/beat in a virtualenv environment.
