### PR TITLE
Adding configuration variable to set max_pool_size for MongoDB connections

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -46,6 +46,7 @@ class MongoBackend(BaseBackend):
     mongodb_password = None
     mongodb_database = 'celery'
     mongodb_taskmeta_collection = 'celery_taskmeta'
+    mongodb_max_pool_size = 10
 
     def __init__(self, *args, **kwargs):
         """Initialize MongoDB backend instance.
@@ -78,6 +79,8 @@ class MongoBackend(BaseBackend):
                     'database', self.mongodb_database)
             self.mongodb_taskmeta_collection = config.get(
                 'taskmeta_collection', self.mongodb_taskmeta_collection)
+            self.mongodb_max_pool_size = config.get(
+                'max_pool_size', self.mongodb_max_pool_size)
 
         self._connection = None
 
@@ -93,11 +96,12 @@ class MongoBackend(BaseBackend):
             # This enables the use of replica sets and sharding.
             # See pymongo.Connection() for more info.
             args = [self.mongodb_host]
+            kwargs = {'max_pool_size': self.mongodb_max_pool_size}
             if isinstance(self.mongodb_host, string_t) \
                     and not self.mongodb_host.startswith('mongodb://'):
                 args.append(self.mongodb_port)
 
-            self._connection = Connection(*args)
+            self._connection = Connection(*args, **kwargs)
 
         return self._connection
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -474,6 +474,13 @@ This is a dict supporting the following keys:
     The collection name to store task meta data.
     Defaults to "celery_taskmeta".
 
+* max_pool_size
+    Passed as max_pool_size to PyMongo's Connection or MongoClient 
+    constructor. It is the maximum number of TCP connections to keep
+    open to MongoDB at a given time. If there are more open connections
+    than max_pool_size, sockets will be closed when they are released.
+    Defaults to 10.
+
 .. _example-mongodb-result-config:
 
 Example configuration


### PR DESCRIPTION
This configuration variable can help alleviate heavy connection churn due to sockets being acquired and released quickly when processing many small tasks.
