### PR TITLE
Make gevent.TaskPool to tell it's pool limit

### DIFF
--- a/celery/concurrency/gevent.py
+++ b/celery/concurrency/gevent.py
@@ -121,3 +121,8 @@ class TaskPool(BasePool):
     @property
     def num_processes(self):
         return len(self._pool)
+        
+    def _get_info(self):
+        info = super(TaskPool, self)._get_info()
+        info['max-concurrency'] = self.limit
+        return info


### PR DESCRIPTION
This is a little improvement. It makes gevent.TaskPool to return information about pool size. Such info is currently totally missing due to default `BasePool` implementation. `eventlet`, `prefork` and `solo` implementations already have this.

This will allow to get pool size via `control.inspect().stats()`. This is essential to have such feature, for example, to know how much tasks a single pool can consume at one time.