### PR TITLE
ClassTask: a metaclass that turns any generic class into a celery task

### DIFF
--- a/celery/contrib/classtask.py
+++ b/celery/contrib/classtask.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+"""
+celery.contrib.classtask
+========================
+
+Metaclass that supports creating tasks out of classes.
+
+Use of this metaclass turns a class and its subclasses into a celery task. With
+minimal differences, the task behaves similarly to a task created by the
+`app.task` function decorator.
+
+
+Key Concepts
+------------
+
+* This metaclass makes instance initialization "lazy".  That is, the
+  conventional python object instantiation process is intercepted, and
+  :meth:`__init__` is explicitly _not_ called.  This delayed _initialization_ of
+  the instance object prevents unnecessary work being done in the synchronous
+  process.
+* References to the `args` and `kwargs` given to __init__ are held by the
+  instance object. They are passed as parameters in the `task` message to fully
+  initialize the class in the external process.
+* After class instantiation, :meth:`enqueue` may be called on the instance
+  object analogously to :meth:`delay` or :meth:`apply_async`. :meth:`enqueue`
+  takes no `args` or `kwargs`. It does however accept the same `options` as
+  :meth:`apply_async`.
+
+
+Use
+---
+
+1) Add `__metaclass__ = ClassTask` to the class definition. Among other
+   things, your class is now a subclass of :class:`ClassTaskBase`.
+2) Override the :meth:`run` method.  This code, along with whatever code
+   is in :meth:`__init__`, will be executed by the external process.
+3) To use your class, instantiate it as normal--i.e.
+   `my_instance = MyClass(*args, **kwargs)`. Then call :meth:`enqueue` on the
+   instantiated object--i.e. `my_instance.enqueue()`. The code in
+   :meth:`__init__` is *not* ran in-process, but rather delayed for the external
+   process to run.
+4) If for some reason you need MyClass initialized in-process, call :meth:`init`
+   on the instance object--i.e. `my_instance.init()`.  In this case, the
+   :meth:`__init__` code will run both in-process *and* in the external process.
+5) One method decorator is provided as auxiliary to this metaclass.
+   If a method is decorated with :decorator:`auto_init`, that method can
+   be accessed without first calling :meth:`init`, and :meth:`init` will
+   _automatically_ be called if :meth:`__init__` has not been ran on the
+   instance object already.
+6) Access to any :decorator:`staticmethod` or :decorator:`classmethod` is
+   allowed even if :meth:`__init__` hasn't been called on the instance.
+
+
+Metaclass Strategy
+------------------
+
+* The metaclass fundamentally delays execution of :meth"`__init__`, and it
+  stores the `args` and `kwargs` passed to the class callable as references
+  :attr:`_args` and :attr:`_kwargs` on the new instance object.
+* The metaclass ensures that the class is a subclass of :class:`ClassTaskBase`
+  which in turn is a subclass of :class:`celery.Task`.  :class:`ClassTaskBase`
+  adds the additional methods (like enqueue and run_async) necessary to turn a
+  generic class into a celery task.
+* Any attributes that might be "dangerous" to call before :meth:`__init__` is
+  called are wrapped to throw a runtime error if :meth:`__init__` is not called
+  before the attribute.  The "dangerous" attributes are any public bound
+  methods (those that do not begin with an underscore), and any
+  :decorator:`@properties`.
+
+"""
+from __future__ import absolute_import
+
+from functools import wraps
+import itertools
+
+from celery import current_app, Task
+from celery.app.task import TaskType
+from celery.local import Proxy
+
+
+__all__ = ['ClassTask', 'auto_init']
+
+
+class ClassTask(TaskType):
+    """A metaclass to enable asynchronous execution of any class.
+
+    Examples:
+        >>> class Math(object):
+        ...     __metaclass__ = ClassTask
+        ...     def __init__(self, a, b):
+        ...         self.a = a
+        ...         self.b = b
+        ...     def run(self):
+        ...         return self.mult() * 2
+        ...     def mult(self):
+        ...         return self.a * self.b
+        >>> b = Math(4, 2)
+        >>> b.mult()  # doctest:+ELLIPSIS
+        Traceback (most recent call last):
+        ...
+        AttributeError: The instance object <@task: async.Math of ttam:...> has not yet been initialized...
+        >>> b.init().mult()
+        8
+        >>> b.enqueue().get()
+        16
+
+    """
+
+    class ClassTaskBase(Task):
+
+        def init(self):
+            """Public method to explicitly call :meth:`__init__` on the instance
+            object.
+
+            :throws AttributeError: When the instance has already been
+                                    initialized.
+            """
+            if not self._initialized:
+                self.__init__(*self._args, **self._kwargs)
+                self._initialized = True
+            else:
+                # only initialize once. this is a safety precaution. if this
+                # error is thrown, you're doing something wrong.  perhaps at
+                # some point, this should be changed to simply logging an error
+                # rather than throwing a runtime exception
+                raise AttributeError("{} has already been initialized.\n"
+                                     "  args: {}\n"
+                                     "  kwargs: {}".format(self.__class__.__name__,
+                                                           self._args,
+                                                           self._kwargs))
+            return self  # return self to allow call chaining
+
+        def enqueue(self, **options):
+            """Used to execute the instance object. Analagous to :meth:`delay`
+            and :meth:`apply_async`, but takes only the optional control
+            arguments given to :meth:`apply_async`.  Any `args` and `kwargs`
+            needed for execution should have been passed on object
+            instantiation.
+            """
+            return self.apply_async(self._args, self._kwargs, **options)
+
+        def __call__(self, *args, **kwargs):
+            # override to instantiate class object, then init and run
+            return self.__class__(*args, **kwargs).init().run()
+
+        def apply_async(self, args=None, kwargs=None, task_id=None,
+                        producer=None, link=None, link_error=None, **options):
+            # override to pull _args and _kwargs off of the instance object
+            # args and kwargs are ignored
+            _apl_as = super(ClassTask.ClassTaskBase, self).apply_async
+            return _apl_as(self._args, self._kwargs, task_id, producer, link,
+                           link_error, **options)
+
+        def apply(self, args=None, kwargs=None, link=None, link_error=None,
+                  **options):
+            # override to pull _args and _kwargs off of the instance object
+            _apl = super(ClassTask.ClassTaskBase, self).apply
+            return _apl(self._args, self._kwargs, link, link_error, **options)
+
+        def retry(self, args=None, kwargs=None, exc=None, throw=True, eta=None,
+                  countdown=None, max_retries=None, **options):
+            # override to pull _args and _kwargs off of the instance object
+            _retry = super(ClassTask.ClassTaskBase, self).retry
+            return _retry(self._args, self._kwargs, exc, throw, eta, countdown,
+                          max_retries, **options)
+
+        def subtask_from_request(self, request=None, args=None, kwargs=None,
+                                 **extra_options):
+            # override to pull _args and _kwargs off of the instance object
+            _sfr = super(ClassTask.ClassTaskBase, self).subtask_from_request
+            return _sfr(request, args=self._args, kwargs=self._kwargs,
+                        **extra_options)
+
+        @classmethod
+        def get_task(cls):
+            return cls._app.tasks[cls.name]
+
+
+    @staticmethod
+    def _ensure_init(attr):
+        # wrapper (i.e. decorator) for methods and properties to make sure
+        #   __init__ gets called before use
+        # decided throwing an explicit runtime error is safer than guessing
+        #  whether a method is designed to be public or private (in theory, any
+        #  public method could auto-initialize the class)
+        def wrapper(self, *args, **kwargs):
+            if not self._initialized:
+                raise AttributeError("The instance object {} has not yet been "
+                                     "initialized. Either call .init() on the "
+                                     "object, or decorate the attribute being "
+                                     "accessed with @allow_access or "
+                                     "@initialize_class. WARNING: Using these "
+                                     "decorated methods within __init__ can "
+                                     "blow the stack.".format(repr(self)))
+            return attr(self, *args, **kwargs)
+        return wrapper
+
+    def __new__(mcs, name, bases, attrs):
+        # get names of all classes and inherited classes in bases
+        mro_list = [kls.__name__ for kls in
+                    itertools.chain(*[type.mro(base) for base in bases])]
+
+        # if ClassTaskBase is not in the mro_set, add it now
+        #  (prepended to make it a mixin)
+        if ClassTask.ClassTaskBase.__name__ not in set(mro_list):
+            bases = (ClassTask.ClassTaskBase, ) + bases
+
+        # for now, all ClassTasks are bound
+        attrs.pop('bind', None)
+
+        # make sure app is set
+        app = attrs.pop('_app', None) or attrs.pop('app', None)
+        if not isinstance(app, Proxy) and app is None:
+            app = current_app
+        attrs['_app'] = app
+
+        # now a standard create of the class object
+        clsobj = super(ClassTask, mcs).__new__(mcs, name, bases, attrs)
+
+        # flag that marks if init() has been called on the instance
+        clsobj._initialized = False
+
+        # wrap public methods and @properties with _ensure_init
+        dont_wrap = ('enqueue', 'init', 'apply_async', 'apply', 'retry',
+                     'subtask_from_request')
+        for key, value in vars(clsobj).iteritems():
+            if not key.startswith('_'):
+                if callable(value) and not (hasattr(value, '_auto_init')
+                                            or key in dont_wrap
+                                            or isinstance(value, staticmethod)
+                                            or isinstance(value, classmethod)):
+                    setattr(clsobj, key, ClassTask._ensure_init(value))
+                elif isinstance(value, property):  # for class @properties
+                    setattr(clsobj, key, property(ClassTask._ensure_init(value.__get__),
+                                                  value.__set__, value.__delattr__))
+        return clsobj
+
+    def __call__(cls, *args, **kwargs):
+        instance = cls.__new__(cls, *args, **kwargs)
+        instance._args = args      # hold reference to args and kwargs
+        instance._kwargs = kwargs  # on class instance
+        return instance  # NOTE: __init__ is not called
+
+
+def auto_init(attr):
+    """A decorator for class attributes that guarantees :meth:`__init__` is
+    called once (and only once) prior to the attribute being accessed.
+    """
+    @wraps(attr)
+    def wrapper(self, *args, **kwargs):
+        if not self._initialized:
+            self.init()
+        return attr(self, *args, **kwargs)
+    wrapper._auto_init = True
+    return wrapper

