### PR TITLE
Changed _apply_chord_incr to use int value

### DIFF
--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -129,7 +129,7 @@ class CacheBackend(KeyValueStoreBackend):
         return self.client.delete(key)
 
     def _apply_chord_incr(self, header, partial_args, group_id, body, **opts):
-        self.client.set(self.get_key_for_chord(group_id), '0', time=86400)
+        self.client.set(self.get_key_for_chord(group_id), 0, time=86400)
         return super(CacheBackend, self)._apply_chord_incr(
             header, partial_args, group_id, body, **opts
         )


### PR DESCRIPTION
Example
```
>>> mc.set('dfdsgfdgfd', '0')                                                   
True
>>> mc.incr('dfdsgfdgfd')                                                       
Traceback (most recent call last):
  File "<console>", line 1, in <module>
_pylibmc.ClientError: 1 keys failed
>>>
```