### PR TITLE
Update tasks.rst

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -176,7 +176,7 @@ add the project directory to the Python path::
 
     import os
     import sys
-    sys.path.append(os.path.dirname(os.path.basename(__file__)))
+    sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
     INSTALLED_APPS = ('myapp', )
 


### PR DESCRIPTION
This is quite perplexing to me, but the following code always seems to return None:

```
os.path.dirname(os.path.basename(__file__))
```

I'm pretty sure this has been in the docs forever and it seemed to work, so I'm baffled why I am the first to discover this. Or maybe it didn't work?

Anyway, assuming I understand this correctly, I've changed it to:

```
sys.path.append(os.path.dirname(os.path.realpath(__file__)))
```

Which seems to actually do what the docs say is intended.