--- a/celery/tests/contrib/test_classtask.py
+++ b/celery/tests/contrib/test_classtask.py
@@ -1,0 +1,174 @@
+from __future__ import absolute_import
+
+from celery.contrib.classtask import ClassTask
+from celery.five import with_metaclass
+from celery.result import EagerResult
+from celery.tests.case import AppCase
+from celery.utils import uuid
+
+
+class ClassTasksCase(AppCase):
+
+    def setup(self):
+
+        self.app.set_current()
+
+        @with_metaclass(ClassTask)
+        class IncrementCounter(object):
+            count = 0
+            shared = False
+
+            def __init__(self, increment_by=1):
+                self.increment_by = increment_by
+
+            def run(self):
+                IncrementCounter.count += self.increment_by or 1
+                return IncrementCounter.count
+        self.IncrementCounter = IncrementCounter
+
+        @with_metaclass(ClassTask)
+        class Raising(object):
+            shared = False
+            def run(self):
+                raise KeyError('foo')
+        self.Raising = Raising
+
+        @with_metaclass(ClassTask)
+        class RetryTask(object):
+            iterations = 0
+            shared = False
+            max_retries = 3
+
+            def __init__(self, arg1, arg2, kwarg=1, max_retries=None, care=True):
+                self.rmax = self.max_retries if max_retries is None else max_retries
+                self.care = care
+                self.arg1 = arg1
+                self.arg2 = arg2
+                self.kwarg = kwarg
+
+            def run(self):
+                self.get_task().iterations += 1
+                assert repr(self.request)
+                retries = self.request.retries
+                if self.care and retries >= self.rmax:
+                    return self.arg1
+                else:
+                    raise self.retry(countdown=0, max_retries=self.rmax)
+        self.RetryTask = RetryTask
+
+        @with_metaclass(ClassTask)
+        class RetryTaskNoargs(object):
+            max_retries = 3
+            iterations = 0
+            shared = False
+
+            def __init__(self):
+                pass
+
+            def run(self):
+                self.get_task().iterations += 1
+                if self.request.retries >= 3:
+                    return 42
+                else:
+                    raise self.retry(countdown=0)
+        self.RetryTaskNoargs = RetryTaskNoargs
+
+
+
+class test_task_retries(ClassTasksCase):
+
+    def test_retry(self):
+        self.RetryTask.max_retries = 3
+        self.RetryTask.get_task().iterations = 0
+        self.RetryTask(0xFF, 0xFFFF).apply()
+        self.assertEqual(self.RetryTask.get_task().iterations, 4)
+
+        self.RetryTask.max_retries = 3
+        self.RetryTask.get_task().iterations = 0
+        self.RetryTask(0xFF, 0xFFFF, max_retries=10).apply()
+        self.assertEqual(self.RetryTask.get_task().iterations, 11)
+
+    def test_retry_no_args(self):
+        self.RetryTaskNoargs.max_retries = 3
+        self.RetryTaskNoargs.get_task().iterations = 0
+        self.RetryTaskNoargs().apply(propagate=True).get()
+        self.assertEqual(self.RetryTaskNoargs.get_task().iterations, 4)
+
+    def test_max_retries_exceeded_Retry(self):
+        self.RetryTask.max_retries = 2
+        self.RetryTask.get_task().iterations = 0
+        result = self.RetryTask(*[0xFF, 0xFFFF], care=False).apply()
+        with self.assertRaises(self.RetryTask.MaxRetriesExceededError):
+            result.get()
+        self.assertEqual(self.RetryTask.get_task().iterations, 3)
+
+        self.RetryTask.max_retries = 1
+        self.RetryTask.get_task().iterations = 0
+        result = self.RetryTask(*[0xFF, 0xFFFF], **{'care': False}).apply()
+        with self.assertRaises(self.RetryTask.MaxRetriesExceededError):
+            result.get()
+        self.assertEqual(self.RetryTask.get_task().iterations, 2)
+
+
+class test_canvas_utils(ClassTasksCase):
+
+    def test_si(self):
+        self.assertTrue(self.RetryTask().si())
+        self.assertTrue(self.RetryTask().si().immutable)
+
+    def test_chunks(self):
+        self.assertTrue(self.RetryTask().chunks(range(100), 10))
+
+    def test_map(self):
+        self.assertTrue(self.RetryTask().map(range(100)))
+
+    def test_starmap(self):
+        self.assertTrue(self.RetryTask().starmap(range(100)))
+
+    def test_on_success(self):
+        self.RetryTask().on_success(1, 1, (), {})
+
+
+class test_tasks(ClassTasksCase):
+
+    def test_AsyncResult(self):
+        task_id = uuid()
+        result = self.RetryTask().AsyncResult(task_id)
+        self.assertEqual(result.backend, self.RetryTask().backend)
+        self.assertEqual(result.id, task_id)
+
+
+class test_apply_task(ClassTasksCase):
+
+    def test_apply_throw(self):
+        with self.assertRaises(KeyError):
+            self.Raising().apply(throw=True)
+
+    def test_apply_with_CELERY_EAGER_PROPAGATES_EXCEPTIONS(self):
+        self.app.conf.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
+        with self.assertRaises(KeyError):
+            self.Raising().apply()
+
+    def test_apply(self):
+        self.IncrementCounter.count = 0
+
+        e = self.IncrementCounter(2).apply()
+        self.assertIsInstance(e, EagerResult)
+        self.assertEqual(e.get(), 2)
+
+        e = self.IncrementCounter().apply()
+        self.assertEqual(e.get(), 3)
+
+        e = self.IncrementCounter(increment_by=3).apply()
+        self.assertEqual(e.get(), 6)
+
+        self.assertTrue(e.successful())
+        self.assertTrue(e.ready())
+        self.assertTrue(repr(e).startswith('<EagerResult:'))
+
+        f = self.Raising().apply()
+        self.assertTrue(f.ready())
+        self.assertFalse(f.successful())
+        self.assertTrue(f.traceback)
+        with self.assertRaises(KeyError):
+            f.get()

