### PR TITLE
Fixed typo where guide was defines a class object using the 'def' keyword.

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -734,7 +734,7 @@ will do roughly this behind the scenes:
 .. code-block:: python
 
     @task
-    def AddTask(Task):
+    class AddTask(Task):
 
         def run(self, x, y):
             return x + y


### PR DESCRIPTION
In the docs/userguide/tasks.rst, a python code example uses the 'def' keyword to create a subclass of Task, this is corrected.
