### PR TITLE
add nose-cov to test requirements

### DIFF
--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,6 +1,4 @@
-coverage>=3.0
 coveralls
-redis
 #pymongo
 #SQLAlchemy
 PyOpenSSL

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,5 @@
 unittest2>=0.5.1
 nose
+coverage>=3.0
 mock>=1.0.1
+redis


### PR DESCRIPTION
Calculating coverage using nose--[as documented](http://docs.celeryproject.org/en/master/contributing.html#calculating-test-coverage)--requires the `nose-cov` package.  There is no indication of the additional package requirement beyond `requirements/test.txt` in the documentation.  Adding `nose-cov` to `requirements/test.txt` seems appropriate.
