### PR TITLE
django.contrib.admin is already uncommented above

### DIFF
--- a/examples/django/proj/settings.py
+++ b/examples/django/proj/settings.py
@@ -134,8 +134,6 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'kombu.transport.django.KombuAppConfig',
     'demoapp',
-    # Uncomment the next line to enable the admin:
-    # 'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
 )


### PR DESCRIPTION
And I don't think the order or where `django.contrib.admin` is placed is of consequence.