### PR TITLE
Change celeryd startup priority in RHEL init script

### DIFF
--- a/contrib/centos/celeryd.init
+++ b/contrib/centos/celeryd.init
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# chkconfig: - 55 45
+# chkconfig: - 85 15
 # description:  Celery worker daemon
 # processname: celeryd
 # config: /etc/sysconfig/celeryd


### PR DESCRIPTION
The default start / stop priorities for mySQL on RHEL are

```
# chkconfig: - 64 36
```

Therefore, if celery is using a database as a broker / message store, it
should be started after the database is up and running, otherwise errors
will ensue. This commit changes the priority in the init script to

```
# chkconfig: - 85 15
```

which are the default recommended settings for 3-rd party applications
and assure that celery will be started after the database service & shut
down before it terminates.

Signed-off-by: Yury V. Zaytsev yury@shurup.com
