### PR TITLE
A missing code line in doc.

### DIFF
--- a/docs/userguide/groups.rst
+++ b/docs/userguide/groups.rst
@@ -95,6 +95,7 @@ tasks were invoked.
     >>> from tasks import add
 
     >>> job = group([
+    ...             add.subtask((2, 2)),
     ...             add.subtask((4, 4)),
     ...             add.subtask((8, 8)),
     ...             add.subtask((16, 16)),


### PR DESCRIPTION
A missing code line in http://celery.readthedocs.org/en/latest/userguide/tasksets.html :

> > > job = TaskSet(tasks=[
> > > ...             add.subtask((4, 4)),
> > > ...             add.subtask((8, 8)),
> > > ...             add.subtask((16, 16)),
> > > ...             add.subtask((32, 32)),
> > > ... ])

should be:

> > > job = TaskSet(tasks=[
> > > ...             add.subtask((2, 2)),
> > > ...             add.subtask((4, 4)),
> > > ...             add.subtask((8, 8)),
> > > ...             add.subtask((16, 16)),
> > > ...             add.subtask((32, 32)),
> > > ... ])

or the result of result.join() can not be [4, 8, 16, 32, 64].

Please merge, thanks.
