### PR TITLE
When ACKS_LATE is enabled, make sure the message is ACK'd on a retry

### DIFF
--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -337,6 +337,9 @@ class Request(object):
                          exception=safe_repr(exc_info.exception.exc),
                          traceback=safe_str(exc_info.traceback))
 
+        if self.task.acks_late:
+            self.acknowledge()
+
         if self._does_info:
             self.logger.info(self.retry_msg.strip(),
                             {"id": self.id,


### PR DESCRIPTION
It seems that when ACKS_LATE is enabled, retried tasks aren't ACK'd, this will hang a worker.. This patch ACKs retried tasks...

Dunno if 2.5-backport is being maintained however.. Same problem exists in master, will send pull request for it too..
