### PR TITLE
threading.Event is a class for python 3.3+ but not for python 3.2

### DIFF
--- a/celery/utils/threads.py
+++ b/celery/utils/threads.py
@@ -18,9 +18,10 @@ from celery.utils.compat import THREAD_TIMEOUT_MAX
 
 USE_FAST_LOCALS = os.environ.get('USE_FAST_LOCALS')
 PY3 = sys.version_info[0] == 3
+NEW_EVENT = (sys.version_info[0] == 3) and (sys.version_info[1] >= 3)
 
 _Thread = threading.Thread
-_Event = threading.Event if PY3 else threading._Event
+_Event = threading.Event if NEW_EVENT else threading._Event
 active_count = (getattr(threading, 'active_count', None) or
                 threading.activeCount)
 


### PR DESCRIPTION
Python has changed the trheading module between python 3.2 and 3.3. Unfortunatly, due to a doc bug, it appears as threading.Thread is a class, but it really isn't.

See trace: https://travis-ci.org/getsentry/raven-python/jobs/6748191

3.2 function:
http://docs.python.org/3.2/library/threading.html
threading.Event()
A factory function that returns a new event object.

3.3 class:
http://docs.python.org/3.3/library/threading.html#threading.Thread
