### PR TITLE
Add Elasticsearch backend

### DIFF
--- a/celery/backends/__init__.py
+++ b/celery/backends/__init__.py
@@ -34,6 +34,7 @@ BACKEND_ALIASES = {
     'couchdb': 'celery.backends.couchdb:CouchDBBackend',
     'riak': 'celery.backends.riak:RiakBackend',
     'disabled': 'celery.backends.base:DisabledBackend',
+    'elasticsearch': 'celery.backends.elasticsearch:ElasticsearchBackend',
 }
 
 #: deprecated alias to ``current_app.backend``.

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -1,0 +1,106 @@
+# -* coding: utf-8 -*-
+"""
+    celery.backends.elasticsearch
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Elasticsearch result store backend.
+    Based on CouchDB backend.
+
+"""
+from __future__ import absolute_import
+
+try:
+    import elasticsearch
+except ImportError:
+    elasticsearch = None  # noqa
+
+from .base import KeyValueStoreBackend
+
+import datetime, base64
+
+from kombu.utils.url import _parse_url
+
+from celery.exceptions import ImproperlyConfigured
+
+__all__ = ['ElasticsearchBackend']
+
+ERR_LIB_MISSING = """\
+You need to install the elasticsearch library to use the Elasticsearch \
+result backend\
+"""
+
+class ElasticsearchBackend(KeyValueStoreBackend):
+    index = 'celery'
+    doc_type = 'backend'
+    scheme = 'http'
+    host = 'localhost'
+    port = 9200
+
+    def __init__(self, url=None, *args, **kwargs):
+        """Initialize Elasticsearch backend instance.
+
+        :raises celery.exceptions.ImproperlyConfigured: if
+            module :mod:`elasticsearch` is not available.
+
+        """
+        super(ElasticsearchBackend, self).__init__(*args, **kwargs)
+
+        if elasticsearch is None:
+            raise ImproperlyConfigured(ERR_LIB_MISSING)
+
+        if url:
+            uscheme, uhost, uport, _, _, uuri, _ = _parse_url(url)  # noqa
+            uuri = uuri.strip('/') if uuri else None
+            uuris = uuri.split("/")
+
+        self.index = uuris[0] if len(uuris) > 0 else index
+        self.doc_type = uuris[1] if len(uuris) > 1 else doc_type
+        self.scheme = uscheme
+        self.host = uhost
+
+        self._server = None
+
+    def _get_server(self):
+        """Connect to the Elasticsearch server."""
+        return elasticsearch.Elasticsearch(self.host)
+
+    @property
+    def server(self):
+        if self._server is None:
+            self._server = self._get_server()
+        return self._server
+
+    def get(self, key):
+        try:
+            out = self.server.get(index=self.index,\
+                                  doc_type=self.doc_type,\
+                                  id=key)
+            if "found" in out and out["found"] and "_source" in out\
+                              and key in out["_source"]:
+                return base64.b16decode(out["_source"][key])
+            else:
+                return None
+        except elasticsearch.exceptions.NotFoundError:
+            return None
+
+    def set(self, key, value):
+        try:
+            data = {}
+            data['@timestamp'] = "{0}Z".format(datetime.datetime.utcnow()\
+                                       .strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3])
+            data[key] = base64.b16encode(value)
+            self.server.index(index=self.index, doc_type=self.doc_type,\
+                              id=key, body=data)
+        except elasticsearch.exceptions.ConflictError:
+            # document already exists, update it
+            data = self.get(key)
+            data[key] = base64.b16encode(value)
+            self.server.index(index=self.index, doc_type=self.doc_type,\
+                              id=key, body=data, refresh=True)
+
+    def mget(self, keys):
+        return [self.get(key) for key in keys]
+
+    def delete(self, key):
+        self.server.delete(index=self.index, doc_type=self.doc_type, id=key)
+

--- a/requirements/extras/elasticsearch.txt
+++ b/requirements/extras/elasticsearch.txt
@@ -1,0 +1,1 @@
+elasticsearch


### PR DESCRIPTION
Add Elasticsearch as backend.

Run on host:

    docker run -d -p 9200:9200 -p 9300:9300 dockerfile/elasticsearch

tasks.py

    from celery import Celery

    app = Celery('tasks', backend="elasticsearch://172.17.0.9:9200/celery/backend", broker='amqp://guest@localhost//')

    @app.task
    def add(url):
        return {"success":True,"result":"hello"}

Run

    celery -A tasks worker --loglevel=info

In shell

    >>> from tasks import add
    >>> t = add.delay("celery is funny")
    >>> t.result
    {'result': 'celery is funny', 'success': True}
    >>> t.task_id
    '8f919acc-3d99-4b05-9d1f-9bb8cf80b9d1'

On Elasticsearch, add concatenate task_id with celery-task-meta-

    curl -XGET http://172.17.0.9:9200/celery/backend/celery-task-meta-8f919acc-3d99-4b05-9d1f-9bb8cf80b9d1
    
    {"_index":"celery","_type":"backend","_id":"celery-task-meta-8f919acc-3d99-4b05-9d1f-9bb8cf80b9d1","_version":1,"found":true,"_source":{"@timestamp": "2015-02-13T00:54:27.533Z", "celery-task-meta-8f919acc-3d99-4b05-9d1f-9bb8cf80b9d1": "80027D710128550673746174757371025507535543434553537103550974726163656261636B71044E5506726573756C7471057D7106286805550F63656C6572792069732066756E6E7971075507737563636573737108887555086368696C6472656E71095D752E"}}

I encode value to base16 to prevent encoding serialization problems.