### PR TITLE
pass options to route_for_task

### DIFF
--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -45,7 +45,7 @@ class Router(object):
     def route(self, options, task, args=(), kwargs={}):
         options = self.expand_destination(options)  # expands 'queue'
         if self.routes:
-            route = self.lookup_route(task, args, kwargs)
+            route = self.lookup_route(task, args, kwargs, options)
             if route:  # expands 'queue' in route.
                 return lpmerge(self.expand_destination(route), options)
         if 'queue' not in options:
@@ -72,8 +72,8 @@ class Router(object):
             route['queue'] = Q
         return route
 
-    def lookup_route(self, task, args=None, kwargs=None):
-        return _first_route(self.routes, task, args, kwargs)
+    def lookup_route(self, task, args=None, kwargs=None, options=None):
+        return _first_route(self.routes, task, args, kwargs, options)
 
 
 def prepare(routes):


### PR DESCRIPTION
Passed options can be used in lookup_route too. e.g. I'm trying to implement priority queue support like this:

Passing `priority=True` to `send_task`:
```
app.send_task('support.test', priority=True)
```

Then route requests using a custom Router:

```
class MyRouter(object):
    def route_for_task(self, task, args=None, kwargs=None, options=None):
        if options and options['priority']:
            return {'queue': task + ".priority"}
        return {'queue': task}
```