### PR TITLE
fix wrong python-dateutil version

### DIFF
--- a/requirements/default-py3k.txt
+++ b/requirements/default-py3k.txt
@@ -1,4 +1,4 @@
-python-dateutil>=2.0.0
+python-dateutil>=2.0
 anyjson>=0.3.1
 pytz
 kombu>=2.1.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
-python-dateutil>=1.5.0,<2.0.0
+python-dateutil>=1.5,<2.0
 anyjson>=0.3.1
 kombu>=2.1.1,<3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,6 @@ upload-dir = docs/.build/html
 requires = uuid
            importlib
            multiprocessing == 2.6.2.1
-           python-dateutil >= 1.5.0
+           python-dateutil >= 1.5
            anyjson >= 0.3.1
            kombu >= 2.1.1

--- a/setup.py
+++ b/setup.py
@@ -118,9 +118,9 @@ install_requires.extend([
     "kombu>=2.1.1,<3.0",
 ])
 if is_py3k:
-    install_requires.append("python-dateutil>=2.0.0")
+    install_requires.append("python-dateutil>=2.0")
 else:
-    install_requires.append("python-dateutil>=1.5.0,<2.0.0")
+    install_requires.append("python-dateutil>=1.5,<2.0")
 
 py_version = sys.version_info
 is_jython = sys.platform.startswith("java")


### PR DESCRIPTION
The version for python-dateutil (on PyPI) is 1.5 or 2.0.
This has no impact to use 1.5.0 or 2.0.0 if using pip, but when we build
(in my case debian) packages using the setup.py, the dependency on
python-dateutil will be wrong. For Debian, 1.5.0 != 1.5.
So, this fix restores the correct versions for the python-dateutil
dependency.
Installation using pip still works perfectly after this fix.
