### PR TITLE
on_message callback added

### DIFF
--- a/celery/backends/amqp.py
+++ b/celery/backends/amqp.py
@@ -231,7 +231,7 @@ class AMQPBackend(BaseBackend):
     def _many_bindings(self, ids):
         return [self._create_binding(task_id) for task_id in ids]
 
-    def get_many(self, task_ids, timeout=None, no_ack=True,
+    def get_many(self, task_ids, timeout=None, no_ack=True, on_message=None,
                  now=monotonic, getfields=itemgetter('status', 'task_id'),
                  READY_STATES=states.READY_STATES,
                  PROPAGATE_STATES=states.PROPAGATE_STATES, **kwargs):
@@ -254,15 +254,17 @@ class AMQPBackend(BaseBackend):
             push_cache = self._cache.__setitem__
             decode_result = self.meta_from_decoded
 
-            def on_message(message):
+            def _on_message(message):
                 body = decode_result(message.decode())
+                if on_message is not None:
+                    on_message(body)
                 state, uid = getfields(body)
                 if state in READY_STATES:
                     push_result(body) \
                         if uid in task_ids else push_cache(uid, body)
 
             bindings = self._many_bindings(task_ids)
-            with self.Consumer(channel, bindings, on_message=on_message,
+            with self.Consumer(channel, bindings, on_message=_on_message,
                                accept=self.accept, no_ack=no_ack):
                 wait = conn.drain_events
                 popleft = results.popleft

--- a/celery/result.py
+++ b/celery/result.py
@@ -580,7 +580,7 @@ class ResultSet(ResultBase):
             interval=interval, callback=callback, no_ack=no_ack, on_message=on_message)
 
     def join(self, timeout=None, propagate=True, interval=0.5,
-             callback=None, no_ack=True):
+             callback=None, no_ack=True, on_message=None):
         """Gathers the results of all tasks as a list in order.
 
         .. note::
@@ -631,6 +631,9 @@ class ResultSet(ResultBase):
         assert_will_not_block()
         time_start = monotonic()
         remaining = None
+
+        if on_message is not None:
+            raise Exception('Your backend not suppored on_message callback')
 
         results = []
         for result in self.results:

--- a/celery/result.py
+++ b/celery/result.py
@@ -567,7 +567,7 @@ class ResultSet(ResultBase):
                 raise TimeoutError('The operation timed out')
 
     def get(self, timeout=None, propagate=True, interval=0.5,
-            callback=None, no_ack=True):
+            callback=None, no_ack=True, on_message=None):
         """See :meth:`join`
 
         This is here for API compatibility with :class:`AsyncResult`,
@@ -577,7 +577,7 @@ class ResultSet(ResultBase):
         """
         return (self.join_native if self.supports_native_join else self.join)(
             timeout=timeout, propagate=propagate,
-            interval=interval, callback=callback, no_ack=no_ack)
+            interval=interval, callback=callback, no_ack=no_ack, on_message=on_message)
 
     def join(self, timeout=None, propagate=True, interval=0.5,
              callback=None, no_ack=True):
@@ -649,7 +649,8 @@ class ResultSet(ResultBase):
                 results.append(value)
         return results
 
-    def iter_native(self, timeout=None, interval=0.5, no_ack=True):
+    def iter_native(self, timeout=None, interval=0.5, no_ack=True,
+                    on_message=None):
         """Backend optimized version of :meth:`iterate`.
 
         .. versionadded:: 2.2
