### PR TITLE
CACHE_BACKEND parsing

### DIFF
--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -62,7 +62,7 @@ class CacheBackend(KeyValueStoreBackend):
         backend = backend or self.app.conf.CELERY_CACHE_BACKEND
         self.expires = int(self.expires)
         self.backend, _, servers = partition(backend, "://")
-        self.servers = servers.split(";")
+        self.servers = servers.rstrip('/').split(";")
         try:
             self.Client = backends[self.backend]
         except KeyError:


### PR DESCRIPTION
Hello,

fixing a bug in parsing CELERY_CACHE_BACKEND. When defining the variable with the slash at the end ("memcache://server:11211/"), the slash is was not cutted off and it string "server:11211/" was passed to the memcache.Client().

The bug only show when using custom CELERY_RESULT_BACKEND that extends celery.backends.cache.CacheBackend and not the "cache" alias, becouse othervise django's parsing is used.

Thanks,

Ales
