### PR TITLE
Patch: update celery.log.setup_task_logger() to new task API

### DIFF
--- a/celery/log.py
+++ b/celery/log.py
@@ -162,8 +162,8 @@ class Logging(object):
         return self.get_default_logger(name=name)
 
     def setup_task_logger(self, loglevel=None, logfile=None, format=None,
-            colorize=None, task_kwargs=None, propagate=False, app=None,
-            **kwargs):
+            colorize=None, task_name='-?-', task_id='-?-', propagate=False,
+            app=None, **kwargs):
         """Setup the task logger.
 
         If `logfile` is not specified, then `sys.stderr` is used.
@@ -176,16 +176,17 @@ class Logging(object):
         if colorize is None:
             colorize = self.supports_color(logfile)
 
-        if task_kwargs is None:
-            task_kwargs = {}
-        task_kwargs.setdefault("task_id", "-?-")
-        task_name = task_kwargs.get("task_name")
-        task_kwargs.setdefault("task_name", "-?-")
         logger = self._setup_logger(self.get_task_logger(loglevel, task_name),
                                     logfile, format, colorize, **kwargs)
         logger.propagate = int(propagate)    # this is an int for some reason.
                                              # better to not question why.
-        return LoggerAdapter(logger, task_kwargs)
+
+        extra = {
+            "task_id": task_id,
+            "task_name": task_name,
+        }
+
+        return LoggerAdapter(logger, extra)
 
     def redirect_stdouts_to_logger(self, logger, loglevel=None):
         """Redirect :class:`sys.stdout` and :class:`sys.stderr` to a

--- a/celery/task/base.py
+++ b/celery/task/base.py
@@ -240,7 +240,8 @@ class BaseTask(object):
         return self.app.log.setup_task_logger(loglevel=loglevel,
                                               logfile=logfile,
                                               propagate=propagate,
-                            task_kwargs=self.request.get("kwargs"))
+                                              task_name=self.name,
+                                              task_id=self.request.id)
 
     @classmethod
     def establish_connection(self, connect_timeout=None):


### PR DESCRIPTION
Updated this to just pass down the task name and task ID from get_logger().

I might be doing something that's not exactly kosher to trigger this behavior, but it doesn't seem like this code should mutate the task_kwargs dict.

Happy to revise this patch for any style concerns, etc.  I really like how you've cleaned up the task context in 2.2.  Thanks!
