### PR TITLE
Fix gevent connection leak

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -118,6 +118,8 @@ class MongoBackend(BaseBackend):
         if self._connection is not None:
             # MongoDB connection will be closed automatically when object
             # goes out of scope
+            del(self.collection)
+            del(self.database)
             self._connection = None
 
     def _store_result(self, task_id, result, status, traceback=None):


### PR DESCRIPTION
Using CELERYD_POOL="gevent" can cause a mongodb connections to leak.

Cleaning up the cached_properties as well as the connection prevents that.
