### PR TITLE
Add helper methods for obtain task info and state (on results module).

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -729,3 +729,19 @@ class EagerResult(AsyncResult):
     @property
     def supports_native_join(self):
         return False
+
+
+def get_task_info(task_id):
+    """
+    Helper method for obtain a info (metadata)
+    asociated with task_id.
+    """
+    return current_app.backend.get_result(task_id)
+
+
+def get_task_state(task_id):
+    """
+    Helper method for obtain a state asociated
+    with a task_id.
+    """
+    return current_app.backend.get_status(task_id)


### PR DESCRIPTION
Add a simple way for obtain task info and task state. 

This helpers removes the boilerplate of continuously creating instance of AsyncResult and obtain a info and state with their properties.

I know that you can access it from backend, but that adds a layer of abstraction and think it's better to have these methods.
