### PR TITLE
Handle task messages with missing fields

### DIFF
--- a/celery/tests/test_worker/test_worker_job.py
+++ b/celery/tests/test_worker/test_worker_job.py
@@ -537,6 +537,24 @@ class test_TaskRequest(unittest.TestCase):
         self.assertIsInstance(tw.kwargs.keys()[0], str)
         self.assertTrue(tw.logger)
 
+    def test_from_message_empty_args(self):
+        body = {"task" : mytask.name, "id": uuid()}
+        m = Message(None, body=anyjson.serialize(body), backend="foo",
+                          content_type="application/json",
+                          content_encoding="utf-8")
+        tw = TaskRequest.from_message(m, m.decode())
+        self.assertIsInstance(tw, TaskRequest)
+        self.assertEquals(tw.args, [])
+        self.assertEquals(tw.kwargs, {})
+
+    def test_from_message_missing_required_fields(self):
+        body = {}
+        m = Message(None, body=anyjson.serialize(body), backend="foo",
+                          content_type="application/json",
+                          content_encoding="utf-8")
+        with self.assertRaises(InvalidTaskError):
+            TaskRequest.from_message(m, m.decode())
+ 
     def test_from_message_nonexistant_task(self):
         body = {"task": "cu.mytask.doesnotexist", "id": uuid(),
                 "args": [2], "kwargs": {u"æØåveéðƒeæ": "bar"}}

--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -276,14 +276,19 @@ class TaskRequest(object):
         delivery_info = dict((key, delivery_info.get(key))
                                 for key in WANTED_DELIVERY_INFO)
 
-        kwargs = body["kwargs"]
+        kwargs = body.get("kwargs", {})
         if not hasattr(kwargs, "items"):
             raise InvalidTaskError("Task keyword arguments is not a mapping.")
+        try:
+            task_name = body["task"]
+            task_id = body["id"]
+        except KeyError, e:
+            raise InvalidTaskError("Task message is missing required field %s" % e)
 
-        return cls(task_name=body["task"],
-                   task_id=body["id"],
+        return cls(task_name=task_name,
+                   task_id=task_id,
                    taskset_id=body.get("taskset", None),
-                   args=body["args"],
+                   args=body.get("args", []),
                    kwargs=kwdict(kwargs),
                    chord=body.get("chord"),
                    retries=body.get("retries", 0),


### PR DESCRIPTION
In Celery 2.3 task messages with missing request fields can crash the worker with a KeyError. This probably isn't an issue when launching tasks from within Python, but is easy to trigger when launching tasks by generating AMQP messages directly (from another language, perhaps).

The [task messages documentation](http://celery.readthedocs.org/en/latest/internals/protocol.html) indicates that if `args` or `kwargs` are omitted, they will be treated as empty. In fact, this will cause a KeyError on the worker.

Similarly, the `id` and `task` fields are required, so if they are missing the worker should dump the message with an `InvalidTaskError`.
