### PR TITLE
No longer ignore Chord result.

### DIFF
--- a/celery/app/builtins.py
+++ b/celery/app/builtins.py
@@ -202,7 +202,7 @@ def add_chord_task(app):
         app = _app
         name = "celery.chord"
         accept_magic_kwargs = False
-        ignore_result = True
+        ignore_result = False
 
         def run(self, header, body, interval=1, max_retries=None,
                 propagate=False, eager=False, **kwargs):


### PR DESCRIPTION
If we ignore Chord results, we can't traverse the dep graph of a task anymore (because the task will have a non-existent child, that is the chord).
