### PR TITLE
Trivial SyntaxError fix

### DIFF
--- a/funtests/suite/test_leak.py
+++ b/funtests/suite/test_leak.py
@@ -40,7 +40,7 @@ class LeakFunCase(unittest.TestCase):
                         shlex.split(cmd % {'pid': os.getpid()}),
                             stdout=subprocess.PIPE).communicate()[0].strip())
         except OSError as exc:
-            raise SkipTest('Can't execute command: %r: %r' % (cmd, exc))
+            raise SkipTest("Can't execute command: %r: %r" % (cmd, exc))
 
     def sample_allocated(self, fun, *args, **kwargs):
         before = self.get_rsize()


### PR DESCRIPTION
I found this because at work we tried to commit Celery to our own repository and we have a commit hook that rejects files with SyntaxError
