### PR TITLE
workdir doesn't work for celeryd_detach

### DIFF
--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -538,4 +538,5 @@ def daemon_options(default_pidfile=None, default_logfile=None):
         Option('--uid', default=None),
         Option('--gid', default=None),
         Option('--umask', default=0, type='int'),
+        Option('--workdir', default=None, dest='working_directory'),
     )


### PR DESCRIPTION
`--workdir`is a preload option for `celeryd`, but it's not stored for `celeryd_detach`.
The context manager `detached` is always called with the default `None`.
