### PR TITLE
celeryctl persistence

### DIFF
--- a/celery/conf.py
+++ b/celery/conf.py
@@ -87,8 +87,7 @@ _DEFAULTS = {
     "CELERY_EVENT_ROUTING_KEY": "celeryevent",
     "CELERY_EVENT_PERSISTENT": True,
     "CELERY_EVENT_SERIALIZER": "json",
-    "CELERY_COMMAND_PERSISTENT": True,
-    "CELERY_COMMAND_AUTO_DELETE": False,
+    "CELERY_BROADCAST_PERSISTENT": True,
     "CELERY_RESULT_EXCHANGE": "celeryresults",
     "CELERY_RESULT_EXCHANGE_TYPE": "direct",
     "CELERY_RESULT_SERIALIZER": "pickle",
@@ -246,6 +245,7 @@ def prepare(m, source=settings, defaults=_DEFAULTS):
     m.BROADCAST_QUEUE = _get("CELERY_BROADCAST_QUEUE")
     m.BROADCAST_EXCHANGE = _get("CELERY_BROADCAST_EXCHANGE")
     m.BROADCAST_EXCHANGE_TYPE = _get("CELERY_BROADCAST_EXCHANGE_TYPE")
+    m.BROADCAST_PERSISTENT = _get("CELERY_BROADCAST_PERSISTENT")
 
     # :--- Event queue settings                     <-   --   --- - ----- -- #
 
@@ -255,11 +255,6 @@ def prepare(m, source=settings, defaults=_DEFAULTS):
     m.EVENT_ROUTING_KEY = _get("CELERY_EVENT_ROUTING_KEY")
     m.EVENT_PERSISTENT = _get("CELERY_EVENT_PERSISTENT")
     m.EVENT_SERIALIZER = _get("CELERY_EVENT_SERIALIZER")
-    
-    # :--- Command queue settings                     <-   --   --- - ----- -- #
-    
-    m.COMMAND_PERSISTENT = _get("CELERY_COMMAND_PERSISTENT")
-    m.COMMAND_AUTO_DELETE = _get("CELERY_COMMAND_AUTO_DELETE")
 
     # :--- AMQP Backend settings                    <-   --   --- - ----- -- #
 

--- a/celery/messaging.py
+++ b/celery/messaging.py
@@ -212,6 +212,8 @@ class BroadcastPublisher(Publisher):
 
     exchange = conf.BROADCAST_EXCHANGE
     exchange_type = conf.BROADCAST_EXCHANGE_TYPE
+    durable = conf.BROADCAST_PERSISTENT
+    auto_delete = not durable
 
     def send(self, type, arguments, destination=None, reply_ticket=None):
         """Send broadcast command."""
@@ -226,10 +228,10 @@ class BroadcastPublisher(Publisher):
 class BroadcastConsumer(Consumer):
     """Consume broadcast commands"""
     queue = conf.BROADCAST_QUEUE
-    durable = conf.COMMAND_PERSISTENT
-    auto_delete = conf.COMMAND_AUTO_DELETE
     exchange = conf.BROADCAST_EXCHANGE
     exchange_type = conf.BROADCAST_EXCHANGE_TYPE
+    durable = conf.BROADCAST_PERSISTENT
+    auto_delete = not durable
     no_ack = True
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Hey, it's vladimir___ from irc, I added two settings to be able to declare celeryctl exchange and queues non-persistent and auto_delete=true:
CELERY_COMMAND_PERSISTENT(defaults to True)
CELERY_COMMAND_AUTO_DELETE(defaults to False)
