### PR TITLE
Fix SyntaxError on 2.5 in call to print_exception

### DIFF
--- a/celery/utils/threads.py
+++ b/celery/utils/threads.py
@@ -41,7 +41,10 @@ class bgThread(Thread):
 
     def on_crash(self, exc_info, msg, *fmt, **kwargs):
         sys.stderr.write((msg + "\n") % fmt)
-        traceback.print_exception(*exc_info, file=sys.stderr)
+        traceback.print_exception(exc_info[0],
+                                  exc_info[1],
+                                  exc_info[2],
+                                  None, sys.__stderr__)
 
     def run(self):
         shutdown = self._is_shutdown

--- a/celery/utils/timer2.py
+++ b/celery/utils/timer2.py
@@ -194,7 +194,10 @@ class Timer(Thread):
                 if not self.schedule.handle_error(exc_info):
                     warnings.warn(TimedFunctionFailed(repr(exc))),
                     sys.stderr.write("Error in timer: %r\n" % (exc, ))
-                    traceback.print_exception(*exc_info, file=sys.stderr)
+                    traceback.print_exception(exc_info[0],
+                                              exc_info[1],
+                                              exc_info[2],
+                                              None, sys.__stderr__)
             finally:
                 del(exc_info)
 


### PR DESCRIPTION
These calls to traceback.print_exception were a SyntaxError on Python 2.5, as far as I can tell because of http://bugs.python.org/issue3473

This changes the calls to be more ugly, but the same as the one in celery/log.py that is valid on 2.5