--- a/celery/tests/contrib/test_classtask.py
+++ b/celery/tests/contrib/test_classtask.py
@@ -1,10 +1,30 @@
 from __future__ import absolute_import
 
+from datetime import datetime, timedelta
+
+from kombu import Queue
+
+from celery import Task
+
 from celery.contrib.classtask import ClassTask
-from celery.five import with_metaclass
+from celery.exceptions import Retry
+from celery.five import items, string_t, with_metaclass
 from celery.result import EagerResult
-from celery.tests.case import AppCase
 from celery.utils import uuid
+from celery.utils.timeutils import parse_iso8601
+
+from celery.tests.case import AppCase, depends_on_current_app, patch
+
+@with_metaclass(ClassTask)
+class MockApplyTask(object):
+    abstract = True
+    applied = 0
+
+    def run(self):
+        return self.x * self.y
+
+    def apply_async(self, *args, **kwargs):
+        self.applied += 1
 
 
 class ClassTasksCase(AppCase):
@@ -12,6 +32,18 @@ class ClassTasksCase(AppCase):
     def setup(self):
 
         self.app.set_current()
+
+        @with_metaclass(ClassTask)
+        class MyTask(object):
+            shared = False
+
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+            def run(self):
+                return True
+        self.MyTask = MyTask
 
         @with_metaclass(ClassTask)
         class IncrementCounter(object):
