### PR TITLE
Fix typo in old changelog.

### DIFF
--- a/docs/history/changelog-2.0.rst
+++ b/docs/history/changelog-2.0.rst
@@ -956,7 +956,7 @@ News
         $ celeryd-multi start 3 -c 3
         celeryd -n celeryd1.myhost -c 3
         celeryd -n celeryd2.myhost -c 3
-        celeryd- n celeryd3.myhost -c 3
+        celeryd -n celeryd3.myhost -c 3
 
         # start 3 named workers
         $ celeryd-multi start image video data -c 3


### PR DESCRIPTION
Found this when reading the docs. The public docs have other similar errors, but they've all since been corrected. This one was still incorrect though.
