### PR TITLE
Fix failure when task has multiple callbacks

### DIFF
--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -273,7 +273,7 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                                     else:
                                         sigs.append(sig)
                                 for group_ in groups:
-                                    group.apply_async((retval, ))
+                                    group_.apply_async((retval, ))
                                 if sigs:
                                     group(sigs).apply_async((retval, ))
                             else:

--- a/celery/tests/tasks/test_trace.py
+++ b/celery/tests/tasks/test_trace.py
@@ -109,11 +109,16 @@ class test_trace(TraceCase):
             pass
         empty.backend = Mock()
 
-        sig = {'chord_size': None, 'task': 'empty', 'args': (), 'options': {}, 'subtask_type': None, 'kwargs': {}, 'immutable': False}
-        callbacks = [
-            sig,
-            {'chord_size': None, 'task': 'celery.group', 'args': (), 'options': {}, 'subtask_type': 'group', 'kwargs': {'tasks': (empty(), empty())}, 'immutable': False}
-        ]
+        sig = {
+            'chord_size': None, 'task': 'empty', 'args': (), 'options': {},
+            'subtask_type': None, 'kwargs': {}, 'immutable': False
+        }
+        group_sig = {
+            'chord_size': None, 'task': 'celery.group', 'args': (),
+            'options': {}, 'subtask_type': 'group',
+            'kwargs': {'tasks': (empty(), empty())}, 'immutable': False
+        }
+        callbacks = [sig, group_sig]
 
         # should not raise an exception
         self.trace(empty, [], {}, request={'callbacks': callbacks})


### PR DESCRIPTION
Exception was:

```
File "celery/app/trace.py", line 276, in trace_task
    group.apply_async((retval, ))
TypeError: unbound method apply_async() must be called with group instance as first argument (got tuple instance instead)
```

Due to a simple typo (group -> group_).

I fixed branch 3.1 only, because it was heavily rewritten in 3.2; but the test is probably useful for 3.2 (at the moment, it fails due to another exception).