### PR TITLE
Improvements and fixes for LimitedSet

### DIFF
--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -686,7 +686,7 @@ class LimitedSet(object):
         now = now or time.time()
         if item in self._data:
             self.discard(item)
-        entry = (now, item)
+        entry = [now, item]  # this must be a list, we are using pointers.
         self._data[item] = entry
         heappush(self._heap, entry)
         if self.maxlen and len(self._data) >= self.maxlen:

--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -673,7 +673,6 @@ class LimitedSet(object):
         """Time consuming recreating of heap. Do not run this too often."""
         self._heap[:] = [
             entry for entry in values(self._data)
-            if entry is not sentinel
         ]
         heapify(self._heap)
 
@@ -751,7 +750,8 @@ class LimitedSet(object):
         """Remove and return the oldest item, or :const:`None` when empty."""
         while self._heap:
             _, item = heappop(self._heap)
-            if self._data.pop(item, None) is not sentinel:
+            if item is not sentinel:
+                del self.data[item]
                 return item
         return default
 

--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -719,7 +719,10 @@ class LimitedSet(object):
                 self.add(obj)
 
     def discard(self, item):
-        """Remove item from LimitedSet. Return None if item was not found."""
+        """Remove item from :class:`LimitedSet`.
+
+        :keyword item: item to delete. If item is not found, nothing happens.
+        """
 
         entry = self._data.pop(item, sentinel)
         if entry is not sentinel:  # item was found in _data

--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -11,7 +11,9 @@ from __future__ import absolute_import, print_function, unicode_literals
 import sys
 import time
 
-from collections import defaultdict, Mapping, MutableMapping, MutableSet
+from collections import (
+    Callable, Mapping, MutableMapping, MutableSet, defaultdict,
+)
 from heapq import heapify, heappush, heappop
 from itertools import chain
 
@@ -19,7 +21,7 @@ from billiard.einfo import ExceptionInfo  # noqa
 from kombu.utils.encoding import safe_str, bytes_to_str
 from kombu.utils.limits import TokenBucket  # noqa
 
-from celery.five import items
+from celery.five import items, values
 from celery.utils.functional import LRUCache, first, uniq  # noqa
 from celery.utils.text import match_case
 
@@ -29,6 +31,10 @@ except ImportError:
     class LazyObject(object):  # noqa
         pass
     LazySettings = LazyObject  # noqa
+
+__all__ = ['GraphFormatter', 'CycleError', 'DependencyGraph',
+           'AttributeDictMixin', 'AttributeDict', 'DictAttribute',
+           'ConfigurationView', 'LimitedSet']
 
 DOT_HEAD = """
 {IN}{type} {id} {{
@@ -41,9 +47,11 @@ DOT_ATTRSEP = ', '
 DOT_DIRS = {'graph': '--', 'digraph': '->'}
 DOT_TAIL = '{IN}}}'
 
-__all__ = ['GraphFormatter', 'CycleError', 'DependencyGraph',
-           'AttributeDictMixin', 'AttributeDict', 'DictAttribute',
-           'ConfigurationView', 'LimitedSet']
+REPR_LIMITED_SET = """\
+<{name}({size}): maxlen={0.maxlen}, expires={0.expires}, minlen={0.minlen}>\
+"""
+
+sentinel = object()
 
 
 def force_mapping(m):
@@ -578,7 +586,6 @@ class ConfigurationView(AttributeDictMixin):
 
         def values(self):
             return list(self._iterate_values())
-
 MutableMapping.register(ConfigurationView)
 
 
@@ -588,10 +595,34 @@ class LimitedSet(object):
     Good for when you need to test for membership (`a in set`),
     but the set should not grow unbounded.
 
-    This version is now changed to be more enforcing those limits.
-    Maxlen is enforced all the time. But you can also configure
-    minlen now, which is minimal residual size of set.
+    Maxlen is enforced at all times, so if the limit is reached
+    we will also remove non-expired items.
 
+    You can also configure minlen, which is the minimal residual size
+    of the set.
+
+    All  arguments are optional, with exception of minlen, which must
+    be smaller than maxlen.  Unconfigured limits will not be enforced.
+
+    :keyword maxlen: Optional max number of items.
+
+        Adding more items than maxlen will result in immediate
+        removal of items sorted by oldest insertion time.
+
+    :keyword expires: TTL for all items.
+
+        Items aging over expiration are purged as keys are inserted.
+
+    :keyword minlen: Minimal residual size of this set.
+        .. versionadded:: 4.0
+
+        Older expired items will be deleted, only after the set
+        exceeds minlen number of items.
+
+    :keyword data: Initial data to initialize set with.
+        Can be an iterable of ``(key, value)`` pairs,
+        a dict (``{key: insertion_time}``), or another instance
+        of :class:`LimitedSet`.
 
     Example::
 
@@ -611,39 +642,18 @@ class LimitedSet(object):
         4000
         >>>> 57000 in s  # even this item is gone now
         False
+
     """
 
