### PR TITLE
Mixing rate limited and non rate limited tasks

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -450,6 +450,12 @@ General
     :setting:`CELERY_DEFAULT_RATE_LIMIT` setting, which if not specified means
     rate limiting for tasks is disabled by default.
 
+    However, be careful when rate limited tasks and non rate limited tasks are
+    routed to the same queue, which is by default if you're not specifying any
+    custom routes. It might happen that all tasks get rate limited. A good
+    practice is to route each type of task that is rate limited to its own
+    queue.
+
 .. attribute:: Task.time_limit
 
     The hard time limit for this task.  If not set then the workers default


### PR DESCRIPTION
Discovered that if we mix rate limited and non rate limited tasks in the same queue, the non rate limited ones might actually also get limited. I'll illustrate with an example:

``` python
  @celery.task(name="experiments.ping")
  def ping():
      print("ping")

  @celery.task(name="experiments.pong", rate_limit="2/m")
  def pong():
      print("pong")

  for i in range(100):
        experiments.ping.delay()
        experiments.pong.delay()
```

The output looks something like this (1 worker instance, concurrency set to 1):

```
  ping
  pong
  ping
  ping
  ping
  ping
[ ... pause 30s...]
  pong
  ping 
[ ... pause 30s ...]
...
```

I understand that this happens because eventually all the pre-fetched tasks will be of type pong, and unless a pong is executed there's no room to fetch new tasks from the broker. Since I did not see this explained anywhere, I thought that the docs should at least warn about this dangerous mix. 
