### PR TITLE
Display PIDs for workers that celery multi stop/restart is waiting on

### DIFF
--- a/celery/bin/multi.py
+++ b/celery/bin/multi.py
@@ -275,8 +275,9 @@ class MultiTool(object):
         def note_waiting():
             left = len(P)
             if left:
-                self.note(self.colored.blue('> Waiting for {0} {1}...'.format(
-                    left, pluralize(left, 'node'))), newline=False)
+                pids = ', '.join(str(pid) for _, _, pid in P)
+                self.note(self.colored.blue('> Waiting for {0} {1} -> {2}...'.format(
+                    left, pluralize(left, 'node'), pids)), newline=False)
 
         if retry:
             note_waiting()


### PR DESCRIPTION
Presently for stalled workers on celery multi restart, one must query the system process list and make an educated guess as to which worker processes should be killed.  This fix will explicitly reference the worker PIDs that are blocking to remove any form of guessing from the equation.