-    REMOVED = object()  # just a placeholder for removed items
-    _MAX_HEAP_PERCENTS_OVERLOAD = 15  #
+    max_heap_percent_overload = 15
 
-    def __init__(self, maxlen=0, expires=0, minlen=0, data=None):
-        """Initialize LimitedSet.
-
-        All  arguments are optional, with exception of minlen, which must
-        be smaller than maxlen. Unconfigured limits will not be enforced.
-
-        :keyword maxlen: max size of this set. Adding more items than maxlen
-                         results in immediate removing of older items.
-        :keyword expires: TTL for an item.
-                          Items aging over expiration are purged.
-        :keyword minlen: minimal residual size of this set.
-                         Oldest expired items will be delete
-                         only until minlen size is reached.
-        :keyword data: data to initialize set with. Can be iterable of keys,
-                       dict {key:inserted_time} or another LimitedSet.
-
-        """
-        if maxlen is None:
-            maxlen = 0
-        if minlen is None:
-            minlen = 0
-        if expires is None:
-            expires = 0
-        self.maxlen = maxlen
-        self.minlen = minlen
-        self.expires = expires
+    def __init__(self, maxlen=0, expires=0, data=None, minlen=0):
+        self.maxlen = 0 if maxlen is None else maxlen
+        self.minlen = 0 if minlen is None else minlen
+        self.expires = 0 if expires is None else expires
         self._data = {}
         self._heap = []
+
         # make shortcuts
         self.__len__ = self._data.__len__
         self.__contains__ = self._data.__contains__
@@ -653,14 +663,17 @@ class LimitedSet(object):
             self.update(data)
 
         if not self.maxlen >= self.minlen >= 0:
-            raise ValueError('Minlen should be positive number, '
-                             'smaller or equal to maxlen.')
+            raise ValueError(
+                'minlen must be a positive number, less or equal to maxlen.')
         if self.expires < 0:
-            raise ValueError('Expires should not be negative!')
+            raise ValueError('expires cannot be negative!')
 
     def _refresh_heap(self):
         """Time consuming recreating of heap. Do not run this too often."""
-        self._heap[:] = [entry for entry in self._data.values()]
+        self._heap[:] = [
+            entry for entry in values(self._data)
+            if entry is not sentinel
+        ]
         heapify(self._heap)
 
     def clear(self):
@@ -669,12 +682,11 @@ class LimitedSet(object):
         self._heap[:] = []
 
     def add(self, item, now=None):
-        'Add a new item or update the time of an existing item'
-        if not now:
-            now = time.time()
+        """Add a new item, or reset the expiry time of an existing item."""
+        now = now or time.time()
         if item in self._data:
             self.discard(item)
-        entry = [now, item]
+        entry = (now, item)
         self._data[item] = entry
         heappush(self._heap, entry)
         if self.maxlen and len(self._data) >= self.maxlen:
@@ -687,43 +699,41 @@ class LimitedSet(object):
             self._refresh_heap()
             self.purge()
         elif isinstance(other, dict):
-            # revokes are sent like dict!
-            for key, inserted in other.items():
+            # revokes are sent as a dict
+            for key, inserted in items(other):
                 if isinstance(inserted, list):
                     # in case someone uses ._data directly for sending update
                     inserted = inserted[0]
                 if not isinstance(inserted, float):
-                    raise ValueError('Expecting float timestamp, got type '
-                                     '"{0}" with value: {1}'.format(
-                                         type(inserted), inserted))
+                    raise ValueError(
+                        'Expecting float timestamp, got type '
+                        '{0!r} with value: {1}'.format(
+                            type(inserted), inserted))
                 self.add(key, inserted)
         else:
-            # AVOID THIS, it could keep old data if more parties
+            # XXX AVOID THIS, it could keep old data if more parties
             # exchange them all over and over again
             for obj in other:
                 self.add(obj)
 
     def discard(self, item):
-        'Mark an existing item as REMOVED. If KeyError is not found, pass.'
-        entry = self._data.pop(item, self.REMOVED)
-        if entry is self.REMOVED:
-            return
-        entry[-1] = self.REMOVED
-        if self._heap_overload > self._MAX_HEAP_PERCENTS_OVERLOAD:
-            self._refresh_heap()
-
+        # mark an existing item as removed. If KeyError is not found, pass.
+        entry = self._data.pop(item, sentinel)
+        if entry is not sentinel:
+            entry[-1] = sentinel
+            if self._heap_overload > self.max_heap_percent_overload:
+                self._refresh_heap()
     pop_value = discard
 
     def purge(self, now=None):
         """Check oldest items and remove them if needed.
 
         :keyword now: Time of purging -- by default right now.
-                      This can be usefull for unittesting.
+                      This can be useful for unit testing.
+
         """
