### PR TITLE
Fixed TypeError when conneting to redis via unix domain socket

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -166,6 +166,11 @@ class RedisBackend(base.BaseKeyValueStoreBackend, async.AsyncBackendMixin):
             # host+port are invalid options when using this connection type.
             connparams.pop('host', None)
             connparams.pop('port', None)
+            if hasattr(self, '_client_capabilities'):
+                # Not all subclasses seem to use the client capability feature
+                # (e.g. during testing), so we do this only if supported for
+                # backwards compatibility.
+                self._client_capabilities['socket_connect_timeout'] = False
         else:
             connparams['db'] = path
 


### PR DESCRIPTION
I have a bug similar to celery/celery#2903 and celery/kombu#590 when trying to connect to a redis result backend via a unix domain socket. This change fixes it for me.


```
  File "/usr/local/lib/python3.4/dist-packages/django/core/handlers/base.py", line 149, in get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.4/dist-packages/django/core/handlers/base.py", line 147, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.4/dist-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/django/views/generic/base.py", line 88, in dispatch
    return handler(request, *args, **kwargs)
  File "/pretix/src/pretix/presale/views/async.py", line 39, in get
    return self.get_result(request)
  File "/pretix/src/pretix/presale/views/async.py", line 48, in get_result
    if not res.ready():
  File "/usr/local/lib/python3.4/dist-packages/celery/result.py", line 259, in ready
    return self.state in self.backend.READY_STATES
  File "/usr/local/lib/python3.4/dist-packages/celery/result.py", line 394, in state
    return self._get_task_meta()['status']
  File "/usr/local/lib/python3.4/dist-packages/celery/result.py", line 339, in _get_task_meta
    return self._maybe_set_cache(self.backend.get_task_meta(self.id))
  File "/usr/local/lib/python3.4/dist-packages/celery/backends/base.py", line 307, in get_task_meta
    meta = self._get_task_meta_for(task_id)
  File "/usr/local/lib/python3.4/dist-packages/celery/backends/base.py", line 518, in _get_task_meta_for
    meta = self.get(self.get_key_for_task(task_id))
  File "/usr/local/lib/python3.4/dist-packages/celery/backends/redis.py", line 140, in get
    return self.client.get(key)
  File "/usr/local/lib/python3.4/dist-packages/redis/client.py", line 880, in get
    return self.execute_command('GET', name)
  File "/usr/local/lib/python3.4/dist-packages/redis/client.py", line 570, in execute_command
    connection = pool.get_connection(command_name, **options)
  File "/usr/local/lib/python3.4/dist-packages/redis/connection.py", line 897, in get_connection
    connection = self.make_connection()
  File "/usr/local/lib/python3.4/dist-packages/redis/connection.py", line 906, in make_connection
    return self.connection_class(**self.connection_kwargs)
TypeError: __init__() got an unexpected keyword argument 'socket_connect_timeout'
```