### PR TITLE
Update task-cookbook.rst

### DIFF
--- a/docs/tutorials/task-cookbook.rst
+++ b/docs/tutorials/task-cookbook.rst
@@ -31,7 +31,7 @@ The cache key expires after some time in case something unexpected happens
     from celery import task
     from celery.utils.log import get_task_logger
     from django.core.cache import cache
-    from django.utils.hashcompat import md5_constructor as md5
+    from hashlib import md5
     from djangofeeds.models import Feed
 
     logger = get_task_logger(__name__)


### PR DESCRIPTION
`django.utils.hashcompat` has been deprecated and removed in 1.6. It's recommended to use the builtin python `hashlib` instead.

https://docs.djangoproject.com/en/1.5/internals/deprecation/