### PR TITLE
Added a check for syncing the schedule even if nothing is in the schedule

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -504,6 +504,8 @@ class Service(object):
                     debug('beat: Waking up %s.',
                           humanize_seconds(interval, prefix='in '))
                     time.sleep(interval)
+                    if self.scheduler.should_sync():
+                        self.scheduler._do_sync()
         except (KeyboardInterrupt, SystemExit):
             self._is_shutdown.set()
         finally:


### PR DESCRIPTION
Currently, if there is nothing in the Beat schedule the schedule won't re-sync unless Beat is restarted. In addition, if there is something in the schedule Beat won't re-sync until a task is run. This could potentially be a very long time. 

This change adds a check to see if Beat should sync the schedule every time it wakes up.