### PR TITLE
fix old callable with new builtin callable

### DIFF
--- a/celery/utils/dispatch/saferef.py
+++ b/celery/utils/dispatch/saferef.py
@@ -10,8 +10,6 @@ from __future__ import absolute_import
 import weakref
 import traceback
 
-from collections import Callable
-
 __all__ = ['safe_ref']
 
 
@@ -35,7 +33,7 @@ def safe_ref(target, on_delete=None):  # pragma: no cover
             don't know how to create reference""".format(target)
         return get_bound_method_weakref(target=target,
                                         on_delete=on_delete)
-    if isinstance(on_delete, Callable):
+    if callable(on_delete):
         return weakref.ref(target, on_delete)
     else:
         return weakref.ref(target)
@@ -140,7 +138,7 @@ class BoundMethodWeakref(object):  # pragma: no cover
                 pass
             for function in methods:
                 try:
-                    if isinstance(function, Callable):
+                    if callable(function):
                         function(self)
                 except Exception as exc:
                     try:


### PR DESCRIPTION
I was getting errors on Python 2.7.5 after installing celery.

This fixes those errors by replacing old isinstance(foo, collections.Callable) with callable(foo) in the safe weak function reference module

The test suite still passes for me after this change.

```
  File "python2.7/site-packages/celery/utils/dispatch/saferef.py", line 143, in remove
    if isinstance(function, Callable):
  File "python2.7/abc.py", line 144, in __instancecheck__
    return cls.__subclasscheck__(subtype)
  File "python2.7/abc.py", line 165, in __subclasscheck__
    cls._abc_cache.add(subclass)
  File "python2.7/_weakrefset.py", line 84, in add
    self.data.add(ref(item, self._remove))
Exception TypeError: TypeError('isinstance() arg 2 must be a class, type, or tuple of classes and types',) in <function remove at 0x1033dbcf8> ignored
```
