### PR TITLE
Fixed maybe_unroll_group to return the task when it is not a group

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -93,7 +93,7 @@ def maybe_unroll_group(g):
         try:
             size = g.tasks.__length_hint__()
         except (AttributeError, TypeError):
-            pass
+            return g
         else:
             return list(g.tasks)[0] if size == 1 else g
     else:

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -607,7 +607,7 @@ def _maybe_group(tasks):
     elif isinstance(tasks, Signature):
         tasks = [tasks]
     else:
-        tasks = map(signature, regen(tasks))
+        tasks = [signature(t) for t in regen(tasks)]
     return tasks
 
 

--- a/celery/tests/case.py
+++ b/celery/tests/case.py
@@ -232,10 +232,15 @@ def _is_magic_module(m):
     # will load _tkinter and other shit when touched.
 
     # pyflakes refuses to accept 'noqa' for this isinstance.
-    cls, modtype = getattr(m, '__class__', None), types.ModuleType
-    return (cls is not modtype and (
-        '__getattr__' in vars(m.__class__) or
-        '__getattribute__' in vars(m.__class__)))
+    cls, modtype = type(m), types.ModuleType
+    try:
+        variables = vars(cls)
+    except TypeError:
+        return True
+    else:
+        return (cls is not modtype and (
+            '__getattr__' in variables or
+            '__getattribute__' in variables))
 
 
 class _AssertWarnsContext(_AssertRaisesBaseContext):

--- a/celery/tests/case.py
+++ b/celery/tests/case.py
@@ -232,7 +232,7 @@ def _is_magic_module(m):
     # will load _tkinter and other shit when touched.
 
     # pyflakes refuses to accept 'noqa' for this isinstance.
-    cls, modtype = m.__class__, types.ModuleType
+    cls, modtype = getattr(m, '__class__', None), types.ModuleType
     return (cls is not modtype and (
         '__getattr__' in vars(m.__class__) or
         '__getattribute__' in vars(m.__class__)))


### PR DESCRIPTION
Having `__length_hint__` doesn't guarantee the object is indexable.