### PR TITLE
Support `CELERY_TASK_TIME_LIMIT` and `CELERY_TASK_SOFT_TIME_LIMIT`

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -143,6 +143,8 @@ NAMESPACES = {
             'interval_step': 0.2}, type='dict'),
         'TASK_RESULT_EXPIRES': Option(timedelta(days=1), type='float'),
         'TASK_SERIALIZER': Option('pickle'),
+        'TASK_SOFT_TIME_LIMIT': Option(type='float'),
+        'TASK_TIME_LIMIT': Option(type='float'),
         'TIMEZONE': Option(type='string'),
         'TRACK_STARTED': Option(False, type='bool'),
         'REDIRECT_STDOUTS': Option(True, type='bool'),

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -246,6 +246,8 @@ class Task(object):
         ('ignore_result', 'CELERY_IGNORE_RESULT'),
         ('store_errors_even_if_ignored',
             'CELERY_STORE_ERRORS_EVEN_IF_IGNORED'),
+        ('time_limit', 'CELERY_TASK_TIME_LIMIT'),
+        ('soft_time_limit', 'CELERY_TASK_SOFT_TIME_LIMIT'),
     )
 
     __bound__ = False


### PR DESCRIPTION
The comments in the Task class specified these settings as defaults for
`time_limit` and `soft_time_limit` respectively. However, the Task class
never actually pulled their values from the configs.

`CELERYD_TASK_TIME_LIMIT` and `CELERYD_TASK_SOFT_TIME_LIMIT` take precedence over the time_limits set on the task. I think it is important to support setting a default time_limit for tasks, say 15 min, while allowing an individual task to set a time_limit of say, 30 seconds.

I saw that you already had tests for "on_timeout" I wasn't sure where/how you would prefer these to be tested. Am happy to write tests if you point me in the right direction.
