### PR TITLE
Correct import in security docs

### DIFF
--- a/docs/userguide/security.rst
+++ b/docs/userguide/security.rst
@@ -168,7 +168,7 @@ with the private key and certificate files located in `/etc/ssl`.
     CELERY_SECURITY_KEY = '/etc/ssl/private/worker.key'
     CELERY_SECURITY_CERTIFICATE = '/etc/ssl/certs/worker.pem'
     CELERY_SECURITY_CERT_STORE = '/etc/ssl/certs/*.pem'
-    from celery import setup_security
+    from celery.security import setup_security
     setup_security()
 
 .. note::


### PR DESCRIPTION
Based on the test here:

http://www.nullege.com/codes/show/src@c@e@celery-3.0.16@celery@tests@security@test_security.py/61/celery.security.setup_security
