### PR TITLE
EmailError : use subject and body from constructor, not the default ones

### DIFF
--- a/celery/utils/mail.py
+++ b/celery/utils/mail.py
@@ -170,10 +170,10 @@ py-celery at {{hostname}}.
         return True
 
     def format_subject(self, context):
-        return self.subject.strip().format(**context)
+        return self.email_subject.strip().format(**context)
 
     def format_body(self, context):
-        return self.body.strip().format(**context)
+        return self.email_body.strip().format(**context)
 
     def send(self, context, exc, fail_silently=True):
         if self.should_send(context, exc):


### PR DESCRIPTION
Hello,

I am directly using Task.send_error_email in one of my projects, and noticed that it was impossible to change the subject or body, despite these lines from EmailError:

```
class ErrorMail(object):

    subject = '....'
    body = '....'

    def __init__(self, task, **kwargs):
        self.task = task
        self.email_subject = kwargs.get('subject', self.subject)
        self.email_body = kwargs.get('body', self.body)
```

and despite that send_email_error passes the kwargs to ErrorEmail

Hence, this pull request fixes the problem by modifying the faulty functions using `self.body` and `self.subject` instead of `self.email_body` and `self.email_subject`

Thanks !
