### PR TITLE
Update optimizing.rst

### DIFF
--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -54,8 +54,8 @@ General Settings
 
 .. _optimizing-librabbitmq:
 
-librabbitmq
------------
+librabbitmq (Python 2 only)
+---------------------------
 
 If you're using RabbitMQ (AMQP) as the broker then you can install the
 :mod:`librabbitmq` module to use an optimized client written in C:


### PR DESCRIPTION
librabbitmq does not support Python 3, and that should be noted in the guide.