### PR TITLE
Replace use of 'if [[...]]' not supported in sh

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -37,9 +37,14 @@ if [ $(id -u) -ne 0 ]; then
     exit 1
 fi
 
+origin_is_runlevel_dir () {
+    set +e
+    dirname $0 | grep -q "/etc/rc.\.d"
+    echo $?
+}
 
 # Can be a runlevel symlink (e.g. S02celeryd)
-if [[ `dirname $0` == /etc/rc*.d ]]; then
+if [ $(origin_is_runlevel_dir) -eq 0 ]; then
     SCRIPT_FILE=$(readlink "$0")
 else
     SCRIPT_FILE="$0"


### PR DESCRIPTION
The use of 'if [[...]]' breaks on Ubuntu that uses dash as its
implementation of sh. Replace wildcard matching with grep.