### PR TITLE
Init script: changed chdir to cd for portability

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -185,7 +185,7 @@ case "$1" in
 
     status)
         (
-            chdir "$CELERYD_CHDIR"
+            cd "$CELERYD_CHDIR"
             $CELERYCTL $CELERY_APP_ARG status $CELERYCTL_OPTS
         )
     ;;


### PR DESCRIPTION
Some shells, such as bash, don't support chdir.  I think this is more portable.  I can't test everywhere, but it works for me on RHEL6.
