### PR TITLE
Fixes issue with configuration options not being pickled.

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -356,8 +356,8 @@ class Celery(object):
 
     def _get_config(self):
         self.configured = True
-        s = Settings({}, [self.prepare_config(self.loader.conf),
-                             deepcopy(DEFAULTS)])
+        s = Settings(self.loader.conf_changes, 
+                     [self.prepare_config(self.loader.conf), deepcopy(DEFAULTS)])
 
         # load lazy config dict initializers.
         pending = self._pending_defaults

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -28,6 +28,8 @@ from celery.utils.imports import (
     import_from_cwd, symbol_by_name, NotAPackage, find_module,
 )
 
+from celery.app.defaults import DEFAULTS
+
 BUILTIN_MODULES = frozenset()
 
 ERROR_ENVVAR_NOT_SET = (
@@ -252,6 +254,12 @@ class BaseLoader(object):
         self.task_modules.update(mod.__name__
             for mod in autodiscover_tasks(packages, related_name) if mod
         )
+
+    @property
+    def conf_changes(self):
+        return dict((key, value) 
+                     for key, value in self.conf.items() 
+                     if key in DEFAULTS.keys())
 
     @property
     def conf(self):


### PR DESCRIPTION
I noticed that a lot of configuration settings to my celery app were being disregarded.  It seems that when the Celery object is pickled, a lot of the config options are dropped.  I'm not sure if this is the most elegant way to fix it, but it appears to work.

I am setting up my options in a celeryconfig.py file and then initializing the Celery instance and setting the config via config_from_object.
