### PR TITLE
Avoid circular imports in celery.loaders

### DIFF
--- a/celery/loaders/__init__.py
+++ b/celery/loaders/__init__.py
@@ -12,14 +12,12 @@
 """
 from __future__ import absolute_import
 
-from celery.app.state import current_app
 from celery.utils import deprecated
 from celery.utils.imports import symbol_by_name
 
 LOADER_ALIASES = {"app": "celery.loaders.app:AppLoader",
                   "default": "celery.loaders.default:Loader",
                   "django": "djcelery.loaders:DjangoLoader"}
-
 
 def get_loader_cls(loader):
     """Get loader class by name/alias"""
@@ -29,10 +27,12 @@ def get_loader_cls(loader):
 @deprecated(deprecation="2.5", removal="3.0",
         alternative="celery.current_app.loader")
 def current_loader():
+    from celery.app.state import current_app
     return current_app.loader
 
 
 @deprecated(deprecation="2.5", removal="3.0",
             alternative="celery.current_app.conf")
 def load_settings():
+    from celery.app.state import current_app
     return current_app.conf


### PR DESCRIPTION
Deal with https://github.com/ask/celery/issues/664 by moving imports inside the relevant functions.
