### PR TITLE
Handle the 'Z' time zone designator in ISO 8601 time stamps

### DIFF
--- a/celery/tests/utils/test_timeutils.py
+++ b/celery/tests/utils/test_timeutils.py
@@ -66,6 +66,9 @@ class test_iso8601(Case):
         iso2 = iso.replace('+00:00', '+01:00')
         d2 = parse_iso8601(iso2)
         self.assertEqual(d2.tzinfo._minutes, +60)
+        iso3 = iso.replace('+00:00', 'Z')
+        d3 = parse_iso8601(iso3)
+        self.assertEqual(d3.tzinfo, pytz.UTC)
 
 
 class test_timeutils(Case):

--- a/celery/utils/iso8601.py
+++ b/celery/utils/iso8601.py
@@ -59,7 +59,9 @@ def parse_iso8601(datestring):
         raise ValueError('unable to parse date string %r' % datestring)
     groups = m.groupdict()
     tz = groups['timezone']
-    if tz and tz != 'Z':
+    if tz == 'Z':
+      tz = FixedOffset(0)
+    elif tz:
         m = TIMEZONE_REGEX.match(tz)
         prefix, hours, minutes = m.groups()
         hours, minutes = int(hours), int(minutes)


### PR DESCRIPTION
Sending a task message with an eta value using the Z time zone designator currently results in an error such as:

InvalidTaskError: invalid eta value '2014-02-09T02:17:06.007Z': tzinfo argument must be None or of a tzinfo subclass, not type 'str'
