### PR TITLE
Fix wrong function add_bucket_for_type used by AsyncTaskBucket object

### DIFF
--- a/celery/worker/buckets.py
+++ b/celery/worker/buckets.py
@@ -60,7 +60,7 @@ class AsyncTaskBucket(object):
         try:
             bucket = self.buckets[name]
         except KeyError:
-            bucket = self.add_bucket_for_type(name)
+            bucket = self.add_task_type(name)
         if not bucket:
             return self._quick_put(request)
         return self.cont(request, bucket, 1)


### PR DESCRIPTION
I got `AttributeError: 'AsyncTaskBucket' object has no attribute 'add_bucket_for_type'` today.

According to the source code of `class AsyncTaskBucket(object)` in celery/worker/buckets.py (3.0 branch), line `bucket = self.add_bucket_for_type(name)` smells like a bug caused by the bad auto-complete editor, since class AsyncTaskBucket only has a function named `add_task_type` which starts with 'add_', which causing my new task failed there. So I rename it and it looks like fine then.

It's strange that the line looks like living there for a while, but our old tasks work fine until our new task deployed today.

```
[2013-10-26 12:35:28,683: WARNING/MainProcess] celery@joker ready.
[2013-10-26 12:35:28,692: INFO/MainProcess] consumer: Connected to redis://localhost:6379/1.
[2013-10-26 12:35:28,712: INFO/MainProcess] Got task from broker: biideal.tasks.test_task[13d53950-f611-4fe8-837a-3f562268a0c5]
/*[2013-10-26 12:35:28,713: ERROR/MainProcess] Unrecoverable error: AttributeError("'AsyncTaskBucket' object has no attribute 'add_bucket_for_type'",)*/
Traceback (most recent call last):
  File "/usr/venv/lib/python2.7/site-packages/celery-3.0.24-py2.7.egg/celery/worker/__init__.py", line 404, in start
    component.start()
  File "/usr/venv/lib/python2.7/site-packages/celery-3.0.24-py2.7.egg/celery/worker/consumer.py", line 410, in start
    self.consume_messages()
  File "/usr/venv/lib/python2.7/site-packages/celery-3.0.24-py2.7.egg/celery/worker/consumer.py", line 495, in consume_messages
    readers[fileno](fileno, event)
  File "/usr/venv/lib/python2.7/site-packages/kombu-2.5.16-py2.7.egg/kombu/transport/redis.py", line 771, in handle_event
    self._callbacks[queue](message)
  File "/usr/venv/lib/python2.7/site-packages/kombu-2.5.16-py2.7.egg/kombu/transport/virtual/__init__.py", line 480, in _callback
    return callback(message)
  File "/usr/venv/lib/python2.7/site-packages/kombu-2.5.16-py2.7.egg/kombu/messaging.py", line 585, in _receive_callback
    return on_m(message) if on_m else self.receive(decoded, message)
  File "/usr/venv/lib/python2.7/site-packages/kombu-2.5.16-py2.7.egg/kombu/messaging.py", line 554, in receive
    [callback(body, message) for callback in callbacks]
  File "/usr/venv/lib/python2.7/site-packages/celery-3.0.24-py2.7.egg/celery/worker/consumer.py", line 453, in on_task_received
    strategies[name](message, body, message.ack_log_error)
  File "/usr/venv/lib/python2.7/site-packages/celery-3.0.24-py2.7.egg/celery/worker/strategy.py", line 25, in task_message_handler
    delivery_info=message.delivery_info))
  File "/usr/venv/lib/python2.7/site-packages/celery-3.0.24-py2.7.egg/celery/worker/consumer.py", line 559, in on_task
    self._quick_put(task)
  File "/usr/venv/lib/python2.7/site-packages/celery-3.0.24-py2.7.egg/celery/worker/buckets.py", line 63, in put
    bucket = self.add_bucket_for_type(name)
AttributeError: 'AsyncTaskBucket' object has no attribute 'add_bucket_for_type'
```

My platform info: OS X 10.9 with system Python 2.7.5 inside a virtualenv newly created, working with Pyramid (not using pyramid_celery egg).

```
Python 2.7.5 (default, Aug 25 2013, 00:04:04)
[GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.0.68)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
```

Note: also found same issue on our Ubuntu LTS 12.04 server, and my patch still works.
