### PR TITLE
Add $CELERYCTL_OPTS to init script

### DIFF
--- a/contrib/generic-init.d/celeryd
+++ b/contrib/generic-init.d/celeryd
@@ -126,7 +126,7 @@ case "$1" in
     ;;
 
     status)
-        $CELERYCTL status
+        $CELERYCTL status $CELERYCTL_OPTS
     ;;
 
     restart)


### PR DESCRIPTION
Add $CELERYCTL_OPTS variable to allow adding --config argument when running celeryd with a Django settings file.  For instance, in /etc/sysconfig/celeryd you could set:

CELERYCTL_OPTS="--config=MyDjangoApp.settings"

Without that argument, "celeryctl status" will complain about being unable to find the settings module.

celeryctl options must come after commands, so this is not something that can be handled by the $CELERYCTL variable itself.
