### PR TITLE
Support Redis Sentinel as result backend

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -180,3 +180,4 @@ Bert Vanderbauwhede, 2014/12/18
 John Anderson, 2014/12/27
 Luke Burden, 2015/01/24
 Mickaël Penhard, 2015/02/15
+Tristan Carel, 2015/03/11

--- a/celery/backends/__init__.py
+++ b/celery/backends/__init__.py
@@ -28,6 +28,7 @@ BACKEND_ALIASES = {
     'rpc': 'celery.backends.rpc.RPCBackend',
     'cache': 'celery.backends.cache:CacheBackend',
     'redis': 'celery.backends.redis:RedisBackend',
+    'sentinel': 'celery.backends.redis:RedisBackend',
     'mongodb': 'celery.backends.mongodb:MongoBackend',
     'db': 'celery.backends.database:DatabaseBackend',
     'database': 'celery.backends.database:DatabaseBackend',

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -116,7 +116,7 @@ class BaseBackend(object):
                                  status=states.SUCCESS, request=request)
 
     def mark_as_failure(self, task_id, exc, traceback=None, request=None):
-        """Mark task as executed with failure. Stores the execption."""
+        """Mark task as executed with failure. Stores the exception."""
         return self.store_result(task_id, exc, status=states.FAILURE,
                                  traceback=traceback, request=request)
 

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -191,15 +191,12 @@ class RedisBackend(KeyValueStoreBackend):
 
     def on_connection_error(self, max_retries, exc, intervals, retries):
         if self.sentinel is not None:
-            # reset cache property so that sentinel provides a new connection during next call
             del self.client
-            return None
-        else:
-            tts = next(intervals)
-            error('Connection to Redis lost: Retry (%s/%s) %s.',
-                  retries, max_retries or 'Inf',
-                  humanize_seconds(tts, 'in '))
-            return tts
+        tts = next(intervals)
+        error('Connection to Redis lost: Retry (%s/%s) %s.',
+              retries, max_retries or 'Inf',
+              humanize_seconds(tts, 'in '))
+        return tts
 
     def set(self, key, value, **retry_policy):
         return self.ensure(self._set, (key, value), **retry_policy)

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -185,6 +185,7 @@ class RedisBackend(KeyValueStoreBackend):
         max_retries = retry_policy.get('max_retries')
         return retry_over_time(
             fun, self.connection_errors, args, {},
+            partial(self.on_connection_error, max_retries),
             **retry_policy
         )
 

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -64,7 +64,7 @@ class RedisBackend(KeyValueStoreBackend):
     def __init__(self, host=None, port=None, db=None, password=None,
                  expires=None, max_connections=None, url=None,
                  connection_pool=None, new_join=False,
-                 sentinel=False, extra_sentinels=None, cluster_name=None, **kwargs):
+                 sentinel=False, extra_sentinels=None, master=None, **kwargs):
         super(RedisBackend, self).__init__(**kwargs)
         conf = self.app.conf
         if self.redis is None:
@@ -109,7 +109,7 @@ class RedisBackend(KeyValueStoreBackend):
             self.connparams.pop('sentinel')
             self.sentinel = None
         else:
-            self.connparams.setdefault('cluster_name', _get("CLUSTER_NAME") or 'mymaster'),
+            self.connparams.setdefault('master', _get("MASTER") or 'mymaster'),
             self.connparams.setdefault('extra_sentinels', _get('EXTRA_SENTINELS') or extra_sentinels)
             self.connparams.setdefault(
                 'min_other_sentinels',
@@ -317,7 +317,7 @@ class RedisBackend(KeyValueStoreBackend):
     def client(self):
         if self.sentinel is not None:
             return self.sentinel_client.master_for(
-                self.connparams['cluster_name'],
+                self.connparams['master'],
                 redis_class=redis.Redis
             )
         else:

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -297,10 +297,12 @@ class RedisBackend(KeyValueStoreBackend):
     @cached_property
     def sentinel_client(self):
         sentinels = [(self.connparams['host'], self.connparams['port'])]
-        sentinels.extend([hostport.split(':') for hostport in \
-            self.connparams.get('extra_sentinels', "").split(',')
-        ])
-
+        sentinels.extend(
+            map(lambda hp: hp if len(hp) == 2 else [hp, RedisBackend.SENTINEL_DEFAULT_PORT],
+                [hostport.split(':') for hostport in \
+                self.connparams.get('extra_sentinels', "").split(',')]
+            )
+        )
         sentinel_args = self._dict_filter_prefix(self.connparams, 'sentinel_')
         redis_connection_args = self._dict_filter_prefix(self.connparams, 'redis_')
 

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -92,8 +92,6 @@ class RedisBackend(KeyValueStoreBackend):
             'password': _get('PASSWORD'),
             'max_connections': self.max_connections,
             'sentinel': _get('SENTINEL') or str(sentinel),
-            'cluster_name': _get("CLUSTER_NAME") or 'mymaster',
-            'extra_sentinels': _get('EXTRA_SENTINELS') or extra_sentinels
         }
         if url:
             self.connparams = self._params_from_url(url, self.connparams)
