### PR TITLE
Fix typo in extending docs

### DIFF
--- a/docs/userguide/extending.rst
+++ b/docs/userguide/extending.rst
@@ -46,7 +46,7 @@ whenever the connection is established:
 
     def send_me_a_message(self, who='world!', producer=None):
         with app.producer_or_acquire(producer) as producer:
-            producer.send(
+            producer.publish(
                 {'hello': who},
                 serializer='json',
                 exchange=my_queue.exchange,


### PR DESCRIPTION
AttributeError: 'TaskProducer' object has no attribute 'send'