### PR TITLE
Stacktrace when shutting down celery when using the eventlet worker pool

### DIFF
--- a/celery/worker/__init__.py
+++ b/celery/worker/__init__.py
@@ -253,6 +253,8 @@ class WorkController(object):
         except SystemTerminate:
             self.terminate()
             raise
+        except SystemExit, e:
+            self.terminate()
         except:
             self.stop()
             try:


### PR DESCRIPTION
Everytime I shut down celery when using the eventlet pool (since version 2.3.0) I get the following exception:

```
(celery_eventlet_test)~/tmp/celery_eventlet_test § celeryd
[2011-09-03 17:54:52,973: WARNING/MainProcess]  

 -------------- celery@Jonatan-Heymans-MacBook-Air.local v2.3.1
---- **** -----
--- * ***  * -- [Configuration]
-- * - **** ---   . broker:      amqplib://tripbirds@localhost:5672/tripbirds
- ** ----------   . loader:      celery.loaders.default.Loader
- ** ----------   . logfile:     [stderr]@WARNING
- ** ----------   . concurrency: 10
- ** ----------   . events:      OFF
- *** --- * ---   . beat:        OFF
-- ******* ----
--- ***** ----- [Queues]
 --------------   . celery:      exchange:celery (direct) binding:celery


[2011-09-03 17:54:52,980: WARNING/MainProcess] celery@Jonatan-Heymans-MacBook-Air.local has started.

^C[2011-09-03 17:54:56,296: WARNING/MainProcess] celeryd: Hitting Ctrl+C again will terminate all running tasks!
[2011-09-03 17:54:56,298: WARNING/MainProcess] celeryd: Warm shutdown (MainProcess)
[2011-09-03 17:54:56,301: WARNING/MainProcess] Traceback (most recent call last):
[2011-09-03 17:54:56,301: WARNING/MainProcess] File "/Users/jonatan/virtualenvs/celery_eventlet_test/bin/celeryd", line 9, in <module>
[2011-09-03 17:54:56,302: WARNING/MainProcess] load_entry_point('celery==2.3.1', 'console_scripts', 'celeryd')()
[2011-09-03 17:54:56,302: WARNING/MainProcess] File "/Users/jonatan/virtualenvs/celery_eventlet_test/lib/python2.7/site-packages/celery/bin/celeryd.py", line 187, in main
[2011-09-03 17:54:56,302: WARNING/MainProcess] worker.execute_from_commandline()
[2011-09-03 17:54:56,302: WARNING/MainProcess] File "/Users/jonatan/virtualenvs/celery_eventlet_test/lib/python2.7/site-packages/celery/bin/base.py", line 72, in execute_from_commandline
[2011-09-03 17:54:56,303: WARNING/MainProcess] return self.handle_argv(prog_name, argv[1:])
[2011-09-03 17:54:56,303: WARNING/MainProcess] File "/Users/jonatan/virtualenvs/celery_eventlet_test/lib/python2.7/site-packages/celery/bin/base.py", line 100, in handle_argv
[2011-09-03 17:54:56,303: WARNING/MainProcess] return self.run(*args, **vars(options))
[2011-09-03 17:54:56,304: WARNING/MainProcess] File "/Users/jonatan/virtualenvs/celery_eventlet_test/lib/python2.7/site-packages/celery/bin/celeryd.py", line 96, in run
[2011-09-03 17:54:56,304: WARNING/MainProcess] return self.app.Worker(**kwargs).run()
[2011-09-03 17:54:56,304: WARNING/MainProcess] File "/Users/jonatan/virtualenvs/celery_eventlet_test/lib/python2.7/site-packages/celery/apps/worker.py", line 140, in run
[2011-09-03 17:54:56,304: WARNING/MainProcess] self.run_worker()
[2011-09-03 17:54:56,305: WARNING/MainProcess] File "/Users/jonatan/virtualenvs/celery_eventlet_test/lib/python2.7/site-packages/celery/apps/worker.py", line 240, in run_worker
[2011-09-03 17:54:56,305: WARNING/MainProcess] worker.start()
[2011-09-03 17:54:56,305: WARNING/MainProcess] File "/Users/jonatan/virtualenvs/celery_eventlet_test/lib/python2.7/site-packages/eventlet/greenthread.py", line 255, in kill
[2011-09-03 17:54:56,306: WARNING/MainProcess] g.main(just_raise, (), {})
[2011-09-03 17:54:56,306: WARNING/MainProcess] File "/Users/jonatan/virtualenvs/celery_eventlet_test/lib/python2.7/site-packages/eventlet/greenthread.py", line 192, in main
[2011-09-03 17:54:56,306: WARNING/MainProcess] result = function(*args, **kwargs)
[2011-09-03 17:54:56,306: WARNING/MainProcess] File "/Users/jonatan/virtualenvs/celery_eventlet_test/lib/python2.7/site-packages/eventlet/greenthread.py", line 249, in just_raise
[2011-09-03 17:54:56,307: WARNING/MainProcess] raise greenlet.GreenletExit()
[2011-09-03 17:54:56,307: WARNING/MainProcess] greenlet
[2011-09-03 17:54:56,307: WARNING/MainProcess] .
[2011-09-03 17:54:56,307: WARNING/MainProcess] GreenletExit
(celery_eventlet_test)~/tmp/celery_eventlet_test § 
```

I've made a small fix that made the problem go away, but I'm not sure that the solution is correct and that the shutdown will be "clean" with it. 
