### PR TITLE
Fix typo in examples/eventlet/README.rst and formatting.

### DIFF
--- a/examples/eventlet/README.rst
+++ b/examples/eventlet/README.rst
@@ -35,13 +35,13 @@ of the response body::
     >>> urlopen.delay("http://www.google.com/").get()
     9980
 
-To open several URLs at once you can do:
+To open several URLs at once you can do::
 
     $ cd examples/eventlet
     $ python
     >>> from tasks import urlopen
     >>> from celery import group
-    >>> result = gruop(urlopen.s(url)
+    >>> result = group(urlopen.s(url)
     ...                     for url in LIST_OF_URLS).apply_async()
     >>> for incoming_result in result.iter_native():
     ...     print(incoming_result, )


### PR DESCRIPTION
There was a typo in the eventlet example ("gruop" -> "group"), and the formatting was wrong. The example code now renders correctly.
