### PR TITLE
Switch to Codecov for coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 script:
   - tox -v -- -v
 after_success:
-  - .tox/$TRAVIS_PYTHON_VERSION/bin/coveralls
+  - .tox/$TRAVIS_PYTHON_VERSION/bin/codecov -e TOXENV
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 script:
   - tox -v -- -v
 after_success:
+  - .tox/$TRAVIS_PYTHON_VERSION/bin/coverage xml
   - .tox/$TRAVIS_PYTHON_VERSION/bin/codecov -e TOXENV
 notifications:
   irc:

--- a/README.rst
+++ b/README.rst
@@ -450,5 +450,5 @@ file in the top distribution directory for the full license text.
 
 .. |build-status| image:: https://travis-ci.org/celery/celery.svg?branch=master
    :target: https://travis-ci.org/celery/celery
-.. |coverage-status| image:: https://coveralls.io/repos/celery/celery/badge.svg
-   :target: https://coveralls.io/r/celery/celery
+.. |coverage-status| image:: https://codecov.io/gh/celery/celery/badge.svg
+   :target: https://codecov.io/gh/celery/celery

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,5 +1,5 @@
 coverage>=3.0
-coveralls
+codecov
 redis
 #riak >=2.0
 #pymongo


### PR DESCRIPTION
> Full disclosure I work for Codecov

Codecov uses Celery to handle all its backend delayed tasks. It would be an honor to have Celery use Codecov for its coverage product.

Some of our core features include:
- Seamless overlay of coverage reports in Github with our browser extensions. [Video](https://www.youtube.com/watch?v=d6wJKODB8_g)
- Awesome pull request comments. [Example](https://gist.github.com/codecov-io/ba612976215481e7f27c)
- Github commit status integration to ensure coverage meets minimum standards
- Automatic unified builds. See [pyca/cryptography](https://codecov.io/github/pyca/cryptography) for example
- Storing build environment variables.

Love all the feedback you have and I look forward to having Celery on Codecov :)

Cheers,
Steve