### PR TITLE
Pass routing overrides to the CELERYBEAT_SCHEDULE for periodic tasks

### DIFF
--- a/celery/task/base.py
+++ b/celery/task/base.py
@@ -114,6 +114,9 @@ class PeriodicTask(Task):
                 "kwargs": {},
                 "options": self.options or {},
                 "relative": self.relative,
+                "routing_key": self.routing_key,
+                "queue": self.queue,
+                "exchange": self.exchange,
         }
 
         super(PeriodicTask, self).__init__()


### PR DESCRIPTION
I was having an issue where when I defined periodic tasks, the routing_key wasn't being respected using Celery 2.3.3 and djcelery as the backend. These periodic tasks were then running on the incorrect celery worker.

@periodic_task(run_every=crontab(minute=0, hour="3, 9, 15, 21"), routing_key='crawl.blah')
def crawl_blah():
    ...
