### PR TITLE
Correct help for migrating in Django

### DIFF
--- a/docs/getting-started/brokers/django.rst
+++ b/docs/getting-started/brokers/django.rst
@@ -36,6 +36,10 @@ configuration values.
 
 .. code-block:: console
 
+    $ python manage.py migrate kombu_transport_django
+
+ Or if you are using a version of Django lower than 1.7
+
     $ python manage.py syncdb
 
 .. _broker-django-limitations:


### PR DESCRIPTION
The help provided does not work for Django 1.9 and should be telling the user to use `migrate` rather than the deprecated `syncdb` by default (https://docs.djangoproject.com/en/1.8/ref/django-admin/#syncdb)