-        if not now:
-            now = time.time()
-        if hasattr(now, '__call__'):
-            now = now()  # if we got this now as function, evaluate it
+        now = now or time.time()
+        now = now() if isinstance(now, Callable) else now
         if self.maxlen:
             while len(self._data) > self.maxlen:
                 self.pop()
@@ -732,32 +742,33 @@ class LimitedSet(object):
             while len(self._data) > self.minlen >= 0:
                 inserted_time, _ = self._heap[0]
                 if inserted_time + self.expires > now:
-                    break  # end this right now, oldest item is not expired yet
+                    break  # oldest item has not expired yet
                 self.pop()
 
-    def pop(self):
-        'Remove and return the lowest time item. Return None if empty.'
+    def pop(self, default=None):
+        """Remove and return the oldest item, or :const:`None` when empty."""
         while self._heap:
             _, item = heappop(self._heap)
-            if item is not self.REMOVED:
-                del self._data[item]
+            if self._data.pop(item, None) is not sentinel:
                 return item
-        return None
+        return default
 
     def as_dict(self):
         """Whole set as serializable dictionary.
+
         Example::
 
-            >>> s=LimitedSet(maxlen=200)
-            >>> r=LimitedSet(maxlen=200)
+            >>> s = LimitedSet(maxlen=200)
+            >>> r = LimitedSet(maxlen=200)
             >>> for i in range(500):
             ...     s.add(i)
             ...
             >>> r.update(s.as_dict())
             >>> r == s
             True
+
         """
-        return {key: inserted for inserted, key in self._data.values()}
+        return {key: inserted for inserted, key in values(self._data)}
 
     def __eq__(self, other):
         return self._data == other._data
@@ -766,15 +777,12 @@ class LimitedSet(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'LimitedSet(maxlen={0}, expires={1}, minlen={2})' \
-            ' Current size:{3}'.format(
-                self.maxlen, self.expires, self.minlen, len(self._data))
+        return REPR_LIMITED_SET.format(
+            self, name=type(self).__name__, size=len(self),
+        )
 
     def __iter__(self):
-        # return (item[1] for item in
-        #         self._heap if item[-1] is not self.REMOVED)
-        # ^ not ordered, slow
-        return (i for _, i in sorted(self._data.values()))
+        return (i for _, i in sorted(values(self._data)))
 
     def __len__(self):
         return len(self._data)
@@ -783,17 +791,13 @@ class LimitedSet(object):
         return key in self._data
 
     def __reduce__(self):
-        """Pickle helper class.
-
-        This object can be pickled and upickled."""
         return self.__class__, (
-            self.maxlen, self.expires, self.minlen, self.as_dict())
+            self.maxlen, self.expires, self.as_dict(), self.minlen)
 
     @property
     def _heap_overload(self):
         """Compute how much is heap bigger than data [percents]."""
-        if len(self._data) == 0:
+        if not self._data:
             return len(self._heap)
-        return len(self._heap)*100/len(self._data) - 100
-
+        return len(self._heap) * 100 / len(self._data) - 100
 MutableSet.register(LimitedSet)

--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -583,120 +583,217 @@ MutableMapping.register(ConfigurationView)
 
 
 class LimitedSet(object):
-    """Kind-of Set with limitations.
+    """Kind-of Set (or priority queue) with limitations.
 
     Good for when you need to test for membership (`a in set`),
     but the set should not grow unbounded.
 
-    :keyword maxlen: Maximum number of members before we start
-                     evicting expired members.
-    :keyword expires: Time in seconds, before a membership expires.
+    This version is now changed to be more enforcing those limits.
+    Maxlen is enforced all the time. But you can also configure
+    minlen now, which is minimal residual size of set.
 
