### PR TITLE
Fix: Django fixup throws error when the app uses custom loader class

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -10,6 +10,7 @@ else:
     from io import StringIO
 
 from kombu.utils import cached_property, symbol_by_name
+from kombu.five import string
 
 from datetime import datetime
 from importlib import import_module
@@ -17,6 +18,7 @@ from importlib import import_module
 from celery import signals
 from celery.app import default_app
 from celery.exceptions import FixupWarning
+from celery.utils.imports import dot
 
 __all__ = ['DjangoFixup', 'fixup']
 
@@ -36,7 +38,8 @@ def _maybe_close_fd(fh):
 
 def fixup(app, env='DJANGO_SETTINGS_MODULE'):
     SETTINGS_MODULE = os.environ.get(env)
-    if SETTINGS_MODULE and 'django' not in app.loader_cls.lower():
+    if SETTINGS_MODULE and \
+        'django' not in (app.loader_cls.lower() if isinstance(app.loader_cls, string) else dot(app.loader_cls)):
         try:
             import django  # noqa
         except ImportError:

--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -14,6 +14,7 @@ import os
 import sys
 
 from contextlib import contextmanager
+from inspect import getmodule
 
 from kombu.utils import symbol_by_name
 
@@ -112,3 +113,7 @@ def module_file(module):
     """Return the correct original file name of a module."""
     name = module.__file__
     return name[:-1] if name.endswith('.pyc') else name
+
+def dot(cls):
+    """It is basically kombu.utils.symbol_by_name reversed"""
+    return getmodule(cls).__name__ + ':' + cls.__name__


### PR DESCRIPTION
This small bug appeared when I instantiated Celery with a custom loader class in my Django project. The problem was that the `celery.fixups.django.fixup` function expected the loader class to be a symbol string, but it can be also the class directly.
I've added this small function `celery.utils.imports.dot` which returns the module and class name as a string too so the condition haven't had to change drastically in the fixup.