### PR TITLE
consumer eventloop multi-fd polling

### DIFF
--- a/celery/worker/consumer.py
+++ b/celery/worker/consumer.py
@@ -429,26 +429,29 @@ class Consumer(object):
                 update_readers(on_poll_start())
                 if readers or writers:
                     connection.more_to_read = True
-                    for fileno, event in poll(poll_timeout) or ():
-                        try:
-                            if event & READ:
-                                readers[fileno](fileno, event)
-                            if event & WRITE:
-                                writers[fileno](fileno, event)
-                            if event & ERR:
-                                for handlermap in readers, writers:
-                                    try:
-                                        handlermap[fileno](fileno, event)
-                                    except KeyError:
-                                        pass
-                        except Empty:
-                            break
-                        except socket.error:
-                            if self._state != CLOSE:  # pragma: no cover
-                                raise
-                    while keep_draining and connection.more_to_read:
-                        drain_nowait()
-                    poll_timeout = 0
+                    while connection.more_to_read:
+                        for fileno, event in poll(poll_timeout) or ():
+                            try:
+                                if event & READ:
+                                    readers[fileno](fileno, event)
+                                if event & WRITE:
+                                    writers[fileno](fileno, event)
+                                if event & ERR:
+                                    for handlermap in readers, writers:
+                                        try:
+                                            handlermap[fileno](fileno, event)
+                                        except KeyError:
+                                            pass
+                            except Empty:
+                                continue
+                            except socket.error:
+                                if self._state != CLOSE:  # pragma: no cover
+                                    raise
+                        if keep_draining:
+                            drain_nowait()
+                            poll_timeout = 0
+                        else:
+                            connection.more_to_read = False
                 else:
                     # no sockets yet, startup is probably not done.
                     sleep(min(poll_timeout, 0.1))


### PR DESCRIPTION
This is needed for the zmq transport since fanout queues are
consumed from a different socket.
