### PR TITLE
Update and fix links to external pages

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -245,7 +245,7 @@ issue tracker.
 
 * Celery: http://github.com/celery/celery/issues/
 * Kombu: http://github.com/celery/kombu/issues
-* pyamqp: http://github.com/celery/pyamqp/issues
+* pyamqp: http://github.com/celery/py-amqp/issues
 * vine: http://github.com/celery/vine/issues
 * librabbitmq: http://github.com/celery/librabbitmq/issues
 * Django-Celery: http://github.com/celery/django-celery/issues

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -230,10 +230,10 @@ been made on your bug. In the event you've turned this feature off, you
 should check back on occasion to ensure you don't miss any questions a
 developer trying to fix the bug might ask.
 
-.. _`GitHub`: http://github.com
-.. _`strace`: http://en.wikipedia.org/wiki/Strace
-.. _`ltrace`: http://en.wikipedia.org/wiki/Ltrace
-.. _`lsof`: http://en.wikipedia.org/wiki/Lsof
+.. _`GitHub`: https://github.com
+.. _`strace`: https://en.wikipedia.org/wiki/Strace
+.. _`ltrace`: https://en.wikipedia.org/wiki/Ltrace
+.. _`lsof`: https://en.wikipedia.org/wiki/Lsof
 
 .. _issue-trackers:
 
@@ -243,12 +243,12 @@ Issue Trackers
 Bugs for a package in the Celery ecosystem should be reported to the relevant
 issue tracker.
 
-* Celery: http://github.com/celery/celery/issues/
-* Kombu: http://github.com/celery/kombu/issues
-* pyamqp: http://github.com/celery/py-amqp/issues
-* vine: http://github.com/celery/vine/issues
-* librabbitmq: http://github.com/celery/librabbitmq/issues
-* Django-Celery: http://github.com/celery/django-celery/issues
+* Celery: https://github.com/celery/celery/issues/
+* Kombu: https://github.com/celery/kombu/issues
+* pyamqp: https://github.com/celery/py-amqp/issues
+* vine: https://github.com/celery/vine/issues
+* librabbitmq: https://github.com/celery/librabbitmq/issues
+* Django-Celery: https://github.com/celery/django-celery/issues
 
 If you are unsure of the origin of the bug you can ask the
 `mailing-list`_, or just use the Celery issue tracker.
@@ -281,9 +281,9 @@ Branches
 
 Current active version branches:
 
