### PR TITLE
Autoscaler logs error when unable to scale down, should only be warning

### DIFF
--- a/celery/worker/autoscale.py
+++ b/celery/worker/autoscale.py
@@ -46,6 +46,9 @@ class Autoscaler(threading.Thread):
             self._last_action = time()
             try:
                 self.pool.shrink(n)
+            except ValueError:
+                self.logger.warn(
+                    "Autoscaler did not scale down, all processes busy")
             except Exception, exc:
                 self.logger.error("Autoscaler: scale_down: %r\n%r" % (
                                     exc, traceback.format_stack()),


### PR DESCRIPTION
When the autoscaler can't scale down due to busy processes I think it should log a warning instead of an error. This is a very common condition, and logging an error there results in many, many uhelpful messages in error logs or error trackers -- there's nothing a developer or administrator can or should do about them. So this diff changes the autoscaler's handling of the specific exception that the pool raises in this case to log a warning instead. An error is still logged if any other exception is raised by the pool on scaling down.
