### PR TITLE
Custom exception was ignored when exc was specified in retry function

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -650,8 +650,9 @@ class Task(object):
         )
 
         if max_retries is not None and retries > max_retries:
+            maybe_reraise()
             if exc:
-                maybe_reraise()
+                exc()
             raise self.MaxRetriesExceededError(
                 "Can't retry {0}[{1}] args:{2} kwargs:{3}".format(
                     self.name, request.id, S.args, S.kwargs))


### PR DESCRIPTION
retry custom exception was not thrown as written in the documentation.

http://docs.celeryproject.org/en/latest/reference/celery.app.task.html#celery.app.task.Task.retry
