### PR TITLE
Update celery/worker/__init__.py

### DIFF
--- a/celery/worker/__init__.py
+++ b/celery/worker/__init__.py
@@ -22,7 +22,7 @@ from functools import partial
 
 from billiard.exceptions import WorkerLostError
 from kombu.syn import detect_environment
-from kombu.utils.finalize import Finalize
+from multiprocessing.util import Finalize
 
 from celery import concurrency as _concurrency
 from celery import platforms


### PR DESCRIPTION
According to this commit - https://github.com/celery/kombu/commit/a4a2d483feae07a0e8ec4c3e11ad621139433c3c kombu.utils.finalize module is removed.

Fixes problem, that is occuring if update kombu from github:

  File "/home/webspm/webspm/env/lib/python2.7/site-packages/celery/worker/**init**.py", line 25, in <module>
    from kombu.utils.finalize import Finalize
ImportError: No module named finalize
