### PR TITLE
Extend Task.rate_limit to accept float values

### DIFF
--- a/celery/tests/slow/test_buckets.py
+++ b/celery/tests/slow/test_buckets.py
@@ -102,13 +102,15 @@ class test_rate_limit_string(Case):
     @skip_if_disabled
     def test_conversion(self):
         self.assertEqual(timeutils.rate(999), 999)
+        self.assertEqual(timeutils.rate(7.5), 7.5)
+        self.assertEqual(timeutils.rate('2.5/s'), 2.5)
         self.assertEqual(timeutils.rate('1456/s'), 1456)
         self.assertEqual(timeutils.rate('100/m'),
                           100 / 60.0)
         self.assertEqual(timeutils.rate('10/h'),
                           10 / 60.0 / 60.0)
 
-        for zero in (0, None, '0', '0/m', '0/h', '0/s'):
+        for zero in (0, None, '0', '0/m', '0/h', '0/s', '0.0/s'):
             self.assertEqual(timeutils.rate(zero), 0)
 
 

--- a/celery/utils/timeutils.py
+++ b/celery/utils/timeutils.py
@@ -202,12 +202,12 @@ def remaining(start, ends_in, now=None, relative=False):
 
 
 def rate(rate):
-    """Parses rate strings, such as `"100/m"` or `"2/h"`
+    """Parses rate strings, such as `"100/m"`, `"2/h"` or `"0.5/s"`
     and converts them to seconds."""
     if rate:
         if isinstance(rate, string_t):
             ops, _, modifier = rate.partition('/')
-            return RATE_MODIFIER_MAP[modifier or 's'](int(ops)) or 0
+            return RATE_MODIFIER_MAP[modifier or 's'](float(ops)) or 0
         return rate or 0
     return 0
 

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -426,7 +426,7 @@ General
     start.
 
     If this is :const:`None` no rate limit is in effect.
-    If it is an integer, it is interpreted as "tasks per second".
+    If it is an integer or float, it is interpreted as "tasks per second".
 
     The rate limits can be specified in seconds, minutes or hours
     by appending `"/s"`, `"/m"` or `"/h"` to the value.


### PR DESCRIPTION
Celery is enforcing rate_limit integer values, but the kombu TokenBucket implementation
fill_rate value is casted to float anyway, therefore remove this limitation.

https://github.com/celery/kombu/blob/master/kombu/utils/limits.py#L40

Why? I really needed a more fine-grained rate_limit control (eg. 0.5/s especially for HTTP API requests, which are often throttled).

This change is backwards compatible, although I'm not sure if my patch can be merged "as is" into master, probably a few other places in the documentation need also to be modified.
