### PR TITLE
Make sure that redis pipelines are always cleaned up

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -190,4 +190,5 @@ Alexander Lebedev, 2015/04/25
 Frantisek Holop, 2015/05/21
 Feanil Patel, 2015/05/21
 Jocelyn Delalande, 2015/06/03
+Justin Patrin, 2015/08/06
 Juan Rossi, 2015/08/10

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -130,6 +130,10 @@ class RedisBackend(KeyValueStoreBackend):
         db = db.strip('/') if isinstance(db, string_t) else db
         connparams['db'] = int(db)
 
+        for key in ['socket_timeout', 'socket_connect_timeout']:
+            if key in query:
+                query[key] = float(query[key])
+
         # Query parameters override other parameters
         connparams.update(query)
         return connparams

--- a/celery/tests/backends/test_redis.py
+++ b/celery/tests/backends/test_redis.py
@@ -37,6 +37,12 @@ class Pipeline(object):
             return self
         return add_step
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        pass
+
     def execute(self):
         return [step(*a, **kw) for step, a, kw in self.steps]
 


### PR DESCRIPTION
I wrote this quick patch to potentially fix issues with celery workers getting stuck when using redis as a backend. I'm regularly getting stuck workers currently and the multiple issues I've seen raised with redis as a backend seemed like a good place to start looking.

Travis checks are failing on python 3, but I'm not sure if that is related to this patch. I've also added support for passing timeouts through CELERY_RESULT_BACKEND for redis.