### PR TITLE
normalize() got an unexpected keyword argument 'is_dst'

### DIFF
--- a/celery/utils/timeutils.py
+++ b/celery/utils/timeutils.py
@@ -286,6 +286,8 @@ def localize(dt, tz):
     else:
         try:
             return _normalize(dt, is_dst=None)
+        except TypeError:
+            return _normalize(dt)
         except AmbiguousTimeError:
             return min(_normalize(dt, is_dst=True),
                        _normalize(dt, is_dst=False))


### PR DESCRIPTION
Here is the traceback, that is raised on celery startup:

```
Traceback (most recent call last):
   File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/celery/worker/__init__.py", line 347, in start
    component.start()
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 391, in start
    self.consume_messages()
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 475, in consume_messages
    readers[fileno](fileno, event)
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/kombu/connection.py", line 201, in drain_nowait
    self.drain_events(timeout=0)
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/kombu/connection.py", line 197, in drain_events
    return self.transport.drain_events(self.connection, **kwargs)
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/kombu/transport/amqplib.py", line 330, in drain_events
    return connection.drain_events(**kwargs)
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/kombu/transport/amqplib.py", line 182, in drain_events
    return amqp_method(channel, args, content)
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/amqplib/client_0_8/channel.py", line 2060, in _basic_deliver
    func(msg)
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/kombu/messaging.py", line 486, in _receive_callback
    self.receive(decoded, message)
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/kombu/messaging.py", line 458, in receive
    [callback(body, message) for callback in callbacks]
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 433, in on_task_received
    strategies[name](message, body, message.ack_log_error)
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/celery/worker/strategy.py", line 25, in task_message_handler
    delivery_info=message.delivery_info))
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/celery/worker/job.py", line 133, in __init__
    self.eta = maybe_make_aware(self.eta, self.tzlocal)
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/celery/utils/timeutils.py", line 319, in maybe_make_aware 
    timezone.utc if tz is None else timezone.tz_or_local(tz))
  File "/home/webspm/webspm/env/local/lib/python2.7/site-packages/celery/utils/timeutils.py", line 304, in localize
    return _normalize(dt, is_dst=None)
TypeError: normalize() got an unexpected keyword argument 'is_dst'
```

Version of pytz is 2012h, celery 3.0.12 (3.0.11 works well):

```
pytz/tzinfo.py:111:    def normalize(self, dt, is_dst=False):
pytz/tzinfo.py:189:    def normalize(self, dt):
```
