### PR TITLE
Fix formatting for deprecation warning in Python 2.x

### DIFF
--- a/celery/__main__.py
+++ b/celery/__main__.py
@@ -19,7 +19,7 @@ $ {new_argv}
 def _warn_deprecated(new):
     print(DEPRECATED_FMT.format(
         old=basename(sys.argv[0]), new=new,
-        new_argv=' '.join([new] + sys.argv[1:])),
+        new_argv=' '.join([new] + sys.argv[1:]))
     )
 
 


### PR DESCRIPTION
An extra comma in the deprecation warning print makes it print the warning as a tuple in Python 2.x:

```
$ celeryd
("\nThe 'celeryd' command is deprecated, please use 'celery worker' instead:\n\n$ celery worker\n\n",)
...
```

Removing the comma makes it print correctly on Py2 and Py3.
