### PR TITLE
Make EventReceiver's queue prefix configurable

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -120,6 +120,7 @@ NAMESPACES = {
         'ENABLE_REMOTE_CONTROL': Option(True, type='bool'),
         'EVENT_SERIALIZER': Option('json'),
         'EVENT_QUEUE_EXPIRES': Option(60.0, type='float'),
+        'EVENT_QUEUE_PREFIX': Option('celeryev'),
         'EVENT_QUEUE_TTL': Option(5.0, type='float'),
         'IMPORTS': Option((), type='tuple'),
         'INCLUDE': Option((), type='tuple'),

--- a/celery/events/__init__.py
+++ b/celery/events/__init__.py
@@ -296,7 +296,7 @@ class EventReceiver(ConsumerMixin):
     app = None
 
     def __init__(self, channel, handlers=None, routing_key='#',
-                 node_id=None, app=None, queue_prefix='celeryev',
+                 node_id=None, app=None, queue_prefix=None,
                  accept=None, queue_ttl=None, queue_expires=None):
         self.app = app_or_default(app or self.app)
         self.channel = maybe_channel(channel)
@@ -304,6 +304,10 @@ class EventReceiver(ConsumerMixin):
         self.routing_key = routing_key
         self.node_id = node_id or uuid()
         self.queue_prefix = queue_prefix
+        if queue_prefix:
+            self.queue_prefix = queue_prefix
+        else:
+            self.queue_prefix = self.app.conf.CELERY_EVENT_QUEUE_PREFIX
         self.exchange = get_exchange(self.connection or self.app.connection())
         self.queue = Queue(
             '.'.join([self.queue_prefix, self.node_id]),

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1754,6 +1754,14 @@ event queue will be deleted (``x-expires``).
 
 Default is never, relying on the queue autodelete setting.
 
+.. setting:: CELERY_EVENT_QUEUE_PREFIX
+
+CELERY_EVENT_QUEUE_PREFIX
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The prefix to use for event receivers' queue name.
+The default is ``celeryev``.
+
 .. setting:: CELERY_EVENT_SERIALIZER
 
 CELERY_EVENT_SERIALIZER


### PR DESCRIPTION
In some message broker instances the queues are access-controlled based on their names, especially when the said broker serves multiple systems.

Allow the event receivers' queue prefix to be configured on the app level, using CELERY_EVENT_QUEUE_PREFIX, rather than always defaulting to 'celeryev'.
