### PR TITLE
Decrease log level for consumer connection retries

### DIFF
--- a/celery/worker/consumer.py
+++ b/celery/worker/consumer.py
@@ -178,7 +178,7 @@ class Consumer(object):
             except self.connection_errors + self.channel_errors:
                 maybe_shutdown()
                 if ns.state != CLOSE and self.connection:
-                    error(CONNECTION_RETRY, exc_info=True)
+                    warn(CONNECTION_RETRY, exc_info=True)
                     ns.restart(self)
 
     def shutdown(self):


### PR DESCRIPTION
This happens any time anything goes wrong at the socket level while the 
consumer is working, filling event monitors like Sentry with a large number
of messages any time a network drops a packet, Rabbit is restarted, etc. A 
reconnect seems like it should be at most WARNING, although perhaps if we 
started tracking successive reconnect failures it could be upgraded after 
protracted downtime.
