### PR TITLE
worker.heartbeat: Update 'interval' doc default to 2 seconds

### DIFF
--- a/celery/worker/heartbeat.py
+++ b/celery/worker/heartbeat.py
@@ -22,7 +22,7 @@ class Heart(object):
     :param timer: Timer instance.
     :param eventer: Event dispatcher used to send the event.
     :keyword interval: Time in seconds between heartbeats.
-                       Default is 30 seconds.
+                       Default is 2 seconds.
 
     """
 


### PR DESCRIPTION
Since the 30-second docs were written in 3eaffda (Hartbeat is now 30 seconds,
but documented as 2 minutes, 2011-06-13), the default has changed twice:
- It was reduced to 5 seconds by 387cf1c (Heartbeat frequency now
  every 5s, and frequency sent with event, 2012-03-28).
- It was reduced to 2 seconds by 6008303 (Persist clock value and
  synchronize revoked tasks with others, 2012-11-05).
