### PR TITLE
Fix #2131 : update systemd extra files and update doc

### DIFF
--- a/extra/systemd/celery.service
+++ b/extra/systemd/celery.service
@@ -7,6 +7,7 @@ Type=forking
 User=celery
 Group=celery
 EnvironmentFile=-/etc/conf.d/celery
+WorkingDirectory=/opt/celery
 ExecStart=/bin/sh '${CELERY_BIN} multi start $CELERYD_NODES \
 	-A $CELERY_APP --logfile=${CELERYD_LOG_FILE} \
 	--pidfile=${CELERYD_PID_FILE} $CELERYD_OPTS'

--- a/extra/systemd/celery.service
+++ b/extra/systemd/celery.service
@@ -7,15 +7,14 @@ Type=forking
 User=celery
 Group=celery
 EnvironmentFile=-/etc/conf.d/celery
-WorkingDirectory=/opt/myproject/
-ExecStart=${CELERY_BIN} multi start $CELERYD_NODES -A \
-	$CELERY_APP -logfile=${CELERYD_LOG_FILE} \
-	--pidfile=${CELERYD_PID_FILE} $CELERYD_OPTS
-ExecStop=${CELERY_BIN} multi stopwait $CELERYD_NODES \
-	--pidfile=${CELERYD_PID_FILE}
-ExecReload=${CELERY_BIN} multi restart $CELERYD_NODES -A \
-	$CELERY_APP --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} \
-	--loglevel="${CELERYD_LOG_LEVEL}" $CELERYD_OPTS
+ExecStart=/bin/sh '${CELERY_BIN} multi start $CELERYD_NODES \
+	-A $CELERY_APP --logfile=${CELERYD_LOG_FILE} \
+	--pidfile=${CELERYD_PID_FILE} $CELERYD_OPTS'
+ExecStop=/bin/sh '${CELERY_BIN} multi stopwait $CELERYD_NODES \
+	--pidfile=${CELERYD_PID_FILE}'
+ExecReload=/bin/sh '${CELERY_BIN} multi restart $CELERYD_NODES \
+	-A $CELERY_APP --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} \
+	--loglevel="${CELERYD_LOG_LEVEL}" $CELERYD_OPTS'
 
 [Install]
 WantedBy=multi-user.target

--- a/extra/systemd/celery.tmpfiles
+++ b/extra/systemd/celery.tmpfiles
@@ -1,0 +1,2 @@
+d /var/run/celery 0755 celery celery -
+d /var/log/celery 0755 celery celery -


### PR DESCRIPTION
I used systemd for celery today and found out that the given example did not work so I just fixed that and updated the doc.

Please note that I also fixed a missing dash (-) in the .service file for the --logfile argument.