### PR TITLE
Adding missing instruction on necessary path for RabbitMQ

### DIFF
--- a/docs/getting-started/brokers/rabbitmq.rst
+++ b/docs/getting-started/brokers/rabbitmq.rst
@@ -90,6 +90,12 @@ Finally, we can install rabbitmq using :program:`brew`:
 
 .. _rabbitmq-osx-system-hostname:
 
+After you have installed rabbitmq with brew you need to add the following to your path to be able to start and stop the broker. Add it to your .bash_profile or .profile
+
+.. code-block:: bash
+
+    `PATH=$PATH:/usr/local/sbin`
+
 Configuring the system host name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
It was missing, pretty easy to search for, but a bit annoying that instructions was not complete. 
