### PR TITLE
Removed safe parameter due to PyMongo deprecation warning

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -128,7 +128,7 @@ class MongoBackend(BaseBackend):
                 'date_done': datetime.utcnow(),
                 'traceback': Binary(self.encode(traceback)),
                 'children': Binary(self.encode(self.current_task_children()))}
-        self.collection.save(meta, safe=True)
+        self.collection.save(meta)
 
         return result
 
@@ -155,7 +155,7 @@ class MongoBackend(BaseBackend):
         meta = {'_id': group_id,
                 'result': Binary(self.encode(result)),
                 'date_done': datetime.utcnow()}
-        self.collection.save(meta, safe=True)
+        self.collection.save(meta)
 
         return result
 
@@ -187,7 +187,7 @@ class MongoBackend(BaseBackend):
         # By using safe=True, this will wait until it receives a response from
         # the server.  Likewise, it will raise an OperationsError if the
         # response was unable to be completed.
-        self.collection.remove({'_id': task_id}, safe=True)
+        self.collection.remove({'_id': task_id})
 
     def cleanup(self):
         """Delete expired metadata."""


### PR DESCRIPTION
I get the following warning when using the MongoDB backend:

```
/eggs/pymongo-2.5-py2.7-linux-x86_64.egg/pymongo/common.py:592: DeprecationWarning: The safe parameter is deprecated. Please use write concern options instead.
  "write concern options instead.", DeprecationWarning)
```

Evidently, [PyMongo has deprecated a lot of things](http://emptysquare.net/blog/pymongos-new-default-safe-writes/) in order to set forth a new API to do safe writes by default. Essentially, we need to migrate this backend away from the `pymongo.Connection` class to the `pymongo.MongoClient` class for interfacing with the database. 
