### PR TITLE
ignore unknown events in consumer

### DIFF
--- a/celery/worker/consumer.py
+++ b/celery/worker/consumer.py
@@ -807,7 +807,7 @@ class Gossip(bootsteps.ConsumerStep):
                     message.payload['hostname'])
         if hostname != self.hostname:
             type, event = prepare(message.payload)
-            obj, subject = self.update_state(event)
+            self.update_state(event)
         else:
             self.clock.forward()
 


### PR DESCRIPTION
Custom event types (not starting with either 'task-' or 'worker-') break Consumer, as it tries to split a `None` returned by state.event()
