### PR TITLE
Update extra/generic-init.d/celeryd

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -37,7 +37,7 @@ fi
 
 # Sets --app argument for CELERY_BIN
 CELERY_APP_ARG=""
-if [ ! -z "$CELERY_APP"]; then
+if [ ! -z "$CELERY_APP" ]; then
     CELERY_APP_ARG="--app=$CELERY_APP"
 fi
 


### PR DESCRIPTION
add one extra space line 40 so dash doesn't throw a missing : error
