### PR TITLE
accept reloader by name in pool restart command

### DIFF
--- a/celery/worker/__init__.py
+++ b/celery/worker/__init__.py
@@ -281,7 +281,12 @@ class WorkController(object):
                 logger.debug('importing module %s', module)
                 imp(module)
             elif reload:
-                logger.debug('reloading module %s', module)
+                if reloader is not None and hasattr(reloader, 'rsplit'):
+                    m, n = reloader.rsplit('.', 1)
+                    if m in sys.modules and hasattr(sys.modules[m], n):
+                        reloader = getattr(sys.modules[m], n)
+                    assert callable(reloader)
+                logger.debug("reloading module %s", module)
                 reload_from_cwd(sys.modules[module], reloader)
 
         if self.consumer:


### PR DESCRIPTION
I tried to use the `reloader` argument to the pool restart command but
kombu wouldn't allow me to pass a function because it isn't JSON
serializable. So this patch provides for passing the reloader as a fully
qualified name to be imported by the worker before doing the reload.