@@ -108,10 +106,15 @@ class RedisBackend(KeyValueStoreBackend):
             )
 
         if not self.connparams['sentinel']:
-            for k in ['sentinel', 'cluster_name', 'extra_sentinels']:
-                self.connparams.pop(k)
+            self.connparams.pop('sentinel')
             self.sentinel = None
         else:
+            self.connparams.setdefault('cluster_name', _get("CLUSTER_NAME") or 'mymaster'),
+            self.connparams.setdefault('extra_sentinels', _get('EXTRA_SENTINELS') or extra_sentinels)
+            self.connparams.setdefault(
+                'min_other_sentinels',
+                int(_get('MIN_OTHER_SENTINELS') or 0)
+            )
             self.sentinel = sentinel_mod
 
         self.url = url
@@ -302,6 +305,7 @@ class RedisBackend(KeyValueStoreBackend):
 
         return self.sentinel.Sentinel(
             sentinels,
+            min_other_sentinels=self.connparams['min_other_sentinels'],
             sentinel_kwargs=sentinel_args,
             **redis_connection_args
         )
@@ -310,7 +314,10 @@ class RedisBackend(KeyValueStoreBackend):
     @cached_property
     def client(self):
         if self.sentinel is not None:
-            return self.sentinel_client.master_for(self.connparams['cluster_name'], redis_class=redis.Redis)
+            return self.sentinel_client.master_for(
+                self.connparams['cluster_name'],
+                redis_class=redis.Redis
+            )
         else:
             return self.redis.Redis(
                 connection_pool=self.ConnectionPool(**self.connparams),

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -98,12 +98,13 @@ class RedisBackend(KeyValueStoreBackend):
 
         self.connparams['sentinel'] = strtobool(self.connparams.get('sentinel', False))
         # resolve default port
-        if 'port' not in self.connparams:
-            self.connparams['port'] = _get('DB') or (\
-                RedisBackend.SENTINEL_DEFAULT_PORT \
-                if self.connparams['sentinel']
-                else RedisBackend.REDIS_DEFAULT_PORT
-            )
+        if not self.connparams.get('path', '').startswith('/'): # no socket connection
+            if 'port' not in self.connparams:
+                self.connparams['port'] = _get('DB') or (\
+                    RedisBackend.SENTINEL_DEFAULT_PORT \
+                    if self.connparams['sentinel']
+                    else RedisBackend.REDIS_DEFAULT_PORT
+                )
 
         if not self.connparams['sentinel']:
             self.connparams.pop('sentinel')

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -152,6 +152,8 @@ class RedisBackend(KeyValueStoreBackend):
             connparams.pop('port', None)
         else:
             connparams['db'] = path
+        if scheme == 'sentinel':
+            connparams['sentinel'] = True
 
         # db may be string and start with / like in kombu.
         db = connparams.get('db') or 0

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -190,7 +190,7 @@ class RedisBackend(KeyValueStoreBackend):
         )
 
     def on_connection_error(self, max_retries, exc, intervals, retries):
-        if self.connparams['sentinel']:
+        if self.sentinel is not None:
             # reset cache property so that sentinel provides a new connection during next call
             del self.client
             return None

--- a/celery/tests/backends/test_redis.py
+++ b/celery/tests/backends/test_redis.py
@@ -252,7 +252,7 @@ class test_RedisBackend(AppCase):
         self.assertTrue(b.client.lrange.call_count)
         gkey = b.get_key_for_group('group_id', '.j')
         b.client.delete.assert_called_with(gkey)
-        b.client.expire.assert_called_witeh(gkey, 86400)
+        b.client.expire.assert_called_with(gkey, 86400)
 
     def test_process_cleanup(self):
         self.Backend(app=self.app, new_join=True).process_cleanup()

--- a/celery/tests/backends/test_redis.py
+++ b/celery/tests/backends/test_redis.py
@@ -133,15 +133,16 @@ class test_RedisBackend(AppCase):
             self.Backend(app=self.app, new_join=True)
 
     def test_url(self):
