### PR TITLE
Fix request expiration timezone

### DIFF
--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -220,7 +220,7 @@ class Request(object):
     def maybe_expire(self):
         """If expired, mark the task as revoked."""
         if self.expires:
-            now = datetime.now(tz_or_local(self.tzlocal) if self.utc else None)
+            now = datetime.now(self.expires.tzinfo)
             if now > self.expires:
                 revoked_tasks.add(self.id)
                 return True


### PR DESCRIPTION
I was getting errors while trying to turn on time zone support for Django and Celery.  I believe this fix makes `now` and `self.expires` always be both time zone aware or time zone unaware so that they can be compared.  

This is basically #1885 turned into a pull request.  
