### PR TITLE
Fix syntax error in one example at the Tasks userguide doc.

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -1622,7 +1622,8 @@ blog/tasks.py
 
         comment = Comment.objects.get(pk=comment_id)
         current_domain = Site.objects.get_current().domain
-        akismet = Akismet(settings.AKISMET_KEY, 'http://{0}'.format(domain))
+        akismet = Akismet(settings.AKISMET_KEY,
+                          'http://{0}'.format(current_domain))
         if not akismet.verify_key():
             raise ImproperlyConfigured('Invalid AKISMET_KEY')
 


### PR DESCRIPTION
While going through the examples in the Tasks user guide, I found this syntax error in the last example, for the blog/tasks.py file - the variable should be 'current_domain' and not 'domain'. I also added an additional line so we don't have a horizontal scroll in the code box.