### PR TITLE
Fix for #2391 (misleading documentation on crontabs)

### DIFF
--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -5,7 +5,7 @@
 ================
 
 .. contents::
-:local:
+    :local:
 
 Introduction
 ============


### PR DESCRIPTION
Hi,

I've fixed the documentation regarding issue #2391. If I remember crontab correctly and understood the documentation correctly, omitting the day_of_week parameter makes it `*`, and therefore the tasks run not only on Sundays.
