### PR TITLE
Removed an extra on_retry entry in the docs.

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -1214,9 +1214,6 @@ Handlers
 
     The return value of this handler is ignored.
 
-on_retry
-~~~~~~~~
-
 .. _task-how-they-work:
 
 How it works


### PR DESCRIPTION
There's an extra `on_retry` entry here: http://docs.celeryproject.org/en/master/userguide/tasks.html?highlight=on_retry#on-retry.