### PR TITLE
Fix Celerybeat from hanging when using --detach mode after dispatching 1st set of tasks.

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -266,7 +266,8 @@ def _create_pidlock(pidfile):
 if hasattr(os, 'closerange'):
 
     def close_open_fds(keep=None):
-        keep = list(uniq(sorted(filter(None, (
+        # using filter(None) causes 0 to be filtered out too
+        keep = list(uniq(sorted(filter(lambda x: x is not None, (
             maybe_fileno(f) for f in keep or []
         )))))
         maxfd = get_fdmax(default=2048)


### PR DESCRIPTION
The change made in https://github.com/celery/celery/commit/022ee4ade9f7d03f995413212b135fe18451be95
caused file descriptor 0 (usually sys.stdin) not to be included in the list of file descriptors to keep.
Doing a filter(none) apparently removes this number from this list, which somehow causes sys.stdin to be closed.
Changed the logic to be filter(lambda: x is not None) to allow 0 to be included.

FYI if we printed out the results from the close_all_fds() (i.e. disabling the os.closerange() calls and
writing the for loops), here's what we would see:

Celery v3.1.4 (working):

low=-1, high=0
low=0, high=1
low=1, high=2
low=2, high=1024
os.closerange(): low + 1 = 3, high=1024

Celery v3.1.5 (breaking):

low=-1, high=1
os.closerange(): low + 1 = 0, high=1
low=1, high=2
low=2, high=1024
os.closerange(): low + 1 = 3, high=1024

Somehow this behavior caused problems with Celerybeat and the UUID generation for task ID's on Ubuntu v12.04.
Celerybeat upon dispatching a few tasks, sleeping, and waking up again, blocks  while trying to generate a UUID for
If the uuidd daemon is invoked before startup, a socket connection is established and task dispatching occurs normally.  After another wakeup period, no subsequent calls are needed to the UUID socket daemon and read calls to /dev/urandom proceed correctly.  (Given that the Python uuid library only tries to use uuid_get_random() calls, there should only be read attempts to /dev/urandom and not to any socket-based connections.)

The latest current libuuid library on Ubuntu 12.04 also has issues with leaking file descriptors for each
UUID call (https://github.com/karelzak/util-linux/commit/c544aa2c25095e6a4d4fca761eb15c46435086fc).  Also,
the /dev/urandom file descriptors are not closed after reuse, so Celery workers that restart themselves
by os.exec() (https://github.com/karelzak/util-linux/commit/a61cac5b6474494fe5c409b82d09236c45856b07)
could end up maxing out on file descriptors.  The long term fix is that Ubuntu v12.04 should update
to the latest version of util-linux that includes the patches for libuuid.
