### PR TITLE
Fix the issue that the INIT script will ignore the environment variables

### DIFF
--- a/extra/generic-init.d/celerybeat
+++ b/extra/generic-init.d/celerybeat
@@ -240,7 +240,7 @@ stop_beat () {
 }
 
 _chuid () {
-    su "$CELERYBEAT_USER" -c "$CELERYBEAT $*"
+    su -l "$CELERYBEAT_USER" -c "$CELERYBEAT $*"
 }
 
 start_beat () {

--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -235,7 +235,7 @@ _get_pids() {
 
 
 _chuid () {
-    su "$CELERYD_USER" -c "$CELERYD_MULTI $*"
+    su -l "$CELERYD_USER" -c "$CELERYD_MULTI $*"
 }
 
 


### PR DESCRIPTION
Fix the issue that the INIT script will ignore the environment variable settings, for example in /etc/profile, such as $PYTHONPATH, and causing error ( but the script continue says start successful ).