### PR TITLE
ensure args to an unpickleable exception are pickleable

### DIFF
--- a/celery/utils/serialization.py
+++ b/celery/utils/serialization.py
@@ -131,11 +131,18 @@ class UnpickleableExceptionWrapper(Exception):
     exc_args = None
 
     def __init__(self, exc_module, exc_cls_name, exc_args, text=None):
+        safe_exc_args = []
+        for arg in exc_args:
+            try:
+                pickle.dumps(deepcopy(arg))
+                safe_exc_args.append(arg)
+            except Exception:
+                safe_exc_args.append(safe_repr(arg))
         self.exc_module = exc_module
         self.exc_cls_name = exc_cls_name
-        self.exc_args = exc_args
+        self.exc_args = safe_exc_args
         self.text = text
-        Exception.__init__(self, exc_module, exc_cls_name, exc_args, text)
+        Exception.__init__(self, exc_module, exc_cls_name, safe_exc_args, text)
 
     def restore(self):
         return create_exception_cls(self.exc_cls_name,


### PR DESCRIPTION
It's possible for an instance of UnpickleableExceptionWrapper to still be unpickleable. This can happen when one of the args of the exception being wrapped is unpickleable itself. As of celery 2.5.5, it appears that the unpickleable exception's arguments are accepted as is without any inspection or sanitation.

I first encountered this scenario while using the requests package to perform a post to a URL with an unresolveable host within a celery task. The requests package wraps exceptions in its own exception classes; often including the original exception as an argument. In this scenario the original exception is unpickleable. Before the fix included in the pull request, the following errors are the end result: http://pastebin.com/wmVS8JaZ.
