### PR TITLE
Set priority from message properties if not in delivery_info

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -192,3 +192,4 @@ Feanil Patel, 2015/05/21
 Jocelyn Delalande, 2015/06/03
 Juan Rossi, 2015/08/10
 Piotr Maślanka, 2015/08/24
+Gerald Manipon, 2015/10/19

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -152,7 +152,8 @@ class Request(object):
             'delivery_info': {
                 'exchange': delivery_info.get('exchange'),
                 'routing_key': delivery_info.get('routing_key'),
-                'priority': delivery_info.get('priority'),
+                'priority': delivery_info.get('priority',
+                                              properties.get('priority')),
                 'redelivered': delivery_info.get('redelivered'),
             }
 


### PR DESCRIPTION
The value of delivery_info["priority"] remains null despite passing in priority=<int> to apply_async(). It is stored in message properties so get the value there if not in delivery_info.
Add contributor.