### PR TITLE
Fix syntax error in `celery_http_gateway` example app.

### DIFF
--- a/examples/celery_http_gateway/manage.py
+++ b/examples/celery_http_gateway/manage.py
@@ -6,7 +6,7 @@ except ImportError:
     import sys
     sys.stderr.write(
         "Error: Can't find the file 'settings.py' in the directory "
-        "containing {0!r}.".format(__file__)
+        "containing {0!r}.".format(__file__))
     sys.exit(1)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The syntax error was found in manage.py, when tried to run the dev server.
