### PR TITLE
Prevent duplicates in LimitedSet

### DIFF
--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -618,6 +618,7 @@ class LimitedSet(object):
         # and it will end up in the correct order.
         self.purge(1, offset=1)
         inserted = now()
+        self.discard(key) # remove this key if it exists to prevent dups
         self._data[key] = inserted
         heappush(self._heap, (inserted, key))
 

--- a/celery/tests/utils/test_datastructures.py
+++ b/celery/tests/utils/test_datastructures.py
@@ -291,6 +291,13 @@ class test_LimitedSet(Case):
         s.add('foo')
         self.assertIsInstance(s.as_dict(), dict)
 
+    def test_no_duplicates(self):
+        s = LimitedSet(maxlen=2)
+        s.add('foo')
+        s.add('foo')
+        self.assertEqual(len(s), 1)
+        self.assertEqual(len(s._data), 1)
+        self.assertEqual(len(s._heap), 1)
 
 class test_AttributeDict(Case):
 


### PR DESCRIPTION
I think this will help prevent dups that are currently reported for me in 3.1.22 by `app.control.inspect().revoked()`