### PR TITLE
Add documentation about CELERY_TASK_RESULT_EXPIRES

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1082,6 +1082,8 @@ stored task tombstones will be deleted.
 A built-in periodic task will delete the results after this time
 (:class:`celery.task.backend_cleanup`).
 
+Setting it to None or 0 will disable results cleanup.
+
 Default is to expire after 1 day.
 
 .. note::


### PR DESCRIPTION
Specify that setting the configuration value to None or 0 will disable task results cleanup
