### PR TITLE
celerymon displays tasks filtered by name incorrectly

### DIFF
--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -331,9 +331,7 @@ class State(object):
         Returns a list of `(uuid, task)` tuples.
 
         """
-        return self._sort_tasks_by_time([(uuid, task)
-                for uuid, task in self.itertasks(limit)
-                    if task.name == name])
+        return self._sort_tasks_by_time([(uuid, task) for uuid, task in self.itertasks() if task.name == name])[0:limit]
 
     def tasks_by_worker(self, hostname, limit=None):
         """Get all tasks by worker.


### PR DESCRIPTION
Hi asksol! Please take a look : you first apply limiting, and than filter by name - wrong order. So when visiting 
http://localhost:8989/api/task/name/mytaskname/?limit=0 I see all tasks, but when visiting 
http://localhost:8989/api/task/name/brightcove.tasks.SyncWithBrightCoveVideosTask/?limit=1 I see nothing.
