### PR TITLE
Fix Invalid command: stopwait

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -129,7 +129,7 @@ export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 
 
 stop_workers () {
-    $CELERYD_MULTI stopwait $CELERYD_NODES --pidfile="$CELERYD_PID_FILE"
+    $CELERYD_MULTI stop $CELERYD_NODES --pidfile="$CELERYD_PID_FILE"
 }
 
 


### PR DESCRIPTION
When you run /etc/init.d/celeryd stop you get an invalid command error msg:

Invalid command: stopwait
celeryd-multi v3.0.9 (Chiastic Slide)
usage:  manage.py celeryd_multi stop <n1 n2 nN|range> [-SIG (default: -TERM)]
