### PR TITLE
Fix delivery_info for unpickleable sqs attributes.

### DIFF
--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -128,8 +128,10 @@ class Request(object):
 
         self.delivery_info = delivery_info or {}
         # amqplib transport adds the channel here for some reason, so need
-        # to remove it.
-        self.delivery_info.pop('channel', None)
+        # to remove it. sqs also adds additional unpickleable attributes
+        # than need to be removed.
+        for key in ['channel', 'sqs_message', 'sqs_queue']:
+            self.delivery_info.pop(key, None)
         self.request_dict = body
 
     @classmethod


### PR DESCRIPTION
Feel free to reject if you want to fix this in a more generic way. I just wanted to make sure that you were aware of the issue.
