### PR TITLE
Add /etc/init.d/celerybeat status

### DIFF
--- a/extra/generic-init.d/celerybeat
+++ b/extra/generic-init.d/celerybeat
@@ -102,7 +102,7 @@ echo "Using configuration: $scripts"
 
 CELERY_BIN=${CELERY_BIN:-"celery"}
 DEFAULT_USER="celery"
-DEFAULT_PID_FILE="/var/run/celery/beat.pid"
+DEFAULT_PID_FILE="/var/run/celerybeat/beat.pid"
 DEFAULT_LOG_FILE="/var/log/celery/beat.log"
 DEFAULT_LOG_LEVEL="INFO"
 DEFAULT_CELERYBEAT="$CELERY_BIN beat"


### PR DESCRIPTION
Design copied from extra/generic-init.d/celeryd
Tested on Ubuntu 12.04 LTS
