### PR TITLE
Fix revoking of reserved tasks

### DIFF
--- a/celery/worker/__init__.py
+++ b/celery/worker/__init__.py
@@ -373,8 +373,10 @@ class WorkController(configurated):
         try:
             req.execute_using_pool(self.pool)
         except TaskRevokedError:
-            if self.semaphore:  # (Issue #877)
-                self.semaphore.release()
+            try:
+                self._quick_release()   # Issue 877
+            except AttributeError:
+                pass
         except Exception, exc:
             logger.critical('Internal error: %r\n%s',
                             exc, traceback.format_exc(), exc_info=True)

--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -40,7 +40,7 @@ def revoke(panel, task_id, terminate=False, signal=None, **kwargs):
     action = 'revoked'
     if terminate:
         signum = _signals.signum(signal or 'TERM')
-        for request in state.active_requests:
+        for request in state.reserved_requests:
             if request.id == task_id:
                 action = 'terminated (%s)' % (signum, )
                 request.terminate(panel.consumer.pool, signal=signum)

--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -246,6 +246,7 @@ class Request(object):
             self._terminate_on_ack = pool, signal
 
     def _announce_revoked(self, reason, terminated, signum, expired):
+        task_ready(self)
         self.send_event('task-revoked',
                         terminated=terminated, signum=signum, expired=expired)
         if self.store_errors:


### PR DESCRIPTION
Here are a couple of fixes to the 3.0 branch:
- Previously terminating task had no effect on reserved but not yet active tasks. When the task became active it executed in spite of the revoke.
- Workers continued to report tasks as active after revoke

Also I backported a change from commit ecfa68b4 which fixed AttributeError
