### PR TITLE
Update imports.py to work properly with celery_http_gateway.

### DIFF
--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -34,7 +34,7 @@ else:
         if not hasattr(obj, '__name__') and hasattr(obj, '__class__'):
             return qualname(obj.__class__)
 
-        return '.'.join([obj.__module__, obj.__name__])
+        return '.'.join([str(obj.__module__), str(obj.__name__)])
 
 
 def symbol_by_name(name, aliases={}, imp=None, package=None,


### PR DESCRIPTION
Without this fix in place the following error is emitted
when trying to query a task status via the celery_http_gateway:
"sequence item 0: expected string, module found"
Traceback: http://pastie.org/4188542
