### PR TITLE
Fix event result is None

### DIFF
--- a/celery/events/cursesmon.py
+++ b/celery/events/cursesmon.py
@@ -320,7 +320,7 @@ class CursesMonitor(object):  # pragma: no cover
             task = self.state.tasks[self.selected_task]
             result = (getattr(task, 'result', None) or
                       getattr(task, 'exception', None))
-            for line in wrap(result, mx - 2):
+            for line in wrap(result or '', mx - 2):
                 self.win.addstr(next(y), 3, line)
 
         return self.alert(
@@ -424,7 +424,7 @@ class CursesMonitor(object):  # pragma: no cover
                 STATUS_SCREEN.format(
                     s=self.state,
                     w_alive=len([w for w in values(self.state.workers)
-                                if w.alive]),
+                                 if w.alive]),
                     w_all=len(self.state.workers),
                 ),
                 curses.A_DIM,


### PR DESCRIPTION
When i want see a pending task's result. i think empty page is better than Error:

![](https://cloud.githubusercontent.com/assets/841395/14596221/856c67ec-0577-11e6-820a-e9df065e37f1.png)

```
File "/home/vagrant/web_develop/venv/local/lib/python2.7/site-packages/celery/events/cursesmon.py", line 328, in selection_result
'Task Result for {0.selected_task}'.format(self),
File "/home/vagrant/web_develop/venv/local/lib/python2.7/site-packages/celery/events/cursesmon.py", line 172, in alert
callback(my, mx, next(y))
File "/home/vagrant/web_develop/venv/local/lib/python2.7/site-packages/celery/events/cursesmon.py", line 323, in alert_callback
for line in wrap(result, mx - 2):
    File "/usr/lib/python2.7/textwrap.py", line 354, in wrap
    return w.wrap(text)
File "/usr/lib/python2.7/textwrap.py", line 325, in wrap
text = self._munge_whitespace(text)
File "/usr/lib/python2.7/textwrap.py", line 154, in _munge_whitespace
text = text.expandtabs()
AttributeError:
    'NoneType' object has no attribute 'expandtabs'
```