-        x = self.Backend(
-            'redis://:bosco@vandelay.com:123//1', app=self.app,
-            new_join=True,
-        )
-        self.assertTrue(x.connparams)
-        self.assertEqual(x.connparams['host'], 'vandelay.com')
-        self.assertEqual(x.connparams['db'], 1)
-        self.assertEqual(x.connparams['port'], 123)
-        self.assertEqual(x.connparams['password'], 'bosco')
+        for scheme in ['redis', 'sentinel']:
+            x = self.Backend(
+                scheme + '://:bosco@vandelay.com:123//1', app=self.app,
+                new_join=True,
+            )
+            self.assertTrue(x.connparams)
+            self.assertEqual(x.connparams['host'], 'vandelay.com')
+            self.assertEqual(x.connparams['db'], 1)
+            self.assertEqual(x.connparams['port'], 123)
+            self.assertEqual(x.connparams['password'], 'bosco')
 
     def test_socket_url(self):
         x = self.Backend(

--- a/celery/tests/utils/test_mail.py
+++ b/celery/tests/utils/test_mail.py
@@ -46,7 +46,7 @@ class test_Mailer(Case):
         mailer = Mailer(use_ssl=False, use_tls=False)
         mailer._send(msg)
 
-        client.sendmail.assert_called_With(msg.sender, msg.to, str(msg))
+        client.sendmail.assert_called_with(msg.sender, msg.to, str(msg))
 
         client.quit.side_effect = SSLError()
         mailer._send(msg)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -199,6 +199,10 @@ Can be one of the following:
     Use `Redis`_ to store the results.
     See :ref:`conf-redis-result-backend`.
 
+* sentinel
+    Use `Sentinel`_ to store the results in `Redis`_
+    See :ref:`conf-sentinel-result-backend`.
+
 * amqp
     Send results back as AMQP messages
     See :ref:`conf-amqp-result-backend`.
@@ -224,6 +228,7 @@ Can be one of the following:
 .. _`memcached`: http://memcached.org
 .. _`MongoDB`: http://mongodb.org
 .. _`Redis`: http://redis.io
+.. _`Sentinel`: http://redis.io/topics/sentinel
 .. _`Cassandra`: http://cassandra.apache.org/
 .. _`IronCache`: http://www.iron.io/cache
 .. _`Couchbase`: http://www.couchbase.com/
@@ -484,6 +489,97 @@ CELERY_REDIS_MAX_CONNECTIONS
 
 Maximum number of connections available in the Redis connection
 pool used for sending and retrieving results.
+
+.. _conf-sentinel-result-backend:
+
+Sentinel backend settings
+-------------------------
+
+Configuring the backend URL
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    The Redis backend requires the :mod:`redis` library:
+    http://pypi.python.org/pypi/redis/
+
+    To install the redis package use `pip` or `easy_install`:
+
+    .. code-block:: bash
+
+        $ pip install redis
+
+This backend requires the :setting:`CELERY_RESULT_BACKEND`
+settings to be set to a Sentinel URL:
+
+    CELERY_RESULT_BACKEND = 'sentinel://:password@host:port/db'
+
+For example::
+
+    CELERY_RESULT_BACKEND = 'sentinel://localhost/0'
+
+which is the same than::
+
+    CELERY_RESULT_BACKEND = 'redis://localhost:26379/0?master=mymaster'
+    CELERY_RESULT_BACKEND = 'redis://'
+
+The fields of the URL is defined as follow:
+
+- *host*
+
+Host name or IP adress of a Sentinel server. Default is `localhost`.
+
+- *port*
+
+Port to the Sentinel server. Default is `26379`.
+
+- *db*
+
+Redis database to connect to. Default value is 0.
+
+- *password*:
+
+Password used to connect to the Redis master.
+
+- *master*:
+
+Redis master alias specified in Sentinel configuration
+with 'monitor' directive. Default value is `mymaster`.
+
+- *extra_sentinels*:
+
+Specifies additional Sentinel servers to implement high-availability.
+For instance:
+
+    CELERY_RESULT_BACKEND = 'sentinel://host1/celery?extra_sentinels=host2,host3:40000'
+
+The URL specifies a cluster of sentinels, properly configured to connect to
+the 'celery' redis master, made of the following servers:
+
+  - host1:26379
+
+  - host2:26379
+
+  - host3:40000
+
+- *min_other_sentinels*:
+
+Specifies the minimum number of Sentinel peers to consider a
+response valid. Default is 0.
+
+- *sentinel_* prefixed options:
+
+URL parameters starting with `sentinel_` are given to the
+`redis.sentinel.Sentinel` constructor in the `sentinel_kwargs`
+parameter. The `sentinel_` prefix is removed from those options
+before being passed to Redis API.
+
+- *redis_* prefixed options:
+
+URL parameters starting with `redis_` are given to the
+`redis.sentinel.Sentinel` constructor in the `**kwargs` parameter.
+The `redis_` prefix is removed from those options
+before being passed to Redis API.
 
 .. _conf-mongodb-result-backend:
 


### PR DESCRIPTION
Hi there,

We (at Cogniteev) recently switched to Redis as result backend that provides a very efficient implementation of chords. Yet we missed high-availability to use it on production.

Here is a patch in Redis result backend that provide support to Sentinel.
