### PR TITLE
fix import error in python 2.5

### DIFF
--- a/celery/__compat__.py
+++ b/celery/__compat__.py
@@ -14,7 +14,12 @@ from __future__ import absolute_import
 import operator
 import sys
 
-from functools import reduce
+# import fails in python 2.5. fallback to reduce in stdlib
+try:
+    from functools import reduce
+except ImportError:
+    pass
+
 from importlib import import_module
 from types import ModuleType
 


### PR DESCRIPTION
3.0.x are the last versions to support python 2.5.  Erroneous import was introduced with a fix for issue #1107
