### PR TITLE
Add killasgroup=true to the supervisord configuration file example for celeryd

### DIFF
--- a/extra/supervisord/celeryd.conf
+++ b/extra/supervisord/celeryd.conf
@@ -26,6 +26,11 @@ startsecs=10
 ; Increase this if you have very long running tasks.
 stopwaitsecs = 600
 
+; When resorting to send SIGKILL to the program to terminate it
+; send SIGKILL to its whole process group instead,
+; taking care of its children as well.
+killasgroup=true
+
 ; if rabbitmq is supervised, set its priority higher
 ; so it starts first
 priority=998


### PR DESCRIPTION
When we stop celeryd with KILL signal, children processes stay alive.
The problem was discussed 2 years ago here: [issues/102](https://github.com/celery/celery/issues/102)

[supervisord](http://supervisord.org/configuration.html) now has a special key `killasgroup` in order to handle this situation:

> If true, when resorting to send SIGKILL to the program to terminate it send it to its whole process group instead, taking care of its children as well, useful e.g with Python programs using multiprocessing.
> Introduced: 3.0a11

This key is ignored for older supervisord versions.

Just added `killasgroup` to the celeryd configuration example
