### PR TITLE
More detail about prefetch and long-running tasks

### DIFF
--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -218,7 +218,7 @@ waiting for long running tasks to complete::
 
     -> send T3 to Process A
     # A still executing T1, T3 stuck in local buffer and will not start until
-    # T1 returns, and other queued tasks will not be sent to idle workers
+    # T1 returns, and other queued tasks will not be sent to idle processes
 
 The worker will send tasks to the process as long as the pipe buffer is
 writable.  The pipe buffer size varies based on the operating system: some may

--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -217,8 +217,8 @@ waiting for long running tasks to complete::
     <- T2 complete
 
     -> send T3 to Process A
-    # A still executing T1, T3 stuck in local buffer and
-    # will not start until T1 returns
+    # A still executing T1, T3 stuck in local buffer and will not start until
+    # T1 returns, and other queued tasks will not be sent to idle workers
 
 The worker will send tasks to the process as long as the pipe buffer is
 writable.  The pipe buffer size varies based on the operating system: some may


### PR DESCRIPTION
When reading docs, I thought T3 would be stuck behind T1, but other tasks would be sent to available workers. I've seen that queued tasks aren't sent to available workers unless -Ofair is used, so clarifying this description.