### PR TITLE
Updated backend to use bson.binary, pymongo >2.1 removed pymongo.binary

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -1,6 +1,9 @@
+
 # -*- coding: utf-8 -*-
 """MongoDB backend for celery."""
 from __future__ import absolute_import
+
+import warnings
 
 from datetime import datetime
 
@@ -94,8 +97,12 @@ class MongoBackend(BaseDictBackend):
 
     def _store_result(self, task_id, result, status, traceback=None):
         """Store return value and status of an executed task."""
-        from pymongo.binary import Binary
-
+        try:
+            from bson.binary import Binary
+        except ImportError:
+            from pymongo.binary import Binary
+            warnings.warn("pymongo.binary has been removed in pymongo>2.2 in favor of bson.binary")
+            
         meta = {"_id": task_id,
                 "status": status,
                 "result": Binary(self.encode(result)),
@@ -124,8 +131,12 @@ class MongoBackend(BaseDictBackend):
 
     def _save_taskset(self, taskset_id, result):
         """Save the taskset result."""
-        from pymongo.binary import Binary
-
+        try:
+            from bson.binary import Binary
+        except ImportError:
+            from pymongo.binary import Binary
+            warnings.warn("pymongo.binary has been removed pymongo >2.1 in favor of bson.binary")
+            
         meta = {"_id": taskset_id,
                 "result": Binary(self.encode(result)),
                 "date_done": datetime.utcnow()}


### PR DESCRIPTION
This was a small update using the web based editor so I have not tested this code. The change is a simple one to use the bson.binary.Binary rather than pymongo.binary.Binary. This changed on 05/01/2012 with the release of pymongo 2.2.

I was unable to fork (dial up internet) and apologize for any inconvenience this patch might cause. 

**NOTE: This patch was created using the web based Fork and edit on github.com and is against MASTER. 

http://api.mongodb.org/python/current/changelog.html
