### PR TITLE
rdb.set_trace stops in contextlib

### DIFF
--- a/celery/contrib/rdb.py
+++ b/celery/contrib/rdb.py
@@ -46,7 +46,6 @@ from pdb import Pdb
 from billiard import current_process
 
 from celery.five import range
-from celery.platforms import ignore_errno
 
 __all__ = ['CELERY_RDB_HOST', 'CELERY_RDB_PORT', 'default_port',
            'Rdb', 'debugger', 'set_trace']
@@ -152,12 +151,6 @@ class Rdb(Pdb):
         self.set_quit()
         return 1
     do_q = do_exit = do_quit
-
-    def set_trace(self, frame=None):
-        if frame is None:
-            frame = _frame().f_back
-        with ignore_errno(errno.ECONNRESET):
-            Pdb.set_trace(self, frame)
 
     def set_quit(self):
         # this raises a BdbQuit exception that we are unable to catch.

--- a/celery/tests/contrib/test_rdb.py
+++ b/celery/tests/contrib/test_rdb.py
@@ -52,8 +52,6 @@ class test_Rdb(Case):
                 rdb.set_trace()
                 rdb.set_trace(Mock())
                 pset.side_effect = SockErr
-                pset.side_effect.errno = errno.ECONNRESET
-                rdb.set_trace()
                 pset.side_effect.errno = errno.ENOENT
                 with self.assertRaises(SockErr):
                     rdb.set_trace()


### PR DESCRIPTION
The ignore_errno context manager there didn't suppress anything as
Pdb.set_trace does not raise an ECONNRESET in any case. After the
removal, the method was the same as Pdb.set_trace, so this just
removes Rdb's override.

The test also asumed that pdb.set_trace might raise ECONNRESET even though this is not possible.
