### PR TITLE
Fix for issue #1326

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -266,13 +266,13 @@ def fileno(f):
 def maybe_fileno(f):
     """Get object fileno, or :const:`None` if not defined."""
     try:
-<<<<<<< HEAD
+#<<<<<<< HEAD
         return f.fileno()
     except FILENO_ERRORS:
-=======
+#=======
         return fileno(f)
     except AttributeError:
->>>>>>> 3.0
+#>>>>>>> 3.0
         pass
 
 


### PR DESCRIPTION
https://github.com/celery/celery/issues/1326

Fixes error when running celery commands:

wh@wh:~/flo/bin$ ./celery worker
Traceback (most recent call last):
  File "./celery", line 8, in <module>
    load_entry_point('celery==3.1.0rc1', 'console_scripts', 'celery')()
  File "/home/wh/flo/local/lib/python2.7/site-packages/celery/**main**.py", line 28, in main
    maybe_patch_concurrency()
  File "/home/wh/flo/local/lib/python2.7/site-packages/celery/**main**.py", line 23, in maybe_patch_concurrency
    from celery.platforms import maybe_patch_concurrency
  File "/home/wh/flo/local/lib/python2.7/site-packages/celery/platforms.py", line 269
    <<<<<<< HEAD
    ^
