### PR TITLE
Update celeryevcam init script to not use set -e

### DIFF
--- a/contrib/generic-init.d/celeryevcam
+++ b/contrib/generic-init.d/celeryevcam
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # ============================================
 #  celeryd - Starts the Celery worker daemon.
 # ============================================
@@ -86,7 +86,9 @@
 # Short-Description: celery event snapshots
 ### END INIT INFO
 
-set -e
+# Cannot use set -e/bash -e since the kill -0 command will abort
+# abnormally in the absence of a valid process ID.
+#set -e
 
 DEFAULT_PID_FILE="/var/run/celeryev.pid"
 DEFAULT_LOG_FILE="/var/log/celeryev.log"


### PR DESCRIPTION
Just like the celerybeat init script, celeryevcam cannot use set -e because then the call to kill -0 fails.
