### PR TITLE
Adding SSL email configuration (support for gmail etc.) 

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -314,7 +314,8 @@ class BaseApp(object):
                                        port=self.conf.EMAIL_PORT,
                                        user=self.conf.EMAIL_HOST_USER,
                                        password=self.conf.EMAIL_HOST_PASSWORD,
-                                       timeout=self.conf.EMAIL_TIMEOUT)
+                                       timeout=self.conf.EMAIL_TIMEOUT,
+                                       use_ssl=self.conf.EMAIL_USE_SSL)
 
     def either(self, default_key, *values):
         """Fallback to the value of a configuration key if none of the

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -150,6 +150,7 @@ NAMESPACES = {
         "HOST_USER": Option(None),
         "HOST_PASSWORD": Option(None),
         "TIMEOUT": Option(2, type="int"),
+        "USE_SSL": Option(False, type="bool"),
     },
     "SERVER_EMAIL": Option("celery@localhost"),
     "ADMINS": Option((), type="tuple"),

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -155,13 +155,13 @@ class BaseLoader(object):
 
     def mail_admins(self, subject, body, fail_silently=False,
             sender=None, to=None, host=None, port=None,
-            user=None, password=None, timeout=None):
+            user=None, password=None, timeout=None, use_ssl=False):
         try:
             message = self.mail.Message(sender=sender, to=to,
                                         subject=subject, body=body)
             mailer = self.mail.Mailer(host=host, port=port,
                                       user=user, password=password,
-                                      timeout=timeout)
+                                      timeout=timeout, use_ssl=use_ssl)
             mailer.send(message)
         except Exception, exc:
             if not fail_silently:

--- a/celery/utils/mail.py
+++ b/celery/utils/mail.py
@@ -40,12 +40,13 @@ class Message(object):
 class Mailer(object):
 
     def __init__(self, host="localhost", port=0, user=None, password=None,
-            timeout=2):
+            timeout=2, use_ssl=False):
         self.host = host
         self.port = port
         self.user = user
         self.password = password
         self.timeout = timeout
+        self.use_ssl = use_ssl
 
     def send(self, message):
         if supports_timeout:
@@ -60,7 +61,10 @@ class Mailer(object):
                 socket.setdefaulttimeout(old_timeout)
 
     def _send(self, message, **kwargs):
-        client = smtplib.SMTP(self.host, self.port, **kwargs)
+        if (self.use_ssl):
+            client = smtplib.SMTP_SSL(self.host, self.port, **kwargs)
+        else:
+            client = smtplib.SMTP(self.host, self.port, **kwargs)
 
         if self.user and self.password:
             client.login(self.user, self.password)


### PR DESCRIPTION
Most e-mailing systems (including gmail) use ssl for sending e-mail with SMTP. This improvement adds the EMAIL_USE_SSL configuration parameter. If it's true, the Mailer uses smtplib.SMTP_SSL instead of smtplib.SMTP to connect to the mail server.