+
+    Example::
+
+        >>> s = LimitedSet(maxlen=50000, expires=3600, minlen=4000)
+        >>> for i in range(60000):
+        ...     s.add(i)
+        ...     s.add(str(i))
+        ...
+        >>> 57000 in s  # last 50k inserted values are kept
+        True
+        >>> '10' in s  # '10' did expire and was purged from set.
+        False
+        >>> len(s)  # maxlen is reached
+        50000
+        >>> s.purge(now=time.time() + 7200)  # clock + 2 hours
+        >>> len(s)  # now only minlen items are cached
+        4000
+        >>>> 57000 in s  # even this item is gone now
+        False
     """
 
-    def __init__(self, maxlen=None, expires=None, data=None, heap=None):
-        # heap is ignored
-        self.maxlen = maxlen
-        self.expires = expires
-        self._data = {} if data is None else data
-        self._heap = []
+    REMOVED = object()  # just a placeholder for removed items
+    _MAX_HEAP_PERCENTS_OVERLOAD = 15  #
 
+    def __init__(self, maxlen=0, expires=0, minlen=0, data=None):
+        """Initialize LimitedSet.
+
+        All  arguments are optional, with exception of minlen, which must
+        be smaller than maxlen. Unconfigured limits will not be enforced.
+
+        :keyword maxlen: max size of this set. Adding more items than maxlen
+                         results in immediate removing of older items.
+        :keyword expires: TTL for an item.
+                          Items aging over expiration are purged.
+        :keyword minlen: minimal residual size of this set.
+                         Oldest expired items will be delete
+                         only until minlen size is reached.
+        :keyword data: data to initialize set with. Can be iterable of keys,
+                       dict {key:inserted_time} or another LimitedSet.
+
+        """
+        if maxlen is None:
+            maxlen = 0
+        if minlen is None:
+            minlen = 0
+        if expires is None:
+            expires = 0
+        self.maxlen = maxlen
+        self.minlen = minlen
+        self.expires = expires
+        self._data = {}
+        self._heap = []
         # make shortcuts
-        self.__len__ = self._heap.__len__
+        self.__len__ = self._data.__len__
         self.__contains__ = self._data.__contains__
 
-        self._refresh_heap()
+        if data:
+            # import items from data
+            self.update(data)
+
+        if not self.maxlen >= self.minlen >= 0:
+            raise ValueError('Minlen should be positive number, '
+                             'smaller or equal to maxlen.')
+        if self.expires < 0:
+            raise ValueError('Expires should not be negative!')
 
     def _refresh_heap(self):
-        self._heap[:] = [(t, key) for key, t in items(self._data)]
+        """Time consuming recreating of heap. Do not run this too often."""
+        self._heap[:] = [entry for entry in self._data.values()]
         heapify(self._heap)
 
-    def add(self, key, now=time.time, heappush=heappush):
-        """Add a new member."""
-        # offset is there to modify the length of the list,
-        # this way we can expire an item before inserting the value,
-        # and it will end up in the correct order.
-        self.purge(1, offset=1)
-        inserted = now()
-        self._data[key] = inserted
-        heappush(self._heap, (inserted, key))
-
     def clear(self):
-        """Remove all members"""
+        """Clear all data, start from scratch again."""
         self._data.clear()
         self._heap[:] = []
 
-    def discard(self, value):
-        """Remove membership by finding value."""
-        try:
-            itime = self._data[value]
-        except KeyError:
-            return
-        try:
-            self._heap.remove((itime, value))
-        except ValueError:
-            pass
-        self._data.pop(value, None)
-    pop_value = discard  # XXX compat
-
-    def purge(self, limit=None, offset=0, now=time.time):
-        """Purge expired items."""
-        H, maxlen = self._heap, self.maxlen
-        if not maxlen:
-            return
-
-        # If the data/heap gets corrupted and limit is None
-        # this will go into an infinite loop, so limit must
-        # have a value to guard the loop.
-        limit = len(self) + offset if limit is None else limit
-
-        i = 0
-        while len(self) + offset > maxlen:
-            if i >= limit:
-                break
-            try:
-                item = heappop(H)
-            except IndexError:
-                break
-            if self.expires:
-                if now() < item[0] + self.expires:
-                    heappush(H, item)
-                    break
-            try:
-                self._data.pop(item[1])
-            except KeyError:  # out of sync with heap
-                pass
-            i += 1
+    def add(self, item, now=None):
+        'Add a new item or update the time of an existing item'
+        if not now:
+            now = time.time()
+        if item in self._data:
+            self.discard(item)
+        entry = [now, item]
+        self._data[item] = entry
+        heappush(self._heap, entry)
+        if self.maxlen and len(self._data) >= self.maxlen:
+            self.purge()
 
     def update(self, other):
+        """Update this LimitedSet from other LimitedSet, dict or iterable."""
         if isinstance(other, LimitedSet):
             self._data.update(other._data)
             self._refresh_heap()
+            self.purge()
+        elif isinstance(other, dict):
+            # revokes are sent like dict!
+            for key, inserted in other.items():
+                if isinstance(inserted, list):
+                    # in case someone uses ._data directly for sending update
+                    inserted = inserted[0]
+                if not isinstance(inserted, float):
+                    raise ValueError('Expecting float timestamp, got type '
+                                     '"{0}" with value: {1}'.format(
+                                         type(inserted), inserted))
+                self.add(key, inserted)
         else:
+            # AVOID THIS, it could keep old data if more parties
+            # exchange them all over and over again
             for obj in other:
                 self.add(obj)
 
+    def discard(self, item):
+        'Mark an existing item as REMOVED. If KeyError is not found, pass.'
+        entry = self._data.pop(item, self.REMOVED)
+        if entry is self.REMOVED:
+            return
+        entry[-1] = self.REMOVED
+        if self._heap_overload > self._MAX_HEAP_PERCENTS_OVERLOAD:
+            self._refresh_heap()
+
+    pop_value = discard
+
+    def purge(self, now=None):
+        """Check oldest items and remove them if needed.
+
+        :keyword now: Time of purging -- by default right now.
+                      This can be usefull for unittesting.
+        """
+        if not now:
+            now = time.time()
+        if hasattr(now, '__call__'):
+            now = now()  # if we got this now as function, evaluate it
+        if self.maxlen:
+            while len(self._data) > self.maxlen:
+                self.pop()
+        # time based expiring:
+        if self.expires:
+            while len(self._data) > self.minlen >= 0:
+                inserted_time, _ = self._heap[0]
+                if inserted_time + self.expires > now:
+                    break  # end this right now, oldest item is not expired yet
+                self.pop()
+
+    def pop(self):
+        'Remove and return the lowest time item. Return None if empty.'
+        while self._heap:
+            _, item = heappop(self._heap)
+            if item is not self.REMOVED:
+                del self._data[item]
+                return item
+        return None
+
     def as_dict(self):
-        return self._data
+        """Whole set as serializable dictionary.
+        Example::
+
+            >>> s=LimitedSet(maxlen=200)
+            >>> r=LimitedSet(maxlen=200)
+            >>> for i in range(500):
+            ...     s.add(i)
+            ...
+            >>> r.update(s.as_dict())
+            >>> r == s
+            True
+        """
+        return {key: inserted for inserted, key in self._data.values()}
 
     def __eq__(self, other):
-        return self._heap == other._heap
+        return self._data == other._data
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'LimitedSet({0})'.format(len(self))
+        return 'LimitedSet(maxlen={0}, expires={1}, minlen={2})' \
+            ' Current size:{3}'.format(
+                self.maxlen, self.expires, self.minlen, len(self._data))
 
     def __iter__(self):
-        return (item[1] for item in self._heap)
+        # return (item[1] for item in
+        #         self._heap if item[-1] is not self.REMOVED)
+        # ^ not ordered, slow
+        return (i for _, i in sorted(self._data.values()))
 
     def __len__(self):
-        return len(self._heap)
+        return len(self._data)
 
     def __contains__(self, key):
         return key in self._data
 
     def __reduce__(self):
-        return self.__class__, (self.maxlen, self.expires, self._data)
+        """Pickle helper class.
+
+        This object can be pickled and upickled."""
+        return self.__class__, (
+            self.maxlen, self.expires, self.minlen, self.as_dict())
+
+    @property
+    def _heap_overload(self):
+        """Compute how much is heap bigger than data [percents]."""
+        if len(self._data) == 0:
+            return len(self._heap)
+        return len(self._heap)*100/len(self._data) - 100
+
 MutableSet.register(LimitedSet)

--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -751,7 +751,7 @@ class LimitedSet(object):
         while self._heap:
             _, item = heappop(self._heap)
             if item is not sentinel:
-                del self.data[item]
+                del self._data[item]
                 return item
         return default
 

--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -719,12 +719,14 @@ class LimitedSet(object):
                 self.add(obj)
 
     def discard(self, item):
-        # mark an existing item as removed. If KeyError is not found, pass.
+        """Remove item from LimitedSet. Return None if item was not found."""
+
         entry = self._data.pop(item, sentinel)
-        if entry is not sentinel:
+        if entry is not sentinel:  # item was found in _data
+            entry[-1] = sentinel   # entry marked removed in _heap.
             if self._heap_overload > self.max_heap_percent_overload:
                 self._refresh_heap()
-    pop_value = discard
+    pop_value = discard  # compatibility alias for old code
 
     def purge(self, now=None):
         """Check oldest items and remove them if needed.

