### PR TITLE
Set script name correctly when invoked via sysv-style init

### DIFF
--- a/extra/centos/celeryd
+++ b/extra/centos/celeryd
@@ -28,7 +28,16 @@
 #
 # Setting `prog` here allows you to symlink this init script, making it easy
 # to run multiple processes on the system.
-prog="$(basename $0)"
+
+# If we're invoked via SysV-style runlevel scripts we need to follow the 
+# link from rcX.d before working out the script name.
+if [[ `dirname $0` == /etc/rc*.d ]]; then
+    target="$(readlink $0)"
+else
+    target=$0
+fi
+
+prog="$(basename $target)"
 
 # Source the centos service helper functions
 source /etc/init.d/functions


### PR DESCRIPTION
The CentOS initscript is designed to be symlinked when creating multiple instances. It examines its own filename to determine the name of the instance. However, when invoked via runlevel scripts (i.e. on boot) there's another level of symlinking that breaks this assumption:

```
/etc/init.d/celeryd-helloworld -> /etc/init.d/celeryd
```

instance is named "celeryd-helloworld"

```
/etc/rc2.d/S50celeryd-helloworld -> /etc/init.d/celeryd-helloworld -> /etc/init.d/celeryd
```

instance is named "S50celeryd-helloworld"

Attached pull request fixes this so the instance name is set consistently.
