### PR TITLE
Fix `UnicodeEncodeError` exception when managed by `supervisord`

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -165,10 +165,10 @@ class Worker(WorkController):
 
         # Dump configuration to screen so we have some basic information
         # for when users sends bug reports.
-        print(''.join([
+        print(safe_str(''.join([
             string(self.colored.cyan(' \n', self.startup_info())),
             string(self.colored.reset(self.extra_info() or '')),
-        ]), file=sys.__stdout__)
+        ])), file=sys.__stdout__)
         self.set_process_status('-active-')
         self.install_platform_tweaks(self)
 


### PR DESCRIPTION
When using `celery` with `supervisord` in Fedora 19(Schrödinger's cat), the `startup_info` contains unicode characters and causes failure in startup:

`UnicodeEncodeError: 'ascii' codec can't encode character u'\xf6' in position 138: ordinal not in range(128)`

I think it has something to do with `supervisord`'s redirection of `stdout` to local files. Anyway, a simple wrap of `safe_str` will fix the problem.
