### PR TITLE
Fixed tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     2.7,
     3.3,
     3.4,
-    pypy
+    pypy,
     pypy3
 
 [testenv]


### PR DESCRIPTION
A comma was missing in `tox.ini`.
