### PR TITLE
backport acks_late fix

### DIFF
--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -333,6 +333,9 @@ class Request(object):
 
     def on_retry(self, exc_info):
         """Handler called if the task should be retried."""
+        if self.task.acks_late:
+            self.acknowledge()
+
         self.send_event("task-retried", uuid=self.id,
                          exception=safe_repr(exc_info.exception.exc),
                          traceback=safe_str(exc_info.traceback))


### PR DESCRIPTION
Backport of the acks_late fix.

Reason we're still on the 2.5 branch: we use the worker on windows and the new requirement billiard doesn't work correct on Windows (7) with Python 2.7 (at least not the required version).
