### PR TITLE
consumer should not retry connection when BROKER_CONNECTION_RETRY is False

### DIFF
--- a/celery/tests/worker/test_consumer.py
+++ b/celery/tests/worker/test_consumer.py
@@ -115,6 +115,13 @@ class test_Consumer(AppCase):
             c.start()
             sleep.assert_called_with(1)
 
+    def test_no_retry_raises_error(self):
+        self.app.conf.BROKER_CONNECTION_RETRY = False
+        c = self.get_consumer()
+        c.blueprint.start.side_effect = socket.error()
+        with self.assertRaises(socket.error):
+            c.start()
+
     def _closer(self, c):
         def se(*args, **kwargs):
             c.blueprint.state = CLOSE

--- a/celery/worker/consumer.py
+++ b/celery/worker/consumer.py
@@ -277,6 +277,10 @@ class Consumer(object):
             try:
                 blueprint.start(self)
             except self.connection_errors as exc:
+                # If we're not retrying connections, no need to catch
+                # connection errors
+                if not self.app.conf.BROKER_CONNECTION_RETRY:
+                    raise
                 if isinstance(exc, OSError) and exc.errno == errno.EMFILE:
                     raise  # Too many open files
                 maybe_shutdown()


### PR DESCRIPTION
Even when `BROKER_CONNECTION_RETRY` is set to `False`, workers will continuously attempt to reconnect to an unaccessible broker. This changes the consumer behavior so that it will just raise the offending exception and fail out.

This new behavior is particularly desirable in cases where the worker process is run under a process manager such as daemontools or supervisord. If a worker is continuously attempting to reconnect, then we should let the manager handle restarts as to involve existing things like flapping daemon reports.

On a more meta note, this feels like a somewhat less than ideal solution, given that we already have a check for `BROKER_CONNECTION_RETRY` in `Consumer.connect`. But it looks like `Consumer` is actually implementing two different kinds of retry logic. First with `Consumer.connect` calling `conn.ensure_connection`, and then again in `Consumer.start` where it's catching connection errors. So I dunno.