### PR TITLE
Patch: Task De-Serialization uses correct mongo url

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -95,7 +95,7 @@ class MongoBackend(BaseBackend):
             self.options.setdefault('max_pool_size', self.max_pool_size)
             self.options.setdefault('auto_start_request', False)
 
-        url = kwargs.get('url')
+        url = kwargs.get('url') or self.app.conf.get('CELERY_RESULT_BACKEND')
         if url:
             # Specifying backend as an URL
             self.host = url

--- a/celery/tests/backends/test_mongodb.py
+++ b/celery/tests/backends/test_mongodb.py
@@ -66,6 +66,11 @@ class test_MongoBackend(AppCase):
         self.app.conf.CELERY_MONGODB_BACKEND_SETTINGS = None
         MongoBackend(app=self.app)
 
+    def test_init_with_results_backend_and_no_url(self):
+        self.app.conf.CELERY_RESULT_BACKEND = 'mongodb://myhost:27017/mydb'
+        backend = MongoBackend(app=self.app)
+        self.assertEqual(backend.host, self.app.conf.CELERY_RESULT_BACKEND)
+
     def test_restore_group_no_entry(self):
         x = MongoBackend(app=self.app)
         x.collection = Mock()


### PR DESCRIPTION
Use url from CELERY_RESULT_BACKEND during un-pickling of AsynResult as only app is passed during the process.

_Explanation_:
During initialization of MongoBackend, url  and app object both are passed so it gets initialized as expected. However, during de-serialization of task, only app object is passed. As a result, the default value for host (localhost), port (27017), user and password is used. 

_Fix_:
Also try to read url from CELERY_RESULT_BACKEND. 

If neither values are set, it will fallback to existing behavior (i.e. try to use values from host, port, user, password in CELERY_MONGODB_BACKEND_SETTINGS.

If url parameter is passed (initialization), it will be used instead.

If url parameter is not passed, and CELERY_RESULT_BACKEND is present in config,  CELERY_RESULT_BACKEND will be used.
