### PR TITLE
worker.startup_info() fails with mongo URI

### DIFF
--- a/celery/tests/bin/test_worker.py
+++ b/celery/tests/bin/test_worker.py
@@ -210,6 +210,13 @@ class test_Worker(WorkerAppCase):
             cd.ARTLINES = prev
 
     @disable_stdouts
+    def test_startup_info_mongo_result_backend(self):
+        self.app.conf.result_backend = "mongodb://user:password@host0.com:43437,host1.com:43437/work4us?replicaSet=rs&ssl=true"
+        worker = self.Worker(app=self.app)
+        worker.on_start()
+        self.assertTrue(worker.startup_info())
+
+    @disable_stdouts
     def test_run(self):
         self.Worker(app=self.app).on_start()
         self.Worker(app=self.app, purge=True).on_start()


### PR DESCRIPTION
This PR illustrate the bug described in #3045