### PR TITLE
Update docs/userguide/tasks.rst

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -176,7 +176,7 @@ add the project directory to the Python path::
 
     import os
     import sys
-    sys.path.append(os.getcwd())
+    sys.path.append(os.path.dirname(os.path.basename(__file__)))
 
     INSTALLED_APPS = ('myapp', )
 


### PR DESCRIPTION
Using os.getcwd() will produce unexpected results since it is based on the current working directory at the time the command is run. It looks fragile to me. The proposed approach uses the location of the setting module itself to determine the appropriate path.
