### PR TITLE
allows to use celery with python 2.5

### DIFF
--- a/celery/utils/compat.py
+++ b/celery/utils/compat.py
@@ -516,8 +516,15 @@ else:
             Schroeder.
             """
             def __init__(self, filename, mode='a', encoding=None, delay=0):
-                logging.FileHandler.__init__(self, filename, mode,
+                try:
+                    logging.FileHandler.__init__(self, filename, mode,
                                              encoding, delay)
+                except TypeError: #wrong number of arguments
+                    # python <= 2.5 does not have delay
+                    # see http://docs.python.org/library/logging.html#filehandler
+                    logging.FileHandler.__init__(self, filename, mode,
+                                             encoding)
+                    
                 if not os.path.exists(self.baseFilename):
                     self.dev, self.ino = -1, -1
                 else:


### PR DESCRIPTION
I've explained better here: https://github.com/ask/celery/issues/367

basically there was a change in the API for logging.FileHandler in 2.6

   Changed in version 2.6: delay was added.

So celeryd_multi and celeryd_detach were failing without even complaining. 

I just added a try:except for type error and try to use the older api

Thanks.
   Adriano
