### PR TITLE
Feature: Dynamic tasks

### DIFF
--- a/celery/contrib/dynamic.py
+++ b/celery/contrib/dynamic.py
@@ -7,6 +7,7 @@ Dynamic Tasks
 Subtasks returned by dynamic tasks are executed right after the first
 task executes. As if they were in a chain.
 You can also return chains and chords, and they will be properly inserted.
+You can have chords in chords etc...
 
 This allows you to design a pipeline that can be completely dynamic, while
 benefiting from Celery's powerful idioms (subtasks, chains, chords...).
@@ -17,15 +18,16 @@ Usage example
 
 .. code-block:: python
 
-    from celery.contrib.dynamic import dynamic_task
+    import celery.contrib.dynamic
+    from celery.contrib.dynamic import dynamic_chord as chord
 
-    @dynamic_task
+    @app.dynamic_task
     def one(i):
         if i > 3:
             return two.s(i)
         return i + 1
 
-    @dynamic_task(ignore_result=True)
+    @app.dynamic_task(ignore_result=True)
     def two(i):
         return i + 2
 


### PR DESCRIPTION
So I submit to you dynamic tasks, and dynamic chords. This is a really powerful concept, and I think it changes the game.

Subtasks returned by dynamic tasks are executed right after the first task executes. As if they were in a chain.
You can also return chains and chords, and they will be properly inserted.

This allows you to design a pipeline that can be completely dynamic, while benefiting from Celery's powerful idioms (subtasks, chains, chords...).

Our whole backend at @veezio is powered by these. They allow use to have extensively dynamic pipelines.
We have pipes inside chords, chords inside chords, tasks put before pipes etc....

To be honest, I can't think of something you can't do with this.

How to use:

```
import celery.contrib.dynamic

@celery.dynamic_task
def test(number):
    if number > 5:
        return more.s()
    return less.()


@celery.dynamic_task
def more():
    print "it's more !"

@celery.dynamic_task
def less():
    print "it's less !"
```

But you can do cool shit too!

```
@celery.dynamic_task
def one(n):
    if n:
        return three.si(n + 4) | four.s() # if you don't use an immutable task, the result of one (a subtask) will be sent to three.
    return n
pipe = one.s(1) | two.s()

pipe.apply_async() # will run: one(1) | three(1+4) | four | two
```

You can also use them in chords! And have chords in chords!:

```
from celery.contrib.dynamic import dynamic_chord as chord

@celery.dynamic_task
def resolve_url(url):
    # do some stuff, and paralellize all that
    return chord(map(do_stuff.si, data), on_finished.s())

resolve_urls = chord(map(resolve_url.si, urls), url_resolved.s())
```

In that case url_resolved will be called with the results from on_finished(), which is:

```
[ [..., ], [..., ] ]
```
