### PR TITLE
Fix Batches class to run on 3.1

### DIFF
--- a/celery/contrib/batches.py
+++ b/celery/contrib/batches.py
@@ -90,6 +90,7 @@ from celery.five import Empty, Queue
 from celery.utils.log import get_logger
 from celery.worker.job import Request
 from celery.utils import noop
+from kombu.async.timer import to_timestamp
 
 __all__ = ['Batches']
 


### PR DESCRIPTION
The method signature for task_message_handler changed in version 3.1 and the Batches class needs to have that method signature updated in order to work.