@@ -73,26 +105,115 @@ class ClassTasksCase(AppCase):
                     raise self.retry(countdown=0)
         self.RetryTaskNoargs = RetryTaskNoargs
 
+        class RetryTaskMockapply(MockApplyTask):
+            max_retries = 3
+            iterations = 0
+            shared = False
+
+            def __init__(self, arg1, arg2, kwarg=1):
+                self.arg1 = arg1
+                self.arg2 = arg2
+                self.kwarg = kwarg
+
+            def run(self):
+                self.get_task().iterations += 1
+
+                retries = self.request.retries
+                if retries >= 3:
+                    return self.arg1
+                raise self.retry(countdown=0)
+        self.RetryTaskMockapply = RetryTaskMockapply
+
+        @with_metaclass(ClassTask)
+        class RetryTaskCustomexc(object):
+            max_retries = 3
+            iterations = 0
+            shared = False
+
+            def __init__(self, arg1, arg2, kwarg=1, **kwargs):
+                self.arg1 = arg1
+                self.arg2 = arg2
+                self.kwarg = kwarg
+                self.kwargs = kwargs
+
+            def run(self):
+                self.get_task().iterations += 1
+
+                retries = self.request.retries
+                if retries >= 3:
+                    return self.arg1 + self.kwarg
+                else:
+                    try:
+                        raise MyCustomException('Elaine Marie Benes')
+                    except MyCustomException as exc:
+                        self.kwargs.update(kwarg=self.kwarg)
+                        raise self.retry(countdown=0, exc=exc)
+        self.RetryTaskCustomexc = RetryTaskCustomexc
+
+
+class MyCustomException(Exception):
+    """Random custom exception."""
+
 
 
 class test_task_retries(ClassTasksCase):
 
     def test_retry(self):
