### PR TITLE
Set celery priority in supervisord higher

### DIFF
--- a/extra/supervisord/celeryd.conf
+++ b/extra/supervisord/celeryd.conf
@@ -29,6 +29,6 @@ stopwaitsecs = 600
 ; taking care of its children as well.
 killasgroup=true
 
-; if rabbitmq is supervised, set its priority higher
-; so it starts first
-priority=998
+; Set Celery priority higher than default (999)
+; so, if rabbitmq is supervised, it will start first.
+priority=1000


### PR DESCRIPTION
The setting for priority refers to ```[program:celery]```

However, the comments either refer to a configuration setting of an unreal rabbitmq section which guarantees that rabbitmq will start first, or they are plain wrong since according to the [docs](http://supervisord.org/configuration.html#program-x-section-values):

> Higher priorities indicate programs that start last and shut down first.

I propose to:

1) Set the celery priority higher than the default (999)
2) Provide an explanation why