### PR TITLE
Fix celery beat --detach in PyPy

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -193,3 +193,4 @@ Justin Patrin, 2015/08/06
 Juan Rossi, 2015/08/10
 Piotr Maślanka, 2015/08/24
 Gerald Manipon, 2015/10/19
+Krzysztof Bujniewicz, 2015/10/23

--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -300,7 +300,7 @@ def fd_by_path(paths):
         except OSError:
             return False
 
-    return [fd for fd in xrange(get_fdmax(2048)) if fd_in_stats(fd)]
+    return [fd for fd in range(get_fdmax(2048)) if fd_in_stats(fd)]
 
 
 if hasattr(os, 'closerange'):

--- a/celery/tests/utils/test_platforms.py
+++ b/celery/tests/utils/test_platforms.py
@@ -4,6 +4,7 @@ import errno
 import os
 import sys
 import signal
+import tempfile
 
 from celery import _find_option_with_arg
 from celery import platforms
@@ -27,6 +28,7 @@ from celery.platforms import (
     setgroups,
     _setgroups_hack,
     close_open_fds,
+    fd_by_path,
 )
 
 try:
@@ -53,6 +55,14 @@ class test_find_option_with_arg(Case):
             _find_option_with_arg(['-f', 'bar'], short_opts=['-f']),
             'bar'
         )
+
+class test_fd_by_path(Case):
+
+    def test_finds(self):
+        test_file = tempfile.NamedTemporaryFile()
+        keep = fd_by_path([test_file])
+        self.assertEqual(keep, [test_file.file.fileno()])
+        test_file.close()
 
 
 class test_close_open_fds(Case):

--- a/celery/tests/utils/test_platforms.py
+++ b/celery/tests/utils/test_platforms.py
@@ -60,7 +60,7 @@ class test_fd_by_path(Case):
 
     def test_finds(self):
         test_file = tempfile.NamedTemporaryFile()
-        keep = fd_by_path([test_file])
+        keep = fd_by_path([test_file.name])
         self.assertEqual(keep, [test_file.file.fileno()])
         test_file.close()
 


### PR DESCRIPTION
While running celery beat under PyPy, file descriptor pointing to
/dev/urandom is closed while daemonizing. This makes shelve, and
in turn beat's scheduler, unable to access it, hence the startup
fails with OSError 9. This is fixed by adding /dev/urandom's fd to
keep list passed to close_open_fds.