-        self.RetryTask.max_retries = 3
         self.RetryTask.get_task().iterations = 0
         self.RetryTask(0xFF, 0xFFFF).apply()
         self.assertEqual(self.RetryTask.get_task().iterations, 4)
 
-        self.RetryTask.max_retries = 3
+        self.RetryTask.get_task().max_retries = 3
         self.RetryTask.get_task().iterations = 0
         self.RetryTask(0xFF, 0xFFFF, max_retries=10).apply()
         self.assertEqual(self.RetryTask.get_task().iterations, 11)
 
     def test_retry_no_args(self):
-        self.RetryTaskNoargs.max_retries = 3
         self.RetryTaskNoargs.get_task().iterations = 0
         self.RetryTaskNoargs().apply(propagate=True).get()
         self.assertEqual(self.RetryTaskNoargs.get_task().iterations, 4)
+
+    def test_retry_kwargs_can_be_empty(self):
+        this_task = self.RetryTaskMockapply(4, 4)
+        this_task.push_request()
+        try:
+            with self.assertRaises(Retry):
+                this_task.retry()
+        finally:
+            this_task.pop_request()
+
+    def test_retry_not_eager(self):
+        this_task = self.RetryTaskMockapply(4, 4)
+        this_task.push_request()
+        try:
+            this_task.request.called_directly = False
+            exc = Exception('baz')
+            try:
+                this_task.retry(exc=exc, throw=False)
+                self.assertTrue(this_task.applied)
+            finally:
+                this_task.applied = 0
+
+            try:
+                with self.assertRaises(Retry):
+                    this_task.retry(exc=exc, throw=True)
+                self.assertTrue(this_task.applied)
+            finally:
+                this_task.applied = 0
+        finally:
+            this_task.pop_request()
+
+    def test_retry_with_kwargs(self):
+        self.RetryTaskCustomexc(*[0xFF, 0xFFFF], **{'kwarg': 0xF}).apply()
+        self.assertEqual(self.RetryTaskCustomexc.get_task().iterations, 4)
+
+    def test_retry_with_custom_exception(self):
+        self.RetryTaskCustomexc.max_retries = 2
+        result = self.RetryTaskCustomexc(*[0xFF, 0xFFFF],
+                                         **{'kwarg': 0xF}).apply()
+        with self.assertRaises(MyCustomException):
+            result.get()
+        self.assertEqual(self.RetryTaskCustomexc.get_task().iterations, 3)
 
     def test_max_retries_exceeded_Retry(self):
         self.RetryTask.max_retries = 2