@@ -667,10 +668,12 @@ class ResultSet(ResultBase):
         return self.backend.get_many(
             set(r.id for r in results),
             timeout=timeout, interval=interval, no_ack=no_ack,
+            on_message=on_message,
         )
 
     def join_native(self, timeout=None, propagate=True,
-                    interval=0.5, callback=None, no_ack=True):
+                    interval=0.5, callback=None, no_ack=True,
+                    on_message=None):
         """Backend optimized version of :meth:`join`.
 
         .. versionadded:: 2.2
@@ -687,7 +690,8 @@ class ResultSet(ResultBase):
             result.id: i for i, result in enumerate(self.results)
         }
         acc = None if callback else [None for _ in range(len(self))]
-        for task_id, meta in self.iter_native(timeout, interval, no_ack):
+        for task_id, meta in self.iter_native(timeout, interval, no_ack,
+                                              on_message):
             value = meta['result']
             if propagate and meta['status'] in states.PROPAGATE_STATES:
                 raise value

--- a/celery/tests/backends/test_amqp.py
+++ b/celery/tests/backends/test_amqp.py
@@ -294,6 +294,36 @@ class test_AMQPBackend(AppCase):
             b.store_result(tids[0], i, states.PENDING)
             list(b.get_many(tids, timeout=0.01))
 
+    def test_get_many_on_message(self):
+        b = self.create_backend(max_cached_results=10)
+
+        tids = []
+        for i in range(10):
+            tid = uuid()
+            b.store_result(tid, '', states.PENDING)
+            b.store_result(tid, 'comment_%i_1' % i, states.STARTED)
+            b.store_result(tid, 'comment_%i_2' % i, states.STARTED)
+            b.store_result(tid, 'final result %i' % i, states.SUCCESS)
+            tids.append(tid)
+
+
+        expected_messages = {}
+        for i, _tid in enumerate(tids):
+            expected_messages[_tid] = []
+            expected_messages[_tid].append( (states.PENDING, '') )
+            expected_messages[_tid].append( (states.STARTED, 'comment_%i_1' % i) )
+            expected_messages[_tid].append( (states.STARTED, 'comment_%i_2' % i) )
+            expected_messages[_tid].append( (states.SUCCESS, 'final result %i' % i) )
+
+        on_message_results = {}
+        def on_message(body):
+            if not body['task_id'] in on_message_results:
+                on_message_results[body['task_id']] = []
+            on_message_results[body['task_id']].append( (body['status'], body['result']) )
+
+        b.get_many(tids, timeout=1, on_message=on_message)
+        self.assertEqual(sorted(on_message_results), sorted(expected_messages))
+
     def test_get_many_raises_outer_block(self):
 
         class Backend(AMQPBackend):

--- a/celery/tests/backends/test_amqp.py
+++ b/celery/tests/backends/test_amqp.py
@@ -321,7 +321,7 @@ class test_AMQPBackend(AppCase):
                 on_message_results[body['task_id']] = []
             on_message_results[body['task_id']].append( (body['status'], body['result']) )
 
-        b.get_many(tids, timeout=1, on_message=on_message)
+        res = list(b.get_many(tids, timeout=1, on_message=on_message))
         self.assertEqual(sorted(on_message_results), sorted(expected_messages))
 
     def test_get_many_raises_outer_block(self):

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,7 +1,4 @@
 coverage>=3.0
 coveralls
 redis
-#riak >=2.0
-#pymongo
-#SQLAlchemy
 PyOpenSSL

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,4 +1,7 @@
 coverage>=3.0
 coveralls
 redis
+#riak >=2.0
+#pymongo
+#SQLAlchemy
 PyOpenSSL


### PR DESCRIPTION
For some tasks it's realy convenient to catch all task state changes. For example, on clients I want catch comment progress cahnges as soon as they received (on backends which support it, like AMQP). So in task-code we will do this:
```
self.update_state(meta = { 'comment': 'some comment 1...'})
...
self.update_state(meta = { 'comment': 'some comment 2...'})
```

But currently in clients we can catch only final status without every seconds sleep like this terrible code:
```
while task.state != 'SUCCESS' and task.state != 'FAILURE' and task.state != 'REVOKED':
	# Check if comment was changed
	curr_comment = result.get('comment', last_comment) if result else last_comment
 
	# Process new lines
	process_state_lines(last_comment, curr_comment)
 
	# Update last comment
	last_comment = curr_comment

	# Get new task result
	time.sleep(1)
	result = task.result
```
It's not a good way. We must sleep and check that comment is changed.

So very easy solution is allow set 'on_message' call back for get_many method. And we can use it like so:
```
	def on_message(body):
		print body

	r = group(task).apply_async()
	r.get(on_message=on_message)
```

Probably, it's also can be usefull for 'chorded' tasks. We can monitor every status change in all tasks. But need more digging for accept this.