### PR TITLE
Fix init script to cd into CELERYD_CHDIR instead of trying to use --workdir which no longer works

### DIFF
--- a/contrib/generic-init.d/celeryd
+++ b/contrib/generic-init.d/celeryd
@@ -153,7 +153,7 @@ stop_workers () {
 
 start_workers () {
     if [ -n "$CELERYD_CHDIR" ]; then
-	cd $CELERYD_CHDIR
+        cd $CELERYD_CHDIR
     fi
     $CELERYD_MULTI start $CELERYD_NODES $DAEMON_OPTS        \
                          --pidfile="$CELERYD_PID_FILE"      \


### PR DESCRIPTION
Updated celeryd init script so that CELERYD_CHDIR works again, should resolve django-celery#67
