### PR TITLE
Corrects @task "behind the scenes" explaination.

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -667,7 +667,6 @@ will do roughly this behind the scenes:
 
 .. code-block:: python
 
-    @task
     def AddTask(Task):
 
         def run(self, x, y):


### PR DESCRIPTION
It isn't true that "behind the scenes" of the @task decorator that the
class is also decorated.  Fixing this.
