### PR TITLE
New style CELERY_REDIS_* configuration should take precedence over old st

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -42,7 +42,7 @@ class RedisBackend(KeyValueStoreBackend):
 
         # For compatability with the old REDIS_* configuration keys.
         def _get(key):
-            for prefix in "REDIS_%s", "CELERY_REDIS_%s":
+            for prefix in "CELERY_REDIS_%s", "REDIS_%s":
                 try:
                     return conf[prefix % key]
                 except KeyError:


### PR DESCRIPTION
New style CELERY_REDIS_\* configuration should take precedence over old style REDIS_\* configuration.
