### PR TITLE
SIGTERM to stop celery process; More explicit examples for sysconfig

### DIFF
--- a/extra/centos/celeryd.init
+++ b/extra/centos/celeryd.init
@@ -69,7 +69,7 @@ start_workers () {
         cd $CELERYD_CHDIR
     fi
 
-    echo -n $"Starting $prog: "
+    log_message "Starting $prog"
     $CELERY multi start $prog \
                                --pidfile=$CELERYD_PID_FILE \
                                --logfile=$CELERYD_LOG_FILE \
@@ -98,27 +98,34 @@ stop_workers () {
         return
     fi
 
-    # First, try to nicely shut it down.
-    $CELERY stop $prog --pidfile=$CELERYD_PID_FILE --quiet
+    # According to the latest Celery workers guide (3.0.x+), 
+    #  stopping workers should be via TERM signals
+    celerypids=$(cat $CELERYD_PID_FILE | xargs echo)
+    echo "Killing PIDs $celerypids"
+    log_message "Killing PIDs $celerypids ..." 
+    kill -s TERM $celerypids
     RETVAL=$?
 
-    # SLeep a few seconds. (this was part of the original script; we can't
-    # trust that it will end immediately, or that running the command will
-    # stop it.
+    # SLeep a few seconds to make sure the process really is dead
     sleep 3
 
-    # If we haven't ended, explicitly kill it!
-    if [ -f $CELERYD_PID_FILE ] && [ -e /proc/$(cat $CELERYD_PID_FILE) ]; then
-        $CELERY stop $prog -KILL --pidfile=$CELERYD_PID_FILE --quiet
-    fi
-
-    if [ "$RETVAL" == "0" ]; then
-        rm -f /var/lock/sybsys/$prog
+    # Now make sure that the process really does not exist
+    RETVAL=$(ps h -p $celerypids)
+    if [ "$RETVAL" == "" ]; then
+        rm -f /var/lock/subsys/$prog
+        log_message "SUCCESS killing PIDs $celerypids" 
         success
     else
+        log_message "FAILED killing PIDs $celerypids" 
         failure
     fi
     echo
+}
+
+log_message() {
+    now=$(/bin/date -u "+%Y-%m-%d %H:%M:%S")
+    echo "[$now:] $1" >> $CELERYD_LOG_FILE
+
 }
 
 case "$1" in

--- a/extra/centos/celeryd.sysconfig
+++ b/extra/centos/celeryd.sysconfig
@@ -1,8 +1,30 @@
+# Path to the virtualenv. This could be /usr if python 
+#   is in /usr/bin
+#BIN_PATH="/path/to/.virtualenvs/myvenv"
+
+# Which Python to use
+#ENV_PYTHON="$BIN_PATH/bin/python"
+
+# Where to chdir before launching celeryd
+#CELERYD_CHDIR="$app_path/current"
+
+# Path to celery - which might be in a virtualenv
+#CELERY="$BIN_PATH/bin/celery"
+
+# Path to the celeryd multi (might be in a virtualenv)
+#CELERYD_MULTI="$BIN_PATH/bin/celeryd-multi"
+
 # Passed into celeryd multi
 #CELERYD="-m celery.bin.celeryd_detach"
+# OR add -b option is set to your broker URL as necessary
+#CELERYD="-m celery.bin.celeryd_detach -b $amqp_url"
 
-# Path to the celerd multi
-#CELERYD_MULTI="/usr/bin/celeryd-multi"
+# How to call "manage.py celeryctl"
+#CELERYCTL="$ENV_PYTHON $CELERYD_CHDIR/manage.py celeryctl"
+
+# Log and PID files
+#CELERYD_LOG_FILE="/path/to/var/log/celeryd/app_name-celeryworker.log"
+#CELERYD_PID_FILE="/path/to/var/run/celeryd/app_name-celeryworker.pid"
 
 # Sets the verbosity of the celeryd logging.
 #CELERYD_LOG_LEVEL="INFO"
@@ -17,5 +39,5 @@
 # Default arguments to be passed into celeryd.
 #CELERYD_OPTS=""
 
-# Change to this directory first before launching celeryd.
-#CELERYD_CHDIR=""
+# Set the task modules that you want to have celery load
+#CELERY_IMPORTS=("tasks", )


### PR DESCRIPTION
- Update killing per Celery 3.0 docs. Use TERM to kill the celery PID(s)
- Do more explicit logging of start and stop functions to help debugging
- Add a full set of examples to sysconfig (also examples on how to support virtualenvs)
