### PR TITLE
Don't fork on HUP to preserve PID for process supervisors

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -355,12 +355,8 @@ else:
     install_worker_int_handler = lambda *a, **kw: None
 
 
-def _clone_current_worker():
-    if os.fork() == 0:
-        platforms.close_open_fds([
-            sys.__stdin__, sys.__stdout__, sys.__stderr__,
-        ])
-        os.execv(sys.executable, [sys.executable] + sys.argv)
+def _reload_current_worker():
+    os.execv(sys.executable, [sys.executable] + sys.argv)
 
 
 def install_worker_restart_handler(worker, sig='SIGHUP'):
@@ -370,7 +366,7 @@ def install_worker_restart_handler(worker, sig='SIGHUP'):
         set_in_sighandler(True)
         safe_say('Restarting celeryd (%s)' % (' '.join(sys.argv), ))
         import atexit
-        atexit.register(_clone_current_worker)
+        atexit.register(_reload_current_worker)
         from celery.worker import state
         state.should_stop = True
     platforms.signals[sig] = restart_worker_sig_handler

--- a/celery/tests/bin/test_celeryd.py
+++ b/celery/tests/bin/test_celeryd.py
@@ -637,10 +637,8 @@ class test_signal_handlers(WorkerAppCase):
 
     @disable_stdouts
     @patch('atexit.register')
-    @patch('os.fork')
     @patch('os.close')
-    def test_worker_restart_handler(self, _close, fork, register):
-        fork.return_value = 0
+    def test_worker_restart_handler(self, _close, register):
         if getattr(os, 'execv', None) is None:
             raise SkipTest('platform does not have excv')
         argv = []
@@ -658,10 +656,6 @@ class test_signal_handlers(WorkerAppCase):
             callback = register.call_args[0][0]
             callback()
             self.assertTrue(argv)
-            argv[:] = []
-            fork.return_value = 1
-            callback()
-            self.assertFalse(argv)
         finally:
             os.execv = execv
             state.should_stop = False


### PR DESCRIPTION
Some process supervisors (e.g. Upstart) rely on a process maintaining its PID when sending a SIGHUP. If the process forks, the supervisors can lose track of the worker's PID.

Since the execv happens in the atexit handler, the woker should have stopped successfully at that point and, as far as I can tell, an execv is all that is needed.

Also, since the worker won't restart if stdout is connected to a terminal, you have to use output redirection to preserve output logging (unless you specify --logfile). Therefore, we shouldn't be closing the stdout and stderr file descriptors.
