### PR TITLE
Remove reference to celeryd-django

### DIFF
--- a/extra/supervisord/supervisord.conf
+++ b/extra/supervisord/supervisord.conf
@@ -26,9 +26,3 @@ serverurl=unix:///tmp/supervisor.sock ; use unix:// schem for a unix sockets.
 # Uncomment this line for celeryd for Python
 ;files=celeryd.conf
 
-# Uncomment this line for celeryd for Django.
-;files=django/celeryd.conf
-
-
-
-


### PR DESCRIPTION
The `celeryd-django` supervisord configuration was removed in aad31dcec1d65fbd8.
Remove a dangling reference to the now non-existent file.
