### PR TITLE
Always make timezones aware in the schedule even if UTC is disabled

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -134,9 +134,7 @@ class schedule(object):
         return schedstate(is_due=False, next=remaining_s)
 
     def maybe_make_aware(self, dt):
-        if self.utc_enabled:
-            return maybe_make_aware(dt, self.tz)
-        return dt
+        return maybe_make_aware(dt, self.tz)
 
     def __repr__(self):
         return '<freq: {0.human_seconds}>'.format(self)

--- a/celery/tests/app/test_beat.py
+++ b/celery/tests/app/test_beat.py
@@ -521,7 +521,7 @@ class test_schedule(AppCase):
         self.assertTrue(d.tzinfo)
         x.utc_enabled = False
         d2 = x.maybe_make_aware(datetime.utcnow())
-        self.assertIsNone(d2.tzinfo)
+        self.assertTrue(d2.tzinfo)
 
     def test_to_local(self):
         x = schedule(10, app=self.app)


### PR DESCRIPTION
Fixes #943.
@monax Please verify that this works for you.
In any event, setting CELERY_UTC_ENABLE to true is a good idea if you are using a Django version newer than 1.4.