### PR TITLE
change celerybeat init script to report service as down when no pid file can be found

### DIFF
--- a/extra/generic-init.d/celerybeat
+++ b/extra/generic-init.d/celerybeat
@@ -254,7 +254,7 @@ check_status () {
     local failed=
     local pid_file=$CELERYBEAT_PID_FILE
     if [ ! -e $pid_file ]; then
-        echo "${SCRIPT_NAME} is up: no pid file found"
+        echo "${SCRIPT_NAME} is down: no pid file found"
         failed=true
     elif [ ! -r $pid_file ]; then
         echo "${SCRIPT_NAME} is in unknown state, user cannot read pid file."


### PR DESCRIPTION
The celerybeat example init script currently reports that the service is up when no pid file can be found.