### PR TITLE
Configuration to disable auto-declare queues in worker

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -170,6 +170,7 @@ NAMESPACES = {
         'AUTOSCALER': Option('celery.worker.autoscale:Autoscaler'),
         'AUTORELOADER': Option('celery.worker.autoreload:Autoreloader'),
         'CONCURRENCY': Option(0, type='int'),
+        'DISABLE_AUTO_DECLARE': Option(False, type='bool'),
         'TIMER': Option(type='string'),
         'TIMER_PRECISION': Option(1.0, type='float'),
         'FORCE_EXECV': Option(False, type='bool'),

--- a/celery/worker/consumer.py
+++ b/celery/worker/consumer.py
@@ -589,8 +589,10 @@ class Tasks(bootsteps.StartStopStep):
 
     def start(self, c):
         c.update_strategies()
+        auto_declare = False if c.app.conf.CELERYD_DISABLE_AUTO_DECLARE else True
         c.task_consumer = c.app.amqp.TaskConsumer(
             c.connection, on_decode_error=c.on_decode_error,
+            auto_declare=auto_declare,
         )
         c.qos = QoS(c.task_consumer.qos, c.initial_prefetch_count)
         c.qos.update()  # set initial prefetch count

--- a/celery/worker/consumer.py
+++ b/celery/worker/consumer.py
@@ -589,10 +589,9 @@ class Tasks(bootsteps.StartStopStep):
 
     def start(self, c):
         c.update_strategies()
-        auto_declare = False if c.app.conf.CELERYD_DISABLE_AUTO_DECLARE else True
         c.task_consumer = c.app.amqp.TaskConsumer(
             c.connection, on_decode_error=c.on_decode_error,
-            auto_declare=auto_declare,
+            auto_declare=(not c.app.conf.CELERYD_DISABLE_AUTO_DECLARE),
         )
         c.qos = QoS(c.task_consumer.qos, c.initial_prefetch_count)
         c.qos.update()  # set initial prefetch count


### PR DESCRIPTION
We found that in our use case — binding to hundreds or thousands of queues, all of which have already been declared by the publisher or by other setup code — skipping the auto-declaration of queues can speed up worker startup time considerably by avoiding unnecessary round trips to call the AMQP `queue.declare` method for each queue.  This helps us get new capacity up and running faster when demand increases.

Does this look good to you?  Any advice or suggestions are welcome, this has only been lightly tested so far.  Usage is to set `CELERYD_DISABLE_AUTO_DECLARE` to True in your celery config.
