### PR TITLE
parse all options when detached

### DIFF
--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -171,7 +171,7 @@ class worker(Command):
         # parse options before detaching so errors can be handled.
         options, args = self.prepare_args(
             *self.parse_options(prog_name, argv, command))
-        self.maybe_detach([command] + argv)
+        self.maybe_detach([command] + sys.argv[1:])
         return self(*args, **options)
 
     def maybe_detach(self, argv, dopts=['-D', '--detach']):


### PR DESCRIPTION
Issue: 
All command-line options after '--'  are ignored in 'detach mode. 

$ celery worker --detach-n w1  -A myapp -c 8  -- celeryd.prefetch_multiplier=16
[2014-01-09 14:56:10,097: DEBUG/MainProcess] basic.qos: prefetch_count-> 32

$  celery worker --detached -n w1  -A myapp -c 8  -- celeryd.prefetch_multiplier=16
[2014-01-09 14:57:30,766: DEBUG/MainProcess] basic.qos: prefetch_count->128
