### PR TITLE
Adding documentation for multiple broker URLs #2749

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1165,6 +1165,20 @@ default is ``amqp``, which uses ``librabbitmq`` by default or falls back to
 ``couchdb``.
 It can also be a fully qualified path to your own transport implementation.
 
+More than broker URL, of the same transport, can also be specified.
+The broker URLs can be passed in as a single string that is semicolon delimited::
+
+    BROKER_URL = 'transport://userid:password@hostname:port//;transport://userid:password@hostname:port//'
+
+Or as a list::
+
+    BROKER_URL = [
+        'transport://userid:password@localhost:port//',
+        'transport://userid:password@hostname:port//'
+    ]
+
+The brokers will then be used in the :setting:`BROKER_FAILOVER_STRATEGY`.
+
 See :ref:`kombu:connection-urls` in the Kombu documentation for more
 information.
 


### PR DESCRIPTION
Updating the configuration documentation to mention multiple broker URLs. 