### PR TITLE
Add a BROKER_LOGIN_METHOD configuration directive

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -308,6 +308,7 @@ class Celery(object):
             connect_timeout=self.either(
                 'BROKER_CONNECTION_TIMEOUT', connect_timeout),
             heartbeat=heartbeat,
+            login_method=self.either('BROKER_LOGIN_METHOD', None),
             transport_options=dict(conf.BROKER_TRANSPORT_OPTIONS,
                                    **transport_options or {}))
     broker_connection = connection


### PR DESCRIPTION
BROKER_LOGIN_METHOD is used as the login_method value of the constructor
of the kombu.connection.Connection class. This can be used to sepcify,
for instance, an EXTERNAL login method with RabbitMQ.

I can't find the documentation in the git repository to update it !
