### PR TITLE
Fix import error in python 2.5

### DIFF
--- a/celery/app/__init__.py
+++ b/celery/app/__init__.py
@@ -18,8 +18,8 @@ from ..local import PromiseProxy
 from ..utils import cached_property
 from ..utils.imports import instantiate
 
-from . import annotations
-from . import base
+from .annotations import _first_match, _first_match_any
+from .base import BaseApp
 from .state import _tls
 from .state import current_task  # noqa
 
@@ -54,7 +54,7 @@ def _unpickle_app(cls, pickler, *args):
     return pickler()(cls, *args)
 
 
-class App(base.BaseApp):
+class App(BaseApp):
     """Celery Application.
 
     :param main: Name of the main module if running as `__main__`.
@@ -195,10 +195,10 @@ class App(base.BaseApp):
 
     def annotate_task(self, task):
         if self.annotations:
-            match = annotations._first_match(self.annotations, task)
+            match = _first_match(self.annotations, task)
             for attr, value in (match or {}).iteritems():
                 setattr(task, attr, value)
-            match_any = annotations._first_match_any(self.annotations)
+            match_any = _first_match_any(self.annotations)
             for attr, value in (match_any or {}).iteritems():
                 setattr(task, attr, value)
 


### PR DESCRIPTION
The patch fixes this error:

```
Traceback (most recent call last):
  File "motloh/manage.py", line 14, in <module>
    execute_manager(settings)
  File "/home/yrik/motloh/.env/lib/python2.5/site-packages/django/core/management/__init__.py", line 459, in execute_manager
    utility.execute()
  File "/home/yrik/motloh/.env/lib/python2.5/site-packages/django/core/management/__init__.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/yrik/motloh/.env/lib/python2.5/site-packages/django/core/management/__init__.py", line 261, in fetch_command
    klass = load_command_class(app_name, subcommand)
  File "/home/yrik/motloh/.env/lib/python2.5/site-packages/django/core/management/__init__.py", line 69, in load_command_class
    module = import_module('%s.management.commands.%s' % (app_name, name))
  File "/home/yrik/motloh/.env/lib/python2.5/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/home/yrik/motloh/.env/src/djcelery/djcelery/management/commands/celeryd.py", line 10, in <module>
    from djcelery.app import app
  File "/home/yrik/motloh/.env/src/djcelery/djcelery/app.py", line 3, in <module>
    from celery.app import default_app
  File "/home/yrik/motloh/.env/src/celery/celery/app/__init__.py", line 21, in <module>
    import annotations
ImportError: No module named annotations
```

I've got this error on my system with latest celery from official repo.

It's connected with import command behavior in python 2.5.
