### PR TITLE
Close all file handles on SIGHUP (fixes #1768)

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -315,6 +315,9 @@ else:  # pragma: no cover
 
 
 def _reload_current_worker():
+    platforms.close_open_fds([
+        sys.__stdin__, sys.__stdout__, sys.__stderr__,
+    ])
     os.execv(sys.executable, [sys.executable] + sys.argv)
 
 


### PR DESCRIPTION
This was originally fixed in 803655b79ccb0403f47cfcd2cfa5a6ed66301cbc
but was broken later in 118b300fcad4e6ffb0178fc00cf9fe26075101a5.