@@ -129,13 +250,203 @@ class test_canvas_utils(ClassTasksCase):
         self.RetryTask().on_success(1, 1, (), {})
 
 
+@with_metaclass(ClassTask)
+class Xxx(object):
+    shared = True
+
+    def run(self):
+        pass
+
 class test_tasks(ClassTasksCase):
+
+    def now(self):
+        return self.app.now()
+
+    @depends_on_current_app
+    def test_unpickle_task(self):
+        import pickle
+        self.assertIs(pickle.loads(pickle.dumps(Xxx())), Xxx.app.tasks[Xxx.name])
 
     def test_AsyncResult(self):
         task_id = uuid()
         result = self.RetryTask().AsyncResult(task_id)
         self.assertEqual(result.backend, self.RetryTask().backend)
         self.assertEqual(result.id, task_id)
+
+    def assertNextTaskDataEqual(self, consumer, presult, task_name,
+                                test_eta=False, test_expires=False, **kwargs):
+        next_task = consumer.queues[0].get(accept=['pickle'])
+        task_data = next_task.decode()
+        self.assertEqual(task_data['id'], presult.id)
+        self.assertEqual(task_data['task'], task_name)
+        task_kwargs = task_data.get('kwargs', {})
+        if test_eta:
+            self.assertIsInstance(task_data.get('eta'), string_t)
+            to_datetime = parse_iso8601(task_data.get('eta'))
+            self.assertIsInstance(to_datetime, datetime)
+        if test_expires:
+            self.assertIsInstance(task_data.get('expires'), string_t)
+            to_datetime = parse_iso8601(task_data.get('expires'))
+            self.assertIsInstance(to_datetime, datetime)
+        for arg_name, arg_value in items(kwargs):
+            self.assertEqual(task_kwargs.get(arg_name), arg_value)
+
+    def test_incomplete_task_cls(self):
+
+        @with_metaclass(ClassTask)
+        class IncompleteTask(object):
+            app = self.app
+            name = 'c.unittest.t.itask'
+
+        with self.assertRaises(NotImplementedError):
+            IncompleteTask().run()
+
+    def test_regular_task(self):
+        self.assertIsInstance(self.MyTask(), Task)
+        self.assertTrue(self.MyTask().init().run())
+        self.assertTrue(
+            callable(self.MyTask()), 'Task class is callable()',
+        )
+        self.assertTrue(self.MyTask(), 'Task class runs run() when called')
+
+        with self.app.connection_or_acquire() as conn:
+            consumer = self.app.amqp.TaskConsumer(conn)
+            with self.assertRaises(NotImplementedError):
+                consumer.receive('foo', 'foo')
+            consumer.purge()
+            self.assertIsNone(consumer.queues[0].get())
+            self.app.amqp.TaskConsumer(conn, queues=[Queue('foo')])
+
+            # Without arguments.
+            presult = self.MyTask().delay()
+            self.assertNextTaskDataEqual(consumer, presult, self.MyTask.name)
+
+            # With arguments.
+            presult2 = self.MyTask(name='George Costanza 1').apply_async()
+            self.assertNextTaskDataEqual(
+                consumer, presult2, self.MyTask.name, name='George Costanza 1',
+            )
+
+            # send_task
+            sresult = self.app.send_task(self.MyTask.name,
+                                         kwargs=dict(name='Elaine M. Benes'))
+            self.assertNextTaskDataEqual(
+                consumer, sresult, self.MyTask.name, name='Elaine M. Benes',
+            )
+
+            # With eta.
+            eta_task = self.MyTask(name='George Costanza 2')
+            eta_eta=self.now() + timedelta(days=1)
+            eta_expires=self.now() + timedelta(days=2)
+            presult2 = eta_task.apply_async(eta=eta_eta, expires=eta_expires)
+            self.assertNextTaskDataEqual(
+                consumer, presult2, self.MyTask.name,
+                name='George Costanza 2', test_eta=True, test_expires=True,
+            )
+
+            # With countdown.
+            presult2 = self.MyTask(name='George Costanza 3').apply_async(
+                countdown=10, expires=12,
+            )
+            self.assertNextTaskDataEqual(
+                consumer, presult2, self.MyTask.name,
+                name='George Costanza 3', test_eta=True, test_expires=True,
+            )
+
+            # Discarding all tasks.
+            consumer.purge()
+            self.MyTask().apply_async()
+            self.assertEqual(consumer.purge(), 1)
+            self.assertIsNone(consumer.queues[0].get())
+
+            self.assertFalse(presult.successful())
+            self.MyTask().backend.mark_as_done(presult.id, result=None)
+            self.assertTrue(presult.successful())
+
+    def test_repr_v2_compat(self):
+        self.MyTask.get_task().__v2_compat__ = True
+        self.assertIn('v2 compatible', repr(self.MyTask.get_task()))
+
+    def test_context_get(self):
+        this_task = self.MyTask()
+        this_task.push_request()
+        try:
+            request = this_task.request
+            request.foo = 32
+            self.assertEqual(request.get('foo'), 32)
+            self.assertEqual(request.get('bar', 36), 36)
+            request.clear()
+        finally:
+            this_task.pop_request()
+
+    def test_task_class_repr(self):
+        self.assertIn('class Task of', repr(self.MyTask.app.Task))
+        self.MyTask.app.Task._app = None
+        self.assertIn('unbound', repr(self.MyTask.app.Task, ))
+
+    def test_bind_no_magic_kwargs(self):
+        self.MyTask.accept_magic_kwargs = None
+        self.MyTask.bind(self.MyTask.app)
+
+    def test_annotate(self):
+        with patch('celery.app.task.resolve_all_annotations') as anno:
+            anno.return_value = [{'FOO': 'BAR'}]
+            @with_metaclass(ClassTask)
+            class ThisTask(object):
+                shared = False
+
+                def run(self):
+                    pass
+
+            ThisTask.annotate()
+            self.assertEqual(ThisTask.FOO, 'BAR')
+
+    def test_after_return(self):
+        this_task = self.MyTask()
+        this_task.push_request()
+        try:
+            this_task.request.chord = this_task.s()
+            this_task.after_return('SUCCESS', 1.0, 'foobar', (), {}, None)
+            this_task.request.clear()
+        finally:
+            this_task.pop_request()
+
+    def test_update_state(self):
+        @with_metaclass(ClassTask)
+        class Yyy(object):
+            shared = False
+
+            def run(self):
+                pass
+
+        yyy = Yyy()
+        yyy.push_request()
+        try:
+            tid = uuid()
+            yyy.update_state(tid, 'FROBULATING', {'fooz': 'baaz'})
+            self.assertEqual(yyy.AsyncResult(tid).status, 'FROBULATING')
+            self.assertDictEqual(yyy.AsyncResult(tid).result, {'fooz': 'baaz'})
+
+            yyy.request.id = tid
+            yyy.update_state(state='FROBUZATING', meta={'fooz': 'baaz'})
+            self.assertEqual(yyy.AsyncResult(tid).status, 'FROBUZATING')
+            self.assertDictEqual(yyy.AsyncResult(tid).result, {'fooz': 'baaz'})
+        finally:
+            yyy.pop_request()
+
+    def test_repr(self):
+        @with_metaclass(ClassTask)
+        class task_test_repr(object):
+            shared = False
+
+        self.assertIn('task_test_repr', repr(task_test_repr()))
+
+    def test_has___name__(self):
+        @with_metaclass(ClassTask)
+        class yyy2(object):
+            shared = False
+
+        self.assertTrue(yyy2.__name__)
 
 
 class test_apply_task(ClassTasksCase):


