### PR TITLE
Remove ROOT_DISCOURAGED warning

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -17,7 +17,6 @@ import os
 import platform as _platform
 import signal as _signal
 import sys
-import warnings
 
 from collections import namedtuple
 
@@ -77,15 +76,6 @@ worker accepts messages serialized with pickle is a very bad idea!
 
 If you really want to continue then you have to set the C_FORCE_ROOT
 environment variable (but please think about this before you do).
-
-User information: uid={uid} euid={euid} gid={gid} egid={egid}
-"""
-
-ROOT_DISCOURAGED = """\
-You are running the worker with superuser privileges, which is
-absolutely not recommended!
-
-Please specify a different user using the -u option.
 
 User information: uid={uid} euid={euid} gid={gid} egid={egid}
 """
@@ -725,6 +715,3 @@ def check_privileges(accept_content):
                     ), file=sys.stderr)
                 finally:
                     os._exit(1)
-        warnings.warn(RuntimeWarning(ROOT_DISCOURAGED.format(
-            uid=uid, euid=euid, gid=gid, egid=egid,
-        )))

--- a/celery/tests/bin/test_worker.py
+++ b/celery/tests/bin/test_worker.py
@@ -287,22 +287,6 @@ class test_Worker(WorkerAppCase):
             worker = self.Worker(app=self.app)
             worker.on_start()
             _exit.assert_called_with(1)
-            from celery import platforms
-            platforms.C_FORCE_ROOT = True
-            try:
-                with self.assertWarnsRegex(
-                        RuntimeWarning,
-                        r'absolutely not recommended'):
-                    worker = self.Worker(app=self.app)
-                    worker.on_start()
-            finally:
-                platforms.C_FORCE_ROOT = False
-            self.app.conf.CELERY_ACCEPT_CONTENT = ['json']
-            with self.assertWarnsRegex(
-                    RuntimeWarning,
-                    r'absolutely not recommended'):
-                worker = self.Worker(app=self.app)
-                worker.on_start()
 
     @disable_stdouts
     def test_redirect_stdouts(self):


### PR DESCRIPTION
This warning creates noise in valid root-using scenarios like docker
containers.  Having users specify C_FORCE_ROOT is sufficient
discouragement from running celery as root.