### PR TITLE
removed centos/celeryd CELERYD_CHDIR quoting

### DIFF
--- a/extra/centos/celeryd
+++ b/extra/centos/celeryd
@@ -95,7 +95,7 @@ if [ -n "$CELERYD_GROUP" ]; then
 fi
 
 if [ -n "$CELERYD_CHDIR" ]; then
-    DAEMON_OPTS="$DAEMON_OPTS --workdir=\"$CELERYD_CHDIR\""
+    DAEMON_OPTS="$DAEMON_OPTS --workdir=$CELERYD_CHDIR"
 fi
 
 check_dev_null() {


### PR DESCRIPTION
Celery cannot run when CELERYD_CHDIR is in quotes producing something like "OSError: [Errno 2] No such file or directory: '"your_path"'". 
