### PR TITLE
Incorrect parsing of crontab ranges with steps

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -153,15 +153,12 @@ class crontab_parser(object):
     def _range_steps(self, toks):
         if len(toks) != 3 or not toks[2]:
             raise self.ParseException("empty filter")
-        return self._filter_steps(self._expand_range(toks[:2]), int(toks[2]))
+        return self._expand_range(toks[:2])[::int(toks[2])]
 
     def _star_steps(self, toks):
         if not toks or not toks[0]:
             raise self.ParseException("empty filter")
-        return self._filter_steps(self._expand_star(), int(toks[0]))
-
-    def _filter_steps(self, numbers, steps):
-        return [n for n in numbers if n % steps == 0]
+        return self._expand_star()[::int(toks[0])]
 
     def _expand_star(self, *args):
         return range(self.max_)

--- a/celery/tests/test_task/__init__.py
+++ b/celery/tests/test_task/__init__.py
@@ -605,12 +605,14 @@ class test_crontab_parser(Case):
 
     def test_parse_composite(self):
         self.assertEqual(crontab_parser(8).parse('*/2'), set([0, 2, 4, 6]))
-        self.assertEqual(crontab_parser().parse('2-9/5'), set([5]))
-        self.assertEqual(crontab_parser().parse('2-10/5'), set([5, 10]))
-        self.assertEqual(crontab_parser().parse('2-11/5,3'), set([3, 5, 10]))
+        self.assertEqual(crontab_parser().parse('2-9/5'), set([2, 7]))
+        self.assertEqual(crontab_parser().parse('2-10/5'), set([2, 7]))
+        self.assertEqual(crontab_parser().parse('2-11/5,3'), set([2, 3, 7]))
         self.assertEqual(crontab_parser().parse('2-4/3,*/5,0-21/4'),
-                set([0, 3, 4, 5, 8, 10, 12, 15, 16,
-                    20, 25, 30, 35, 40, 45, 50, 55]))
+                set([0, 2, 4, 5, 8, 10, 12, 15, 16,
+                     20, 25, 30, 35, 40, 45, 50, 55]))
+        self.assertEqual(crontab_parser().parse('1-9/2'),
+                set([1, 3, 5, 7, 9]))
 
     def test_parse_errors_on_empty_string(self):
         with self.assertRaises(ParseException):


### PR DESCRIPTION
Hi,

according to crontab(5) _Ranges  can  include  "steps",  so  "1-9/2" is the same as "1,3,5,7,9"._

However, crontab_parser behaves differently:

```
>>> from celery.schedules import crontab_parser
>>> crontab_parser().parse("1-9/2")
set([8, 2, 4, 6])
```

I fixed the behavior of crontab_parser and the related tests.
