### PR TITLE
group and chord: subtasks are not executed until entire generator is consumed

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -371,6 +371,9 @@ class BaseBackend(object):
     def on_chord_part_return(self, request, state, result, **kwargs):
         pass
 
+    def set_chord_size(self, group_id, chord_size):
+        pass
+
     def fallback_chord_unlock(self, group_id, body, result=None,
                               countdown=1, **kwargs):
         kwargs['result'] = [r.as_tuple() for r in result]
@@ -379,11 +382,13 @@ class BaseBackend(object):
         )
 
     def apply_chord(self, header, partial_args, group_id, body,
-                    options={}, **kwargs):
+                    options={}, result=None, **kwargs):
+        # result is a generator, expand it
+        result = list(result)
         fixed_options = {k: v for k, v in items(options) if k != 'task_id'}
-        result = header(*partial_args, task_id=group_id, **fixed_options or {})
-        self.fallback_chord_unlock(group_id, body, **kwargs)
-        return result
+        res = header(*partial_args, task_id=group_id, **fixed_options or {})
+        self.fallback_chord_unlock(group_id, body, result=result, **kwargs)
+        return res
 
     def current_task_children(self, request=None):
         request = request or getattr(current_task(), 'request', None)

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -18,7 +18,7 @@ from collections import MutableSequence, deque
 from copy import deepcopy
 from functools import partial as _partial, reduce
 from operator import itemgetter
-from itertools import chain as _chain, izip, tee
+from itertools import chain as _chain, tee
 
 from kombu.utils import cached_property, fxrange, reprcall, uuid
 
@@ -29,6 +29,7 @@ from celery.utils import abstract
 from celery.utils.functional import (
     maybe_list, is_list, _regen, regen, lookahead, chunks as _chunks,
 )
