### PR TITLE
Fix ImportError

### DIFF
--- a/examples/django/proj/settings.py
+++ b/examples/django/proj/settings.py
@@ -132,7 +132,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.admin',
-    'kombu.transport.django.KombuAppConfig',
+    'kombu.transport.django',
     'demoapp',
     # Uncomment the next line to enable the admin:
     # 'django.contrib.admin',


### PR DESCRIPTION
With 'kombu.transport.django.KombuAppConfig' in INSTALLED_APPS,
running any manage.py command throws:

ImportError: No module named KombuAppConfig

It is fixed by changing 'kombu.transport.django.KombuAppConfig' to 'kombu.transport.django'