### PR TITLE
Avoid bashism in extra/generic-init.d/celeryd

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -175,7 +175,8 @@ check_status () {
     for pid_file in $pid_files; do
         local node=`basename "$pid_file" .pid`
         local pid=`cat "$pid_file"`
-        if [ -z "$pid" ] || [ "${pid//[0-9]/}" ]; then
+        local cleaned_pid=`echo "$pid" | sed -e 's/[^0-9]//g'`
+        if [ -z "$pid" ] || [ "$cleaned_pid" != "$pid" ]; then
             echo "bad pid file ($pid_file)"
         else
             local failed=


### PR DESCRIPTION
The example init script depends on bash for validating pid files when running `/etc/init.d/celeryd status`. Thus, the status command won't work on Ubuntu and other distributions where bash isn't the default `/bin/sh`.

Fixed by using `sed` to accomplish the same thing in a more portable way.
