### PR TITLE
Fix to chord oddities when tasks in the chord's taskset dispatch other tasks

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -82,9 +82,10 @@ class RedisBackend(KeyValueStoreBackend):
         setid = task.request.taskset
         key = keyprefix % setid
         deps = TaskSetResult.restore(setid, backend=task.backend)
-        if self.client.incr(key) >= deps.total:
-            subtask(task.request.chord).delay(deps.join(propagate=propagate))
-            deps.delete()
+        if task.request.id in [result.task_id for result in deps.results]:
+            if self.client.incr(key) >= deps.total:
+                subtask(task.request.chord).delay(deps.join(propagate=propagate))
+                deps.delete()
         self.client.expire(key, 86400)
 
     @cached_property


### PR DESCRIPTION
Testing has revealed that tasks dispatched async by tasks in the taskset of a chord have the task.request.chord value set, and thus they inappropriately call on_chord_part_return. This results in premature dispatch of the chord callback and errors on later calls within the taskset because, once deleted on chord callback dispatch, deps == None. The best solution would be to not have those subtasks' request object not carry the chord, but this workaround fixes the symptom.
