### PR TITLE
Change tasks.reload_tasks to tasks.reload_cache

### DIFF
--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -573,7 +573,7 @@ copies of tasks to all workers connected to it:
 
     CELERY_ROUTES = {'tasks.reload_cache': {'queue': 'broadcast_tasks'}}
 
-Now the ``tasks.reload_tasks`` task will be sent to every
+Now the ``tasks.reload_cache`` task will be sent to every
 worker consuming from this queue.
 
 .. admonition:: Broadcast & Results


### PR DESCRIPTION
'tasks.reload_tasks' should be 'tasks.reload_cache' on userguide/routing/broadcast docs.