### PR TITLE
Hint for CELERYBEAT_SCHEDULE args for 1-item tuple

### DIFF
--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -131,6 +131,9 @@ Example: Run the `tasks.add` task every 30 seconds.
     please see :ref:`celerytut-configuration`.  You can either
     set these options on your app directly or you can keep
     a separate module for configuration.
+    
+    If you want to use a single item tuple for `args`, don't forget
+    that the constructor is a comma and not a pair of parentheses.
 
 Using a :class:`~datetime.timedelta` for the schedule means the task will
 be sent in 30 second intervals (the first task will be sent 30 seconds


### PR DESCRIPTION
It took me a long time to figure out(around 2 days of trying out different things) why I was getting

`celerybeat raised exception : TypeError('argument 2 to map() must support iteration',)`

I was testing it out with a Task that only had one argument and mapped `args` to `(3)` instead of `(3,)`