### PR TITLE
Added cleaning of corrupted scheduler files for some storage backend errors

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -374,6 +374,12 @@ class PersistentScheduler(Scheduler):
     def setup_schedule(self):
         try:
             self._store = self._open_schedule()
+            # In some cases there may be different errors from a storage
+            # backend for corrupted files. Example - DBPageNotFoundError
+            # exception from bsddb. In such case the file will be
+            # successfully opened but the error will be raised on first key
+            # retrieving.
+            self._store.keys()
         except Exception as exc:
             self._store = self._destroy_open_corrupted_schedule(exc)
 


### PR DESCRIPTION
Hello!
Recently I've got  an error during initialization of PersistentScheduler:

```
[uwsgi-daemons] spawning "/usr/bin/celery -A kubedock.tasks --concurrency=4 worker -B -s /tmp/celerybeat-schedule" (uid: 995 gid: 993)
[2015-12-31 12:03:15,032: ERROR/Beat] Process Beat
Traceback (most recent call last):
File "/usr/lib64/python2.7/site-packages/billiard/process.py", line 292, in _bootstrap
self.run()
File "/usr/lib/python2.7/site-packages/celery/beat.py", line 529, in run
self.service.start(embedded_process=True)
File "/usr/lib/python2.7/site-packages/celery/beat.py", line 453, in start
humanize_seconds(self.scheduler.max_interval))
File "/usr/lib/python2.7/site-packages/kombu/utils/__init__.py", line 322, in __get__
value = obj.__dict__[self.__name__] = self.__get(obj)
File "/usr/lib/python2.7/site-packages/celery/beat.py", line 493, in scheduler
return self.get_scheduler()
File "/usr/lib/python2.7/site-packages/celery/beat.py", line 488, in get_scheduler
lazy=lazy)
File "/usr/lib/python2.7/site-packages/celery/utils/imports.py", line 53, in instantiate
return symbol_by_name(name)(*args, **kwargs)
File "/usr/lib/python2.7/site-packages/celery/beat.py", line 357, in __init__
Scheduler.__init__(self, *args, **kwargs)
File "/usr/lib/python2.7/site-packages/celery/beat.py", line 184, in __init__
self.setup_schedule()
File "/usr/lib/python2.7/site-packages/celery/beat.py", line 376, in setup_schedule
self._store['entries']
File "/usr/lib64/python2.7/shelve.py", line 121, in __getitem__
f = StringIO(self.dict[key])
File "/usr/lib64/python2.7/bsddb/__init__.py", line 270, in __getitem__
return _DeadlockWrap(lambda: self.db[key])  # self.db[key]
File "/usr/lib64/python2.7/bsddb/dbutils.py", line 68, in DeadlockWrap
return function(*_args, **_kwargs)
File "/usr/lib64/python2.7/bsddb/__init__.py", line 270, in <lambda>
return _DeadlockWrap(lambda: self.db[key])  # self.db[key]
DBPageNotFoundError: (-30986, 'BDB0075 DB_PAGE_NOTFOUND: Requested page not found')
```
This small patch resolves such errors by removing corrupted files. Also here is a sample corrupted 'celerybeat-schedule' file to check the error.
[celerybeat-schedule.corrupted.zip](https://github.com/celery/celery/files/79489/celerybeat-schedule.corrupted.zip)


