### PR TITLE
Fix 2to3 race which prevents installation on Py3k

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -109,3 +109,4 @@ Eran Rundstein, 2012/06/24
 John Watson, 2012/06/27
 David Markey, 2012/07/05
 Jared Biel, 2012/07/05
+Jed Smith, 2012/07/08

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ try:
         print('Upgrade: no old version found.')
     finally:
         sys.path[:] = orig_path
-except ImportError:
+except:
     pass
 
 


### PR DESCRIPTION
setup.py correctly identifies that it needs to run 2to3 but, before it does so, attempts to import celery.app which results in an AttributeError due to celery's usage of iteritems().

```
Downloading/unpacking Celery
  Running setup.py egg_info for package Celery
    Traceback (most recent call last):
      File "<string>", line 14, in <module>
      File "/Users/jed/[snip]/build/Celery/setup.py", line 16, in <module>
        import celery.app
      File "celery/__init__.py", line 38, in <module>
        VERSION=VERSION, SERIES=SERIES, VERSION_BANNER=VERSION_BANNER,
      File "celery/__compat__.py", line 164, in recreate_module
        origins = get_origins(by_module)
      File "celery/__compat__.py", line 196, in get_origins
        for module, items in defs.iteritems():
    AttributeError: 'dict' object has no attribute 'iteritems'
```

This is a temporary emergency fix which allows Celery to install successfully on Pythons where 2to3 is required but better handling of this should be examined.
