### PR TITLE
Requeue tasks that failed due to Worker Lost Error

### DIFF
--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -439,7 +439,8 @@ class Request(object):
                     send_failed_event = False  # already sent revoked event
             # (acks_late) acknowledge after result stored.
             if self.task.acks_late:
-                self.acknowledge()
+                if not isinstance(exc, WorkerLostError):
+                    self.acknowledge()
         self._log_error(exc_info, send_failed_event=send_failed_event)
 
     def _log_error(self, einfo, send_failed_event=True):


### PR DESCRIPTION
When setting CELERY_ACKS_LATE to True, one would expect that the tasks that failed due to WorkerLost error will be sent back to queue. This change implements what I think should be the expected behavior.