### PR TITLE
glob returns wildcard pattern when no pids have been found

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -292,6 +292,12 @@ check_status () {
 
     local one_failed=
     for pid_file in "$CELERYD_PID_DIR"/*.pid; do
+        if [ ! -r $pid_file ]; then
+            echo "${SCRIPT_NAME} is stopped: no pids were found"
+            one_failed=true
+            break
+        fi
+
         local node=`basename "$pid_file" .pid`
         local pid=`cat "$pid_file"`
         local cleaned_pid=`echo "$pid" | sed -e 's/[^0-9]//g'`


### PR DESCRIPTION
### Description

Status command isn't usable when no workers are running.
### Expected results

Script should give a message about stopped service
### Actual results

Script fails with following message

```
cat: /var/run/celery/*.pid: No such file or directory                                                                 │85597 nobody        1  20    0   228M  2924K kqread 23   1:11  0.00% nginx
bad pid file (/var/run/celery/*.pid) 
```
