### PR TITLE
non-string dict keys in django-celery configs

### DIFF
--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -14,7 +14,7 @@ import tempfile
 from kombu.utils.encoding import safe_repr
 
 from celery.exceptions import WorkerShutdown
-from celery.five import UserDict, items
+from celery.five import UserDict, items, string_t
 from celery.platforms import signals as _signals
 from celery.utils import timeutils
 from celery.utils.functional import maybe_list
@@ -364,7 +364,7 @@ def active_queues(state):
 
 
 def _wanted_config_key(key):
-    return key.isupper() and not key.startswith('__')
+    return isinstance(key, string_t) and key.isupper() and not key.startswith('__')
 
 
 @Panel.register


### PR DESCRIPTION
This fix allows celery-flower to not have problems displaying
configurations for projects that still use configurations embedded
in django settings files.  In this instance there are some int
dict keys that are totally unrelated to celery but that are causing
frequent error messages in the celeryd logs.

Here is the stacktrace from the error:

[2014-03-28 07:25:46,400: ERROR/MainProcess] pidbox command error: AttributeError("'int' object has no attribute 'isupper'",)
Traceback (most recent call last):
  File "/home/instaedu/.virtualenvs/instaedu/local/lib/python2.7/site-packages/kombu/pidbox.py", line 105, in dispatch
    reply = handle(method, kwdict(arguments))
  File "/home/instaedu/.virtualenvs/instaedu/local/lib/python2.7/site-packages/kombu/pidbox.py", line 123, in handle_call
    return self.handle(method, arguments)
  File "/home/instaedu/.virtualenvs/instaedu/local/lib/python2.7/site-packages/kombu/pidbox.py", line 120, in handle
    return self.handlers[method](self.state, **arguments)
  File "/home/instaedu/.virtualenvs/instaedu/local/lib/python2.7/site-packages/celery/worker/control.py", line 374, in dump_conf
    unknown_type_filter=safe_repr)
  File "/home/instaedu/.virtualenvs/instaedu/local/lib/python2.7/site-packages/celery/utils/**init**.py", line 280, in jsonify
    for k, v in items(obj)
  File "/home/instaedu/.virtualenvs/instaedu/local/lib/python2.7/site-packages/celery/utils/**init**.py", line 281, in <genexpr>
    if (keyfilter(k) if keyfilter else 1))
  File "/home/instaedu/.virtualenvs/instaedu/local/lib/python2.7/site-packages/celery/utils/**init**.py", line 280, in jsonify
    for k, v in items(obj)
  File "/home/instaedu/.virtualenvs/instaedu/local/lib/python2.7/site-packages/celery/utils/**init**.py", line 281, in <genexpr>
    if (keyfilter(k) if keyfilter else 1))
  File "/home/instaedu/.virtualenvs/instaedu/local/lib/python2.7/site-packages/celery/worker/control.py", line 367, in _wanted_config_key
    return key.isupper() and not key.startswith('__')
AttributeError: 'int' object has no attribute 'isupper'
