### PR TITLE
Document the local-only behavior of Task.retry() max_retries

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -571,10 +571,12 @@ class Task(object):
         :keyword countdown: Time in seconds to delay the retry for.
         :keyword eta: Explicit time and date to run the retry at
                       (must be a :class:`~datetime.datetime` instance).
-        :keyword max_retries: If set, overrides the default retry limit.
-            A value of :const:`None`, means "use the default", so if you want
-            infinite retries you would have to set the :attr:`max_retries`
-            attribute of the task to :const:`None` first.
+        :keyword max_retries: If set, overrides the default retry limit for
+            this execution. Changes to this parameter do not propagate to
+            subsequent task retry attempts. A value of :const:`None`, means
+            "use the default", so if you want infinite retries you would
+            have to set the :attr:`max_retries` attribute of the task to
+            :const:`None` first.
         :keyword time_limit: If set, overrides the default time limit.
         :keyword soft_time_limit: If set, overrides the default soft
                                   time limit.


### PR DESCRIPTION
Related to https://github.com/celery/celery/issues/2857