### PR TITLE
Fixed basic.publish command in celery amqp program

### DIFF
--- a/celery/bin/amqp.py
+++ b/celery/bin/amqp.py
@@ -175,7 +175,7 @@ class AMQShell(cmd.Cmd):
         'basic.get': Spec(('queue', str),
                           ('no_ack', bool, 'off'),
                           returns=dump_message),
-        'basic.publish': Spec(('msg', Message),
+        'basic.publish': Spec(('msg', str),
                               ('exchange', str),
                               ('routing_key', str),
                               ('mandatory', bool, 'no'),


### PR DESCRIPTION
Example from docs

> basic.publish 'This is a message!' testexchange testkey

fail with

> must be string or read-only character buffer, not Message

After change to str, works good.
