### PR TITLE
Configuration parameter name was part of `p #id`

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -310,8 +310,11 @@ the :setting:`CELERY_RESULT_ENGINE_OPTIONS` setting::
     # echo enables verbose logging from SQLAlchemy.
     CELERY_RESULT_ENGINE_OPTIONS = {'echo': True}
 
-
 .. setting:: CELERY_RESULT_DB_SHORT_LIVED_SESSIONS
+
+Short lived sessions
+~~~~~~~~~~~~~~~~~~~~
+
     CELERY_RESULT_DB_SHORT_LIVED_SESSIONS = True
 
 Short lived sessions are disabled by default.  If enabled they can drastically reduce


### PR DESCRIPTION
Fixed missing newline after `.. setting::` which led to wrong HTML markup (see screenshot below).
Also added header for this (`CELERY_RESULT_DB_SHORT_LIVED_SESSIONS`) parameter name.
![20150129_13 04 58](https://cloud.githubusercontent.com/assets/829944/5955812/e098d12e-a7b7-11e4-8ad5-44391c1158aa.png)