### PR TITLE
Add description of default value to time limits

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1514,6 +1514,8 @@ CELERYD_TASK_TIME_LIMIT
 Task hard time limit in seconds.  The worker processing the task will
 be killed and replaced with a new one when this is exceeded.
 
+Default is ``None``, meaning there is no upper time limit
+
 .. setting:: CELERYD_TASK_SOFT_TIME_LIMIT
 
 CELERYD_TASK_SOFT_TIME_LIMIT
@@ -1537,6 +1539,8 @@ Example:
             return do_work()
         except SoftTimeLimitExceeded:
             cleanup_in_a_hurry()
+
+Default is ``None``, meaning there is no upper time limit
 
 .. setting:: CELERY_STORE_ERRORS_EVEN_IF_IGNORED
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1514,7 +1514,7 @@ CELERYD_TASK_TIME_LIMIT
 Task hard time limit in seconds.  The worker processing the task will
 be killed and replaced with a new one when this is exceeded.
 
-Default is ``None``, meaning there is no upper time limit
+Default is ``None``, meaning the default 300 second limit from Billiard is used.
 
 .. setting:: CELERYD_TASK_SOFT_TIME_LIMIT
 
@@ -1540,7 +1540,7 @@ Example:
         except SoftTimeLimitExceeded:
             cleanup_in_a_hurry()
 
-Default is ``None``, meaning there is no upper time limit
+Default is ``None``, meaning the default 300 second limit from Billiard is used.
 
 .. setting:: CELERY_STORE_ERRORS_EVEN_IF_IGNORED
 


### PR DESCRIPTION
Documentation is quite confusing when it comes to figuring out whether or not tasks can time out. This should clarify that they *by default* don't time out.

Hope I'm also assuming correctly :)