### PR TITLE
Fix for custom apps on workers.

### DIFF
--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -78,7 +78,7 @@ class Command(object):
         if config_module:
             os.environ["CELERY_CONFIG_MODULE"] = config_module
         if app:
-            self.app = self.get_cls_by_name(app)
+            self.app = self.get_cls_by_name(app)()
         else:
             self.app = self.get_app(loader=loader)
         if self.enable_config_from_cmdline:


### PR DESCRIPTION
This is the fix for what we've discussed in irc some time ago.
It fixes ability to run custom apps on standalone workers. Problem was in custom app class not being instantiated.
