### PR TITLE
Update redis examples

### DIFF
--- a/docs/getting-started/brokers/redis.rst
+++ b/docs/getting-started/brokers/redis.rst
@@ -34,6 +34,10 @@ Where the URL is in the format of::
 all fields after the scheme are optional, and will default to localhost on port 6379,
 using database 0.
 
+If a unix socket connection should be used, the URL needs to be in the format::
+
+    redis+socket:///path/to/redis.sock
+
 .. _redis-visibility_timeout:
 
 Visibility Timeout


### PR DESCRIPTION
The documentation should include how a unix socket can be used as well since the backend implementation has already been updated in kombu
