### PR TITLE
Fixed #1373 Celery won't start due to UnicodeDecodeError

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -196,7 +196,7 @@ class Worker(WorkController):
             version=VERSION_BANNER,
             conninfo=self.app.connection().as_uri(),
             concurrency=concurrency,
-            platform=_platform.platform(),
+            platform=safe_str(_platform.platform()),
             events=events,
             queues=app.amqp.queues.format(indent=0, indent_first=False),
         ).splitlines()


### PR DESCRIPTION
This fixes the Celery won't start due to UnicodeDecodeError bug (#1373). 
