### PR TITLE
BacklogLimitExceeded exception removed

### DIFF
--- a/celery/tests/backends/test_amqp.py
+++ b/celery/tests/backends/test_amqp.py
@@ -180,13 +180,6 @@ class test_AMQPBackend(AppCase):
 
         yield results, backend, Message
 
-    def test_backlog_limit_exceeded(self):
-        with self._result_context() as (results, backend, Message):
-            for i in range(1001):
-                results.put(Message(task_id='id', status=states.RECEIVED))
-            with self.assertRaises(backend.BacklogLimitExceeded):
-                backend.get_task_meta('id')
-
     def test_poll_result(self):
         with self._result_context() as (results, backend, Message):
             tid = uuid()


### PR DESCRIPTION
Hey guys! Thanks for developing this awesome library! 

Recently I have stumbled across a problem where I have a long running task, which updates it's progress every second. If that task runs for say 1567 seconds without any other code requesting to see it's progress, I get BacklogLimitExceeded exception on progress or result request. Second time I request for result it woks fine as it now has only 567 entries to parse. 

I made a workaround on my app which catches BacklogLimitExceeded exception and tries again until it gets to actual result, but that seems to me like it sounds - a workaround.

Dunno why you guys added that exception here, so here is my pull request to remove it. If it's necessary for some corner cases which I am not aware of, please share your knowledge on why it's needed. 

Thank you. Appreciate your work!
