### PR TITLE
More accurate check of file descriptors

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -301,7 +301,7 @@ class DaemonContext(object):
         self.stdfds = (sys.stdin, sys.stdout, sys.stderr)
 
     def redirect_to_null(self, fd):
-        if fd:
+        if fd is not None:
             dest = os.open(os.devnull, os.O_RDWR)
             os.dup2(dest, fd)
 


### PR DESCRIPTION
the "if fd" condition doesn't work for stdin(0), which perhaps must be redirected to /dev/null among stdout and stderr
Let's be more verbose and make a check for None
