### PR TITLE
Add SIGQUIT handler

### DIFF
--- a/celery/tests/test_bin/test_celeryd.py
+++ b/celery/tests/test_bin/test_celeryd.py
@@ -567,3 +567,12 @@ class test_signal_handlers(AppCase):
             self.assertTrue(argv)
         finally:
             os.execv = execv
+
+
+    @disable_stdouts
+    def test_worker_term_hard_handler(self):
+        worker = self._Worker()
+        handlers = self.psig(cd.install_worker_term_hard_handler, worker)
+        with self.assertRaises(SystemExit):
+            handlers["SIGQUIT"]("SIGQUIT", object())
+        self.assertTrue(worker.terminated)


### PR DESCRIPTION
The handler call pool.terminate(), therefore stopping any running workers.  This is better than calling SIGKILL or SIGTERM which leaves workers running.  If used with ACKS_LATE, the tasks will be run again when the worker is restarted.  Not sure if this should be documented somewhere, as I didn't find where the signals are documented.
