### PR TITLE
pycassa ConnectionPool server argument fix

### DIFF
--- a/celery/backends/cassandra.py
+++ b/celery/backends/cassandra.py
@@ -106,7 +106,7 @@ class CassandraBackend(BaseDictBackend):
 
     def _get_column_family(self):
         if self._column_family is None:
-            conn = pycassa.ConnectionPool(self.keyspace, servers=self.servers,
+            conn = pycassa.ConnectionPool(self.keyspace, server_list=self.servers,
                                    **self.cassandra_options)
             self._column_family = \
               pycassa.ColumnFamily(conn, self.column_family,


### PR DESCRIPTION
The argument for specifying servers for ConnectionPool is `server_list` while in the old `connect` function it was `servers`. The argument was being passed silently to ConnectionPool and just being ignored, defaulting to localhost:9160 regardless of what it was set to. This fixes that.
