### PR TITLE
Interpret basic.publish text as a Message object

### DIFF
--- a/celery/bin/amqp.py
+++ b/celery/bin/amqp.py
@@ -15,6 +15,7 @@ import pprint
 from functools import partial
 from itertools import count
 
+from amqp import Message
 from kombu.utils.encoding import safe_str
 
 from celery.utils.functional import padlist
@@ -174,7 +175,7 @@ class AMQShell(cmd.Cmd):
         'basic.get': Spec(('queue', str),
                           ('no_ack', bool, 'off'),
                           returns=dump_message),
-        'basic.publish': Spec(('msg', str),
+        'basic.publish': Spec(('msg', Message),
                               ('exchange', str),
                               ('routing_key', str),
                               ('mandatory', bool, 'no'),


### PR DESCRIPTION
py-amqp expects a Message object for Channel.basic_publish.
https://github.com/celery/celery/issues/2013