### PR TITLE
Remove duplicate line "sudo: false" in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,3 @@ notifications:
       - "chat.freenode.net#celery"
     on_success: change
     on_failure: change
-sudo: false


### PR DESCRIPTION
sudo: false has already been added in 4fd22bb88aeef1385ce9d057f46cedfac07b569a.