### PR TITLE
Fix an import which prevents celeryctl from working

### DIFF
--- a/celery/bin/celeryctl.py
+++ b/celery/bin/celeryctl.py
@@ -12,7 +12,7 @@ from anyjson import deserialize
 
 from celery import __version__
 from celery.app import app_or_default, current_app
-from celeryutils import term
+from celery.utils import term
 
 from celery.bin.base import Command as CeleryCommand
 


### PR DESCRIPTION
The import should be

``` python
from celery.util import term
```

The module `celeryutil` does not exist.

This is the same bug as ask/celery#538