-* master (http://github.com/celery/celery/tree/master)
-* 3.1 (http://github.com/celery/celery/tree/3.1)
-* 3.0 (http://github.com/celery/celery/tree/3.0)
+* master (https://github.com/celery/celery/tree/master)
+* 3.1 (https://github.com/celery/celery/tree/3.1)
+* 3.0 (https://github.com/celery/celery/tree/3.0)
 
 You can see the state of any branch by looking at the Changelog:
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
  celery - Distributed Task Queue
 =================================
 
-.. image:: http://cloud.github.com/downloads/celery/celery/celery_128.png
+.. image:: https://cloud.github.com/downloads/celery/celery/celery_128.png
 
 :Version: 4.0.0rc1 (0today8)
 :Web: http://celeryproject.org/
@@ -150,13 +150,13 @@ It supports...
 .. _`Eventlet`: http://eventlet.net/
 .. _`gevent`: http://gevent.org/
 
-.. _RabbitMQ: http://rabbitmq.com
+.. _RabbitMQ: http://www.rabbitmq.com/
 .. _Redis: http://redis.io
-.. _MongoDB: http://mongodb.org
-.. _Beanstalk: http://kr.github.com/beanstalkd
+.. _MongoDB: https://www.mongodb.org/
+.. _Beanstalk: http://kr.github.io/beanstalkd/
 .. _CouchDB: http://couchdb.apache.org
-.. _SQLAlchemy: http://sqlalchemy.org
-.. _`IronMQ`: http://iron.io
+.. _SQLAlchemy: http://www.sqlalchemy.org/
+.. _`IronMQ`: https://www.iron.io/
 
 Framework Integration
 =====================
@@ -182,15 +182,15 @@ The integration packages are not strictly necessary, but they can make
 development easier, and sometimes they add important hooks like closing
 database connections at ``fork``.
 
-.. _`Django`: http://djangoproject.com/
-.. _`Pylons`: http://pylonsproject.org/
+.. _`Django`: https://www.djangoproject.com/
+.. _`Pylons`: http://www.pylonsproject.org/
 .. _`Flask`: http://flask.pocoo.org/
 .. _`web2py`: http://web2py.com/
 .. _`Bottle`: http://bottlepy.org/
 .. _`Pyramid`: http://docs.pylonsproject.org/en/latest/docs/pyramid.html
-.. _`pyramid_celery`: http://pypi.python.org/pypi/pyramid_celery/
-.. _`django-celery`: http://pypi.python.org/pypi/django-celery
-.. _`celery-pylons`: http://pypi.python.org/pypi/celery-pylons
+.. _`pyramid_celery`: https://pypi.python.org/pypi/pyramid_celery/
+.. _`django-celery`: https://pypi.python.org/pypi/django-celery
+.. _`celery-pylons`: https://pypi.python.org/pypi/celery-pylons
 .. _`web2py-celery`: http://code.google.com/p/web2py-celery/
 .. _`Tornado`: http://www.tornadoweb.org/
 .. _`tornado-celery`: https://github.com/mher/tornado-celery/
@@ -320,7 +320,7 @@ Downloading and installing from source
 --------------------------------------
 
 Download the latest version of Celery from
-http://pypi.python.org/pypi/celery/
+https://pypi.python.org/pypi/celery/
 
 You can install it by doing the following,::
 
@@ -369,7 +369,7 @@ Mailing list
 For discussions about the usage, development, and future of celery,
 please join the `celery-users`_ mailing list.
 
-.. _`celery-users`: http://groups.google.com/group/celery-users/
+.. _`celery-users`: https://groups.google.com/forum/#!forum/celery-users
 
 .. _irc-channel:
 
@@ -394,7 +394,7 @@ to our issue tracker at https://github.com/celery/celery/issues/
 Wiki
 ====
 
-http://wiki.github.com/celery/celery/
+https://github.com/celery/celery/wiki
 
 .. _contributing-short:
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 :Version: 4.0.0rc1 (0today8)
 :Web: http://celeryproject.org/
 :Download: http://pypi.python.org/pypi/celery/
-:Source: http://github.com/celery/celery/
+:Source: https://github.com/celery/celery/
 :Keywords: task queue, job queue, asynchronous, async, rabbitmq, amqp, redis,
   python, webhooks, queue, distributed
 
@@ -193,7 +193,7 @@ database connections at ``fork``.
 .. _`celery-pylons`: http://pypi.python.org/pypi/celery-pylons
 .. _`web2py-celery`: http://code.google.com/p/web2py-celery/
 .. _`Tornado`: http://www.tornadoweb.org/
-.. _`tornado-celery`: http://github.com/mher/tornado-celery/
+.. _`tornado-celery`: https://github.com/mher/tornado-celery/
 
 .. _celery-documentation:
 
@@ -387,7 +387,7 @@ Bug tracker
 ===========
 
 If you have any suggestions, bug reports or annoyances please report them
-to our issue tracker at http://github.com/celery/celery/issues/
+to our issue tracker at https://github.com/celery/celery/issues/
 
 .. _wiki:
 
@@ -401,7 +401,7 @@ http://wiki.github.com/celery/celery/
 Contributing
 ============
 
-Development of `celery` happens at Github: http://github.com/celery/celery
+Development of `celery` happens at Github: https://github.com/celery/celery
 
 You are highly encouraged to participate in the development
 of `celery`. If you don't like Github (for some reason) you're welcome

--- a/TODO
+++ b/TODO
@@ -1,2 +1,2 @@
 Please see our Issue Tracker at GitHub:
-    http://github.com/celery/celery/issues
+    https://github.com/celery/celery/issues

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -232,7 +232,7 @@ class Worker(WorkController):
             # into the background.
             if self.app.IS_OSX:
                 # OS X can't exec from a process using threads.
-                # See http://github.com/celery/celery/issues#issue/152
+                # See https://github.com/celery/celery/issues#issue/152
                 install_HUP_not_supported_handler(worker)
             else:
                 install_worker_restart_handler(worker)
@@ -243,7 +243,7 @@ class Worker(WorkController):
         install_rdb_handler()
 
     def osx_proxy_detection_workaround(self):
-        """See http://github.com/celery/celery/issues#issue/161"""
+        """See https://github.com/celery/celery/issues#issue/161"""
         os.environ.setdefault('celery_dummy_proxy', 'set_by_celeryd')
 
     def set_process_status(self, info):

--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -232,7 +232,7 @@ class DependencyGraph(object):
     def _khan62(self):
         """Khans simple topological sort algorithm from '62
 
-        See http://en.wikipedia.org/wiki/Topological_sorting
+        See https://en.wikipedia.org/wiki/Topological_sorting
 
         """
         count = defaultdict(lambda: 0)

--- a/docs/THANKS
+++ b/docs/THANKS
@@ -2,5 +2,5 @@ Thanks to Rune Halvorsen <runeh@opera.com> for the name.
 Thanks to Anton Tsigularov <antont@opera.com> for the previous name (crunchy)
     which we had to abandon because of an existing project with that name.
 Thanks to Armin Ronacher for the Sphinx theme.
-Thanks to Brian K. Jones for bunny.py (http://github.com/bkjones/bunny), the
+Thanks to Brian K. Jones for bunny.py (https://github.com/bkjones/bunny), the
     tool that inspired 'celery amqp'.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ extensions = ['sphinx.ext.autodoc',
               'celerydocs']
 
 
-LINKCODE_URL = 'http://github.com/{proj}/tree/{branch}/{filename}.py'
+LINKCODE_URL = 'https://github.com/{proj}/tree/{branch}/{filename}.py'
 GITHUB_PROJECT = 'celery/celery'
 GITHUB_BRANCH = 'master'
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -856,7 +856,7 @@ MongoDB backend settings
 .. note::
 
     The MongoDB backend requires the :mod:`pymongo` library:
-    http://github.com/mongodb/mongo-python-driver/tree/master
+    https://github.com/mongodb/mongo-python-driver/tree/master
 
 .. setting:: mongodb_backend_settings
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -246,7 +246,7 @@ issue tracker.
 
 * Celery: http://github.com/celery/celery/issues/
 * Kombu: http://github.com/celery/kombu/issues
-* pyamqp: http://github.com/celery/pyamqp/issues
+* pyamqp: http://github.com/celery/py-amqp/issues
 * vine: http://github.com/celery/vine/issues
 * librabbitmq: http://github.com/celery/librabbitmq/issues
 * Django-Celery: http://github.com/celery/django-celery/issues

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -231,10 +231,10 @@ been made on your bug. In the event you've turned this feature off, you
 should check back on occasion to ensure you don't miss any questions a
 developer trying to fix the bug might ask.
 
-.. _`GitHub`: http://github.com
-.. _`strace`: http://en.wikipedia.org/wiki/Strace
-.. _`ltrace`: http://en.wikipedia.org/wiki/Ltrace
-.. _`lsof`: http://en.wikipedia.org/wiki/Lsof
+.. _`GitHub`: https://github.com
+.. _`strace`: https://en.wikipedia.org/wiki/Strace
+.. _`ltrace`: https://en.wikipedia.org/wiki/Ltrace
+.. _`lsof`: https://en.wikipedia.org/wiki/Lsof
 
 .. _issue-trackers:
 
@@ -244,12 +244,12 @@ Issue Trackers
 Bugs for a package in the Celery ecosystem should be reported to the relevant
 issue tracker.
 
-* Celery: http://github.com/celery/celery/issues/
-* Kombu: http://github.com/celery/kombu/issues
-* pyamqp: http://github.com/celery/py-amqp/issues
-* vine: http://github.com/celery/vine/issues
-* librabbitmq: http://github.com/celery/librabbitmq/issues
-* Django-Celery: http://github.com/celery/django-celery/issues
+* Celery: https://github.com/celery/celery/issues/
+* Kombu: https://github.com/celery/kombu/issues
+* pyamqp: https://github.com/celery/py-amqp/issues
+* vine: https://github.com/celery/vine/issues
+* librabbitmq: https://github.com/celery/librabbitmq/issues
+* Django-Celery: https://github.com/celery/django-celery/issues
 
 If you are unsure of the origin of the bug you can ask the
 :ref:`mailing-list`, or just use the Celery issue tracker.
@@ -282,9 +282,9 @@ Branches
 
 Current active version branches:
 
-* master (http://github.com/celery/celery/tree/master)
-* 3.1 (http://github.com/celery/celery/tree/3.1)
-* 3.0 (http://github.com/celery/celery/tree/3.0)
+* master (https://github.com/celery/celery/tree/master)
+* 3.1 (https://github.com/celery/celery/tree/3.1)
+* 3.0 (https://github.com/celery/celery/tree/3.0)
 
 You can see the state of any branch by looking at the Changelog:
 

--- a/docs/getting-started/brokers/ironmq.rst
+++ b/docs/getting-started/brokers/ironmq.rst
@@ -9,7 +9,7 @@
 Installation
 ============
 
-For IronMQ support, you'll need the [iron_celery](http://github.com/iron-io/iron_celery) library:
+For IronMQ support, you'll need the [iron_celery](https://github.com/iron-io/iron_celery) library:
 
 .. code-block:: console
 
@@ -67,4 +67,4 @@ This will default to a cache named "Celery", if you want to change that::
 More Information
 ================
 
-You can find more information in the [iron_celery README](http://github.com/iron-io/iron_celery).
+You can find more information in the [iron_celery README](https://github.com/iron-io/iron_celery).

--- a/docs/getting-started/brokers/rabbitmq.rst
+++ b/docs/getting-started/brokers/rabbitmq.rst
@@ -91,7 +91,7 @@ Finally, we can install rabbitmq using :program:`brew`:
 
     $ brew install rabbitmq
 
-.. _`Homebrew`: http://github.com/mxcl/homebrew/
+.. _`Homebrew`: https://github.com/mxcl/homebrew/
 .. _`Homebrew documentation`: https://github.com/Homebrew/homebrew/wiki/Installation
 
 .. _rabbitmq-osx-system-hostname:

--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -254,7 +254,7 @@ database connections at :manpage:`fork(2)`.
 .. _`celery-pylons`: http://pypi.python.org/pypi/celery-pylons
 .. _`web2py-celery`: http://code.google.com/p/web2py-celery/
 .. _`Tornado`: http://www.tornadoweb.org/
-.. _`tornado-celery`: http://github.com/mher/tornado-celery/
+.. _`tornado-celery`: https://github.com/mher/tornado-celery/
 
 Quickjump
 =========

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -80,7 +80,7 @@ Glossary
         unintended effects, but not necessarily side-effect free in the pure
         sense (compare to :term:`nullipotent`).
 
-        Further reading: http://en.wikipedia.org/wiki/Idempotent
+        Further reading: https://en.wikipedia.org/wiki/Idempotent
 
     nullipotent
         describes a function that will have the same effect, and give the same

--- a/docs/history/changelog-1.0.rst
+++ b/docs/history/changelog-1.0.rst
@@ -819,7 +819,7 @@ News
 * worker: now sends events if enabled with the `-E` argument.
 
     Excellent for monitoring tools, one is already in the making
-    (http://github.com/celery/celerymon).
+    (https://github.com/celery/celerymon).
 
     Current events include: :event:`worker-heartbeat`,
     task-[received/succeeded/failed/retried],

--- a/docs/history/changelog-2.1.rst
+++ b/docs/history/changelog-2.1.rst
@@ -251,7 +251,7 @@ News
 
 * README/introduction/homepage: Added link to `Flask-Celery`_.
 
-.. _`Flask-Celery`: http://github.com/ask/flask-celery
+.. _`Flask-Celery`: https://github.com/ask/flask-celery
 
 .. _version-2.1.0:
 
@@ -740,7 +740,7 @@ Experimental
 
 * Added generic init.d script using `celeryd-multi`
 
-    http://github.com/celery/celery/tree/master/extra/generic-init.d/celeryd
+    https://github.com/celery/celery/tree/master/extra/generic-init.d/celeryd
 
 .. _v210-documentation:
 

--- a/docs/history/changelog-2.2.rst
+++ b/docs/history/changelog-2.2.rst
@@ -29,7 +29,7 @@ Security Fixes
 
 
 .. _`CELERYSA-0001`:
-    http://github.com/celery/celery/tree/master/docs/sec/CELERYSA-0001.txt
+    https://github.com/celery/celery/tree/master/docs/sec/CELERYSA-0001.txt
 
 .. _version-2.2.7:
 

--- a/docs/history/changelog-2.3.rst
+++ b/docs/history/changelog-2.3.rst
@@ -29,7 +29,7 @@ Security Fixes
 
 
 .. _`CELERYSA-0001`:
-    http://github.com/celery/celery/tree/master/docs/sec/CELERYSA-0001.txt
+    https://github.com/celery/celery/tree/master/docs/sec/CELERYSA-0001.txt
 
 Fixes
 -----

--- a/docs/history/changelog-2.4.rst
+++ b/docs/history/changelog-2.4.rst
@@ -46,7 +46,7 @@ Security Fixes
 
 
 .. _`CELERYSA-0001`:
-    http://github.com/celery/celery/tree/master/docs/sec/CELERYSA-0001.txt
+    https://github.com/celery/celery/tree/master/docs/sec/CELERYSA-0001.txt
 
 .. _v244-fixes:
 

--- a/docs/history/changelog-3.0.rst
+++ b/docs/history/changelog-3.0.rst
@@ -901,7 +901,7 @@ If you're looking for versions prior to 3.0.x you should go to :ref:`history`.
         the files from source control and update them manually.
         You can find the init scripts for version 3.0.x at:
 
-            http://github.com/celery/celery/tree/3.0/extra/generic-init.d
+            https://github.com/celery/celery/tree/3.0/extra/generic-init.d
 
 - Now depends on billiard 2.7.3.17
 

--- a/docs/history/changelog-3.1.rst
+++ b/docs/history/changelog-3.1.rst
@@ -523,7 +523,7 @@ Security Fixes
     the umask of the parent process will be used.
 
 .. _`CELERYSA-0002`:
-    http://github.com/celery/celery/tree/master/docs/sec/CELERYSA-0002.txt
+    https://github.com/celery/celery/tree/master/docs/sec/CELERYSA-0002.txt
 
 News
 ----

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,7 +1,7 @@
 :Version: 4.0.0rc2 (0today8)
 :Web: http://celeryproject.org/
 :Download: http://pypi.python.org/pypi/celery/
-:Source: http://github.com/celery/celery/
+:Source: https://github.com/celery/celery/
 :Keywords: task queue, job queue, asynchronous, async, rabbitmq, amqp, redis,
   python, webhooks, queue, distributed
 
@@ -187,7 +187,7 @@ database connections at ``fork``.
 .. _`celery-pylons`: http://pypi.python.org/pypi/celery-pylons
 .. _`web2py-celery`: http://code.google.com/p/web2py-celery/
 .. _`Tornado`: http://www.tornadoweb.org/
-.. _`tornado-celery`: http://github.com/mher/tornado-celery/
+.. _`tornado-celery`: https://github.com/mher/tornado-celery/
 
 .. _celery-documentation:
 

--- a/docs/includes/resources.txt
+++ b/docs/includes/resources.txt
@@ -29,7 +29,7 @@ Bug tracker
 ===========
 
 If you have any suggestions, bug reports or annoyances please report them
-to our issue tracker at http://github.com/celery/celery/issues/
+to our issue tracker at https://github.com/celery/celery/issues/
 
 .. _wiki:
 
@@ -43,7 +43,7 @@ http://wiki.github.com/celery/celery/
 Contributing
 ============
 
-Development of `celery` happens at Github: http://github.com/celery/celery
+Development of `celery` happens at Github: https://github.com/celery/celery
 
 You are highly encouraged to participate in the development
 of `celery`. If you don't like Github (for some reason) you're welcome

--- a/docs/tutorials/daemonizing.rst
+++ b/docs/tutorials/daemonizing.rst
@@ -23,7 +23,7 @@ This directory contains generic bash init scripts for the
 these should run on Linux, FreeBSD, OpenBSD, and other Unix-like platforms.
 
 .. _`extra/generic-init.d/`:
-    http://github.com/celery/celery/tree/3.1/extra/generic-init.d/
+    https://github.com/celery/celery/tree/3.1/extra/generic-init.d/
 
 .. _generic-initd-celeryd:
 
@@ -415,7 +415,7 @@ you should :ref:`report it <reporting-bugs>`).
 * `extra/supervisord/`_
 
 .. _`extra/supervisord/`:
-    http://github.com/celery/celery/tree/3.1/extra/supervisord/
+    https://github.com/celery/celery/tree/3.1/extra/supervisord/
 .. _`supervisord`: http://supervisord.org/
 
 .. _daemon-launchd:
@@ -426,7 +426,7 @@ launchd (OS X)
 * `extra/osx`_
 
 .. _`extra/osx`:
-    http://github.com/celery/celery/tree/3.1/extra/osx/
+    https://github.com/celery/celery/tree/3.1/extra/osx/
 
 
 .. _daemon-windows:

--- a/docs/userguide/concurrency/eventlet.rst
+++ b/docs/userguide/concurrency/eventlet.rst
@@ -58,8 +58,8 @@ some examples taking use of Eventlet support.
 .. _`epoll(4)`: http://linux.die.net/man/4/epoll
 .. _`libevent`: http://monkey.org/~provos/libevent/
 .. _`highly scalable non-blocking I/O`:
-    http://en.wikipedia.org/wiki/Asynchronous_I/O#Select.28.2Fpoll.29_loops
-.. _`Coroutines`: http://en.wikipedia.org/wiki/Coroutine
+    https://en.wikipedia.org/wiki/Asynchronous_I/O#Select.28.2Fpoll.29_loops
+.. _`Coroutines`: https://en.wikipedia.org/wiki/Coroutine
 .. _`Eventlet examples`:
     https://github.com/celery/celery/tree/master/examples/eventlet
 

--- a/docs/userguide/extending.rst
+++ b/docs/userguide/extending.rst
@@ -526,7 +526,7 @@ Attributes
     may be used as long as it conforms to the same interface and defines the
     two methods above.
 
-    .. _`token bucket algorithm`: http://en.wikipedia.org/wiki/Token_bucket
+    .. _`token bucket algorithm`: https://en.wikipedia.org/wiki/Token_bucket
 
 .. _extending_consumer-qos:
 

--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -324,7 +324,7 @@ For a complete list of options use ``--help``:
 
     $ celery events --help
 
-.. _`celerymon`: http://github.com/celery/celerymon/
+.. _`celerymon`: https://github.com/celery/celerymon/
 
 .. _monitoring-rabbitmq:
 
@@ -435,7 +435,7 @@ maintaining a Celery cluster.
 
 * rabbitmq-munin: Munin plug-ins for RabbitMQ.
 
-    http://github.com/ask/rabbitmq-munin
+    https://github.com/ask/rabbitmq-munin
 
 * celery_tasks: Monitors the number of times each task type has
   been executed (requires `celerymon`).

--- a/docs/userguide/remote-tasks.rst
+++ b/docs/userguide/remote-tasks.rst
@@ -134,4 +134,4 @@ Since calling tasks can be done via HTTP using the
 :func:`djcelery.views.apply` view, calling tasks from other languages is easy.
 For an example service exposing tasks via HTTP you should have a look at
 `examples/celery_http_gateway` in the Celery distribution:
-http://github.com/celery/celery/tree/master/examples/celery_http_gateway/
+https://github.com/celery/celery/tree/master/examples/celery_http_gateway/

--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -301,7 +301,7 @@ as plug-ins to RabbitMQ, like the `last-value-cache plug-in`_ by Michael
 Bridgen.
 
 .. _`last-value-cache plug-in`:
-    http://github.com/squaremo/rabbitmq-lvc-plugin
+    https://github.com/squaremo/rabbitmq-lvc-plugin
 
 .. _amqp-exchange-type-direct:
 

--- a/docs/userguide/security.rst
+++ b/docs/userguide/security.rst
@@ -17,7 +17,7 @@ Depending on your `Security Policy`_, there are
 various steps you can take to make your Celery installation more secure.
 
 
-.. _`Security Policy`: http://en.wikipedia.org/wiki/Security_policy
+.. _`Security Policy`: https://en.wikipedia.org/wiki/Security_policy
 
 
 Areas of Concern
@@ -85,10 +85,10 @@ same network access as the machine on which it's running. If the worker
 is located on an internal network it's recommended to add firewall rules for
 outbound traffic.
 
-.. _`chroot`: http://en.wikipedia.org/wiki/Chroot
-.. _`jail`: http://en.wikipedia.org/wiki/FreeBSD_jail
+.. _`chroot`: https://en.wikipedia.org/wiki/Chroot
+.. _`jail`: https://en.wikipedia.org/wiki/FreeBSD_jail
 .. _`sandboxing`:
-    http://en.wikipedia.org/wiki/Sandbox_(computer_security)
+    https://en.wikipedia.org/wiki/Sandbox_(computer_security)
 
 Serializers
 ===========
@@ -136,7 +136,7 @@ for more information.
 
 .. _`pickle`: http://docs.python.org/library/pickle.html
 .. _`Public-key cryptography`:
-    http://en.wikipedia.org/wiki/Public-key_cryptography
+    https://en.wikipedia.org/wiki/Public-key_cryptography
 
 .. _message-signing:
 
@@ -185,9 +185,9 @@ with the private key and certificate files located in `/etc/ssl`.
     a message, so if needed this will have to be enabled separately.
 
 .. _`pyOpenSSL`: http://pypi.python.org/pypi/pyOpenSSL
-.. _`X.509`: http://en.wikipedia.org/wiki/X.509
+.. _`X.509`: https://en.wikipedia.org/wiki/X.509
 .. _`Certificate Authority`:
-    http://en.wikipedia.org/wiki/Certificate_authority
+    https://en.wikipedia.org/wiki/Certificate_authority
 
 Intrusion Detection
 ===================
@@ -213,7 +213,7 @@ support for using syslog.
 A tip for the paranoid is to send logs using UDP and cut the
 transmit part of the logging server's network cable :-)
 
-.. _`syslog-ng`: http://en.wikipedia.org/wiki/Syslog-ng
+.. _`syslog-ng`: https://en.wikipedia.org/wiki/Syslog-ng
 .. _`rsyslog`: http://www.rsyslog.com/
 
 Tripwire
@@ -242,4 +242,4 @@ that can be used.
 .. _`Samhain`: http://la-samhna.de/samhain/index.html
 .. _`AIDE`: http://aide.sourceforge.net/
 .. _`Open Source Tripwire`: http://sourceforge.net/projects/tripwire/
-.. _`ZFS`: http://en.wikipedia.org/wiki/ZFS
+.. _`ZFS`: https://en.wikipedia.org/wiki/ZFS

--- a/docs/whatsnew-3.0.rst
+++ b/docs/whatsnew-3.0.rst
@@ -74,7 +74,7 @@ Highlights
 
 .. _`website`: http://celeryproject.org/
 .. _`django-celery changelog`:
-    http://github.com/celery/django-celery/tree/master/Changelog
+    https://github.com/celery/django-celery/tree/master/Changelog
 .. _`django-celery 3.0`: http://pypi.python.org/pypi/django-celery/
 
 .. contents::
@@ -156,8 +156,8 @@ for the no-execv patch to work.
 - Issue #625
 - Issue #627
 - Issue #640
-- `django-celery #122 <http://github.com/celery/django-celery/issues/122`
-- `django-celery #124 <http://github.com/celery/django-celery/issues/122`
+- `django-celery #122 <https://github.com/celery/django-celery/issues/122`
+- `django-celery #124 <https://github.com/celery/django-celery/issues/122`
 
 :mod:`celery.app.task` no longer a package
 ------------------------------------------

--- a/docs/whatsnew-3.1.rst
+++ b/docs/whatsnew-3.1.rst
@@ -344,7 +344,7 @@ the :envvar:`DJANGO_SETTINGS_MODULE` environment variable is set.
 The distribution ships with a new example project using Django
 in :file:`examples/django`:
 
-http://github.com/celery/celery/tree/3.1/examples/django
+https://github.com/celery/celery/tree/3.1/examples/django
 
 Some features still require the :mod:`django-celery` library:
 

--- a/examples/celery_http_gateway/settings.py
+++ b/examples/celery_http_gateway/settings.py
@@ -34,7 +34,7 @@ if django.VERSION[:3] < (1, 3):
     DATABASE_PORT = DATABASES['default']['PORT']
 
 # Local time zone for this installation. Choices can be found here:
-# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+# https://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.

--- a/examples/django/proj/settings.py
+++ b/examples/django/proj/settings.py
@@ -39,7 +39,7 @@ DATABASES = {
 }
 
 # Local time zone for this installation. Choices can be found here:
-# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+# https://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
 # In a Windows environment this must be set to your system time zone.
 TIME_ZONE = 'America/Chicago'

--- a/examples/httpexample/settings.py
+++ b/examples/httpexample/settings.py
@@ -27,7 +27,7 @@ DATABASE_HOST = ''
 DATABASE_PORT = ''
 
 # Local time zone for this installation. Choices can be found here:
-# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+# https://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.

--- a/funtests/setup.py
+++ b/funtests/setup.py
@@ -42,7 +42,7 @@ setup(
     description='Functional test suite for Celery',
     author='Ask Solem',
     author_email='ask@celeryproject.org',
-    url='http://github.com/celery/celery',
+    url='https://github.com/celery/celery',
     platforms=['any'],
     packages=[],
     data_files=[],


### PR DESCRIPTION
This PR updates links to external pages. It:

1. Changes http:// to https:// for many pages, like GitHub and Wikipedia, which always redirect to https.
2. Changes https://github.com/celery/pyamqp/issues, which returns a 404, to https://github.com/celery/py-amqp/issues
3. Updates links to other services, where to skip unnecessary redirects.

One thing I didn't fix is the link to http://leapfrogdevelopment.github.com/rcelery/. That project, and organization, doesn't seem to exist any more.

What do you think? I'd be happy to squash the commits, or skip some of them if you think this changes too much.