### PR TITLE
Fix for issue #3068 - Worker crash with multiple cache results backends

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -200,15 +200,20 @@ class Worker(WorkController):
         if not self.send_events:
             events = 'OFF (enable -E to monitor this worker)'
 
+        result_backend = self.app.conf.result_backend or 'disabled'
+        if result_backend.startswith('cache+memcache://'):
+            fmt_results = ";".join([maybe_sanitize_url(part) for part in result_backend.split(';')])
+            fmt_results.replace('/;', ';')
+        else:
+            fmt_results = maybe_sanitize_url(result_backend)
+
         banner = BANNER.format(
             app=appr,
             hostname=safe_str(self.hostname),
             timestamp=datetime.now().replace(microsecond=0),
             version=VERSION_BANNER,
             conninfo=self.app.connection().as_uri(),
-            results=maybe_sanitize_url(
-                self.app.conf.result_backend or 'disabled',
-            ),
+            results=fmt_results,
             concurrency=concurrency,
             platform=safe_str(_platform.platform()),
             events=events,

--- a/celery/tests/bin/test_worker.py
+++ b/celery/tests/bin/test_worker.py
@@ -210,6 +210,13 @@ class test_Worker(WorkerAppCase):
             cd.ARTLINES = prev
 
     @disable_stdouts
+    def test_startup_info_results_backend(self):
+        self.app.conf.result_backend = 'cache+memcache://user:pass@127.0.0.1:11211;127.0.0.2:11211;127.0.0.3/'
+        worker = self.Worker(app=self.app)
+        worker.on_start()
+        self.assertTrue(worker.startup_info())
+
+    @disable_stdouts
     def test_run(self):
         self.Worker(app=self.app).on_start()
         self.Worker(app=self.app, purge=True).on_start()


### PR DESCRIPTION
Correctly format the CELERY_RESULT_BACKEND setting if it's not a single URL