### PR TITLE
Speed up the precedence state lookup

### DIFF
--- a/celery/states.py
+++ b/celery/states.py
@@ -71,6 +71,10 @@ PRECEDENCE = ['SUCCESS',
               'RETRY',
               'PENDING']
 
+#: Hash lookup of PRECEDENCE to index
+PRECEDENCE_LOOKUP = dict(zip(PRECEDENCE, range(0, len(PRECEDENCE))))
+NONE_PRECEDENCE = PRECEDENCE_LOOKUP[None]
+
 
 def precedence(state):
     """Get the precedence index for state.
@@ -79,9 +83,9 @@ def precedence(state):
 
     """
     try:
-        return PRECEDENCE.index(state)
-    except ValueError:
-        return PRECEDENCE.index(None)
+        return PRECEDENCE_LOOKUP[state]
+    except KeyError:
+        return NONE_PRECEDENCE
 
 
 class state(str):


### PR DESCRIPTION
`PRECEDENCE.index(state)` is an O(n) operation, and the hash lookup is O(1)

For this, I could have easily just built the dict by hand and used `PRECEDENCE`, but I didn't want to clobber that variable incase someone out there is importing it for some other weird purpose. Better to play it safe. :)
