### PR TITLE
Added code to source the $CELERYD_USER's environment on startup

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -149,6 +149,10 @@ if [ -n "$CELERYD_CHDIR" ]; then
     DAEMON_OPTS="$DAEMON_OPTS --workdir=$CELERYD_CHDIR"
 fi
 
+# Source the user's .bashrc file to setup the correct environment
+if [ -n "$CELERYD_USER" ] && [ -r "/u/$CELERYD_USER/.bashrc" ]; then
+    source "/u/$CELERYD_USER/.bashrc"
+fi
 
 check_dev_null() {
     if [ ! -c /dev/null ]; then


### PR DESCRIPTION
Added code to source the $CELERYD_USER's environment on startup. This is necessary for Python projects which require special environment variables to be set, for example in the case of Theano where the $THEANORC and $THEANO_FLAGS environment variables. Without sourcing the environment in this case, Celery crashes and core dumps.