### PR TITLE
django-celery link to it's docs

### DIFF
--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -136,7 +136,7 @@ concrete app instance:
 Using the Django ORM/Cache as a result backend.
 -----------------------------------------------
 
-The ``django-celery`` library defines result backends that
+The [``django-celery``](https://github.com/celery/django-celery) library defines result backends that
 uses the Django ORM and Django Cache frameworks.
 
 To use this with your project you need to follow these four steps:


### PR DESCRIPTION
This needs to be linked. The current ReadTheDocs don't tell of all the other things that need to happen to get django-celery working like `import djcelery
djcelery.setup_loader()` in `settings.py` for example.