### PR TITLE
Loggers expect exc_info to be falsey or a tuple, pass in the tuple

### DIFF
--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -355,7 +355,7 @@ class Request(object):
         if _does_info:
             info(self.retry_msg.strip(), {
                 "id": self.id, "name": self.name,
-                "exc": safe_repr(exc_info.exception.exc)}, exc_info=exc_info)
+                "exc": safe_repr(exc_info.exception.exc)}, exc_info=exc_info.exc_info)
 
     def on_failure(self, exc_info):
         """Handler called if the task raised an exception."""


### PR DESCRIPTION
I'm actually not sure how useful sending exc_info is at all. It may also be desirable to have some flag here so that exc_info can be omitted when it's a RetryTaskError called from on_failure. IMO, logging those tracebacks probably isn't that helpful.
