### PR TITLE
result: make base backend and iter_native interval default value agree

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -512,7 +512,7 @@ class ResultSet(ResultBase):
                                       interval=interval))
         return results
 
-    def iter_native(self, timeout=None, interval=None):
+    def iter_native(self, timeout=None, interval=0.5):
         """Backend optimized version of :meth:`iterate`.
 
         .. versionadded:: 2.2


### PR DESCRIPTION
The base backend has a default of 0.5, when we passed None in
that caused it to ignore the default (since we passed a value)
and raised an error when calling time.sleep.
