### PR TITLE
bind() on Task instance was being called twice

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -224,7 +224,6 @@ class Celery(object):
             '__doc__': fun.__doc__,
             '__module__': fun.__module__}, **options))()
         task = self._tasks[T.name]  # return global instance.
-        task.bind(self)
         return task
 
     def finalize(self):


### PR DESCRIPTION
In _task_from_fun(), an instance of Task is created at https://github.com/celery/celery/blob/master/celery/app/base.py#L220
This line calls the metaclass of Task.

The metaclass for Task calls bind() at https://github.com/celery/celery/blob/master/celery/app/task.py#L148

So, it should not be required to call bind() again from _task_from_fun() since we are working with the same instance of Task at both the places.
