### PR TITLE
Fix Django sample.

### DIFF
--- a/examples/django/proj/celery.py
+++ b/examples/django/proj/celery.py
@@ -4,10 +4,11 @@ import os
 
 from celery import Celery
 
-from django.conf import settings
-
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings')
+
+# load the settings after we tell it which settings to load.
+from django.conf import settings
 
 app = Celery('proj')
 


### PR DESCRIPTION
Importing Django's settings module can't happen until after we've 
told it what settings module to import.