### PR TITLE
Fix chains + groups not working with json task serializer (#2076)

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -467,7 +467,8 @@ class chain(Signature):
         tasks = d['kwargs']['tasks']
         if d['args'] and tasks:
             # make sure that tasks are made into signatures (Issue #2076)
-            tasks[0] = signature(tasks[0])
+            if not isinstance(tasks[0], Signature):
+                tasks[0] = signature(tasks[0])
             # partial args passed on to first task in chain (Issue #1057).
             tasks[0]['args'] = tasks[0]._merge(d['args'])[0]
         return chain(*d['kwargs']['tasks'], app=app, **d['options'])
@@ -594,7 +595,8 @@ class group(Signature):
             # partial args passed on to all tasks in the group (Issue #1057).
             for task in tasks:
                 # make sure that tasks are made into signatures (Issue #2076)
-                task = signature(task)
+                if not isinstance(tasks[0], Signature):
+                    task = signature(task)
                 task['args'] = task._merge(d['args'])[0]
         return group(tasks, app=app, **d['options'])
 


### PR DESCRIPTION
Was having the same issue as described in #2706, and had a little look into it.
It seems that when using the JSON serializer, the tasks were being passed as dicts, so I've simply called `signature()` on them before continuing, which will build the signature from a dict.

This should be fine even if they are already signatures, as it just calls clone and passes it back.
