### PR TITLE
Fix handling of non-string keys in filter_hidden_settings

### DIFF
--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -175,11 +175,12 @@ def filter_hidden_settings(conf):
     def maybe_censor(key, value, mask='*' * 8):
         if isinstance(value, Mapping):
             return filter_hidden_settings(value)
-        if isinstance(value, string_t) and HIDDEN_SETTINGS.search(key):
-            return mask
-        if isinstance(key, string_t) and 'BROKER_URL' in key.upper():
-            from kombu import Connection
-            return Connection(value).as_uri(mask=mask)
+        if isinstance(key, string_t):
+            if HIDDEN_SETTINGS.search(key):
+                return mask
+            if 'BROKER_URL' in key.upper():
+                from kombu import Connection
+                return Connection(value).as_uri(mask=mask)
         return value
 
     return {k: maybe_censor(k, v) for k, v in items(conf)}

--- a/celery/tests/app/test_utils.py
+++ b/celery/tests/app/test_utils.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from collections import Mapping, MutableMapping
 
-from celery.app.utils import Settings, bugreport
+from celery.app.utils import Settings, filter_hidden_settings, bugreport
 
 from celery.tests.case import AppCase, Mock
 
@@ -18,6 +18,22 @@ class TestSettings(AppCase):
     def test_is_mutable_mapping(self):
         """Settings should be a collections.MutableMapping"""
         self.assertTrue(issubclass(Settings, MutableMapping))
+
+
+class test_filter_hidden_settings(AppCase):
+
+    def test_handles_non_string_keys(self):
+        """filter_hidden_settings shouldn't raise an exception when handling
+        mappings with non-string keys"""
+        conf = {
+            'STRING_KEY': 'VALUE1',
+            ('NON', 'STRING', 'KEY'): 'VALUE2',
+            'STRING_KEY2': {
+                'STRING_KEY3': 1,
+                ('NON', 'STRING', 'KEY', '2'): 2
+            },
+        }
+        filter_hidden_settings(conf)
 
 
 class test_bugreport(AppCase):


### PR DESCRIPTION
The `filter_hidden_settings` function raises a `ValueError` when the configuration object is a mapping with non-string keys because it tests the value rather than the key in the `isinstance` check. This fixes that error.
