### PR TITLE
add note about Django 1.6 transaction changes to userguide

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -1548,6 +1548,16 @@ depending on state from the current transaction*:
             transaction.commit()
             expand_abbreviations.delay(article.pk)
 
+Note that Django 1.6 and later enable autocommit mode by default
+(deprecating `commit_on_success` and `commit_manually`), automatically
+wrapping each SQL query in its own transaction, avoiding the race
+condition by default and making it less likely that you'll encounter
+the above problem. However, enabling `ATOMIC_REQUESTS` on the database
+connection will bring back the transaction per request model and the
+race condition along with it. In this case, the simplest solution is
+just to use the `@transaction.non_atomic_requests` to switch it back
+to autocommit for that view.
+
 .. _task-example:
 
 Example


### PR DESCRIPTION
See #2472.

Django 1.6 introduced a change to the tranasction model, switching to autocommit
by default and deprecating much of the old transaction API, with plans to
remove it completely in 1.8.

This commit adds a note to the userguide section that discusses race conditions
involving database transactions, pointing out the ramifications of the
example code in Django 1.6+. The upside is that the new default autocommit behavior makes it less likely that users will encounter the race condition described unless they explicitly enable `ATOMIC_REQUESTS`.

For now, I put it in as a note after the existing section, which uses 1.5 style sample code. Since `commit_on_success` and `commit_manually` will be completely removed in Django 1.8, the user guide at some point should probably switch the order around so the discussion of race conditions focuses on the current versions of Django first and then only mentions the older APIs as an aside.

Anyway, this is a first draft. Happy to rewrite if anyone has suggestions.