### PR TITLE
Fix CELERYD_HIJACK_ROOT_LOGGER description

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1387,11 +1387,10 @@ CELERYD_HIJACK_ROOT_LOGGER
 
 .. versionadded:: 2.2
 
-By default any previously configured logging options will be reset,
-because the Celery programs "hijacks" the root logger.
-
-If you want to customize your own logging then you can disable
-this behavior.
+By default any previously configured handlers on the root logger will be
+removed. If you want to customize your own logging handlers, then you
+can disable this behavior by setting
+`CELERYD_HIJACK_ROOT_LOGGER = False`.
 
 .. note::
 


### PR DESCRIPTION
`CELERYD_HIJACK_ROOT_LOGGER` doesn't actually reset e.g. logger
levels and filters, or handlers and formatters attached to loggers
other than the root logger. Just removes any handlers already
attached to the root logger. This says so more clearly.
