### PR TITLE
Patch missing isEnabledFor in LoggerAdapter

### DIFF
--- a/celery/utils/compat.py
+++ b/celery/utils/compat.py
@@ -159,6 +159,16 @@ try:
     from logging import LoggerAdapter
 except ImportError:
     LoggerAdapter = _CompatLoggerAdapter  # noqa
+else:
+    if not hasattr(LoggerAdapter, 'isEnabledFor'):
+        def isEnabledFor(self, level):
+            """
+            See if the underlying logger is enabled for the specified level.
+            """
+            return self.logger.isEnabledFor(level)
+        LoggerAdapter.isEnabledFor = isEnabledFor
+        del isEnabledFor
+
 
 ############## itertools.zip_longest #######################################
 


### PR DESCRIPTION
This method is missing in Python <2.7, causing errors at runtime when tasks try to call this method on their task loggers.

This is a fairly old Celery version to be maintaining — but the people running it are likely to be just the same people as those who are running Python <2.7, so I thought this would have some value anyway. :)
