### PR TITLE
New option "queue" to 'task-sent' event

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -239,7 +239,8 @@ class TaskPublisher(messaging.Publisher):
                                                kwargs=repr(task_kwargs),
                                                retries=retries,
                                                eta=eta,
-                                               expires=expires)
+                                               expires=expires,
+                                               queue=queue)
         return task_id
 
     def __exit__(self, *exc_info):

--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -540,7 +540,7 @@ This list contains the events sent by the worker, and their arguments.
 Task Events
 ~~~~~~~~~~~
 
-* ``task-sent(uuid, name, args, kwargs, retries, eta, expires)``
+* ``task-sent(uuid, name, args, kwargs, retries, eta, expires, queue)``
 
    Sent when a task message is published and
    the :setting:`CELERY_SEND_TASK_SENT_EVENT` setting is enabled.


### PR DESCRIPTION
I propose to add a new 'queue' option to the "task-sent" event. In fact, the utility [celery-watcher](https://github.com/imankulov/celery-watcher) I have just written for my needs is based heavily on the fact that "queue" argument is passed along with others by task-sent. If you merged my pull request to upstream, it would certainly simplify my life in some aspects:). Thanks
