### PR TITLE
memory leak in concurrency.threads

### DIFF
--- a/celery/concurrency/threads.py
+++ b/celery/concurrency/threads.py
@@ -2,6 +2,17 @@ from __future__ import absolute_import
 
 from .base import apply_target, BasePool
 
+class BlackholeDictionary(object):
+    
+    def __setitem__(self, k, v):
+        pass
+
+    def __delitem__(self, k):
+        pass
+
+    def __getitem__(self, k):
+        raise Exception("Unsupported operation on blackhole dictionary")
+
 
 class TaskPool(BasePool):
 
@@ -17,6 +28,9 @@ class TaskPool(BasePool):
 
     def on_start(self):
         self._pool = self.ThreadPool(self.limit)
+        # threadpool stores all work requests until they are processed
+        # lets overwrite the dict because they are never processed
+        self._pool.workRequests = BlackholeDictionary()
 
     def on_stop(self):
         self._pool.dismissWorkers(self.limit, do_join=True)


### PR DESCRIPTION
Currently the ThreadPool leaks memory over time because tasks are never deleted, and while processing lots of tasks the celery process eats up a lot of memory (8G+ in my case). The problem goes away with this patch.
