### PR TITLE
Test Case for failing signatures and backwards compatible fix

### DIFF
--- a/celery/tests/security/test_serialization.py
+++ b/celery/tests/security/test_serialization.py
@@ -10,6 +10,7 @@ from celery.security.key import PrivateKey
 from . import CERT1, CERT2, KEY1, KEY2
 from .case import SecurityCase
 
+import os,base64
 
 class test_SecureSerializer(SecurityCase):
 
@@ -53,3 +54,9 @@ class test_SecureSerializer(SecurityCase):
     def test_register_auth(self):
         register_auth(KEY1, CERT1, '')
         self.assertIn('application/data', registry._decoders)
+
+    def test_lots_of_sign(self):
+        for i in range(1000):
+            rdata = base64.urlsafe_b64encode(os.urandom(265))
+            s = self._get_s(KEY1, CERT1, [CERT1])
+            self.assertEqual(s.deserialize(s.serialize(rdata)), rdata)


### PR DESCRIPTION
This pull request replaces my last one which wasn't backwards compatible, this one is.

```
- Added unit test case to better test signing and show the bug. Current test only ensures that you can sign a fixed string. Replaced with a test that generates lots of random strings. Old method reliably fails the test in under ~2000 passes.
```
- Reworked auth serialization code to use the sized of the signature for splitting up the string as well as seperator splitting. This should be backwards compatible, in fact the encoding method remains unchanged.
