### PR TITLE
fix a bug with priority queue handling (tested with a redis backend)

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -201,7 +201,7 @@ class TaskProducer(Producer):
              immediate=immediate, routing_key=routing_key,
              serializer=serializer or self.serializer,
              compression=compression or self.compression,
-             retry=retry, retry_policy=_rp, delivery_mode=delivery_mode,
+             retry=retry, retry_policy=_rp, delivery_mode=delivery_mode, priority=priority,
              declare=[self.queues[queue]] if queue else [],
              **kwargs)
 


### PR DESCRIPTION
I believe this is a followup for the following pull request:
https://github.com/ask/kombu/pull/111

I have tried to get it work however it failed and debugging showed that priority is always passed as 0 from the client side.
The pull request provides a simple change that fixes this. With this test priorities seem to be working perfectly.

Thanks! :)
