### PR TITLE
Redis: experimental new_join setting ignores the propagate preference for redis backend.

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -180,13 +180,13 @@ class RedisBackend(KeyValueStoreBackend):
     def add_to_chord(self, group_id, result):
         self.client.incr(self.get_key_for_group(group_id, '.t'), 1)
 
-    def _unpack_chord_result(self, tup, decode,
+    def _unpack_chord_result(self, tup, decode, propagate,
                              EXCEPTION_STATES=states.EXCEPTION_STATES,
                              PROPAGATE_STATES=states.PROPAGATE_STATES):
         _, tid, state, retval = decode(tup)
         if state in EXCEPTION_STATES:
             retval = self.exception_to_python(retval)
-        if state in PROPAGATE_STATES:
+        if propagate and state in PROPAGATE_STATES:
             raise ChordError('Dependency {0} raised {1!r}'.format(tid, retval))
         return retval
 
@@ -228,7 +228,7 @@ class RedisBackend(KeyValueStoreBackend):
                     .delete(tkey)               \
                     .execute()
                 try:
-                    callback.delay([unpack(tup, decode) for tup in resl])
+                    callback.delay([unpack(tup, decode, propagate) for tup in resl])
                 except Exception as exc:
                     error('Chord callback for %r raised: %r',
                           request.group, exc, exc_info=1)


### PR DESCRIPTION
When using chord(group(task_set))(callback) 

Without this patch, chord won't call callback if one of the task in task_set throws an exception.