### PR TITLE
Three fixes for the debian init.d scripts

### DIFF
--- a/contrib/debian/init.d/celerybeat
+++ b/contrib/debian/init.d/celerybeat
@@ -110,6 +110,11 @@ if [ -n "$2" ]; then
     CELERYBEAT_OPTS="$CELERYBEAT_OPTS $2"
 fi
 
+# Append the Django settings module to use, if specified
+if [ -n "$DJANGO_SETTINGS_MODULE" ]; then
+    CELERYBEAT_OPTS="$CELERYBEAT_OPTS --settings=$DJANGO_SETTINGS_MODULE"
+fi
+
 # Extra start-stop-daemon options, like user/group.
 if [ -n "$CELERYBEAT_USER" ]; then
     DAEMON_OPTS="$DAEMON_OPTS --chuid $CELERYBEAT_USER"

--- a/contrib/debian/init.d/celeryd
+++ b/contrib/debian/init.d/celeryd
@@ -106,6 +106,11 @@ if [ -n "$2" ]; then
     CELERYD_OPTS="$CELERYD_OPTS $2"
 fi
 
+# Append the Django settings module to use, if specified
+if [ -n "$DJANGO_SETTINGS_MODULE" ]; then
+    CELERYD_OPTS="$CELERYD_OPTS --settings=$DJANGO_SETTINGS_MODULE"
+fi
+
 # Extra start-stop-daemon options, like user/group.
 if [ -n "$CELERYD_USER" ]; then
     DAEMON_OPTS="$DAEMON_OPTS --chuid $CELERYD_USER"

--- a/contrib/debian/init.d/celeryevcam
+++ b/contrib/debian/init.d/celeryevcam
@@ -123,6 +123,11 @@ if [ -n "$2" ]; then
     CELERYEV_OPTS="$CELERYEV_OPTS $2"
 fi
 
+# Append the Django settings module to use, if specified
+if [ -n "$DJANGO_SETTINGS_MODULE" ]; then
+    CELERYEV_OPTS="$CELERYEV_OPTS --settings=$DJANGO_SETTINGS_MODULE"
+fi
+
 # Extra start-stop-daemon options, like user/group.
 if [ -n "$CELERYEV_USER" ]; then
     DAEMON_OPTS="$DAEMON_OPTS --chuid $CELERYEV_USER"


### PR DESCRIPTION
This pull includes the following fixes:
- Fixes the documentation to ensure CELERYD is an absolute path to `manage.py` and the `celeryd` parameter is given in `CELERYD_OPTS`
- Support for virtualenv when starting `celeryd` with `manage.py`
- Honours the `DJANGO_SETTINGS_MODULE` when calling `manage.py`
