### PR TITLE
Fix flatten_reply() to merge dictionary values

### DIFF
--- a/celery/app/control.py
+++ b/celery/app/control.py
@@ -18,9 +18,12 @@ from . import app_or_default
 def flatten_reply(reply):
     nodes = {}
     for item in reply:
-        nodes.update(item)
+        for (k, v) in item.iteritems():
+            if k not in nodes:
+                nodes[k] = v
+            else:
+                nodes[k] += v
     return nodes
-
 
 class Inspect(object):
     app = None


### PR DESCRIPTION
Fix flatten_reply() to merge dictionary values instead of selecting one of them arbitrarily. Refer to https://github.com/celery/celery/issues/1377 for more details including a test case.
