### PR TITLE
Add nodes names to DuplicateNodenameWarning

### DIFF
--- a/celery/app/control.py
+++ b/celery/app/control.py
@@ -23,7 +23,7 @@ from celery.utils.text import pluralize
 __all__ = ['Inspect', 'Control', 'flatten_reply']
 
 W_DUPNODE = """\
-Received multiple replies from node name: {0!r}.
+Received multiple replies from node {0}: {1}.
 Please make sure you give each node a unique nodename using the `-n` option.\
 """
 

--- a/celery/tests/app/test_control.py
+++ b/celery/tests/app/test_control.py
@@ -7,6 +7,7 @@ from functools import wraps
 from kombu.pidbox import Mailbox
 
 from celery.app import control
+from celery.exceptions import DuplicateNodenameWarning
 from celery.utils import uuid
 from celery.tests.case import AppCase
 
@@ -48,14 +49,15 @@ class test_flatten_reply(AppCase):
             {'foo@example.com': {'hello': 20}},
             {'bar@example.com': {'hello': 30}}
         ]
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarns(DuplicateNodenameWarning) as w:
             nodes = control.flatten_reply(reply)
-            self.assertIn(
-                'multiple replies',
-                str(w[-1].message),
-            )
-            self.assertIn('foo@example.com', nodes)
-            self.assertIn('bar@example.com', nodes)
+
+        self.assertIn(
+            'Received multiple replies from node name: foo@example.com.',
+            str(w.warning)
+        )
+        self.assertIn('foo@example.com', nodes)
+        self.assertIn('bar@example.com', nodes)
 
 
 class test_inspect(AppCase):


### PR DESCRIPTION
DuplicateNodenameWarning didn't have a list of duplicates included
into the warning text.