### PR TITLE
Added remote command to get queue list from workers.

### DIFF
--- a/celery/task/control.py
+++ b/celery/task/control.py
@@ -70,6 +70,9 @@ class Inspect(object):
     def cancel_consumer(self, queue, **kwargs):
         return self._request("cancel_consumer", queue=queue, **kwargs)
 
+    def worker_queues(self):
+        return self._request("worker_queues")
+
 
 class Control(object):
     Mailbox = Mailbox

--- a/celery/worker/control/builtins.py
+++ b/celery/worker/control/builtins.py
@@ -212,3 +212,9 @@ def cancel_consumer(panel, queue=None, **_):
     cset = panel.consumer.task_consumer
     cset.cancel_by_queue(queue)
     return {"ok": "no longer consuming from %s" % (queue, )}
+    
+@Panel.register
+def worker_queues(panel):
+    """Returns the queues associated with each worker."""
+    return dict(panel.consumer.queues.iteritems())
+


### PR DESCRIPTION
I've added a remote command that returns the list of queues attached to each worker.  It is available through the Inspect class and through worker.controls.builtins.

This information is necessary for a Django-based Celery management app that I am helping to develop at Opus (http://opus.ncsu.edu/).  The alternative to having this functionality within Celery is to make users of the management app add a custom command module to CELERY_IMPORTS.  However, this complicates the installation and is something I'd like to avoid.

https://github.com/dpwhite2/celery/commit/710b8d571d7e63268d128a71bb5b1eb3eda1b2db

Thanks,
David White