### PR DESCRIPTION
I would like to submit this pull request for _feedback only_ right now, with the possibility of merging into `celery:master` after further work. It is not currently ready to integrate into the celery code base (although as you'll see, all tests pass and I don't think it would create any issues).

My objective here was to create some type of class modifier (mixin, decorator, metaclass, etc) that turned the _entire_ class into a task.  A small example might best illustrate what I want.

```
class WelcomeEmail(ClassTaskMixin, EmailBase):

    def __init__(self, recipient_address, template_name, template_context):
        self.recipient_address = recipient_address
        self.template_name = template_name
        self.template_context = template_context

   def send(self):
       self.render_templates()
       self.construct_mime()
       self.archive_to_db()
       return self.send_smtp_email()

   def run(self):
       return self.send()
```

The `WelcomeEmail` class would then be used as

```
we = WelcomeEmail(recipient_address, template_name, template_context)
we.enqueue()
```

where the `enqueue` method is provided by `ClassTaskMixin` and is analogous to the celery `delay` or `apply_async`.  Here, since the `run` method redirects to `send`, `enqueue` would simply send the email in the asynchronous process.

It's important to note that one of my goals was/is **delayed initialization of the instance object**.  That is, the python standard call to `__init__` should be "lazy" and **not** called when the instance is created.  This is important.  With a _lazy_ `__init__`, the user need not worry about "heavy" and duplicitous work being done in `__init__` (duplicitous because without lazy `__init__` the work would be done in both the synchronous and worker processes).  In the `WelcomeEmail` example, the coder may have for whatever reason put the calls to `render_templates` and `construct_mime` within `__init__`; and here, calling `render_templates` and `construct_mime` in the synchronous process is wasteful.

Now, I am aware of `celery.contrib.methods`, and after the above explanation, you can see that what I'm after is a bit more extensive.

I believe the pull request I am submitting here accomplishes my goals.  Rather than a class mixin, it was necessary to create a metaclass to accomplish the lazy initialization.  The two files in this pull request contain the `ClassTask` metaclass and a retrofitting of the first 12 of 32 tests for `celery.Task` (in `celery/tests/tasks/test_tasks.py`)

I am _very_ much interested in community input.  This code will likely be used in production for my employer.  And if the community thinks this might be more broadly useful, I am happy to contribute it to the celery library.

Some questions to start with...
1) Are there better/more direct ways to test the `ClassTask` code than be retrofitting/duplicating what's in `celery/tests/tasks/test_tasks.py`?
2) For the methods in `ClassTaskBase` that are almost nearly just a call to `super` (_i.e._ `apply_async`, `apply`, `retry`, etc.), is there a better way to avoid the wrote code?  My guess is there will be even more of these methods once I work through all of the applicable unit tests.
3) Any general comments/critiques/criticisms/questions/insights to help me make this code better?
