### PR TITLE
Fix missing call to log_daemon_msg

### DIFF
--- a/contrib/generic-init.d/celeryevcam
+++ b/contrib/generic-init.d/celeryevcam
@@ -198,12 +198,11 @@ case "$1" in
   stop)
     stop_evcam
     ;;
-
   reload|force-reload)
     echo "Use start+stop"
     ;;
   restart)
-    log_daemon_msg "Restarting celery event snapshots" "celeryev"
+    echo "Restarting celery event snapshots" "celeryev"
     stop_evcam
     check_dev_null
     start_evcam


### PR DESCRIPTION
`log_daemon_msg` doesn't exist in the celeryevcam script. Just use `echo` instead.
