### PR TITLE
Add command option --executable

### DIFF
--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -63,6 +63,10 @@ in any command that also has a `--detach` option.
 
     Optional directory to change to after detaching.
 
+.. cmdoption:: --executable
+
+    Executable to use for the detached process.
+
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
@@ -650,4 +654,5 @@ def daemon_options(default_pidfile=None, default_logfile=None):
         Option('--uid', default=None),
         Option('--gid', default=None),
         Option('--umask', default=None),
+        Option('--executable', default=None),
     )

--- a/celery/bin/celeryd_detach.py
+++ b/celery/bin/celeryd_detach.py
@@ -38,10 +38,13 @@ OPTION_LIST = daemon_options(default_pidfile='celeryd.pid') + (
 
 
 def detach(path, argv, logfile=None, pidfile=None, uid=None,
-           gid=None, umask=None, working_directory=None, fake=False, app=None):
+           gid=None, umask=None, working_directory=None, fake=False, app=None,
+           executable=None):
     fake = 1 if C_FAKEFORK else fake
     with detached(logfile, pidfile, uid, gid, umask, working_directory, fake):
         try:
+            if executable is not None:
+                path = executable
             os.execv(path, [path] + argv)
         except Exception:
             if app is None:

--- a/celery/bin/multi.py
+++ b/celery/bin/multi.py
@@ -247,7 +247,7 @@ class MultiTool(object):
         self.note('> Starting nodes...')
         for node in multi_args(p, cmd):
             self.note('\t> {0}: '.format(node.name), newline=False)
-            retcode = self.waitexec(node.argv)
+            retcode = self.waitexec(node.argv, path=p.options['--executable'])
             self.note(retcode and self.FAILED or self.OK)
             retcodes.append(retcode)
         self.retcode = int(any(retcodes))
@@ -259,6 +259,7 @@ class MultiTool(object):
             '--cmd',
             '-m {0}'.format(celery_exe('worker', '--detach')),
         )
+        _setdefaultopt(p.options, ['--executable'], sys.executable)
 
     def signal_node(self, nodename, pid, sig):
         try:
@@ -379,7 +380,7 @@ class MultiTool(object):
         def on_node_shutdown(nodename, argv, pid):
             self.note(self.colored.blue(
                 '> Restarting node {0}: '.format(nodename)), newline=False)
-            retval = self.waitexec(argv)
+            retval = self.waitexec(argv, path=p.options['--executable'])
             self.note(retval and self.FAILED or self.OK)
             retvals.append(retval)
 


### PR DESCRIPTION
I have added a command option `--executable` that can be used to pass the path of a Python-executable to the commands `worker --detach` and `multi`. This Python-executable will then be used instead of `sys.executable`. This patch fixes the problem of running the Celery daemon inside of Buildout, as described by [issue 364](https://github.com/celery/celery/issues/364), especially [the last comment by bnkr](https://github.com/celery/celery/issues/364#issuecomment-16454187).

I haven't written any tests, because I have no clue how I should test this. Sorry for that.
