### PR TITLE
Fix TypeError raised in logging (validate_models)

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -156,7 +156,7 @@ class DjangoWorkerFixup(object):
             pass
         else:
             django_setup()
-        s = StringIO.StringIO()
+        s = StringIO()
         try:
             from django.core.management.validation import get_validation_errors
         except ImportError:

--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -4,7 +4,7 @@ import os
 import sys
 import warnings
 
-if sys.version_info[0] < 3:
+if sys.version_info[0] < 3 and not hasattr(sys, 'pypy_version_info'):
     from StringIO import StringIO
 else:
     from io import StringIO

--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import
 
-import StringIO
 import os
 import sys
 import warnings
+
+if sys.version_info[0] < 3:
+    from StringIO import StringIO
+else:
+    from io import StringIO
 
 from kombu.utils import cached_property, symbol_by_name
 

--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import io
+import StringIO
 import os
 import sys
 import warnings
@@ -152,7 +152,7 @@ class DjangoWorkerFixup(object):
             pass
         else:
             django_setup()
-        s = io.StringIO()
+        s = StringIO.StringIO()
         try:
             from django.core.management.validation import get_validation_errors
         except ImportError:


### PR DESCRIPTION
Fix TypeError raised in logging (validate_models)
celery -A proj worker -l info
Windows 8
celery 3.1.17, django 1.6.10