### PR TITLE
Hostname should also be passed through safe_str

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -199,7 +199,7 @@ class Worker(WorkController):
 
         banner = BANNER.format(
             app=appr,
-            hostname=self.hostname,
+            hostname=safe_str(self.hostname),
             version=VERSION_BANNER,
             conninfo=self.app.connection().as_uri(),
             concurrency=concurrency,


### PR DESCRIPTION
Sometimes self.hostname can contain bad characters (when PC name is not written in english) like 'MY-\xcf\xca' and that causes unicodedecodeerror when trying to format a banner.
