### PR TITLE
Move base64 to utils.serialization

### DIFF
--- a/celery/security/serialization.py
+++ b/celery/security/serialization.py
@@ -8,24 +8,15 @@
 """
 from __future__ import absolute_import
 
-import base64
-
 from kombu.serialization import registry, dumps, loads
 from kombu.utils.encoding import bytes_to_str, str_to_bytes, ensure_bytes
 
 from .certificate import Certificate, FSCertStore
 from .key import PrivateKey
 from .utils import reraise_errors
+from celery.utils.serialization import b64encode, b64decode
 
 __all__ = ['SecureSerializer', 'register_auth']
-
-
-def b64encode(s):
-    return bytes_to_str(base64.b64encode(str_to_bytes(s)))
-
-
-def b64decode(s):
-    return base64.b64decode(str_to_bytes(s))
 
 
 class SecureSerializer(object):

--- a/celery/utils/serialization.py
+++ b/celery/utils/serialization.py
@@ -8,6 +8,7 @@
 """
 from __future__ import absolute_import
 
+from base64 import b64encode as base64encode, b64decode as base64decode
 from inspect import getmro
 from itertools import takewhile
 
@@ -15,6 +16,8 @@ try:
     import cPickle as pickle
 except ImportError:
     import pickle  # noqa
+
+from kombu.utils.encoding import bytes_to_str, str_to_bytes
 
 from .encoding import safe_repr
 
@@ -165,3 +168,11 @@ def get_pickled_exception(exc):
     if isinstance(exc, UnpickleableExceptionWrapper):
         return exc.restore()
     return exc
+
+
+def b64encode(s):
+    return bytes_to_str(base64encode(str_to_bytes(s)))
+
+
+def b64decode(s):
+    return base64decode(str_to_bytes(s))


### PR DESCRIPTION
I don't want to re-write `b64encode/b64decode` functions, but when I import them from `celery.security.serialization` I also import OpenSSL, which is very slow and cause almost 1 million calls (from cProfile):

```
996542 function calls (972825 primitive calls) in 0.971 seconds
```

With my patch, importing these functions from `celery.utils.serialization` results in almost 8x times speed up:

```
127645 function calls (122927 primitive calls) in 0.179 seconds
```
