### PR TITLE
docs pickleable stuff

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -710,7 +710,7 @@ you have to pass them as regular args:
             self.headers = headers
             self.body = body
 
-            super(Exception, self).__init__(status_code, headers, body)
+            super(HttpError, self).__init__(status_code, headers, body)
 
 .. _task-custom-classes:
 


### PR DESCRIPTION
Hi, I think this is the correct version. We should be calling **init** of  HttpError class' parent, which is Exception.
