### PR TITLE
setup: only try removing the working dir from the path if its on it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,8 @@ if sys.version_info < (2, 5):
 try:
     orig_path = sys.path[:]
     for path in (os.path.curdir, os.getcwd()):
-        try:
+        if path in sys.path:
             sys.path.remove(path)
-        except ValueError:
-            pass
     try:
         import celery.app
         import imp


### PR DESCRIPTION
...it

The existance of a thrown exception in setup.py on my box was causing
a test failure for me:
## ERROR: test_retry_kwargs_can_be_empty (celery.tests.tasks.test_tasks.test_task_retries)

Traceback (most recent call last):
  File "/var/unsecure/src/celery/celery/tests/tasks/test_tasks.py", line 133, in test_retry_kwargs_can_be_empty
    retry_task_mockapply.retry(args=[4, 4], kwargs=None)
  File "/var/unsecure/src/celery/celery/app/task.py", line 563, in retry
    maybe_reraise()
  File "setup.py", line 15, in <module>
    sys.path.remove(path)
ValueError: list.remove(x): x not in list
