### PR TITLE
Fixed web addresses in init.d scripts

### DIFF
--- a/extra/generic-init.d/celerybeat
+++ b/extra/generic-init.d/celerybeat
@@ -6,7 +6,7 @@
 # :Usage: /etc/init.d/celerybeat {start|stop|force-reload|restart|try-restart|status}
 # :Configuration file: /etc/default/celerybeat or /etc/default/celeryd
 #
-# See http://docs.celeryq.org/en/latest/cookbook/daemonizing.html#init-script-celerybeat
+# See http://docs.celeryproject.org/en/latest/tutorials/daemonizing.html#generic-init-scripts 
 
 ### BEGIN INIT INFO
 # Provides:          celerybeat

--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -6,7 +6,7 @@
 # :Usage: /etc/init.d/celeryd {start|stop|force-reload|restart|try-restart|status}
 # :Configuration file: /etc/default/celeryd
 #
-# See http://docs.celeryq.org/en/latest/cookbook/daemonizing.html#init-script-celeryd
+# See http://docs.celeryproject.org/en/latest/tutorials/daemonizing.html#generic-init-scripts 
 
 
 ### BEGIN INIT INFO


### PR DESCRIPTION
They still pointed to celeryq.org.
