### PR TITLE
zsh: no matches found: celery[redis]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,9 +234,9 @@ by using brackets.  Multiple bundles can be specified by separating them by
 commas.
 ::
 
-    $ pip install celery[librabbitmq]
+    $ pip install "celery[librabbitmq]"
 
-    $ pip install celery[librabbitmq,redis,auth,msgpack]
+    $ pip install "celery[librabbitmq,redis,auth,msgpack]"
 
 The following bundles are available:
 

--- a/docs/getting-started/brokers/beanstalk.rst
+++ b/docs/getting-started/brokers/beanstalk.rst
@@ -24,7 +24,7 @@ the ``celery[beanstalk]`` :ref:`bundle <bundles>`:
 
 .. code-block:: bash
 
-    $ pip install -U celery[beanstalk]
+    $ pip install -U "celery[beanstalk]"
 
 .. _broker-beanstalk-configuration:
 

--- a/docs/getting-started/brokers/couchdb.rst
+++ b/docs/getting-started/brokers/couchdb.rst
@@ -22,7 +22,7 @@ the ``celery[couchdb]`` :ref:`bundle <bundles>`:
 
 .. code-block:: bash
 
-    $ pip install -U celery[couchdb]
+    $ pip install -U "celery[couchdb]"
 
 .. _broker-couchdb-configuration:
 

--- a/docs/getting-started/brokers/mongodb.rst
+++ b/docs/getting-started/brokers/mongodb.rst
@@ -22,7 +22,7 @@ the ``celery[mongodb]`` :ref:`bundle <bundles>`:
 
 .. code-block:: bash
 
-    $ pip install -U celery[mongodb]
+    $ pip install -U "celery[mongodb]"
 
 .. _broker-mongodb-configuration:
 

--- a/docs/getting-started/brokers/redis.rst
+++ b/docs/getting-started/brokers/redis.rst
@@ -15,7 +15,7 @@ the ``celery[redis]`` :ref:`bundle <bundles>`:
 
 .. code-block:: bash
 
-    $ pip install -U celery[redis]
+    $ pip install -U "celery[redis]"
 
 .. _broker-redis-configuration:
 

--- a/docs/includes/installation.txt
+++ b/docs/includes/installation.txt
@@ -28,9 +28,9 @@ commas.
 
 .. code-block:: bash
 
-    $ pip install celery[librabbitmq]
+    $ pip install "celery[librabbitmq]"
 
-    $ pip install celery[librabbitmq,redis,auth,msgpack]
+    $ pip install "celery[librabbitmq,redis,auth,msgpack]"
 
 The following bundles are available:
 

--- a/docs/whatsnew-3.1.rst
+++ b/docs/whatsnew-3.1.rst
@@ -607,7 +607,7 @@ You install extras by specifying them inside brackets:
 
 .. code-block:: bash
 
-    $ pip install celery[redis,mongodb]
+    $ pip install "celery[redis,mongodb]"
 
 The above will install the dependencies for Redis and MongoDB.  You can list
 as many extras as you want.


### PR DESCRIPTION
I met this error message when installing celery[redis]

```
$ sudo pip install -U celery[redis]
zsh: no matches found: celery[redis]
```

This is because [zsh uses square brackets to pattern-match](http://zsh.sourceforge.net/Guide/zshguide05.html).

Therefore,

```
$ pip install -U "celery[redis]"
```

instead of 

```
$ pip install -U celery[redis]
```

would be better I think.
