### PR TITLE
celery bug - celery crashes after "git pull"

### DIFF
--- a/celery/worker/autoreload.py
+++ b/celery/worker/autoreload.py
@@ -255,10 +255,11 @@ class Autoreloader(bgThread):
             self._monitor.start()
 
     def _maybe_modified(self, f):
-        digest = file_hash(f)
-        if digest != self._hashes[f]:
-            self._hashes[f] = digest
-            return True
+        if os.path.exists(f):
+            digest = file_hash(f)
+            if digest != self._hashes[f]:
+                self._hashes[f] = digest
+                return True
         return False
 
     def on_change(self, files):


### PR DESCRIPTION
If tasks.py file is modified in git repository and I run git pull on server, then celery crashes if --autoreload is ON.

"Git pull" first removes the file and then restores it, but pyinotify catches removal event.

I updated _maybe_modified function to first verify if file exists and if not then mark file as "unmodified", because afterwards will be another event when file is recreated and tasks are reloaded.

Error dump:

```
'Autoreloader' crashed: IOError(2, 'No such file or directory')
Traceback (most recent call last):
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/celery/utils/threads.py", line 72, in run
body()
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/celery/worker/autoreload.py", line 251, in body
self._monitor.start()
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/celery/worker/autoreload.py", line 179, in start
self._notifier.loop()
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/pyinotify.py", line 1400, in loop
self.process_events()
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/pyinotify.py", line 1295, in process_events
self._default_proc_fun(revent)
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/pyinotify.py", line 937, in __call__
return _ProcessEvent.__call__(self, event)
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/pyinotify.py", line 662, in __call__
return meth(event)
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/celery/worker/autoreload.py", line 190, in process_
self.on_change([event.path])
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/celery/worker/autoreload.py", line 196, in on_change
return self._on_change(modified)
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/celery/worker/autoreload.py", line 261, in on_change
modified = [f for f in files if self._maybe_modified(f)]
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/celery/worker/autoreload.py", line 254, in _maybe_modified
digest = file_hash(f)
File "/home/django/.virtualenv/projectX/local/lib/python2.7/site-packages/celery/worker/autoreload.py", line 63, in file_hash
with open(filename, 'rb') as f:
IOError: [Errno 2] No such file or directory: '/home/django/projectX/submission/tasks.py'
```
