### PR TITLE
Broken Pipe on `safe_say`

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -71,7 +71,7 @@ def active_thread_count():
 
 
 def safe_say(msg):
-    print('\n{0}'.format(msg), file=sys.__stderr__)
+    print('\n{0}'.format(msg), file=sys.stderr)
 
 ARTLINES = [
     ' --------------',


### PR DESCRIPTION
When celery is started with uWSGI and `smart-attach-daemon` option and when celery is once restarted then calling `safe_say` will raise Broken Pipe error. This will prevent further restarting of the worker without brutally killing it.

In python documentation `sys.stderr` is prefered way for writing to stderr instead of `sys.__stderr__`, and when it is used in safe_say, the celery worker is restarted without problems.
