### PR TITLE
events.state: Default to 1000 tasks in memory

### DIFF
--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -393,7 +393,7 @@ class State(object):
 
     def __init__(self, callback=None,
                  workers=None, tasks=None, taskheap=None,
-                 max_workers_in_memory=5000, max_tasks_in_memory=10000,
+                 max_workers_in_memory=5000, max_tasks_in_memory=1000,
                  on_node_join=None, on_node_leave=None):
         self.event_callback = callback
         self.workers = (LRUCache(max_workers_in_memory)


### PR DESCRIPTION
The previous default was a _lot_, and responsible for up to 500 MB of
memory usage per worker MainProcess - this caused memory pressure on
our production boxes.  I now know we can turn this off with
`--without-gossip`, but lowering this by an order of magnitude be a lot
nicer to everyone who doesn't specify this optional flag.
