### PR TITLE
When using eventlet I have noticed a sizeable memory leak, this patch fixes it

### DIFF
--- a/celery/concurrency/eventlet.py
+++ b/celery/concurrency/eventlet.py
@@ -110,6 +110,7 @@ class TaskPool(base.BasePool):
         from eventlet.greenpool import GreenPool
         self.Pool = GreenPool
         self.getcurrent = greenthread.getcurrent
+        self.getpid = lambda: id(greenthread.getcurrent())
         self.spawn_n = greenthread.spawn_n
 
         super(TaskPool, self).__init__(*args, **kwargs)
@@ -130,4 +131,4 @@ class TaskPool(base.BasePool):
                 target=target, args=args, kwargs=kwargs)
         self._pool.spawn_n(apply_target, target, args, kwargs,
                            callback, accept_callback,
-                           self.getcurrent)
+                           self.getpid)


### PR DESCRIPTION
accept_callback on a task was trying to json serialize task info which was raising a TypeError (because instead of having a pid it was receiving a greenlet instance which can't be json serialized) and that was leaking the whole greenlet on every processed task.

This was happening with eventlet 0.9.16
