### PR TITLE
Add signals after_setup_logger and after_setup_task_logger

### DIFF
--- a/celery/log.py
+++ b/celery/log.py
@@ -118,7 +118,11 @@ class Logging(object):
             for logger in filter(None, (root, mp)):
                 self._setup_logger(logger, logfile, format, colorize, **kwargs)
                 logger.setLevel(loglevel)
+                signals.after_setup_logger.send(sender=None, logger=logger,
+                                        loglevel=loglevel, logfile=logfile,
+                                        format=format, colorize=colorize)
         Logging._setup = True
+        
         return receivers
 
     def _detect_handler(self, logfile=None):
@@ -181,6 +185,9 @@ class Logging(object):
                                     logfile, format, colorize, **kwargs)
         logger.propagate = int(propagate)    # this is an int for some reason.
                                              # better to not question why.
+        signals.after_setup_task_logger.send(sender=None, logger=logger,
+                                     loglevel=loglevel, logfile=logfile,
+                                     format=format, colorize=colorize)
         return LoggerAdapter(logger, {"task_id": task_id,
                                       "task_name": task_name})
 

--- a/celery/signals.py
+++ b/celery/signals.py
@@ -290,6 +290,10 @@ worker_shutdown = Signal(providing_args=[])
 
 setup_logging = Signal(providing_args=["loglevel", "logfile",
                                        "format", "colorize"])
+after_setup_logger = Signal(providing_args=["logger","loglevel", "logfile",
+                                       "format", "colorize"])
+after_setup_task_logger = Signal(providing_args=["logger","loglevel", "logfile",
+                                       "format", "colorize"])
 
 beat_init = Signal(providing_args=[])
 beat_embedded_init = Signal(providing_args=[])


### PR DESCRIPTION
Whit this signals is possible to extend the logging features in a proper way, the signals give you back the logger object already built. In this way it's easy to add handlers for send all the logs to a sys-log server in the same format as celery write logs on disk.
