### PR TITLE
Feature: Autoretry for task

### DIFF
--- a/celery/task/base.py
+++ b/celery/task/base.py
@@ -11,6 +11,7 @@
 """
 from __future__ import absolute_import
 
+import functools
 from kombu import Exchange
 
 from celery import current_app
@@ -224,3 +225,37 @@ def periodic_task(*args, **options):
 
     """
     return task(**dict({'base': PeriodicTask}, **options))
+
+
+def task_autoretry(*args_task, **kwargs_task):
+    """ This decorator expands behavior of @task decorator by adding
+    automatic task retries on exceptions. `autoretry_on` parameter defines
+    tuple of exceptions, that will be handled. Default value is `Exception`,
+    which means retrying on every exception
+
+        .. admonition:: Examples
+            @task_autoretry(max_retries=5, default_retry_delay=1, autoretry_on=(ZeroDivisionError, IndexError))
+            def foo(a, b):
+                pass
+            @task_autoretry(max_retries=5, default_retry_delay=1, autoretry_on=ZeroDivisionError)
+            def baz(a, b):
+                pass
+    """
+    def real_decorator(func):
+        """
+        Top level wrapper, which use args_task and kwargs_task as params
+        for @task
+        """
+        @task(*args_task, **kwargs_task)
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            """
+            Wrapper, that catch exceptions
+            """
+            try:
+                func(*args, **kwargs)
+            except kwargs_task.get('autoretry_on', Exception), exc:
+                log.exception(exc)
+                wrapper.retry(exc=exc)
+        return wrapper
+    return real_decorator

--- a/celery/task/base.py
+++ b/celery/task/base.py
@@ -240,6 +240,9 @@ def task_autoretry(*args_task, **kwargs_task):
             @task_autoretry(max_retries=5, default_retry_delay=1, autoretry_on=ZeroDivisionError)
             def baz(a, b):
                 pass
+            @task_autoretry(max_retries=5)
+            def bar(a, b):
+                pass
     """
     def real_decorator(func):
         """


### PR DESCRIPTION
Consider the following task:

    @task(max_retries=5, default_retry_delay=1)
    def div(a, b):
        try:
            return a / b
        except ZeroDivisionError, exc:
            raise div.retry(exc=exc)

If we want to retry task on particular exception, we have to put ugly `try-except`s in all our tasks. The code would be much cleaner, if you can tell Celery to retry task automatically. like so:

    @task_autoretry(max_retries=5, default_retry_delay=1, autoretry_on=ZeroDivisionError)
    def div(a, b):
        return a / b

I wrote decorator for this purpose in my own project, and I decided to share it with you. 