--- a/celery/tests/app/test_app.py
+++ b/celery/tests/app/test_app.py
@@ -16,7 +16,7 @@ from celery import _state
 from celery.app import base as _appbase
 from celery.app import defaults
 from celery.exceptions import ImproperlyConfigured
-from celery.five import items, keys
+from celery.five import keys
 from celery.loaders.base import BaseLoader, unconfigured
 from celery.platforms import pyimplementation
 from celery.utils.serialization import pickle
@@ -38,6 +38,7 @@ from celery.tests.case import (
 )
 from celery.utils import uuid
 from celery.utils.mail import ErrorMail
+from celery.utils.objects import Bunch
 
 THIS_IS_A_KEY = 'this is a value'
 
@@ -56,13 +57,6 @@ class ObjectConfig2(object):
     CALL_ME_BACK = 123456789
     WANT_ME_TO = False
     UNDERSTAND_ME = True
-
-
-class Object(object):
-
-    def __init__(self, **kwargs):
-        for key, value in items(kwargs):
-            setattr(self, key, value)
 
 
 def _get_test_config():
@@ -647,10 +641,10 @@ class test_App(AppCase):
 
         _args = {'foo': 'bar', 'spam': 'baz'}
 
-        self.app.config_from_object(Object())
+        self.app.config_from_object(Bunch())
         self.assertEqual(self.app.conf.broker_transport_options, {})
 
