### PR TITLE
celery.contrib.conflator: add a Conflator task subclass

### DIFF
--- a/celery/contrib/conflator.py
+++ b/celery/contrib/conflator.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""celery.contrib.conflator
+======================
+
+.. versionadded :: 3.2.0
+
+A task which will check that it's enqueued time is after the last time
+a task with the same conflation ID was executed to clear backed up
+work that's already been done.
+
+This is useful for e.g. periodic tasks which occasionally take longer
+than their period to execute such as checking in with a remote system
+which may be down, experiencing performance issues or so on.
+
+It's important that things should work out satisfactorily at task
+execution time if all previously scheduled tasks execute or if they
+have all been conflated into 1.
+
+**Simple Example**
+
+.. code-block:: python
+
+    # sync from a remote system
+    @app.periodic_task(base=Conflator, run_every=timedelta(minutes=1))
+    def update_from_remote():
+        from remote_system import update
+        update()
+
+"""
+
+from datetime import datetime
+
+from celery import states, Task
+from celery.utils.log import get_logger
+
+logger = get_logger(__name__)
+
+class Conflator(Task):
+
+    abstract = True
+
+    conflation_key = None
+
+    def apply_async(self, *args, **kwargs):
+        conflation_key = self.conflation_key
+        if conflation_key is None:
+            conflation_key = kwargs.get('conflation_key', 
+                                        self.__class__.__name__)
+        pending = self.backend.get_task_meta(conflation_key)
+
+        # If there's a pending task just skip it
+        if not pending['result']:
+            self.backend.store_result(conflation_key, True, 
+                                      "conflating")
+            return super(Conflator, self).apply_async(args, kwargs)
+        else:
+            logger.info("Conflating task with key %s", conflation_key)
+
+    def __call__(self, *args, **kwargs):
+
+        conflation_key = self.conflation_key
+        if conflation_key is None:
+            conflation_key = self.__class__.__name__
+
+        # always clear the conflation key so tasks that error out
+        # don't block the queue
+        self.backend.forget(conflation_key)
+        return super(Conflator, self).__call__(*args, **kwargs)

--- a/celery/tests/contrib/test_conflator.py
+++ b/celery/tests/contrib/test_conflator.py
@@ -1,0 +1,111 @@
+import celery.contrib.conflator
+from celery.contrib.conflator import Conflator
+from celery.tests.case import AppCase, depends_on_current_app
+from celery.tests.tasks.test_tasks import TasksCase
+from celery.utils.log import get_logger
+
+logger = get_logger(__name__)
+
+
+class test_ConflatingTask(TasksCase):
+
+    task_count = 0
+
+    class ConflatingCounter(Conflator):
+
+        conflation_key = 'a'
+        task_count = 0
+
+        def __init__(self, parent):
+            self.parent = parent
+            super(Conflator, self).__init__()
+
+        def run(self):
+            logger.debug("incrementing task_count")
+            self.parent.task_count += 1
+
+    class DyingConflater(Conflator):
+
+        conflation_key = 'a'
+
+        def run(self):
+            raise Exception("boom!")
+
+    def setup(self):
+        celery.contrib.conflator.cache = None
+        self.task_count = 0
+        self.app.conf.CELERY_CACHE_BACKEND = 'memory://'
+
+    def _test_conflator_multiple_tasks(self, total):
+        """ Schedule N tasks """
+
+        # FIXME: It would be better if this could spin up a worker and
+        # run through the actually scheduled tasks on the queue
+        to_run = []
+        for i in range(total):
+            t = self.ConflatingCounter(self)
+            if t.delay():
+                to_run.append(t)
+
+        for t in to_run:
+            t()
+
+        self.assertEqual(1, self.task_count)
+
+    @depends_on_current_app
+    def test_conflator_three_at_once(self):
+        self._test_conflator_multiple_tasks(3)
+
+    @depends_on_current_app
+    def test_conflator_task_after(self):
+        self._test_conflator_multiple_tasks(2)
+        # Next task should execute as it's scheduled after the first
+        # two have executed
+        t = self.ConflatingCounter(self)
+        if t.delay():
+            t()
+        self.assertEqual(2, self.task_count)
+
+    @depends_on_current_app
+    def test_raising_conflator(self):
+        first_counter = self.ConflatingCounter(self)
+        if first_counter.delay():
+            first_counter()
+
+        raiser = self.DyingConflater()
+        if raiser.delay():
+            self.assertRaises(Exception, raiser)
+        else:
+            self.fail("DyingConflator should have been scheduled")
+
+        second_counter = self.ConflatingCounter(self)
+        if second_counter.delay():
+            second_counter()
+
+        self.assertEquals(2, self.task_count)
+
+    @depends_on_current_app
+    def test_common_conflation_key(self):
+        first_counter = self.ConflatingCounter(self)
+        first_counter.delay()
+
+        raiser = self.DyingConflater()
+        if raiser.delay():
+            self.fail("DyingConflator should not have been scheduled")
+
+        first_counter()
+        
+        second_counter = self.ConflatingCounter(self)
+        if second_counter.delay():
+            second_counter()
+
+        self.assertEquals(2, self.task_count)
+
+    @depends_on_current_app
+    def test_rehydrating_conflator(self):
+        first_counter = self.ConflatingCounter(self)
+
+        second_counter = self.ConflatingCounter(self)
+        second_counter.delay()
+        second_counter()
+        self.assertEquals(1, self.task_count)

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -541,6 +541,34 @@ call, pass `retry_kwargs` argument to `~@Celery.task` decorator:
 
 .. _task-options:
 
+Conflation
+==========
+
+Often multiple instances of the same task can be created, either
+directly or through :ref:`Periodic Tasks <guide-beat>`. If you only want one of
+them to execute and the others are effectively noops you can use a
+conflating task. This task type will not execute any tasks which were
+scheduled before the most recent execution occured.
+
+For instance synchornisation tasks which poll a remote system for
+updates and which have become backed up may be a good candidate for
+this task type to reduce unnecessary load.
+
+The conflation key can be set on the task itself or can be inferred,
+the former is useful if you have subclasses of the task
+
+.. code-block:: python
+
+    from celery.contrib.conflator import Conflator
+
+    class ConflatingTask(Conflator):
+
+          conflation_key = "system_update"
+
+          def run(self):
+              something_that_takes_a_while()
+
+
 List of Options
 ===============
 


### PR DESCRIPTION
Sometimes life gives you a periodic task which can get backed up
and you only really want one of them to execute and the others are
effectively noops (for instance because they'd poll a remote system
for updates which had just been retrieved). This task type will
not execute any tasks which were scheduled before the most recent
execution occured.

With a memory cache backend this will only apply to a single worker
however if memcached is configured then any pool of workers with
access to the same memcache will be able to share this information.
