### PR TITLE
docs: broker_connection_timeout disabled for gevent

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1733,7 +1733,8 @@ Default (since 2.5) is to use a pool of 10 connections.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The default timeout in seconds before we give up establishing a connection
-to the AMQP server.  Default is 4 seconds.
+to the AMQP server.  Default is 4 seconds. This setting is disabled when using
+gevent.
 
 .. setting:: broker_connection_retry
 


### PR DESCRIPTION
Mentioned in 3.0.10 release notes: http://docs.celeryproject.org/en/3.0/changelog.html#version-3-0-10
Implemented here: https://github.com/celery/celery/blob/d23c8c/celery/worker/consumer/consumer.py#L205-L209