-        self.app.config_from_object(Object(broker_transport_options=_args))
+        self.app.config_from_object(Bunch(broker_transport_options=_args))
         self.assertEqual(self.app.conf.broker_transport_options, _args)
 
     def test_Windows_log_color_disabled(self):

--- a/celery/tests/app/test_beat.py
+++ b/celery/tests/app/test_beat.py
@@ -9,11 +9,9 @@ from celery import beat
 from celery.five import keys, string_t
 from celery.schedules import schedule
 from celery.utils import uuid
+from celery.utils.objects import Bunch
+
 from celery.tests.case import AppCase, Mock, SkipTest, call, patch
-
-
-class Object(object):
-    pass
 
 
 class MockShelve(dict):
@@ -353,8 +351,9 @@ def create_persistent_scheduler(shelv=None):
 
     class MockPersistentScheduler(beat.PersistentScheduler):
         sh = shelv
-        persistence = Object()
-        persistence.open = lambda *a, **kw: shelv
+        persistence = Bunch(
+            open=lambda *a, **kw: shelv,
+        )
         tick_raises_exit = False
         shutdown_service = None
 

--- a/celery/tests/backends/test_cassandra.py
+++ b/celery/tests/backends/test_cassandra.py
@@ -5,15 +5,12 @@ from datetime import datetime
 
 from celery import states
 from celery.exceptions import ImproperlyConfigured
+from celery.utils.objects import Bunch
 from celery.tests.case import (
     AppCase, Mock, mock_module, depends_on_current_app
 )
 
 CASSANDRA_MODULES = ['cassandra', 'cassandra.auth', 'cassandra.cluster']
-
-
-class Object(object):
-    pass
 
 
 class test_CassandraBackend(AppCase):
@@ -42,8 +39,9 @@ class test_CassandraBackend(AppCase):
             from celery.backends import cassandra as mod
             mod.cassandra = Mock()
 
-            cons = mod.cassandra.ConsistencyLevel = Object()
-            cons.LOCAL_QUORUM = 'foo'
+            cons = mod.cassandra.ConsistencyLevel = Bunch(
+                LOCAL_QUORUM='foo',
+            )
 
             self.app.conf.cassandra_read_consistency = 'LOCAL_FOO'
             self.app.conf.cassandra_write_consistency = 'LOCAL_FOO'

--- a/celery/tests/bin/test_base.py
+++ b/celery/tests/bin/test_base.py
@@ -8,13 +8,11 @@ from celery.bin.base import (
     Extensions,
     HelpFormatter,
 )
+from celery.utils.objects import Bunch
+
 from celery.tests.case import (
     AppCase, Mock, depends_on_current_app, override_stdouts, patch,
 )
-
-
-class Object(object):
-    pass
 
 
 class MyApp(object):
@@ -27,9 +25,7 @@ class MockCommand(Command):
     mock_args = ('arg1', 'arg2', 'arg3')
 
     def parse_options(self, prog_name, arguments, command=None):
-        options = Object()
-        options.foo = 'bar'
-        options.prog_name = prog_name
+        options = Bunch(foo='bar', prog_name=prog_name)
         return options, self.mock_args
 
     def run(self, *args, **kwargs):

--- a/celery/tests/concurrency/test_prefork.py
+++ b/celery/tests/concurrency/test_prefork.py
@@ -9,9 +9,12 @@ from itertools import cycle
 
 from celery.app.defaults import DEFAULTS
 from celery.datastructures import AttributeDict
-from celery.five import items, range
+from celery.five import range
 from celery.utils.functional import noop
+from celery.utils.objects import Bunch
+
 from celery.tests.case import AppCase, Mock, SkipTest, patch, restore_logging
+
 try:
     from celery.concurrency import prefork as mp
     from celery.concurrency import asynpool
