### PR TITLE
Feature: Add a 'root_id' task option to track related canvas tasks

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -189,7 +189,7 @@ class TaskProducer(Producer):
                      queue=None, now=None, retries=0, chord=None,
                      callbacks=None, errbacks=None, routing_key=None,
                      serializer=None, delivery_mode=None, compression=None,
-                     declare=None, **kwargs):
+                     declare=None, root_id=None, **kwargs):
         """Send task message."""
 
         qname = queue
@@ -227,6 +227,7 @@ class TaskProducer(Producer):
         body = {
             'task': task_name,
             'id': task_id,
+            'root_id': root_id,
             'args': task_args,
             'kwargs': task_kwargs,
             'retries': retries or 0,
@@ -259,6 +260,7 @@ class TaskProducer(Producer):
                 'task-sent',
                 {
                     'uuid': task_id,
+                    'root_id': root_id,
                     'name': task_name,
                     'args': safe_repr(task_args),
                     'kwargs': safe_repr(task_kwargs),

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -249,8 +249,11 @@ class BaseBackend(object):
     def fallback_chord_unlock(self, group_id, body, result=None,
                               countdown=1, **kwargs):
         kwargs['result'] = [r.id for r in result]
+        root_id = None
+        if hasattr(body, 'options'):
+            root_id = body.options.get('root_id', None)
         self.app.tasks['celery.chord_unlock'].apply_async(
-            (group_id, body, ), kwargs, countdown=countdown,
+            (group_id, body, ), kwargs, countdown=countdown, root_id=root_id,
         )
     on_chord_apply = fallback_chord_unlock
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -170,7 +170,8 @@ class Signature(dict):
             tid = opts['task_id']
         except KeyError:
             tid = opts['task_id'] = _id or uuid()
-        return self.AsyncResult(tid)
+        rid = opts.get('root_id', None)
+        return self.AsyncResult(tid, root_id=rid)
 
     def replace(self, args=None, kwargs=None, options=None):
         s = self.clone()
@@ -256,6 +257,7 @@ class Signature(dict):
         except KeyError:
             return _partial(current_app.send_task, self['task'])
     id = _getitem_property('options.task_id')
+    root_id = _getitem_property('options.root_id')
     task = _getitem_property('task')
     args = _getitem_property('args')
     kwargs = _getitem_property('kwargs')
@@ -412,13 +414,16 @@ class group(Signature):
             gid = opts['group']
         except KeyError:
             gid = opts['group'] = uuid()
+        rid = opts.get('root_id', None)
         new_tasks, results = [], []
         for task in self.tasks:
             task = maybe_subtask(task).clone()
+            if rid:
+                task.options['root_id'] = rid
             results.append(task._freeze())
             new_tasks.append(task)
         self.tasks = self.kwargs['tasks'] = new_tasks
-        return GroupResult(gid, results)
+        return GroupResult(gid, results, root_id=rid)
 
     def skew(self, start=1.0, stop=None, step=1.0):
         _next_skew = fxrange(start, stop, step, repeatlast=True).next
@@ -467,7 +472,11 @@ class chord(Signature):
         if _chord.app.conf.CELERY_ALWAYS_EAGER:
             return self.apply((), kwargs)
         callback_id = body.options.setdefault('task_id', uuid())
-        return _chord.AsyncResult(callback_id, parent=_chord(**kwargs))
+        root_id = self.options.get('root_id', None)
+        if root_id:
+            body.options.setdefault('root_id', root_id)
+        return _chord.AsyncResult(callback_id, parent=_chord(**kwargs),
+                                  root_id=root_id)
 
     def clone(self, *args, **kwargs):
         s = Signature.clone(self, *args, **kwargs)

--- a/celery/contrib/abortable.py
+++ b/celery/contrib/abortable.py
@@ -143,9 +143,10 @@ class AbortableTask(Task):
     """
 
     @classmethod
-    def AsyncResult(cls, task_id):
+    def AsyncResult(cls, task_id, root_id=None):
         """Returns the accompanying AbortableAsyncResult instance."""
-        return AbortableAsyncResult(task_id, backend=cls.backend)
+        return AbortableAsyncResult(task_id, backend=cls.backend,
+                                    root_id=root_id)
 
     def is_aborted(self, **kwargs):
         """Checks against the backend whether this
@@ -161,7 +162,8 @@ class AbortableTask(Task):
 
         """
         task_id = kwargs.get('task_id', self.request.id)
-        result = self.AsyncResult(task_id)
+        root_id = kwargs.get('root_id', self.request.root_id)
+        result = self.AsyncResult(task_id, root_id=root_id)
         if not isinstance(result, AbortableAsyncResult):
             return False
         return result.is_aborted()

--- a/celery/tests/worker/test_request.py
+++ b/celery/tests/worker/test_request.py
@@ -812,6 +812,7 @@ class test_TaskRequest(AppCase):
                 'logfile': None,
                 'loglevel': None,
                 'task_id': tw.id,
+                'root_id': None,
                 'task_retries': 0,
                 'task_is_eager': False,
                 'delivery_info': {

--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -75,7 +75,7 @@ class Request(object):
         __slots__ = (
             'app', 'name', 'id', 'args', 'kwargs', 'on_ack', 'delivery_info',
             'hostname', 'eventer', 'connection_errors', 'task', 'eta',
-            'expires', 'request_dict', 'acknowledged',
+            'expires', 'request_dict', 'acknowledged', 'root_id',
             'utc', 'time_start', 'worker_pid', '_already_revoked',
             '_terminate_on_ack',
             '_tzlocal', '__weakref__',
@@ -110,6 +110,7 @@ class Request(object):
         self.app = app or app_or_default(app)
         name = self.name = body['task']
         self.id = body['id']
+        self.root_id = body.get('root_id', None)
         self.args = body.get('args', [])
         self.kwargs = body.get('kwargs', {})
         try:
@@ -190,6 +191,7 @@ class Request(object):
         default_kwargs = {'logfile': None,   # deprecated
                           'loglevel': None,  # deprecated
                           'task_id': self.id,
+                          'root_id': self.root_id,
                           'task_name': self.name,
                           'task_retries': self.request_dict.get('retries', 0),
                           'task_is_eager': False,


### PR DESCRIPTION
I know this still needs work (docs/testing), but I wanted to get a first impression of whether the approach looks good or not.

Also a couple questions I had during the implementation:
1.) Should the backend support this directly? At the moment I wrote a custom backend that uses current_task.request.root_id in order to save the extra field with my models without breaking the API.
2.) Should the signals callbacks support this? I could see it being useful, but again it could be API breaking so I left it out.