### PR TITLE
Remove unnecessary colon in docs/userguide/application.rst

### DIFF
--- a/docs/userguide/application.rst
+++ b/docs/userguide/application.rst
@@ -376,7 +376,7 @@ chain breaks::
     created.
 
     For example, in the beginning it was possible to use any callable as
-    a task::
+    a task:
 
     .. code-block:: python
 


### PR DESCRIPTION
With this extra colon the following "code-python" directive is interpreted (and shown in the docs!) as verbatim: http://celery.github.com/celery/userguide/application.html  (Evolving the API)
