### PR TITLE
Problem in celery.contrib.abortable.AbortableTask

### DIFF
--- a/celery/contrib/abortable.py
+++ b/celery/contrib/abortable.py
@@ -155,7 +155,8 @@ class AbortableTask(Task):
         often (for performance).
 
         """
-        result = self.AsyncResult(kwargs["task_id"])
+        task_id = kwargs.get('task_id', self.request.id)
+        result = self.AsyncResult(task_id)
         if not isinstance(result, AbortableAsyncResult):
             return False
         return result.is_aborted()


### PR DESCRIPTION
task_id is not getting sent in with the kwargs, so the task is failing right off. Changed behavior to fall back on self.request.id
