### PR TITLE
fixes broken little-worker example

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -39,7 +39,7 @@ fi
 
 
 # Can be a runlevel symlink (e.g. S02celeryd)
-if [ -L "$0" ]; then
+if [[ `dirname $0` == /etc/rc*.d ]]; then
     SCRIPT_FILE=$(readlink "$0")
 else
     SCRIPT_FILE="$0"


### PR DESCRIPTION
using the -L test breaks the ability to use multiple instances of init script as described in the top of file