### PR TITLE
Slight tweak to generic init.d/celeryd script

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -97,7 +97,7 @@ export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 
 
 stop_workers () {
-    $CELERYD_MULTI stopwait $CELERYD_NODES --pidfile="$CELERYD_PID_FILE"
+    $CELERYD_MULTI stop_verify $CELERYD_NODES --pidfile="$CELERYD_PID_FILE"
 }
 
 


### PR DESCRIPTION
I replaced 'stopwait' with 'stop_verify' in the stop_workers() function
