### PR TITLE
flake8 fixes

### DIFF
--- a/celery/backends/__init__.py
+++ b/celery/backends/__init__.py
@@ -10,8 +10,6 @@ from __future__ import absolute_import
 
 import sys
 
-from kombu.utils.url import urlparse
-
 from celery.local import Proxy
 from celery._state import current_app
 from celery.five import reraise

--- a/funtests/benchmarks/bench_worker.py
+++ b/funtests/benchmarks/bench_worker.py
@@ -8,7 +8,7 @@ os.environ.update(
     USE_FAST_LOCALS='yes',
 )
 
-from celery import Celery, group
+from celery import Celery
 from celery.five import range
 from kombu.five import monotonic
 
@@ -71,7 +71,6 @@ def bench_apply(n=DEFAULT_ITS):
     task = it._get_current_object()
     with app.producer_or_acquire() as producer:
         [task.apply_async((i, n), producer=producer) for i in range(n)]
-    #group(s(i, n) for i in range(n))()
     print('-- apply {0} tasks: {1}s'.format(n, monotonic() - time_start))
 
 


### PR DESCRIPTION
Just a couple of flake8 fixes.

Fixes these issues:

```
./funtests/benchmarks/bench_worker.py:11:1: F401 'group' imported but unused
./funtests/benchmarks/bench_worker.py:74:5: E265 block comment should start with '# '
./celery/backends/__init__.py:13:1: F401 'urlparse' imported but unused
```
