### PR TITLE
Cassandra backend - catch pycassa.AllServersUnavailable exception

### DIFF
--- a/celery/backends/cassandra.py
+++ b/celery/backends/cassandra.py
@@ -106,6 +106,7 @@ class CassandraBackend(BaseBackend):
             except (pycassa.InvalidRequestException,
                     pycassa.TimedOutException,
                     pycassa.UnavailableException,
+                    pycassa.AllServersUnavailable,
                     socket.error,
                     socket.timeout,
                     Thrift.TException) as exc:

--- a/celery/tests/backends/test_cassandra.py
+++ b/celery/tests/backends/test_cassandra.py
@@ -33,11 +33,15 @@ def install_exceptions(mod):
     class TimedOutException(Exception):
         pass
 
+    class AllServersUnavailable(Exception):
+        pass
+
     mod.NotFoundException = NotFoundException
     mod.TException = TException
     mod.InvalidRequestException = InvalidRequestException
     mod.TimedOutException = TimedOutException
     mod.UnavailableException = UnavailableException
+    mod.AllServersUnavailable = AllServersUnavailable
 
 
 class test_CassandraBackend(AppCase):


### PR DESCRIPTION
Catch the pycassa.AllServersUnavailable exception so the request is
retried. Without this the parent celery process freezes if this
exception is thrown. Fixes issue #1010.
