### PR TITLE
ConfigurationView (hence Settings) is a MutableMapping

### DIFF
--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import sys
 import time
 
-from collections import defaultdict
+from collections import defaultdict, MutableMapping
 from functools import partial
 from itertools import chain
 from operator import itemgetter
@@ -419,11 +419,11 @@ class DictAttribute(object):
 class ConfigurationView(AttributeDictMixin):
     """A view over an applications configuration dicts.
 
-    If the key does not exist in ``changes``, the ``defaults`` dict
-    is consulted.
+    If the key does not exist in ``changes``, the ``defaults`` dicts
+    are consulted.
 
     :param changes:  Dict containing changes to the configuration.
-    :param defaults: Dict containing the default configuration.
+    :param defaults: List of dicts containing the default configuration.
 
     """
     changes = None
@@ -480,6 +480,11 @@ class ConfigurationView(AttributeDictMixin):
     def __iter__(self):
         return self._iterate_keys()
 
+    def __len__(self):
+        # The logic for iterating keys includes uniq(),
+        # so to be safe we count by explicitly iterating
+        return len(self.keys())
+
     def _iter(self, op):
         # defaults must be first in the stream, so values in
         # changes takes precedence.
@@ -505,6 +510,9 @@ class ConfigurationView(AttributeDictMixin):
 
     def values(self):
         return list(self._iterate_values())
+
+
+MutableMapping.register(ConfigurationView)
 
 
 class LimitedSet(object):

--- a/celery/tests/app/test_utils.py
+++ b/celery/tests/app/test_utils.py
@@ -1,0 +1,25 @@
+"""
+Tests of celery.app.utils
+"""
+
+from __future__ import absolute_import
+
+
+import unittest
+
+
+class TestSettings(unittest.TestCase):
+    """
+    Tests of celery.app.utils.Settings
+    """
+    def test_is_mapping(self):
+        """Settings should be a collections.Mapping"""
+        from celery.app.utils import Settings
+        from collections import Mapping
+        self.assertTrue(issubclass(Settings, Mapping))
+
+    def test_is_mutable_mapping(self):
+        """Settings should be a collections.MutableMapping"""
+        from celery.app.utils import Settings
+        from collections import MutableMapping
+        self.assertTrue(issubclass(Settings, MutableMapping))

--- a/celery/tests/test_datastructures.py
+++ b/celery/tests/test_datastructures.py
@@ -1,0 +1,24 @@
+"""
+Tests of celery.datastructures.
+"""
+from __future__ import absolute_import
+
+
+import unittest
+
+
+class TestConfigurationView(unittest.TestCase):
+    """
+    Tests of celery.datastructures.ConfigurationView
+    """
+    def test_is_mapping(self):
+        """ConfigurationView should be a collections.Mapping"""
+        from celery.datastructures import ConfigurationView
+        from collections import Mapping
+        self.assertTrue(issubclass(ConfigurationView, Mapping))
+
+    def test_is_mutable_mapping(self):
+        """ConfigurationView should be a collections.MutableMapping"""
+        from celery.datastructures import ConfigurationView
+        from collections import MutableMapping
+        self.assertTrue(issubclass(ConfigurationView, MutableMapping))


### PR DESCRIPTION
The <code>celery.datastructures.ConfigurationView</code> acts like a dictionary, so it should register itself as such with the <code>MutableMapping</code> abstract base class. This is useful for code which detects dict-like things.

(Many of the <code>collections</code> abstract base classes, such as <code>Iterable</code>, implement <code>subclasshook</code> to define themselves via duck-typing, checking for implemented methods. Unfortunately <code>Mapping</code> and <code>MutableMapping</code> do not do this, so it is necessary to explicitly register.)

Includes an implementation of <code>len</code>, to complete the interface, and unit tests.

Also includes what I believe is a correction of misleading documentation -- it appears that in <code>ConfigurationView(changes, defaults)</code>, <code>defaults</code> is a list of dicts, not a dict.
