### PR TITLE
test to ensure that celery does not scale down by negative values

### DIFF
--- a/celery/tests/worker/test_autoscale.py
+++ b/celery/tests/worker/test_autoscale.py
@@ -209,7 +209,6 @@ class test_Autoscaler(AppCase):
             x.body()
             total_num_processes.append(self.pool.num_processes)
 
-        self. assertTrue(all(i <= x.min_concurrency for i in total_num_processes)
-                        )
-        self. assertTrue(all(i <= x.max_concurrency for i in total_num_processes)
-                        )
+        self. assertTrue(
+            all(x.min_concurrency <= i <= x.max_concurrency for i in total_num_processes)
+        )

--- a/celery/tests/worker/test_autoscale.py
+++ b/celery/tests/worker/test_autoscale.py
@@ -192,3 +192,24 @@ class test_Autoscaler(AppCase):
             sys.stderr = p
         _exit.assert_called_with(1)
         self.assertTrue(stderr.write.call_count)
+
+    def test_no_negative_scale(self):
+        total_num_processes = []
+        worker = Mock(name='worker')
+        x = autoscale.Autoscaler(self.pool, 10, 3, worker=worker)
+        x.body() #the body func scales up or down
+
+        for i in range(35):
+            state.reserved_requests.add(i)
+            x.body()
+            total_num_processes.append(self.pool.num_processes)
+
+        for i in range(35):
+            state.reserved_requests.remove(i)
+            x.body()
+            total_num_processes.append(self.pool.num_processes)
+
+        self. assertTrue(all(i <= x.min_concurrency for i in total_num_processes)
+                        )
+        self. assertTrue(all(i <= x.max_concurrency for i in total_num_processes)
+                        )


### PR DESCRIPTION
This is in relation to this issue: https://github.com/celery/celery/issues/1967

So, it looks like that issue has been fixed in the current master(tip) but there has not been any testcase. This fixes that.
@insertjokehere had intimated that he had a fix but didn't have a good testcase; https://github.com/celery/celery/issues/1967#issuecomment-196491985 

So the gist of this pull request is to add the neccesary testcase