### PR TITLE
Add units to time_limit description.

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -521,7 +521,7 @@ General
 
 .. attribute:: Task.time_limit
 
-    The hard time limit for this task.  If not set then the workers default
+    The hard time limit, in seconds, for this task.  If not set then the workers default
     will be used.
 
 .. attribute:: Task.soft_time_limit


### PR DESCRIPTION
So readers don't have to hunt for the units for this attribute.
