### PR TITLE
fix ImproperlyConfigured raised when django.db.backends.dummy used with ...

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -178,7 +178,10 @@ class DjangoFixup(object):
         try:
             funs = [conn.close for conn in self._db.connections]
         except AttributeError:
-            funs = [self._db.close_connection]  # pre multidb
+            if hasattr(self._db, 'close_old_connections'):  # django 1.6
+                funs = [self._db.close_old_connections]
+            else:
+                funs = [self._db.close_connection]  # pre multidb, pending deprication in django 1.6
 
         for close in funs:
             try:


### PR DESCRIPTION
...django 1.6

Celery worker dies as soon as it's started because `celery.fixups.django.DjangoFixup` calls `django.db.close_connection` (pending deprecation in django 1.6), it's replacement `django.db.close_old_connections` conveniently catches `DatabaseError` so all is good if we use that. https://github.com/django/django/blob/1.6/django/db/__init__.py#L67

As a side note, `conn.close` raises `AttributeError` because a `django.db.backends.dummy` 'connection' doesn't have a close method.
