### PR TITLE
avoid Celery crashing for channel errors

### DIFF
--- a/celery/worker/consumer.py
+++ b/celery/worker/consumer.py
@@ -305,7 +305,7 @@ class Consumer(object):
             try:
                 self.reset_connection()
                 self.consume_messages()
-            except self.connection_errors:
+            except self.connection_errors + self.channel_errors:
                 self.logger.error("Consumer: Connection to broker lost."
                                 + " Trying to re-establish the connection...",
                                 exc_info=sys.exc_info())


### PR DESCRIPTION
This stack trace can happen during network hiccups when the RabbitMQ host is connected to another one.  AMQPChannelException's get thrown, but not AMQPConnectionExceptions.   Seems to be a similar fix used already for Celery control commands.  Test included.

File "/usr/local/lib/python2.6/dist-packages/celery/worker/consumer.py", line 303, in start
self.consume_messages()
File "/usr/local/lib/python2.6/dist-packages/celery/worker/consumer.py", line 319, in consume_messages
self.connection.drain_events(timeout=1)
File "/usr/local/lib/python2.6/dist-packages/kombu/connection.py", line 175, in drain_events
return self.transport.drain_events(self.connection, **kwargs)
File "/usr/local/lib/python2.6/dist-packages/kombu/transport/pyamqplib.py", line 238, in drain_events
return connection.drain_events(**kwargs)
File "/usr/local/lib/python2.6/dist-packages/kombu/transport/pyamqplib.py", line 57, in drain_events
return self.wait_multi(self.channels.values(), timeout=timeout)
File "/usr/local/lib/python2.6/dist-packages/kombu/transport/pyamqplib.py", line 82, in wait_multi
return amqp_method(channel, args)
File "/usr/local/lib/python2.6/dist-packages/amqplib/client_0_8/channel.py", line 273, in _close
(class_id, method_id))
amqplib.client_0_8.exceptions
.
AMQPChannelException
:
(404, u"NOT_FOUND - no exchange 'reply.celeryd.pidbox' in vhost 'myvhost'", (60, 40), 'Channel.basic_publish')
