### PR TITLE
Batches silently failing

### DIFF
--- a/celery/contrib/batches.py
+++ b/celery/contrib/batches.py
@@ -53,9 +53,13 @@ from celery.worker import state
 def apply_batches_task(task, args, loglevel, logfile):
     task.request.update({"loglevel": loglevel, "logfile": logfile})
     try:
-        return task(*args)
+        result = task(*args)
+    except Exception, exp:
+        result = None
+        task.logger.error("There was an Exception: %s" % exp)
     finally:
         task.request.clear()
+    return result
 
 
 class SimpleRequest(object):


### PR DESCRIPTION
Added an except clause to the Batches task to log the error. Would be nice if
the Exception could bubble up and be reported on by celeryd, however I'm not
sure how to achieve this given the execution method of Batches.
