### PR TITLE
Fix async loop bug causing all jobs to be considered partially written.

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -792,6 +792,9 @@ class AsynPool(_pool.Pool):
                     else:
                         errors = 0
             finally:
+                if errors == 0:  # job successfully written
+                    job._write_to = None
+
                 hub_remove(fd)
                 write_stats[proc.index] += 1
                 # message written, so this fd is now available


### PR DESCRIPTION
If MAX_TASKS_PER_CHILD is set to a low number, then the Billiard async loop
attempts to call on_job_process_down().  This call causes the process to be
marked dead, preventing cleanup work done by on_process_down().  Without the
cleanup, then certain file descriptors are removed when the process starts
up with the on_poll_start.

Related to issue: https://github.com/celery/celery/issues/1785

job._write_to resolves to True always and therefore triggers the self.on_partial_read() call.  This function does some cleanup work but prevents on_process_down() from being executed properly.

```
    def on_job_process_down(self, job, pid_gone):
        """Handler called for each job when the process it was assigned to                                                                                                                                   
        exits."""
        if job._write_to and not job._write_to._is_alive():
            # job was partially written                                                                                                                                                                      
            self.on_partial_read(job, job._write_to)
```
