### PR TITLE
Fix Exception marshalling with JSON serializer

### DIFF
--- a/celery/backends/amqp.py
+++ b/celery/backends/amqp.py
@@ -195,7 +195,7 @@ class AMQPBackend(BaseBackend):
 
         def callback(meta, message):
             if meta['status'] in states.READY_STATES:
-                results[meta['task_id']] = meta
+                results[meta['task_id']] = self.meta_from_decoded(meta)
 
         consumer.callbacks[:] = [callback]
         time_start = now()

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps = -r{toxinidir}/requirements/default.txt
        -r{toxinidir}/requirements/dev.txt
 setenv = C_DEBUG_TEST = 1
 commands = {toxinidir}/extra/release/removepyc.sh {toxinidir}
-           pip install -U -r{toxinidir}/requirements/dev.txt
+           pip install -q -U -r{toxinidir}/requirements/dev.txt
            nosetests -xsv --with-coverage --cover-inclusive --cover-erase []
 
 [testenv:pypy3]
@@ -59,7 +59,7 @@ deps = -r{toxinidir}/requirements/default.txt
        -r{toxinidir}/requirements/dev.txt
 setenv = C_DEBUG_TEST = 1
 commands = {toxinidir}/extra/release/removepyc.sh {toxinidir}
-           pip install -U -r{toxinidir}/requirements/dev.txt
+           pip install -q -U -r{toxinidir}/requirements/dev.txt
            nosetests -xsv --with-coverage --cover-inclusive --cover-erase []
 
 [testenv:docs]


### PR DESCRIPTION
When using the JSON serializer, exceptions get serialized as dicts. The code in `drain_events` in `amqp.py` naively then sets the result dict to such a dict without transforming the dict structure back into an actual Exception through `exception_to_python` [[1]](https://github.com/celery/celery/blob/6592ff64b6b024a4b68abcc53b151888fdf0dee3/celery/backends/amqp.py#L198).

When a task raises an exception, `AsyncResult.get` and `AsyncResult.maybe_reraise` try to raise the
exception [[2]](https://github.com/celery/celery/blob/6592ff64b6b024a4b68abcc53b151888fdf0dee3/celery/result.py#L890) [[3]](https://github.com/celery/celery/blob/6592ff64b6b024a4b68abcc53b151888fdf0dee3/celery/result.py#L273), which is actually still a dict and fail with:

```
TypeError: exceptions must be old-style classes or derived from
BaseException, not dict
```

This patch makes `drain_events` call `meta_from_decoded` which is
responsible for that, just like it is called in `get_many` [[4]](https://github.com/celery/celery/blob/33e72fdbc7b07fc26d13bcdc36fb6f42c8291b66/celery/backends/amqp.py#L255). Then,
raising the exception in `AsyncResult` works fine.

To reproduce, see the testcase in #2518. Then, apply the patch and see
stuff start to work again.

closes #2518