### PR TITLE
Sync documentation with reality

### DIFF
--- a/celery/app/builtins.py
+++ b/celery/app/builtins.py
@@ -23,7 +23,7 @@ def add_backend_cleanup_task(app):
     backend.
 
     If the configured backend requires periodic cleanup this task is also
-    automatically configured to run every day at midnight (requires
+    automatically configured to run every day at 4am (requires
     :program:`celery beat` to be running).
 
     """

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1239,7 +1239,7 @@ A built-in periodic task will delete the results after this time
 A value of :const:`None` or 0 means results will never expire (depending
 on backend specifications).
 
-Default is to expire after 1 day.
+Default is to expire after 12 hours.
 
 .. note::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1239,7 +1239,7 @@ A built-in periodic task will delete the results after this time
 A value of :const:`None` or 0 means results will never expire (depending
 on backend specifications).
 
-Default is to expire after 12 hours.
+Default is to expire after 1 day.
 
 .. note::
 


### PR DESCRIPTION
according to `celery.beat.install_default_entries()`,
the job is scheduled for 4am (instead of midnight),
and the default expire time is 12 hours (instead of 1 day).