+from celery.five import zip
 from celery.utils.text import truncate
 
 __all__ = ['Signature', 'chain', 'xmap', 'xstarmap', 'chunks',
@@ -827,7 +828,7 @@ class group(Signature):
         results = regen(
             self._freeze_tasks(tasks1, group_id, chord, root_id, parent_id))
         # if self.tasks is consumed, it will also populate the group results
-        self.tasks = regen(x[0] for x in izip(tasks2, results))
+        self.tasks = regen(x[0] for x in zip(tasks2, results))
         return self.app.GroupResult(gid, results)
     _freeze = freeze
 

--- a/celery/tests/backends/test_cache.py
+++ b/celery/tests/backends/test_cache.py
@@ -14,6 +14,7 @@ from celery.backends.cache import CacheBackend, DummyClient
 from celery.exceptions import ImproperlyConfigured
 from celery.five import items, string, text_t
 from celery.utils import uuid
+from celery.utils.functional import regen
 
 from celery.tests.case import (
     AppCase, Mock, mask_modules, patch, reset_modules,
@@ -66,7 +67,8 @@ class test_CacheBackend(AppCase):
 
     def test_apply_chord(self):
         tb = CacheBackend(backend='memory://', app=self.app)
-        gid, res = uuid(), [self.app.AsyncResult(uuid()) for _ in range(3)]
+        gid = uuid()
+        res = regen(self.app.AsyncResult(uuid()) for _ in range(3))
         tb.apply_chord(group(app=self.app), (), gid, {}, result=res)
 
     @patch('celery.result.GroupResult.restore')

--- a/celery/tests/tasks/test_canvas.py
+++ b/celery/tests/tasks/test_canvas.py
@@ -580,7 +580,7 @@ class test_group(CanvasCase):
         self.assertListEqual(list(iter(g)), g.tasks)
 
     def test_maintains_generator(self):
-        g = group(self.add.s(x, x) for x in xrange(3))
+        g = group(self.add.s(x, x) for x in range(3))
         self.assertIsInstance(g.tasks, _regen)
         self.assertFalse(g.tasks.fully_consumed())
         g.freeze()
@@ -664,7 +664,7 @@ class test_chord(CanvasCase):
         x.freeze()
 
     def test_maintains_generator(self):
-        x = chord((self.add.s(i, i) for i in xrange(3)), body=self.mul.s(4))
+        x = chord((self.add.s(i, i) for i in range(3)), body=self.mul.s(4))
         self.assertIsInstance(x.tasks, _regen)
         self.assertFalse(x.tasks.fully_consumed())
         x.freeze()

--- a/celery/tests/tasks/test_canvas.py
+++ b/celery/tests/tasks/test_canvas.py
@@ -15,6 +15,7 @@ from celery.canvas import (
     maybe_unroll_group,
 )
 from celery.result import EagerResult
+from celery.utils.functional import _regen
 
 from celery.tests.case import (
     AppCase, ContextMock, MagicMock, Mock, depends_on_current_app,
@@ -578,6 +579,14 @@ class test_group(CanvasCase):
         g = group([self.add.s(i, i) for i in range(10)])
         self.assertListEqual(list(iter(g)), g.tasks)
 
+    def test_maintains_generator(self):
+        g = group(self.add.s(x, x) for x in xrange(3))
+        self.assertIsInstance(g.tasks, _regen)
+        self.assertFalse(g.tasks.fully_consumed())
+        g.freeze()
+        self.assertIsInstance(g.tasks, _regen)
+        self.assertFalse(g.tasks.fully_consumed())
+
 
 class test_chord(CanvasCase):
 
@@ -653,6 +662,14 @@ class test_chord(CanvasCase):
         x.freeze()
         x.tasks = [self.add.s(2, 2)]
         x.freeze()
+
+    def test_maintains_generator(self):
+        x = chord((self.add.s(i, i) for i in xrange(3)), body=self.mul.s(4))
+        self.assertIsInstance(x.tasks, _regen)
+        self.assertFalse(x.tasks.fully_consumed())
+        x.freeze()
+        self.assertIsInstance(x.tasks, group)
+        self.assertFalse(x.tasks.tasks.fully_consumed())
 
 
 class test_maybe_signature(CanvasCase):

--- a/celery/tests/utils/test_functional.py
+++ b/celery/tests/utils/test_functional.py
@@ -18,6 +18,7 @@ from celery.utils.functional import (
     memoize,
     mlazy,
     padlist,
+    lookahead,
     regen,
 )
 
@@ -185,6 +186,10 @@ class test_utils(Case):
         iterations[0] = 0
         self.assertIsNone(first(predicate, range(10, 20)))
         self.assertEqual(iterations[0], 10)
+
+    def test_lookahead(self):
+        self.assertEqual(list(lookahead(x for x in range(6))),
+                         [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, None)])
 
     def test_maybe_list(self):
         self.assertEqual(maybe_list(1), [1])

--- a/celery/tests/utils/test_functional.py
+++ b/celery/tests/utils/test_functional.py
@@ -224,6 +224,9 @@ class test_mlazy(Case):
 
 class test_regen(Case):
 
+    def setUp(self):
+        self.g = regen(iter(list(range(10))))
+
     def test_regen_list(self):
         l = [1, 2]
         r = regen(iter(l))
@@ -235,39 +238,57 @@ class test_regen(Case):
         fun, args = r.__reduce__()
         self.assertEqual(fun(*args), l)
 
-    def test_regen_gen(self):
-        g = regen(iter(list(range(10))))
-        self.assertEqual(g[7], 7)
-        self.assertEqual(g[6], 6)
-        self.assertEqual(g[5], 5)
-        self.assertEqual(g[4], 4)
-        self.assertEqual(g[3], 3)
-        self.assertEqual(g[2], 2)
-        self.assertEqual(g[1], 1)
-        self.assertEqual(g[0], 0)
-        self.assertEqual(g.data, list(range(10)))
-        self.assertEqual(g[8], 8)
-        self.assertEqual(g[0], 0)
-        g = regen(iter(list(range(10))))
-        self.assertEqual(g[0], 0)
-        self.assertEqual(g[1], 1)
-        self.assertEqual(g.data, list(range(10)))
-        g = regen(iter([1]))
-        self.assertEqual(g[0], 1)
+    def test_regen_gen_index(self):
+        self.assertEqual(self.g[7], 7)
+        self.assertEqual(self.g[6], 6)
+        self.assertEqual(self.g[5], 5)
+        self.assertEqual(self.g[4], 4)
+        self.assertEqual(self.g[3], 3)
+        self.assertEqual(self.g[2], 2)
+        self.assertEqual(self.g[1], 1)
+        self.assertEqual(self.g[0], 0)
+        self.assertFalse(self.g.fully_consumed())
+        self.assertEqual(self.g.data, list(range(10)))
+        self.assertTrue(self.g.fully_consumed())
+        self.assertEqual(self.g[8], 8)
+        self.assertEqual(self.g[0], 0)
+        self.assertListEqual(list(iter(self.g)), list(range(10)))
+
+    def test_regen_gen_index_2(self):
+        self.assertEqual(self.g[0], 0)
+        self.assertEqual(self.g[1], 1)
+        self.assertEqual(self.g.data, list(range(10)))
+
+    def test_regen_gen_index_error(self):
+        self.assertEqual(self.g[0], 0)
         with self.assertRaises(IndexError):
-            g[1]
-        self.assertEqual(g.data, [1])
+            self.g[11]
+        self.assertTrue(self.g.fully_consumed())
+        self.assertListEqual(list(iter(self.g)), list(range(10)))
 
-        g = regen(iter(list(range(10))))
-        self.assertEqual(g[-1], 9)
-        self.assertEqual(g[-2], 8)
-        self.assertEqual(g[-3], 7)
-        self.assertEqual(g[-4], 6)
-        self.assertEqual(g[-5], 5)
-        self.assertEqual(g[5], 5)
-        self.assertEqual(g.data, list(range(10)))
+    def test_regen_gen_negative_index(self):
+        self.assertEqual(self.g[-1], 9)
+        self.assertEqual(self.g[-2], 8)
+        self.assertEqual(self.g[-3], 7)
+        self.assertEqual(self.g[-4], 6)
+        self.assertEqual(self.g[-5], 5)
+        self.assertEqual(self.g[5], 5)
+        self.assertEqual(self.g.data, list(range(10)))
 
-        self.assertListEqual(list(iter(g)), list(range(10)))
+        self.assertListEqual(list(iter(self.g)), list(range(10)))
+
+    def test_regen_gen_iter(self):
+        list(iter(self.g))
+        self.assertTrue(self.g.fully_consumed())
+        self.assertListEqual(list(iter(self.g)), list(range(10)))
+
+    def test_regen_gen_repr(self):
+        repr(self.g)
+        self.assertFalse(self.g.fully_consumed())
+
+    def test_regen_gen_nonzero(self):
+        bool(self.g)
+        self.assertFalse(self.g.fully_consumed())
 
 
 class test_head_from_fun(Case):

--- a/celery/utils/abstract.py
+++ b/celery/utils/abstract.py
@@ -96,10 +96,6 @@ class CallableSignature(CallableTask):  # pragma: no cover
         pass
 
     @abstractproperty
-    def chord_size(self):
-        pass
-
-    @abstractproperty
     def immutable(self):
         pass
 

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -17,7 +17,7 @@ try:
     from inspect import isfunction, getfullargspec as getargspec
 except ImportError:  # Py2
     from inspect import isfunction, getargspec  # noqa
-from itertools import chain, islice
+from itertools import chain, islice, tee, izip_longest
 
 from amqp import promise
 from kombu.utils.functional import (
@@ -28,7 +28,8 @@ from celery.five import UserDict, UserList, keys, range
 
 __all__ = ['LRUCache', 'is_list', 'maybe_list', 'memoize', 'mlazy', 'noop',
            'first', 'firstmethod', 'chunks', 'padlist', 'mattrgetter', 'uniq',
-           'regen', 'dictfilter', 'lazy', 'maybe_evaluate', 'head_from_fun']
+           'lookahead', 'regen', 'dictfilter', 'lazy', 'maybe_evaluate',
+           'head_from_fun']
 
 IS_PY3 = sys.version_info[0] == 3
 IS_PY2 = sys.version_info[0] == 2
@@ -310,6 +311,22 @@ def uniq(it):
     """Return all unique elements in ``it``, preserving order."""
     seen = set()
     return (seen.add(obj) or obj for obj in it if obj not in seen)
+
+
+def lookahead(it):
+    """Yield pairs of (current, next) items in `it`. 
+
+    `next` is None if `current` is the last item.
+
+    Example:
+
+        >>> list(lookahead(x for x in range(6)))
+        [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, None)]
+
+    """
+    a, b = tee(it)
+    next(b, None)
+    return izip_longest(a, b, fillvalue=None)
 
 
 def regen(it):

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -353,10 +353,11 @@ class _regen(UserList, list):
         return self.__it.__length_hint__()
 
     def __repr__(self):
+        # override list.__repr__ to avoid consuming the generator
         if self.__done:
             return repr(self.__consumed)
         else:
-            return '[{}]'.format(', '.join(
+            return '[{0}]'.format(', '.join(
                 [repr(x) for x in self.__consumed] + ['...']))
 
     def __iter__(self):
@@ -384,6 +385,8 @@ class _regen(UserList, list):
                 return self.__consumed[index]
 
     def __nonzero__(self):
+        # nonzero for list calls len() which would consume the generator: 
+        # override to consume maximum of one item.
         if len(self.__consumed):
             return True
         try:
@@ -402,6 +405,7 @@ class _regen(UserList, list):
         return self.__consumed
 
     def fully_consumed(self):
+        """Return whether the iterator has been fully consumed"""
         return self.__done
 
 

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -382,6 +382,9 @@ class _regen(UserList, list):
         list(iter(self))
         return self.__consumed
 
+    def fully_consumed(self):
+        return self.__done
+
 
 def _argsfromspec(spec, replace_defaults=True):
     if spec.defaults:

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -17,14 +17,14 @@ try:
     from inspect import isfunction, getfullargspec as getargspec
 except ImportError:  # Py2
     from inspect import isfunction, getargspec  # noqa
-from itertools import chain, islice, tee, izip_longest
+from itertools import chain, islice, tee
 
 from amqp import promise
 from kombu.utils.functional import (
     dictfilter, lazy, maybe_evaluate, is_list, maybe_list,
 )
 
-from celery.five import UserDict, UserList, keys, range
+from celery.five import UserDict, UserList, keys, range, zip_longest
 
 __all__ = ['LRUCache', 'is_list', 'maybe_list', 'memoize', 'mlazy', 'noop',
            'first', 'firstmethod', 'chunks', 'padlist', 'mattrgetter', 'uniq',
@@ -326,7 +326,7 @@ def lookahead(it):
     """
     a, b = tee(it)
     next(b, None)
-    return izip_longest(a, b, fillvalue=None)
+    return zip_longest(a, b, fillvalue=None)
 
 
 def regen(it):
@@ -392,6 +392,8 @@ class _regen(UserList, list):
             return False
         else:
             return True
+    # Py3
+    __bool__ = __nonzero__
 
     @property
     def data(self):

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -327,6 +327,7 @@ class _regen(UserList, list):
         self.__it = it
         self.__index = 0
         self.__consumed = []
+        self.__done = False
 
     def __reduce__(self):
         return list, (self.data,)
@@ -334,8 +335,21 @@ class _regen(UserList, list):
     def __length_hint__(self):
         return self.__it.__length_hint__()
 
+    def __repr__(self):
+        if self.__done:
+            return repr(self.__consumed)
+        else:
+            return '[{}]'.format(', '.join(
+                [repr(x) for x in self.__consumed] + ['...']))
+
     def __iter__(self):
-        return chain(self.__consumed, self.__it)
+        for x in self.__consumed:
+            yield x
+        if not self.__done:
+            for y in self.__it:
+                self.__consumed.append(y)
+                yield y
+            self.__done = True
 
     def __getitem__(self, index):
         if index < 0:
@@ -343,20 +357,29 @@ class _regen(UserList, list):
         try:
             return self.__consumed[index]
         except IndexError:
+            it = iter(self)
             try:
                 for i in range(self.__index, index + 1):
-                    self.__consumed.append(next(self.__it))
+                    next(it)
             except StopIteration:
                 raise IndexError(index)
             else:
                 return self.__consumed[index]
 
+    def __nonzero__(self):
+        if len(self.__consumed):
+            return True
+        try:
+            next(iter(self))
+        except StopIteration:
+            return False
+        else:
+            return True
+
     @property
     def data(self):
-        try:
-            self.__consumed.extend(list(self.__it))
-        except StopIteration:
-            pass
+        # consume the generator
+        list(iter(self))
         return self.__consumed
 
 


### PR DESCRIPTION
When passing a generator to `group` or `chord`, sub-tasks are not submitted to the backend for execution until the entire generator is consumed.  The expected result is that subtasks are submitted during iteration, as soon as they are yielded.  This can have a big impact on performance if generators yield subtasks over a long period of time.

I also opened issue #3021 on the subject.  [This explanation](https://github.com/celery/celery/issues/3021#issuecomment-176729202) from @eli-green I think is pretty on point.

So far I've only added support for redis.  I started looking at the other backends but I ran out of time.  It would be great to get some feedback on what I have so far and to get some thoughts on how difficult it will be to add for the other backends.
