### PR TITLE
Update configuration.rst

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1144,6 +1144,11 @@ Result backends caches ready results used by the client.
 This is the total number of results to cache before older results are evicted.
 The default is 5000.
 
+.. note::
+    
+    These results are kept in memory.  Reduce this setting if your Celery is utilizing
+    a large amount of memory.
+
 .. setting:: CELERY_CHORD_PROPAGATES
 
 CELERY_CHORD_PROPAGATES


### PR DESCRIPTION
Clarify that CELERY_MAX_CACHED_RESULTS can greatly affect Celery memory usage.
