### PR TITLE
Fixed HTTP POST requests.

### DIFF
--- a/celery/task/http.py
+++ b/celery/task/http.py
@@ -141,8 +141,9 @@ class HttpDispatch(object):
 
     def make_request(self, url, method, params):
         """Makes an HTTP request and returns the response."""
-        request = urllib2.Request(url, params, headers=self.http_headers)
-        request.headers.update(self.http_headers)
+        request = urllib2.Request(url, params)
+        for key, val in self.http_headers.items():
+            request.add_header(key, val)
         response = urllib2.urlopen(request)         # user catches errors.
         return response.read()
 
@@ -159,8 +160,7 @@ class HttpDispatch(object):
 
     @property
     def http_headers(self):
-        headers = {"Content-Type": "application/json",
-                   "User-Agent": self.user_agent}
+        headers = {"User-Agent": self.user_agent}
         return headers
 
 


### PR DESCRIPTION
HTTP POST requests do not really work. At least Django is not able to parse them properly (even request.raw_post_data is empty). There are few reasons for that but main is that headers have been set explicitly so urllib2 has not populate them itself. For example, content-length is one of such missing.

Also some non-documented internals have been used to manipulate headers. Public API provides only `request.add_header`.

I have changed code so that Celery headers are added after urllib2 populates its own. `Content-Type` is changed to `application/x-www-form-urlencoded` which in fact correct as payload is urlencoded and not JSON encoded.

Request before my changes looked like this:

```
POST /foo/ HTTP/1.0
Host: localhost:8080
Content-Type: application/json
User-Agent: celery/2.4.0rc1
Content-type: application/json
User-agent: celery/2.4.0rc1
```

Yes, headers were doubled.

Now they look like this:

```
POST /foo/ HTTP/1.0
Content-type: application/x-www-form-urlencoded
Content-length: 411
Host: localhost:8080
User-agent: celery/2.4.0rc1
```
