### PR TITLE
Pass additional options in Task.retry

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -565,6 +565,7 @@ class Task(object):
         S = self.subtask_from_request(
             request, args, kwargs,
             countdown=countdown, eta=eta, retries=retries,
+            **options
         )
 
         if max_retries is not None and retries > max_retries:


### PR DESCRIPTION
Additional options like queue or routing_key were not being correctly passed to apply_async when a task is retried.
