### PR TITLE
https://github.com/celery/celery/issues/2357

### DIFF
--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -61,7 +61,6 @@ def default(task, app, consumer,
     call_at = consumer.timer.call_at
     apply_eta_task = consumer.apply_eta_task
     rate_limits_enabled = not consumer.disable_rate_limits
-    bucket = consumer.task_buckets[task.name]
     handle = consumer.on_task_request
     limit_task = consumer._limit_task
     body_can_be_buffer = consumer.pool.body_can_be_buffer
@@ -116,6 +115,7 @@ def default(task, app, consumer,
                 call_at(eta, apply_eta_task, (req, ), priority=6)
         else:
             if rate_limits_enabled:
+                bucket = consumer.task_buckets[task.name]
                 if bucket:
                     return limit_task(req, bucket, 1)
             task_reserved(req)


### PR DESCRIPTION
I debugged through the code and found the root cause is because

the bucket in strategy.py default's function was initialized only in the beginning of the function

When we call celery control rate_limit proj.tasks.mul 60/m
The code goes to consumer.py and calls reset_rate_limits which reset the buckets in consumer.task_buckets. However strategy.py bucket variable is still referencing the old one, so the rate limit never take effect.

I am forking a repo to make fix for this. I just move the bucket assignment just before the if check so it always get the latest bucket.

Please review them, and if you like deliver them to master / 3.x releases.
