### PR TITLE
celeryd can't process signals if the workers are full (it's blocking a on a lock).

### DIFF
--- a/celery/concurrency/processes/pool.py
+++ b/celery/concurrency/processes/pool.py
@@ -794,9 +794,12 @@ class Pool(object):
                              error_callback, soft_timeout, timeout)
 
         if waitforslot and self._putlock is not None:
-            self._putlock.acquire()
-            if self._state != RUN:
-                return
+            while True:
+                if self._putlock.acquire(False):
+                    break
+                if self._state != RUN:
+                    return
+                time.sleep(0.2)
         if timeout or soft_timeout:
             # start the timeout handler thread when required.
             self._start_timeout_handler()


### PR DESCRIPTION
Changed Pool._putloc.acquire call to be non-blocking (and poll at 0.2 secs).
