### PR TITLE
4+4=8

### DIFF
--- a/docs/getting-started/first-steps-with-celery.rst
+++ b/docs/getting-started/first-steps-with-celery.rst
@@ -253,7 +253,7 @@ You can wait for the result to complete, but this is rarely used
 since it turns the asynchronous call into a synchronous one::
 
     >>> result.get(timeout=1)
-    4
+    8
 
 In case the task raised an exception, :meth:`~@AsyncResult.get` will
 re-raise the exception, but you can override this by specifying


### PR DESCRIPTION
Just making the tutorial flow as if the user was following this directly.

tasks.add simply adds the first argument to the second so when the user makes a call to add, it should just add 4 and 4.

```
@celery.task
def add(x, y):
    return x + y
```
