### PR TITLE
Mark revoked tasks always as REVOKED

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -113,3 +113,4 @@ Jared Biel, 2012/07/05
 Jed Smith, 2012/07/08
 Łukasz Langa, 2012/07/10
 Rinat Shigapov, 2012/07/20
+Hynek Schlawack, 2012/07/23

--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -228,8 +228,6 @@ class Request(object):
         """If expired, mark the task as revoked."""
         if self.expires and datetime.now(self.tzlocal) > self.expires:
             revoked_tasks.add(self.id)
-            if self.store_errors:
-                self.task.backend.mark_as_revoked(self.id)
             return True
 
     def terminate(self, pool, signal=None):
@@ -251,6 +249,8 @@ class Request(object):
         if self.id in revoked_tasks:
             warn('Skipping revoked task: %s[%s]', self.name, self.id)
             self.send_event('task-revoked', uuid=self.id)
+            if self.store_errors:
+                self.task.backend.mark_as_revoked(self.id)
             self.acknowledge()
             self._already_revoked = True
             send_revoked(self.task, terminated=False,


### PR DESCRIPTION
Before, only expired tasks were marked as REVOKED. Revoked retrying tasks would
stay as RETRY.
