### PR TITLE
Retries should behave the same in eager and not eager mode.

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -595,6 +595,8 @@ class Task(object):
             # if task was executed eagerly using apply(),
             # then the retry must also be executed eagerly.
             S.apply().get()
+            if throw:
+                raise ret
             return ret
 
         try:


### PR DESCRIPTION
Right now if you use the retry method.  If you are not running in eager mode, than the value of the `throw` paramater is honored(the function throws an exception with the results).  However if you are running in eager moder, this paramater is not honored.