@@ -36,12 +39,6 @@ except ImportError:
                 pass
     mp = _mp()  # noqa
     asynpool = None  # noqa
-
-
-class Object(object):   # for writeable attributes.
-
-    def __init__(self, **kwargs):
-        [setattr(self, k, v) for k, v in items(kwargs)]
 
 
 class MockResult(object):
@@ -132,7 +129,7 @@ class MockPool(object):
         self.maintain_pool = Mock()
         self._state = mp.RUN
         self._processes = kwargs.get('processes')
-        self._pool = [Object(pid=i, inqW_fd=1, outqR_fd=2)
+        self._pool = [Bunch(pid=i, inqW_fd=1, outqR_fd=2)
                       for i in range(self._processes)]
         self._current_proc = cycle(range(self._processes))
 
@@ -405,7 +402,7 @@ class test_TaskPool(PoolCase):
 
     def test_info(self):
         pool = TaskPool(10)
-        procs = [Object(pid=i) for i in range(pool.limit)]
+        procs = [Bunch(pid=i) for i in range(pool.limit)]
 
         class _Pool(object):
             _pool = procs

--- a/celery/tests/fixups/test_django.py
+++ b/celery/tests/fixups/test_django.py
@@ -10,6 +10,7 @@ from celery.fixups.django import (
     DjangoFixup,
     DjangoWorkerFixup,
 )
+from celery.utils.objects import Bunch
 
 from celery.tests.case import (
     AppCase, Mock, patch, patch_modules, mask_modules,
@@ -275,10 +276,7 @@ class test_DjangoWorkerFixup(FixupCase):
             with self.assertRaises(KeyError):
                 f._close_database()
 
-            class Object(object):
-                pass
-            o = Object()
-            o.close_connection = Mock()
+            o = Bunch(close_connection=Mock())
             f._db = o
             f._close_database()
             o.close_connection.assert_called_with()

--- a/celery/tests/utils/test_datastructures.py
+++ b/celery/tests/utils/test_datastructures.py
@@ -233,7 +233,7 @@ class test_LimitedSet(Case):
         self.assertEqual(s.minlen, len(s))
         self.assertLessEqual(
             len(s._heap),
-            s.maxlen * (100. + s._MAX_HEAP_PERCENTS_OVERLOAD) / 100,
+            s.maxlen * (100. + s.max_heap_percent_overload) / 100,
         )
 
     def test_pickleable(self):
@@ -314,13 +314,12 @@ class test_LimitedSet(Case):
 
     def test_iterable_and_ordering(self):
         s = LimitedSet(maxlen=35, expires=None)
-        for i in reversed(range(15)):
+        for i in range(15):
             s.add(i)
-        j = 40
-        for i in s:
-            self.assertLess(i, j)  # each item is smaller and smaller
-            j = i
-        self.assertEqual(i, 0)  # last item = 0
+        # NOTE: This test used to reverse the input numbers, but
+        # timestamps do not have enough precision to keep the data
+        # ordered when inserted quickly.
+        self.assertEqual(list(s), list(range(15)))
 
     def test_pop_and_ordering_again(self):
         s = LimitedSet(maxlen=5)

--- a/celery/tests/utils/test_datastructures.py
+++ b/celery/tests/utils/test_datastructures.py
@@ -337,6 +337,14 @@ class test_LimitedSet(Case):
         s.add('foo')
         self.assertIsInstance(s.as_dict(), Mapping)
 
+    def test_pop_ordering(self):
+        s = LimitedSet()
+        s.add('a', 1)
+        s.add('b', 2)
+        s.add('a', 3)
+        item = s.pop()
+        self.assertEqual(item, 'b')
+
 
 class test_AttributeDict(Case):
 

--- a/celery/tests/utils/test_datastructures.py
+++ b/celery/tests/utils/test_datastructures.py
@@ -17,18 +17,15 @@ from celery.datastructures import (
     DependencyGraph,
 )
 from celery.five import items
+from celery.utils.objects import Bunch
 
-from celery.tests.case import Case, Mock, WhateverIO, SkipTest, patch
-
-
-class Object(object):
-    pass
+from celery.tests.case import Case, Mock, WhateverIO, SkipTest
 
 
 class test_DictAttribute(Case):
 
     def test_get_set_keys_values_items(self):
-        x = DictAttribute(Object())
+        x = DictAttribute(Bunch())
         x['foo'] = 'The quick brown fox'
         self.assertEqual(x['foo'], 'The quick brown fox')
         self.assertEqual(x['foo'], x.obj.foo)
@@ -46,21 +43,20 @@ class test_DictAttribute(Case):
         self.assertIn('The quick yellow fox', list(x.values()))
 
     def test_setdefault(self):
-        x = DictAttribute(Object())
+        x = DictAttribute(Bunch())
         x.setdefault('foo', 'NEW')
         self.assertEqual(x['foo'], 'NEW')
         x.setdefault('foo', 'XYZ')
         self.assertEqual(x['foo'], 'NEW')
 
     def test_contains(self):
-        x = DictAttribute(Object())
+        x = DictAttribute(Bunch())
         x['foo'] = 1
         self.assertIn('foo', x)
         self.assertNotIn('bar', x)
 
     def test_items(self):
-        obj = Object()
-        obj.attr1 = 1
+        obj = Bunch(attr1=1)
         x = DictAttribute(obj)
         x['attr2'] = 2
         self.assertEqual(x['attr1'], 1)
@@ -123,8 +119,7 @@ class test_ConfigurationView(Case):
         self.assertEqual(self.view.foo, 10)
 
     def test_add_defaults_object(self):
-        defaults = Object()
-        defaults.foo = 10
+        defaults = Bunch(foo=10)
         self.view.add_defaults(defaults)
         self.assertEqual(self.view.foo, 10)
 

--- a/celery/tests/worker/test_autoscale.py
+++ b/celery/tests/worker/test_autoscale.py
@@ -7,10 +7,7 @@ from celery.five import monotonic
 from celery.worker import state
 from celery.worker import autoscale
 from celery.tests.case import AppCase, Mock, patch, sleepdeprived
-
-
-class Object(object):
-    pass
+from celery.utils.objects import Bunch
 
 
 class MockPool(BasePool):
@@ -19,8 +16,7 @@ class MockPool(BasePool):
 
     def __init__(self, *args, **kwargs):
         super(MockPool, self).__init__(*args, **kwargs)
-        self._pool = Object()
-        self._pool._processes = self.limit
+        self._pool = Bunch(_processes=self.limit)
 
     def grow(self, n=1):
         self._pool._processes += n

--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -276,7 +276,7 @@ def hello(state, from_node, revoked=None, **kwargs):
         logger.info('sync with %s', from_node)
         if revoked:
             worker_state.revoked.update(revoked)
-        return {'revoked': worker_state.revoked._data,
+        return {'revoked': worker_state.revoked.as_dict(),
                 'clock': state.app.clock.forward()}
 
 

--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -38,8 +38,11 @@ SOFTWARE_INFO = {'sw_ident': 'py-celery',
 REVOKES_MAX = 50000
 
 #: how many seconds a revoke will be active before
-#: being expired when the max limit has been exceeded.
+#: being expired and removed from the set
 REVOKE_EXPIRES = 10800
+
+# minimal number of newest revokes to keep, even if they expired
+REVOKE_MIN = 10000
 
 #: set of all reserved :class:`~celery.worker.request.Request`'s.
 reserved_requests = set()
@@ -54,7 +57,8 @@ total_count = Counter()
 all_total_count = [0]
 
 #: the list of currently revoked tasks.  Persistent if statedb set.
-revoked = LimitedSet(maxlen=REVOKES_MAX, expires=REVOKE_EXPIRES)
+revoked = LimitedSet(maxlen=REVOKES_MAX, expires=REVOKE_EXPIRES,
+                     minlen=REVOKE_MIN)
 
 #: Update global state when a task has been reserved.
 task_reserved = reserved_requests.add

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -39,7 +39,8 @@ The API defines a standard set of execution options, as well as three methods:
 .. topic:: Quick Cheat Sheet
 
     - ``T.delay(arg, kwarg=value)``
-        always a shortcut to ``.apply_async``.
+        Star arguments shortcut to ``.apply_async``.
+        (``.delay(*args, **kwargs)`` calls ``.apply_async(args, kwargs)``).
 
     - ``T.apply_async((arg,), {'kwarg': value})``
 

--- a/examples/app/myapp.py
+++ b/examples/app/myapp.py
@@ -1,6 +1,6 @@
 """myapp.py
 
-Usage:
+Usage::
 
    (window1)$ python myapp.py worker -l info
 


### PR DESCRIPTION
Getting rid of leaking memory + adding minlen size of the set.
Minlen is minimal residual size of set after operating for long time.
Minlen items are kept, even if they should be expired by time, until
we get newer items.

Problems with older and even more old code:

1. Heap would tend to grow in some scenarios
   (like adding an item multiple times).

2. Adding many items fast would not clean them soon enough (if ever).

3. When talking to other workers, revoked._data was sent, but
   it was processed on the other side as iterable.
   That means giving those keys new (current)
   timestamp. By doing this workers could recycle
   items forever. Combined with 1) and 2), this means that in
   large set of workers, you are getting out of memory soon.

All those problems should be fixed now,
also some new unittests are added.

This should fix issues #3095, #3086.