### PR TITLE
Fixing grammar in configuration options docs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -508,7 +508,7 @@ This is a dict supporting the following keys:
     Defaults to "celery_taskmeta".
 
 * max_pool_size
-    Passed as max_pool_size to PyMongo's Connection or MongoClient 
+    Passed as max_pool_size to PyMongo's Connection or MongoClient
     constructor. It is the maximum number of TCP connections to keep
     open to MongoDB at a given time. If there are more open connections
     than max_pool_size, sockets will be closed when they are released.
@@ -735,7 +735,7 @@ as the routing key and the ``C.dq`` exchange::
 CELERY_CREATE_MISSING_QUEUES
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If enabled (default), any queues specified that is not defined in
+If enabled (default), any queues specified that are not defined in
 :setting:`CELERY_QUEUES` will be automatically created. See
 :ref:`routing-automatic`.
 
@@ -749,7 +749,7 @@ no route or no custom queue has been specified.
 
 
 This queue must be listed in :setting:`CELERY_QUEUES`.
-If :setting:`CELERY_QUEUES` is not specified then it this automatically
+If :setting:`CELERY_QUEUES` is not specified then it is automatically
 created containing one queue entry, where this name is used as the name of
 that queue.
 
@@ -774,7 +774,7 @@ The default is: `celery`.
 CELERY_DEFAULT_EXCHANGE_TYPE
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Default exchange type used when no custom exchange type is specified.
+Default exchange type used when no custom exchange type is specified
 for a key in the :setting:`CELERY_QUEUES` setting.
 The default is: `direct`.
 


### PR DESCRIPTION
Title says it all - I was going through the docs while I was trying to figure out how to change the default queue name and found some grammatical errors so I said I'd make life easier for others who might be looking at this section of the docs.
