### PR TITLE
Provide BROKER_FAILOVER_STRATEGY option in Celery.

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -258,7 +258,8 @@ class Celery(object):
     def connection(self, hostname=None, userid=None,
                    password=None, virtual_host=None, port=None, ssl=None,
                    insist=None, connect_timeout=None, transport=None,
-                   transport_options=None, heartbeat=None, **kwargs):
+                   transport_options=None, heartbeat=None,
+                   failover_strategy=None, **kwargs):
         conf = self.conf
         return self.amqp.Connection(
             hostname or conf.BROKER_HOST,
@@ -272,6 +273,7 @@ class Celery(object):
             connect_timeout=self.either(
                 'BROKER_CONNECTION_TIMEOUT', connect_timeout),
             heartbeat=heartbeat,
+            failover_strategy=failover_strategy or conf.BROKER_FAILOVER_STRATEGY,
             transport_options=dict(conf.BROKER_TRANSPORT_OPTIONS,
                                    **transport_options or {}))
     broker_connection = connection

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -67,6 +67,7 @@ NAMESPACES = {
         'CONNECTION_TIMEOUT': Option(4, type='float'),
         'CONNECTION_RETRY': Option(True, type='bool'),
         'CONNECTION_MAX_RETRIES': Option(100, type='int'),
+        'FAILOVER_STRATEGY': Option(None, type='string'),
         'HEARTBEAT': Option(None, type='int'),
         'HEARTBEAT_CHECKRATE': Option(3.0, type='int'),
         'POOL_LIMIT': Option(10, type='int'),

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -818,6 +818,26 @@ Example::
 
 .. setting:: BROKER_TRANSPORT
 
+BROKER_FAILOVER_STRATEGY
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default failover strategy for the broker Connection object. If supplied,
+may map to a key in 'kombu.connection.failover_strategies', or be a reference
+to any method that yields a single item from a supplied list.
+
+Example::
+
+    # Random failover strategy
+    def random_failover_strategy(servers):
+        it = list(it)  # don't modify callers list
+        shuffle = random.shuffle
+        for _ in repeat(None):
+            shuffle(it)
+            yield it[0]
+
+    BROKER_FAILOVER_STRATEGY=random_failover_strategy
+
+
 BROKER_TRANSPORT
 ~~~~~~~~~~~~~~~~
 :Aliases: ``BROKER_BACKEND``


### PR DESCRIPTION
This option allows for either selecting pre-existing kombu.connection
failover strategies, or passing in your own method reference.
