### PR TITLE
Set __package__ the same way in celeryd as elsewhere

### DIFF
--- a/celery/bin/celeryd.py
+++ b/celery/bin/celeryd.py
@@ -73,7 +73,7 @@
 """
 from __future__ import absolute_import
 
-if "__main__" and __package__ is None:
+if __name__ == "__main__" and __package__ is None:
     __package__ = "celery.bin.celeryd"
 
 import sys


### PR DESCRIPTION
This fixes what looks like a simple typo, but caused a NameError on **package** that got me on Python 2.5:

File "[...]/celery/bin/celeryd.py", line 76, in <module>
    if "**main**" and **package** is None:
NameError: name '**package**' is not defined
