### PR TITLE
Adding the __bool__ and __nonzero__ methods to ResultSet

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -714,10 +714,6 @@ class ResultSet(ResultBase):
     def __len__(self):
         return len(self.results)
 
-    def __bool__(self):
-        return True
-    __nonzero__ = __bool__  # Included for Py2 backwards compatibility
-
     def __eq__(self, other):
         if isinstance(other, ResultSet):
             return other.results == self.results
@@ -803,6 +799,10 @@ class GroupResult(ResultSet):
 
     def __reduce_args__(self):
         return self.id, self.results
+
+    def __bool__(self):
+        return bool(self.id or self.results)
+    __nonzero__ = __bool__  # Included for Py2 backwards compatibility
 
     def __eq__(self, other):
         if isinstance(other, GroupResult):

--- a/celery/result.py
+++ b/celery/result.py
@@ -714,6 +714,10 @@ class ResultSet(ResultBase):
     def __len__(self):
         return len(self.results)
 
+    def __bool__(self):
+        return True
+    __nonzero__ = __bool__  # Included for Py2 backwards compatibility
+
     def __eq__(self, other):
         if isinstance(other, ResultSet):
             return other.results == self.results

--- a/celery/tests/app/test_builtins.py
+++ b/celery/tests/app/test_builtins.py
@@ -100,8 +100,10 @@ class test_group(BuiltinsCase):
         x = group(app=self.app)
         x.apply()
         res = x.apply_async()
-        self.assertFalse(res)
         self.assertFalse(res.results)
+        self.assertTrue(res)
+        res.id = None
+        self.assertFalse(res)
 
     def test_apply_async_with_parent(self):
         _task_stack.push(self.add)


### PR DESCRIPTION
This is to fix an issue where a ResultSet or GroupResult with an empty
result list are not properly tupled with the as_tuple() method when it is
a parent result. This is due to the as_tuple() method performing a logical
and operation on the ResultSet.

A snippet from celery/result.py:AsyncResult.as_tuple()

```python
return (self.id, parent and parent.as_tuple()), None
```

This is testing to make sure parent is not boolean False; if it is not boolean False then return the tuple. Per the Python docs an 'and' operation first checks \__bool__ then \__len__ if \__bool__ is not defined.[1][2] In the case of ResultSet and GroupResult \__bool__ is not defined but \__len__ is which returns the length of the ResultSet.results. If the list of results is empty the \__len__ method will return 0 which equates to False. This results in the 'and' operation return the first item, in this case the ResultSet or GroupResult instance.

I have added the \__bool__ method so that any ResultSet instances equate to boolean True as long as they exist.

The \__bool__ method is aliased to the  \__nonzero__ method for backwards compatibility with Python2.

Here is some PoC code that demonstrates the issue

```python
import uuid
from celery.result import AsyncResult, GroupResult


def main():
	gr_id = str(uuid.uuid4())
	ar_id = str(uuid.uuid4())
	group_result = GroupResult(id=gr_id, results=[])
	async_result = AsyncResult(id=ar_id, parent=group_result)
	print(async_result.as_tuple())	# Would expect all tuples but it contains a GroupResult instance


def proof():
	gr_id = str(uuid.uuid4())
	group_result = GroupResult(id=gr_id, results=[])
	print(group_result and group_result.as_tuple())  # Would expect a tuple but it's a GroupResult instance


if __name__ == "__main__":
	main()
	proof()
```

References:
[1] [Explanation of how the and operator works](https://docs.python.org/3.4/reference/expressions.html#boolean-operations)
[2] [\__len__ is called if \__bool__ is not found](https://docs.python.org/3.4/reference/datamodel.html#object.__bool__)