### PR TITLE
docs: add note about chord and result backend

### DIFF
--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -651,6 +651,13 @@ Chords
 
 .. versionadded:: 2.3
 
+.. note::
+
+    Tasks used within a chord must *not* ignore their results. If the result
+    backend is disabled for *any* task (header or body) in your chord you
+    should read ":ref:`chord-important-notes`".
+    
+
 A chord is a task that only executes after all of the tasks in a group have
 finished executing.
 


### PR DESCRIPTION
Added a note at the beginning of the chord to point at the necessity to enable result backend for tasks inside a chord.

Proof of stupidity/lack of clarity in the docs/RTFM: #1857
