### PR TITLE
Feature: Adds prefix (package/module) task route derivation to CELERY_ROUTES + documentation changes

### DIFF
--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -21,13 +21,39 @@ _first_route = firstmethod('route_for_task')
 class MapRoute(object):
     """Creates a router out of a :class:`dict`."""
 
+    no_route = object()  # sentinel value representing task w/ no route
+
     def __init__(self, map):
-        self.map = map
+        self.map = {}
+        self.prefix_map = {}
+
+        for name, route in map.items():  # discern routes that are prefix vs. fully-qualified
+            if name.endswith('.'):
+                self.prefix_map[name[:-1]] = route  # slice off period suffix
+            else:
+                self.map[name] = route
 
     def route_for_task(self, task, *args, **kwargs):
+
+        def derive_route(name):
+            split = name.rsplit('.', 1)
+            if len(split) == 1:  # can't traverse any deeper
+                self.map[task] = self.no_route
+                return
+
+            name = split[0]
+            route = self.prefix_map.get(name)
+            if route:
+                self.map[task] = route
+                return dict(route)
+            return derive_route(name)
+
         route = self.map.get(task)
+        if route == self.no_route:
+            return
         if route:
             return dict(route)
+        return derive_route(task)
 
 
 class Router(object):

--- a/docs/AUTHORS.txt
+++ b/docs/AUTHORS.txt
@@ -79,6 +79,7 @@ Keith Perkins <keith@tasteoftheworld.us>
 Kevin Tran <hekevintran@gmail.com>
 Kornelijus Survila <kornholijo@gmail.com>
 Leo Dirac <leo@banyanbranch.com>
+Loren Abrams <loren.abrams@gmail.com>
 Luis Clara Gomez <ekkolabs@gmail.com>
 Lukas Linhart <lukas.linhart@centrumholdings.com>
 Luke Zapart <drx@drx.pl>

--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -41,8 +41,21 @@ configuration::
     CELERY_ROUTES = {'feed.tasks.import_feed': {'queue': 'feeds'}}
 
 With this route enabled import feed tasks will be routed to the
-`"feeds"` queue, while all other tasks will be routed to the default queue
-(named `"celery"` for historical reasons).
+`"feeds"` queue.
+
+Alternately, you can specify that all feed related tasks -- located beneath
+`"feed.tasks"` in this instance -- should be routed to the `"feeds"` queue::
+
+    CELERY_ROUTES = {'feed.tasks.': {'queue': 'feeds'}}
+
+The `.` following the name of the route indicates that a prefix match should be
+performed against it.  As such, `"feed.tasks.import_feed"` will match the
+`"feed.tasks."` prefix and be routed to the `"feeds"` queue.  If multiple
+prefixes match for a given task, the most specific (longest) prefix's route
+will be selected.
+
+All tasks that don't map to routes in :setting:`CELERY_ROUTES` will be routed to
+the default queue (named `"celery"` for historical reasons).
 
 Now you can start server `z` to only process the feeds queue like this:
 


### PR DESCRIPTION
Presently, if one wants to specify routes in *CELERY_ROUTES*, one must provide the fully-qualified task  name.  This PR introduces prefix task routing.

In other words, say you would like to specify routes for the following (totally contrived) tasks to the queue *some_queue*:

```python
# we're in module 'foo.bar'

@task
def lorem():
    pass

@task
def ipsum():
    pass

# .. now we're in module 'foo.baz'

@task
def hello():
    pass
````

Currently you would need to specify the routing as such:

```python
CELERY_ROUTES = {
    "foo.bar.lorem": {"queue": "some_queue"},
    "foo.bar.ipsum": {"queue": "some_queue"},
    "foo.baz.hello": {"queue": "some_queue"}
}
```

With this PR you can instead specify the following module-level prefix routing -- note the '.' after the route names, denoting that prefix matching should take place:

```python
CELERY_ROUTES = {
    "foo.bar.": {"queue": "some_queue"},
    "foo.baz.": {"queue": "some_queue"}
}
```

.. or package-scoped prefix routing:

```python
CELERY_ROUTES = {
    "foo.": {"queue": "some_queue"}
}
```

Note that towards optimal efficiency all derived prefix routes are cached.  So for any given task -- even if that task is found to have no explicit route -- derivation occurs at most once.