### PR TITLE
Bugfix: Always intialize the Task.request context

### DIFF
--- a/celery/task/base.py
+++ b/celery/task/base.py
@@ -40,6 +40,9 @@ _default_context = {"logfile": None,
 
 class Context(threading.local):
 
+    def __init__(self):
+        self.update(_default_context)
+
     def update(self, d, **kwargs):
         self.__dict__.update(d, **kwargs)
 


### PR DESCRIPTION
Found this while running the test:
    tests.test_task.test_task.TestCeleryTasks.test_get_logger
which failed because task.request.id was not set. The proposed fix initializes Context instances with the default context.
