### PR TITLE
Add CELERY_EMAIL_CHARSET option

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -465,6 +465,7 @@ class Celery(object):
                 timeout=conf.EMAIL_TIMEOUT,
                 use_ssl=conf.EMAIL_USE_SSL,
                 use_tls=conf.EMAIL_USE_TLS,
+                charset=conf.EMAIL_CHARSET,
             )
 
     def select_queues(self, queues=None):

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -220,6 +220,7 @@ NAMESPACES = {
         'TIMEOUT': Option(2, type='float'),
         'USE_SSL': Option(False, type='bool'),
         'USE_TLS': Option(False, type='bool'),
+        'CHARSET': Option('us-ascii'),
     },
     'SERVER_EMAIL': Option('celery@localhost'),
     'ADMINS': Option((), type='tuple'),

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -224,10 +224,11 @@ class BaseLoader(object):
     def mail_admins(self, subject, body, fail_silently=False,
                     sender=None, to=None, host=None, port=None,
                     user=None, password=None, timeout=None,
-                    use_ssl=False, use_tls=False):
+                    use_ssl=False, use_tls=False, charset='us-ascii'):
         message = self.mail.Message(sender=sender, to=to,
                                     subject=safe_str(subject),
-                                    body=safe_str(body))
+                                    body=safe_str(body),
+                                    charset=charset)
         mailer = self.mail.Mailer(host=host, port=port,
                                   user=user, password=password,
                                   timeout=timeout, use_ssl=use_ssl,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1633,6 +1633,14 @@ to the SMTP server when sending emails.
 
 The default is 2 seconds.
 
+EMAIL_CHARSET
+~~~~~~~~~~~~~
+
+Charset for outgoing emails. Default is "us-ascii".
+
+.. setting:: EMAIL_CHARSET
+
+
 .. _conf-example-error-mail-config:
 
 Example E-Mail configuration


### PR DESCRIPTION
This PR adds CELERY_EMAIL_CHARSET option that allows to set charset for outgoing emails. Default value is set to "us-ascii" (as it was in older versions, for compatibility), but that charset causes UnicodeDecodeError in python 3 when email contains unicode characters. With this option user can set charset to more appropriate encoding ("utf-8" or other).

Fixes #2648