### PR TITLE
Added missing back tick.

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -432,7 +432,7 @@ class Task(object):
         :keyword link_error: A single, or a list of tasks to apply
                       if an error occurs while executing the task.
 
-        :keyword producer: :class:~@kombu.Producer` instance to use.
+        :keyword producer: :class:`~@kombu.Producer` instance to use.
         :keyword add_to_parent: If set to True (default) and the task
             is applied while executing another task, then the result
             will be appended to the parent tasks ``request.children``


### PR DESCRIPTION
Added missing back tick in `celery.app.task.Task:producer`.
