### PR TITLE
DisabledBackend now shows a warning when celery attempts to store result...

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import time
 import sys
+import warnings
 
 from datetime import timedelta
 
@@ -477,7 +478,7 @@ class DisabledBackend(BaseBackend):
     _cache = {}   # need this attribute to reset cache in tests.
 
     def store_result(self, *args, **kwargs):
-        pass
+	    warnings.warn("{} consumed store_result call with args {}, {}".format(self.__class__.__name__, args, kwargs))
 
     def _is_disabled(self, *args, **kwargs):
         raise NotImplementedError(


### PR DESCRIPTION
When celery backend misconfiguration happens, it is immensely time-consuming to pinpoint why certain functionality stops working properly.

Introducing this warning message (that should show only once per program run) should simplify the process of the configuration debug quite noticeably.

As "warnings" library have been part of Python batteries since version 2.1, this change should be compatible with most setups out there.
