### PR TITLE
Wrong command in "control disable_events" example line

### DIFF
--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -134,7 +134,7 @@ Commands
 
     .. code-block:: bash
 
-        $ celery inspect disable_events
+        $ celery control disable_events
 
 * **migrate**: Migrate tasks from one broker to another (**EXPERIMENTAL**).
 


### PR DESCRIPTION
The example command line should be `celery control disable_events` instead of `celery inspect disable_events`.
