### PR TITLE
Setting self.options in apply_async if the options parameter is empty

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -460,6 +460,7 @@ class Task(object):
         app = self._get_app()
         router = router or self.app.amqp.router
         conf = app.conf
+        options = options or self.options
 
         # add 'self' if this is a bound method.
         if self.__self__ is not None:


### PR DESCRIPTION
The periodic tasks have an attribute called "options" where you can specify extra things. Celery beat gets them and calls apply_async passing this attribute as the **options parameter this method has.

But, if you want to run the periodic task without celery, for example in a Python shell calling MyTask.delay() the "options" task attribute is ignored since the apply_async method does not check if the task already has something in the "options" attribute, it just only consider the parameter.

Taking advantage that those options are already in the task itself ( self.options ), the apply_async method should be able to use it if the **options parameter is empty.
