### PR TITLE
add celery as a docs build dependency

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,4 @@
 Sphinx
 sphinxcontrib-issuetracker>=0.9
 SQLAlchemy
+celery


### PR DESCRIPTION
sphinx will error out if celery is not installed when running `make html`.
