### PR TITLE
When ACKS_LATE is set, acknowledge a task that is retried

### DIFF
--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -321,6 +321,9 @@ class Request(object):
                          exception=safe_repr(exc_info.exception.exc),
                          traceback=safe_str(exc_info.traceback))
 
+        if self.task.acks_late:
+            self.acknowledge()
+
         if _does_info:
             info(self.retry_msg.strip(), {
                 'id': self.id, 'name': self.name,


### PR DESCRIPTION
Without this patch, ACKS_LATE and retries will cause a worker to hang...
