### PR TITLE
Fixed #2785 -- Changed multi stopwait to wait on pidfiles instead of process.

### DIFF
--- a/celery/bin/multi.py
+++ b/celery/bin/multi.py
@@ -106,7 +106,10 @@ import sys
 from collections import OrderedDict, defaultdict, namedtuple
 from functools import partial
 from subprocess import Popen
-from time import sleep
+import threading
+
+import watchdog.events
+import watchdog.observers
 
 from kombu.utils import cached_property
 from kombu.utils.encoding import from_utf8
@@ -275,16 +278,38 @@ class MultiTool(object):
             return False
         return True
 
-    def node_alive(self, pid):
-        try:
-            os.kill(pid, 0)
-        except OSError as exc:
-            if exc.errno == errno.ESRCH:
-                return False
-            raise
-        return True
+    def init_pidfile_observers(self, nodes):
+        handlers = []
+        observer = watchdog.observers.Observer()
+        for node in nodes:
+            _, _, _, pidfile = node
+            pidfile = os.path.abspath(pidfile)
+            handler = PidfileDeleteHandler(node, pidfile)
+            observer.schedule(handler, os.path.dirname(pidfile))
+            handlers.append(handler)
+        observer.start()
+        return observer, handlers
 
-    def shutdown_nodes(self, nodes, sig=signal.SIGTERM, retry=None,
+    def wait_pidfiles(self, nodes, observer, handlers, on_down):
+        def note_waiting():
+            left = len(nodes)
+            if left:
+                pids = ', '.join(str(pid) for _, _, pid, _ in nodes)
+                self.note(self.colored.blue(
+                    '> Waiting for {0} {1} -> {2}...'.format(
+                        left, pluralize(left, 'node'), pids)), newline=False)
+
+        for handler in handlers:
+            note_waiting()
+            handler.lock.acquire()
+            nodename, _, _, _ = handler.node
+            self.note('\n\t> {0}: {1}'.format(nodename, self.OK))
+            on_down(handler.node)
+
+        observer.stop()
+        observer.join()
+
+    def shutdown_nodes(self, nodes, sig=signal.SIGTERM, wait=False,
                        callback=None):
         if not nodes:
             return
@@ -293,41 +318,22 @@ class MultiTool(object):
         def on_down(node):
             P.discard(node)
             if callback:
-                callback(*node)
+                callback(*node[:3])
+
+        if wait:
+            observer, handlers = self.init_pidfile_observers(P)
 
         self.note(self.colored.blue('> Stopping nodes...'))
         for node in list(P):
             if node in P:
-                nodename, _, pid = node
+                nodename, _, pid, _ = node
                 self.note('\t> {0}: {1} -> {2}'.format(
                     nodename, SIGMAP[sig][3:], pid))
                 if not self.signal_node(nodename, pid, sig):
                     on_down(node)
 
-        def note_waiting():
-            left = len(P)
-            if left:
-                pids = ', '.join(str(pid) for _, _, pid in P)
-                self.note(self.colored.blue(
-                    '> Waiting for {0} {1} -> {2}...'.format(
-                        left, pluralize(left, 'node'), pids)), newline=False)
-
-        if retry:
-            note_waiting()
-            its = 0
-            while P:
-                for node in P:
-                    its += 1
-                    self.note('.', newline=False)
-                    nodename, _, pid = node
-                    if not self.node_alive(pid):
-                        self.note('\n\t> {0}: {1}'.format(nodename, self.OK))
-                        on_down(node)
-                        note_waiting()
-                        break
-                if P and not its % len(P):
-                    sleep(float(retry))
-            self.note('')
+        if wait:
+            self.wait_pidfiles(P, observer, handlers, on_down)
 
     def getpids(self, p, cmd, callback=None):
         _setdefaultopt(p.options, ['--pidfile', '-p'], '%n.pid')
@@ -347,7 +353,7 @@ class MultiTool(object):
             except ValueError:
                 pass
             if pid:
-                nodes.append((node.name, tuple(node.argv), pid))
+                nodes.append((node.name, tuple(node.argv), pid, pidfile))
             else:
                 self.note('> {0.name}: {1}'.format(node, self.DOWN))
                 if callback:
@@ -358,20 +364,20 @@ class MultiTool(object):
     def kill(self, argv, cmd):
         self.splash()
         p = NamespacedOptionParser(argv)
-        for nodename, _, pid in self.getpids(p, cmd):
+        for nodename, _, pid, _ in self.getpids(p, cmd):
             self.note('Killing node {0} ({1})'.format(nodename, pid))
             self.signal_node(nodename, pid, signal.SIGKILL)
 
-    def stop(self, argv, cmd, retry=None, callback=None):
+    def stop(self, argv, cmd, wait=False, callback=None):
         self.splash()
         p = NamespacedOptionParser(argv)
-        return self._stop_nodes(p, cmd, retry=retry, callback=callback)
+        return self._stop_nodes(p, cmd, wait=wait, callback=callback)
 
-    def _stop_nodes(self, p, cmd, retry=None, callback=None):
+    def _stop_nodes(self, p, cmd, wait=False, callback=None):
         restargs = p.args[len(p.values):]
         self.shutdown_nodes(self.getpids(p, cmd, callback=callback),
                             sig=findsig(restargs),
-                            retry=retry,
+                            wait=wait,
                             callback=callback)
 
     def restart(self, argv, cmd):
@@ -387,14 +393,14 @@ class MultiTool(object):
             self.note(retval and self.FAILED or self.OK)
             retvals.append(retval)
 
-        self._stop_nodes(p, cmd, retry=2, callback=on_node_shutdown)
+        self._stop_nodes(p, cmd, wait=True, callback=on_node_shutdown)
         self.retval = int(any(retvals))
 
     def stopwait(self, argv, cmd):
         self.splash()
         p = NamespacedOptionParser(argv)
         self.with_detacher_default_options(p)
-        return self._stop_nodes(p, cmd, retry=2)
+        return self._stop_nodes(p, cmd, wait=True)
     stop_verify = stopwait  # compat
 
     def expand(self, argv, cmd=None):
@@ -634,6 +640,18 @@ def _setdefaultopt(d, alt, value):
         except KeyError:
             pass
     return d.setdefault(alt[0], value)
+
+
+class PidfileDeleteHandler(watchdog.events.FileSystemEventHandler):
+    def __init__(self, node, pidfile):
+        self.lock = threading.Lock()
+        self.lock.acquire()
+        self.node = node
+        self.pidfile = pidfile
+
+    def on_deleted(self, event):
+        if not event.is_directory and event.src_path == self.pidfile:
+            self.lock.release()
 
 
 if __name__ == '__main__':              # pragma: no cover

--- a/celery/tests/bin/test_multi.py
+++ b/celery/tests/bin/test_multi.py
@@ -255,7 +255,7 @@ class test_MultiTool(AppCase):
         self.t.shutdown_nodes = Mock()
         self.t.stop(['a', 'b', '-INT'], 'celery worker')
         self.t.shutdown_nodes.assert_called_with(
-            [2, 3, 4], sig=signal.SIGINT, retry=None, callback=None,
+            [2, 3, 4], sig=signal.SIGINT, wait=False, callback=None,
 
         )
 
@@ -264,9 +264,9 @@ class test_MultiTool(AppCase):
             raise SkipTest('SIGKILL not supported by this platform')
         self.t.getpids = Mock()
         self.t.getpids.return_value = [
-            ('a', None, 10),
-            ('b', None, 11),
-            ('c', None, 12)
+            ('a', None, 10, None),
+            ('b', None, 11, None),
+            ('c', None, 12, None)
         ]
         sig = self.t.signal_node = Mock()
 
@@ -332,14 +332,14 @@ class test_MultiTool(AppCase):
 
     @patch('celery.bin.multi.Pidfile')
     @patch('socket.gethostname')
-    @patch('celery.bin.multi.sleep')
-    def test_shutdown_nodes(self, slepp, gethostname, Pidfile):
+    def test_shutdown_nodes(self, gethostname, Pidfile):
         gethostname.return_value = 'e.com'
         self.prepare_pidfile_for_getpids(Pidfile)
         self.assertIsNone(self.t.shutdown_nodes([]))
         self.t.signal_node = Mock()
-        node_alive = self.t.node_alive = Mock()
-        self.t.node_alive.return_value = False
+        self.t.init_pidfile_observers = Mock()
+        self.t.init_pidfile_observers.return_value = None, []
+        self.t.wait_pidfiles = Mock()
 
         callback = Mock()
         self.t.stop(['foo', 'bar', 'baz'], 'celery worker', callback=callback)
@@ -357,29 +357,8 @@ class test_MultiTool(AppCase):
         self.assertTrue(callback.called)
         self.t.stop(['foo', 'bar', 'baz'], 'celery worker', callback=None)
 
-        def on_node_alive(pid):
-            if node_alive.call_count > 4:
-                return True
-            return False
         self.t.signal_node.return_value = True
-        self.t.node_alive.side_effect = on_node_alive
-        self.t.stop(['foo', 'bar', 'baz'], 'celery worker', retry=True)
-
-    @patch('os.kill')
-    def test_node_alive(self, kill):
-        kill.return_value = True
-        self.assertTrue(self.t.node_alive(13))
-        esrch = OSError()
-        esrch.errno = errno.ESRCH
-        kill.side_effect = esrch
-        self.assertFalse(self.t.node_alive(13))
-        kill.assert_called_with(13, 0)
-
-        enoent = OSError()
-        enoent.errno = errno.ENOENT
-        kill.side_effect = enoent
-        with self.assertRaises(OSError):
-            self.t.node_alive(13)
+        self.t.stop(['foo', 'bar', 'baz'], 'celery worker', wait=True)
 
     @patch('os.kill')
     def test_signal_node(self, kill):
@@ -455,7 +434,7 @@ class test_MultiTool(AppCase):
     def test_stopwait(self):
         self.t._stop_nodes = Mock()
         self.t.stopwait(['foo', 'bar', 'baz'], 'celery worker')
-        self.assertEqual(self.t._stop_nodes.call_args[1]['retry'], 2)
+        self.assertEqual(self.t._stop_nodes.call_args[1]['wait'], True)
 
     @patch('celery.bin.multi.MultiTool')
     def test_main(self, MultiTool):

--- a/requirements/extras/watchdog.txt
+++ b/requirements/extras/watchdog.txt
@@ -1,0 +1,1 @@
+watchdog


### PR DESCRIPTION
Sending signals to kill a process has a race condition where a pid may
be recycled by a new, unrelated process.

Instead, now use watchdog to watch the directory containing the
pidfile. Hold a lock until the pidfile is deleted. Once all pidfiles
are deleted, all celery processes have finished.

Introduces a dependecy on watchdog.

Fixes #2785

---

All feedback welcome.