### PR TITLE
fix issue in gevent when killing celery, fixes #911 and #936

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -216,7 +216,7 @@ class Worker(WorkController):
 def _shutdown_handler(worker, sig='TERM', how='Warm', exc=SystemExit,
         callback=None):
 
-    def _handle_request(signum, frame):
+    def _handle_request(*args):
         with in_sighandler():
             from celery.worker import state
             if current_process()._name == 'MainProcess':
@@ -259,7 +259,7 @@ def _clone_current_worker():
 
 def install_worker_restart_handler(worker, sig='SIGHUP'):
 
-    def restart_worker_sig_handler(signum, frame):
+    def restart_worker_sig_handler(*args):
         """Signal handler restarting the current python program."""
         set_in_sighandler(True)
         safe_say('Restarting celeryd ({0})'.format(' '.join(sys.argv)))
@@ -275,7 +275,7 @@ def install_cry_handler():
     if is_jython or is_pypy:  # pragma: no cover
         return
 
-    def cry_handler(signum, frame):
+    def cry_handler(*args):
         """Signal handler logging the stacktrace of all active threads."""
         with in_sighandler():
             safe_say(cry())
@@ -285,7 +285,7 @@ def install_cry_handler():
 def install_rdb_handler(envvar='CELERY_RDBSIG',
                         sig='SIGUSR2'):  # pragma: no cover
 
-    def rdb_handler(signum, frame):
+    def rdb_handler(*args):
         """Signal handler setting a rdb breakpoint at the current frame."""
         with in_sighandler():
             from celery.contrib import rdb
@@ -296,7 +296,7 @@ def install_rdb_handler(envvar='CELERY_RDBSIG',
 
 def install_HUP_not_supported_handler(worker, sig='SIGHUP'):
 
-    def warn_on_HUP_handler(signum, frame):
+    def warn_on_HUP_handler(*args):
         with in_sighandler():
             safe_say('{sig} not supported: Restarting with {sig} is '
                      'unstable on this platform!'.format(sig=sig))

--- a/celery/concurrency/gevent.py
+++ b/celery/concurrency/gevent.py
@@ -13,8 +13,15 @@ import os
 PATCHED = [0]
 if not os.environ.get('GEVENT_NOPATCH') and not PATCHED[0]:
     PATCHED[0] += 1
-    from gevent import monkey
+    from gevent import monkey, version_info
     monkey.patch_all()
+    if version_info[0] == 0:
+        # Signals are not working along gevent in version prior 1.0
+        # and they are not monkey patch by monkey.patch_all()
+        from gevent import signal as _gevent_signal
+        _signal = __import__('signal')
+        _signal.signal = _gevent_signal
+
 
 from time import time
 


### PR DESCRIPTION
gevent in version prior to 1.0 does not work well with signals, and as it
doesn't monkey patch them, signal handlers must be specified using the
gevent.signal method.
Another issue is that the interface for handlers is not the same
with signal.signal and gevent.signal, as gevent.signal does not
call the handler will the signum and the frame.
When celery will depends on gevent 1.0 (still not stable), this fix
won't be necessary.
