### PR TITLE
 Fixed a trivial bug that prevented backends.base.get_many from hitting timeout.

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -357,7 +357,7 @@ class KeyValueStoreBackend(BaseBackend):
             if timeout and iterations * interval >= timeout:
                 raise TimeoutError('Operation timed out ({0})'.format(timeout))
             time.sleep(interval)  # don't busy loop.
-            iterations += 0
+            iterations += 1
 
     def _forget(self, task_id):
         self.delete(self.get_key_for_task(task_id))


### PR DESCRIPTION
I've noticed that calling `get` on a group hanged. It turned out, that in `backends.base.get_many` there was a sweet `iterations += 0`. This pull request is for a one-line patch that fixes it.
