### PR TITLE
Properly pass traceback object to handlers instead of str representation

### DIFF
--- a/celery/task/trace.py
+++ b/celery/task/trace.py
@@ -120,7 +120,7 @@ class TraceInfo(object):
             signals.task_failure.send(sender=task, task_id=req.id,
                                       exception=exc, args=req.args,
                                       kwargs=req.kwargs,
-                                      traceback=einfo.traceback,
+                                      traceback=einfo.tb,
                                       einfo=einfo)
             return einfo
         finally:


### PR DESCRIPTION
To allow failure handlers to access the Traceback info properly, they need the full Traceback object instead of the string representation.

This should fix the following issue (#905):
https://github.com/celery/celery/issues/905
