### PR TITLE
Let celery make tasks from functions with type hints

### DIFF
--- a/celery/tests/utils/test_functional.py
+++ b/celery/tests/utils/test_functional.py
@@ -291,3 +291,20 @@ class test_head_from_fun(Case):
             g(1)
         g(1, 2)
         g(1, 2, kwarg=3)
+
+    def test_from_fun_with_hints(self):
+        local = {}
+        fun = ('def f_hints(x: int, y: int, kwarg: int=1):'
+               '    pass')
+        try:
+            exec(fun, {}, local)
+        except SyntaxError:
+            # py2
+            return
+        f_hints = local['f_hints']
+
+        g = head_from_fun(f_hints)
+        with self.assertRaises(TypeError):
+            g(1)
+        g(1, 2)
+        g(1, 2, kwarg=3)


### PR DESCRIPTION
Making a task from a function involves call head_from_fun in utils/functional.py, which uses getargspec. This will fail if said function has type hints (PEP 0484), so call getfullargspec instead -- but only when using python 3+