### PR TITLE
Added working celery.service and celery.conf for CentOS 7

### DIFF
--- a/extra/systemd/celery.conf
+++ b/extra/systemd/celery.conf
@@ -4,10 +4,7 @@
 CELERY_APP="proj"
 CELERYD_NODES="worker"
 CELERYD_OPTS=""
-CELERY_BIN="/usr/bin/python2 -m celery"
+CELERY_BIN="/usr/bin/celery"
 CELERYD_PID_FILE="/var/run/celery/%n.pid"
 CELERYD_LOG_FILE="/var/log/celery/%n%I.log"
 CELERYD_LOG_LEVEL="INFO"
-
-d /run/celery 0755 user users -
-d /var/log/celery 0755 user users -

--- a/extra/systemd/celery.service
+++ b/extra/systemd/celery.service
@@ -1,23 +1,21 @@
 [Unit]
-Description=Celery workers
+Description=Celery Service
 After=network.target
 
 [Service]
 Type=forking
-User=user
-Group=users
+User=celery
+Group=celery
 EnvironmentFile=-/etc/conf.d/celery
-WorkingDirectory=/opt/Myproject/
-ExecStart=${CELERY_BIN} multi start $CELERYD_NODES \
-    -A $CELERY_APP --pidfile=${CELERYD_PID_FILE} \
-    --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
-    $CELERYD_OPTS
+WorkingDirectory=/opt/myproject/
+ExecStart=${CELERY_BIN} multi start $CELERYD_NODES -A \
+	$CELERY_APP -logfile=${CELERYD_LOG_FILE} \
+	--pidfile=${CELERYD_PID_FILE} $CELERYD_OPTS
 ExecStop=${CELERY_BIN} multi stopwait $CELERYD_NODES \
-    --pidfile=${CELERYD_PID_FILE}
-ExecReload=${CELERY_BIN} multi restart $CELERYD_NODES \
-    -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
-    --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
-    $CELERYD_OPTS
+	--pidfile=${CELERYD_PID_FILE}
+ExecReload=${CELERY_BIN} multi restart $CELERYD_NODES -A \
+	$CELERY_APP --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} \
+	--loglevel="${CELERYD_LOG_LEVEL}" $CELERYD_OPTS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
These are working celery.service and celery.conf files that I am currently using on CentOS 7, with some things removed to make it a more generalized example.