### PR TITLE
os.kill is not available in windows before python 2.7

### DIFF
--- a/celery/concurrency/processes/__init__.py
+++ b/celery/concurrency/processes/__init__.py
@@ -6,8 +6,6 @@ Process Pools.
 import platform
 import signal as _signal
 
-from os import kill as _kill
-
 from celery.concurrency.base import BasePool
 from celery.concurrency.processes.pool import Pool, RUN
 
@@ -17,6 +15,8 @@ if platform.system() == "Windows":  # pragma: no cover
     # *and its children* (if any).
     from celery.concurrency.processes import _win
     _kill = _win.kill_processtree  # noqa
+else:
+    from os import kill as _kill
 
 
 class TaskPool(BasePool):


### PR DESCRIPTION
As per the topic, the current celery implementation (>=2.3.0) crashes on windows using python 2.5 and 2.6, because it uses os.kill which is not available in windows before python 2.7
