### PR TITLE
honor hijack setting for root loglevel

### DIFF
--- a/celery/app/log.py
+++ b/celery/app/log.py
@@ -113,10 +113,10 @@ class Logging(object):
                 get_logger('celery.task').handlers = []
                 get_logger('celery.redirected').handlers = []
 
-            # Configure root logger
-            self._configure_logger(
-                root, logfile, loglevel, format, colorize, **kwargs
-            )
+                # Configure root logger
+                self._configure_logger(
+                    root, logfile, loglevel, format, colorize, **kwargs
+                )
 
             # Configure the multiprocessing logger
             self._configure_logger(


### PR DESCRIPTION
if CELERYD_HIJACK_ROOT_LOGGER is False, then, in addition to avoiding changing the handler, celery should also not change the root logger's loglevel setting.
