### PR TITLE
Fix de-serialization of exception (when used with json serializer)

### DIFF
--- a/celery/backends/amqp.py
+++ b/celery/backends/amqp.py
@@ -180,7 +180,8 @@ class AMQPBackend(BaseBackend):
                 raise self.BacklogLimitExceeded(task_id)
 
             if latest:
-                payload = self._cache[task_id] = latest.payload
+                payload = self._cache[task_id] = \
+                    self.meta_from_decoded(latest.payload)
                 latest.requeue()
                 return payload
             else:


### PR DESCRIPTION
This PR addresses issue with de-serialization of exception when used with amqp backend with json serializer.

A simple example to reproduce this issue: 
```
@app.task
def fail_task():
    raise IOError('something')

@app.task
def join_task():
    pass

@app.task
def chord_task(self):
    return chord(
        group(
            fail_task.si(),
            fail_task.si(),
        join_task.si()).delay()

# Client code
chord_task.si().delay()
```

The issue seems to be having because get_task_meta of amqp backend caches the result in form of dictionary  and during chord unlock, when [error is thrown] (https://github.com/celery/celery/blob/3.1/celery/result.py#L691),  it results in 
```
TypeError: exceptions must be old-style classes or derived from BaseException, not dict
```
