### PR TITLE
Ensure CELERY_IMPORTS loads first

### DIFF
--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -122,13 +122,12 @@ class BaseLoader(object):
             self.import_task_module(m) for m in (
                 set(maybe_list(self.app.conf.CELERY_IMPORTS)))
         ]
-        remaining = [
+        return preload + [
             self.import_task_module(m) for m in (
                 set(maybe_list(self.app.conf.CELERY_IMPORTS))
                 | set(maybe_list(self.app.conf.CELERY_INCLUDE))
                 | self.builtin_modules)
         ]
-        return [preload[0] | remaining[0]]
 
     def init_worker(self):
         if not self.worker_initialized:


### PR DESCRIPTION
This forces CELERY_IMPORTS to load first, as a preload of sorts. Otherwise the set of imports will be thrown into whatever willy nilly order the interpreter decides upon. The old behaviour can cause issues with some finicky libraries. In my case, haystack.
