### PR TITLE
Small documentation fixes

### DIFF
--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -494,7 +494,7 @@ and return the result of the last task in the chain::
     640
 
 And calling ``apply_async`` will create a dedicated
-task so that the act of calling the chain happens
+task so that the act of sending the messages for the chain happens
 in a worker::
 
     >>> res = chain(add.s(4, 4), mul.s(8), mul.s(10)).apply_async()
@@ -908,8 +908,8 @@ To create a chunks subtask you can use :meth:`@Task.chunks`:
 
     >>> add.chunks(zip(range(100), range(100)), 10)
 
-As with :class:`~celery.group` the act of **calling**
-the chunks will call the tasks in the current process:
+As with :class:`~celery.group` the act of sending the messages for
+the chunks will happen in the current process when called:
 
 .. code-block:: python
 


### PR DESCRIPTION
- there was a missing ) and a mistake in the way chunks are described.
- i changed "calling" to "message sending" in two places for consistency. as someone new to celery i was expecting to have the tasks processed in my local process when called directly, when it is only the message sending, that happens in the local process. subtasks are always processed by workers.
