### PR TITLE
Attempting to resolve issue-1387 by first declaring local pid_file= to n...

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -168,7 +168,8 @@ restart_workers () {
 }
 
 check_status () {
-    local pid_files=`_get_pid_files`
+    local pid_files=
+    pid_files=`_get_pid_files`
     [ -z "$pid_files" ] && echo "celeryd not running (no pidfile)" && exit 1
 
     local one_failed=


### PR DESCRIPTION
...ull in check_status()

Found that if _get_pid_files returns more than one file the local pid_files=`_get_pid_files` line 161 results in a bad variable name on ubuntu 12.04.
