### PR TITLE
Retry BUG in windows with prefork concurrency option after v3.1.12

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -33,7 +33,7 @@ from celery._state import (
     _announce_app_finalized,
 )
 from celery.exceptions import AlwaysEagerIgnored, ImproperlyConfigured
-from celery.five import values
+from celery.five import items, values
 from celery.loaders import get_loader_cls
 from celery.local import PromiseProxy, maybe_evaluate
 from celery.utils import gen_task_name
@@ -508,6 +508,10 @@ class Celery(object):
         while pending_beat:
             pargs, pkwargs = pending_beat.popleft()
             self._add_periodic_task(*pargs, **pkwargs)
+        # Settings.__setitem__ method, set Settings.change
+        if self._preconf:
+            for key, value in items(self._preconf):
+                setattr(s, key, value)
         self.on_after_configure.send(sender=self, source=s)
         return s
 


### PR DESCRIPTION
Retrying a task in Windows would not work with prefork concurrency option cause lacking of the broker url while child process be instantiated. so, child process would establish a default broker connection with the default broker url, not the broker url we have specified, after v3.1.12.

The broker url we have specified would be restored in self._preconf when our Celery class be instantiated in father process. we must invoke Settings.__setitem__ method, like setattr(s._preconf, k, v), than the broker url would be restored in Settings.change. eventually, father process could pass the Settings.change to child process for instantiating Celery class.

In Linux, child process would inherit resources from it`s father process, so the broker url.