### PR TITLE
Another unbound local variable as seen in #1684

### DIFF
--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -194,7 +194,7 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
     signature = canvas.maybe_signature  # maybe_ does not clone if already
 
     def trace_task(uuid, args, kwargs, request=None):
-        R = I = retval = None
+        R = I = retval = state = None
         kwargs = kwdict(kwargs)
         try:
             push_task(task)


### PR DESCRIPTION
```
[2013-11-27 23:38:39,167: WARNING/Worker-1] /Users/jokey/.virtualenvs/sampleapp/lib/python2.7/site-packages/celery/app/trace.py:326: RuntimeWarning: Exception raised outside body: UnboundLocalError("local variable 'state' referenced before assignment",):
Traceback (most recent call last):
  File "/Users/jokey/.virtualenvs/sampleapp/lib/python2.7/site-packages/celery/app/trace.py", line 268, in trace_task
    retval=retval, state=state)
UnboundLocalError: local variable 'state' referenced before assignment
```
