### PR TITLE
Remove slashes from Userguide example code

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -791,7 +791,7 @@ base class for new task types.
     class DebugTask(Task):
         abstract = True
 
-        def after_return(self, \*args, \*\*kwargs):
+        def after_return(self, *args, **kwargs):
             print("Task returned: %r" % (self.request, ))
 
 


### PR DESCRIPTION
Abstract classes: args and kwargs parameters' asterisks had escaping-slashes ahead of them, but those slashes render in the generated HTML output. These should be fine without slashes?
