### PR TITLE
Add additional information about the backend_cleanup task

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1352,7 +1352,8 @@ Time (in seconds, or a :class:`~datetime.timedelta` object) for when after
 stored task tombstones will be deleted.
 
 A built-in periodic task will delete the results after this time
-(:class:`celery.task.backend_cleanup`).
+(``celery.backend_cleanup``), assuming that ``celery beat`` is
+enabled.  The task runs daily at 4am.
 
 A value of :const:`None` or 0 means results will never expire (depending
 on backend specifications).


### PR DESCRIPTION
I think this content is fairly straightforward.  However, there's another bit I'd like to add.

I don't use beat, so I need to do the cleanup through other means.  Is it OK to call this task directly (`app.tasks['celery.backend_cleanup'].apply_async()`), and if so, is it OK to add that to the documentation here?

[edit: add `celery.` to task name]