### PR TITLE
Fix #celery/2269 - Better documents the queue attribute of a Task apply_async call

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -494,10 +494,15 @@ class Task(object):
                               ``queue`` argument only used to specify custom
                               routing keys to topic exchanges.
 
-        :keyword queue: The queue to route the task to.  This must be a key
-                        present in :setting:`CELERY_QUEUES`, or
-                        :setting:`CELERY_CREATE_MISSING_QUEUES` must be
-                        enabled.  See :ref:`guide-routing` for more
+        :keyword queue: The queue specified by name that must exist as a key
+                        in :setting:`CELERY_QUEUES`. If queue is not in
+                        :setting: `CELERY_QUEUES` then if
+                        :setting:`CELERY_CREATE_MISSING_QUEUES` is enabled
+                        the queue will be created, which can cause problems
+                        if another dispatching client created the queue
+                        already. To send to a dedicated worker queue
+                        use the queue name provided by the ``worker_direct``
+                        helper function. To See :ref:`guide-routing` for more
                         information.
 
         :keyword exchange: Named custom exchange to send the task to.


### PR DESCRIPTION
This is a documentation fix for https://github.com/celery/celery/issues/2269

This PR is against 3.1, but the documentation should be in both 3.1 and master I think. Celery doesn't seem to merge forward the 3.1 release branch to master and both 3.1 and master have changes that are not appropriate for the other branch.

As such, please cherry pick the commit 409ef054bd843ff418d993a678f6c9c3d3dc0ae0 onto master also.
