### PR TITLE
Update docs/userguide/tasks.rst (typo fix)

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -878,7 +878,7 @@ The task may raise :exc:`~@Ignore` to force the worker to ignore the
 task.  This means that no state will be recorded for the task, but the
 message is still acknowledged (removed from queue).
 
-This is can be used if you want to implement custom revoke-like
+This can be used if you want to implement custom revoke-like
 functionality, or manually store the result of a task.
 
 Example keeping revoked tasks in a Redis set:


### PR DESCRIPTION
Typo fix: "This is can".
