### PR TITLE
Only create PID file once

### DIFF
--- a/celery/events/snapshot.py
+++ b/celery/events/snapshot.py
@@ -83,9 +83,6 @@ def evcam(camera, freq=1.0, maxrate=None, loglevel=0,
     logger = app.log.setup_logger(loglevel=loglevel,
                                   logfile=logfile,
                                   name="celery.evcam")
-    if pidfile:
-        pidlock = platforms.create_pidlock(pidfile).acquire()
-        atexit.register(pidlock.release)
 
     logger.info(
         "-> evcam: Taking snapshots with %s (every %s secs.)\n" % (


### PR DESCRIPTION
removed a duplicate piece of code that was creating a pid file. evcam was trying to create the same pid file twice and getting an error because it already existed (the second time).
