### PR TITLE
fix for test_MultiTool.test_error

### DIFF
--- a/celery/tests/bin/test_multi.py
+++ b/celery/tests/bin/test_multi.py
@@ -176,15 +176,15 @@ class test_MultiTool(AppCase):
         self.assertFalse(self.fh.getvalue())
 
     def test_error(self):
-        self.t.say = Mock()
+        self.t.carp = Mock()
         self.t.usage = Mock()
         self.assertEqual(self.t.error('foo'), 1)
-        self.t.say.assert_called_with('foo')
+        self.t.carp.assert_called_with('foo')
         self.t.usage.assert_called_with()
 
-        self.t.say = Mock()
+        self.t.carp = Mock()
         self.assertEqual(self.t.error(), 1)
-        self.assertFalse(self.t.say.called)
+        self.assertFalse(self.t.carp.called)
 
         self.assertEqual(self.t.retcode, 1)
 


### PR DESCRIPTION
proper mocking - `carp` instead of `say`
