### PR TITLE
Fix test_monthly_moy_execution_is_not_due

### DIFF
--- a/celery/tests/tasks/test_tasks.py
+++ b/celery/tests/tasks/test_tasks.py
@@ -6,6 +6,7 @@ from functools import wraps
 from mock import patch
 from pickle import loads, dumps
 
+import pytz
 from kombu import Queue
 
 from celery.task import (
@@ -1271,15 +1272,16 @@ class test_crontab_is_due(AppCase):
         self.assertTrue(due)
         self.assertEqual(remaining, 60.)
 
-    @patch_crontab_nowfun(monthly_moy, datetime(2013, 6, 28, 14, 30))
+    @patch_crontab_nowfun(monthly_moy, datetime(2013, 6, 28, 14, 30,
+                                                tzinfo=pytz.utc))
     def test_monthly_moy_execution_is_not_due(self):
         due, remaining = monthly_moy.run_every.is_due(
             datetime(2013, 6, 28, 22, 14))
         self.assertFalse(due)
         attempt = (
             time.mktime(datetime(2014, 2, 26, 22, 0).timetuple()) -
-            time.mktime(datetime(2013, 6, 28, 14, 30).timetuple()) -
-            60 * 60
+            time.mktime(datetime(2013, 6, 28, 14, 30,
+                                 tzinfo=pytz.utc).timetuple())
         )
         self.assertEqual(remaining, attempt)
 


### PR DESCRIPTION
Received a mail from Travis, here is a fix

Force utc in test_monthly_moy_execution_is_not_due

Its appear there is some strange behaviour with
the localtime. There is an offset of 3600 on
some timezone, (on GMT+xx but not on GMT-xx),
furthermore, some GMT+xx works without the offset,
like Puerto Rico.
