### PR TITLE
Set all groups for new user

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -330,6 +330,14 @@ def parse_gid(gid):
         raise
 
 
+def setgroups(uid):
+    if grp and pwd:
+        user_name = pwd.getpwuid(uid)[0]
+        user_groups = [gr.gr_gid for gr in grp.getgrall()
+                                                if user_name in gr.gr_mem]
+        os.setgroups(user_groups)
+
+
 def setegid(gid):
     """Set effective group id."""
     gid = parse_gid(gid)
@@ -363,6 +371,7 @@ def set_effective_user(uid=None, gid=None):
         if not gid and pwd:
             gid = pwd.getpwuid(uid).pw_gid
         setegid(gid)
+        setgroups(uid)
         seteuid(uid)
     else:
         gid and setegid(gid)


### PR DESCRIPTION
This commit fixes problem described here http://bugs.python.org/issue10032

To reproduce problem run something like this(everything as root):

Create file
`lmo:/tmp# > test_file`

Read/write access only for user and group. Change group to `games`, gid=60.
`lmo:/tmp# chmod 660 test_file 
lmo:/tmp# chgrp games test_file`

Read file as root
`lmo:/tmp# python -c "open('test_file').read()"`

Read file as user who is added to group `games`.
`lmo:/tmp# python -c "import os; os.setuid(1000); open('test_file').read()"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
IOError: [Errno 13] Permission denied: 'test_file'`

Read file as user who is added to group `games`. Group was also set.
`lmo:/tmp# python -c "import os; os.setgroups([60]);os.setuid(1000); open('test_file').read()"
lmo:/tmp#`
