### PR TITLE
[datastructures] Fix LimitedSet.discard()

### DIFF
--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -633,7 +633,7 @@ class LimitedSet(object):
         except KeyError:
             return
         try:
-            self._heap.remove((value, itime))
+            self._heap.remove((itime, value))
         except ValueError:
             pass
         self._data.pop(value, None)

--- a/celery/tests/utils/test_datastructures.py
+++ b/celery/tests/utils/test_datastructures.py
@@ -259,6 +259,8 @@ class test_LimitedSet(Case):
         s.add('foo')
         s.discard('foo')
         self.assertNotIn('foo', s)
+        self.assertEqual(len(s._data), 0)
+        self.assertEqual(len(s._heap), 0)
         s.discard('foo')
 
     def test_clear(self):


### PR DESCRIPTION
This was raising ValueError every time it was called, because the
argument order was backward, resulting in unbounded memory growth for
callers using discard() to remove items from LimitedSet.

Closes #3087