### PR TITLE
Fix typo, children were populated AFTER the result was stored.

### DIFF
--- a/celery/task/trace.py
+++ b/celery/task/trace.py
@@ -237,12 +237,12 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                     [subtask(errback).apply_async((uuid, ))
                         for errback in task_request.errbacks or []]
                 else:
-                    if publish_result:
-                        store_result(uuid, retval, SUCCESS)
                     # callback tasks must be applied before the result is
                     # stored, so that result.children is populated.
                     [subtask(callback).apply_async((retval, ))
                         for callback in task_request.callbacks or []]
+                    if publish_result:
+                        store_result(uuid, retval, SUCCESS)
                     if task_on_success:
                         task_on_success(retval, uuid, args, kwargs)
                     if success_receivers:


### PR DESCRIPTION
If seems to be a typo, but the children were dispatched after the result was stored in the backend, hence skipping the children!
