### PR TITLE
Error while restarting using SIGHUP

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -216,15 +216,13 @@ class Worker(configurated):
         }
 
     def run_worker(self):
-        if self.pidfile:
-            pidlock = platforms.create_pidlock(self.pidfile).acquire()
-            atexit.register(pidlock.release)
         worker = self.WorkController(app=self.app,
                                     hostname=self.hostname,
                                     ready_callback=self.on_consumer_ready,
                                     embed_clockservice=self.embed_clockservice,
                                     autoscale=self.autoscale,
                                     autoreload=self.autoreload,
+                                    pidfile=self.pidfile,
                                     **self.confopts_as_dict())
         self.install_platform_tweaks(worker)
         signals.worker_init.send(sender=worker)

--- a/celery/tests/test_bin/test_celeryd.py
+++ b/celery/tests/test_bin/test_celeryd.py
@@ -263,35 +263,6 @@ class test_Worker(AppCase):
             os.getuid = prev
 
     @disable_stdouts
-    def test_use_pidfile(self):
-        from celery import platforms
-
-        class create_pidlock(object):
-            instance = [None]
-
-            def __init__(self, file):
-                self.file = file
-                self.instance[0] = self
-
-            def acquire(self):
-                self.acquired = True
-
-                class Object(object):
-                    def release(self):
-                        pass
-
-                return Object()
-
-        prev, platforms.create_pidlock = platforms.create_pidlock, \
-                                         create_pidlock
-        try:
-            worker = self.Worker(pidfile="pidfilelockfilepid")
-            worker.run_worker()
-            self.assertTrue(create_pidlock.instance[0].acquired)
-        finally:
-            platforms.create_pidlock = prev
-
-    @disable_stdouts
     def test_redirect_stdouts(self):
         worker = self.Worker()
         worker.redirect_stdouts = False


### PR DESCRIPTION
There was an error, saying "Pidfile is already exists" while restarting
using SIGHUP. The problem arises only when "--pidfile" option is used.

Related to: https://github.com/ask/celery/issues/26
