### PR TITLE
Fix 'celery migrate ...'

### DIFF
--- a/celery/contrib/migrate.py
+++ b/celery/contrib/migrate.py
@@ -236,6 +236,7 @@ def start_filter(app, conn, filter, limit=None, timeout=1.0,
                  consume_from=None, state=None, **kwargs):
     state = state or State()
     queues = prepare_queues(queues)
+    consume_from = [_maybe_queue(app, q) for q in consume_from or queues.keys()]
     if isinstance(tasks, basestring):
         tasks = set(tasks.split(','))
     if tasks is None:


### PR DESCRIPTION
consume_from isn't passed by the command so grab the queues from the
keys of queues if consume_from is None
