### PR TITLE
celerybeat daemon restart fails on ubuntu 14.04 LTS

### DIFF
--- a/extra/generic-init.d/celerybeat
+++ b/extra/generic-init.d/celerybeat
@@ -202,14 +202,17 @@ create_paths () {
     create_default_dir "$CELERYBEAT_PID_DIR"
 }
 
+is_running() {
+    pid=$1
+    ps $pid > /dev/null 2>&1
+}
 
 wait_pid () {
     pid=$1
     forever=1
     i=0
     while [ $forever -gt 0 ]; do
-        kill -0 $pid 1>/dev/null 2>&1
-        if [ $? -eq 1 ]; then
+        if ! is_running $pid; then
             echo "OK"
             forever=0
         else


### PR DESCRIPTION
The celerybeat daemon fails to detect if the process was killed.

### Reproduction steps
sudo service celerybeat start
kill the celerybeat process manually
sudo service celerybeat restart

### Expected result
Stopping celerybeat... OK
Starting celerybeat...

### Actual result
Stopping celerybeat...

### Testing using vagrant
* Install vagrant + virtualbox
* Download: https://gist.github.com/OriHoch/621e8e0f023f662ac209
* In the directory of the Vagrantfile, run: "vagrant up"