### PR TITLE
Created an OrderedTaskSet class - Will execute in a synchronous order but launch asynchronously

### DIFF
--- a/celery/task/sets.py
+++ b/celery/task/sets.py
@@ -74,3 +74,15 @@ class TaskSet(list):
     @tasks.setter  # noqa
     def tasks(self, tasks):
         self[:] = tasks
+
+class OrderedTaskSet(TaskSet):
+    def _async_results(self, taskset_id, publisher):
+        main_task = current_root = self[0]
+        self.remove(current_root)
+
+        for index, task in enumerate(self):
+            current_root = current_root.link(task)
+
+        return main_task.apply_async(taskset_id=taskset_id,
+            publisher=publisher
+        )

--- a/celery/tests/tasks/test_sets.py
+++ b/celery/tests/tasks/test_sets.py
@@ -4,7 +4,7 @@ import anyjson
 
 from celery import current_app
 from celery.task import Task
-from celery.task.sets import subtask, TaskSet
+from celery.task.sets import subtask, TaskSet, OrderedTaskSet
 from celery.canvas import Signature
 
 from celery.tests.utils import Case
@@ -184,3 +184,15 @@ class test_TaskSet(Case):
         ts = TaskSet([])
         ts.Publisher = 42
         self.assertEqual(ts.Publisher, 42)
+
+class test_OrderedTaskSet(Case):
+    def test_apply_async(self):
+        tasks = [MockTask.subtask((i, i)) for i in (2, 4, 8)]
+
+        ts = OrderedTaskSet(tasks)
+
+        ts.apply_async()
+
+        self.assertEqual(tasks[0].options['link'][0], tasks[1])
+        self.assertEqual(tasks[1].options['link'][0], tasks[2])
+        self.assertEqual(tasks, tasks[0].flatten_links())


### PR DESCRIPTION
This is for the case that you have a lot of tasks that must be executed in order but don't want to just Apply them, you still want it to be ran async.
