### PR TITLE
Update the Celery app config with preconfig as non-defaults so they will be pickled

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -197,3 +197,4 @@ Krzysztof Bujniewicz, 2015/10/21
 Sukrit Khera, 2015/10/26
 Dave Smith, 2015/10/27
 Dennis Brakhane, 2015/10/30
+Jeremy Zafran, 2016/05/17

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -452,14 +452,21 @@ class Celery(object):
         self.on_configure()
         if self._config_source:
             self.loader.config_from_object(self._config_source)
-        defaults = dict(deepcopy(DEFAULTS), **self._preconf)
         self.configured = True
         s = Settings({}, [self.prepare_config(self.loader.conf),
-                          defaults])
+                          deepcopy(DEFAULTS)])
         # load lazy config dict initializers.
         pending = self._pending_defaults
         while pending:
             s.add_defaults(maybe_evaluate(pending.popleft()()))
+
+        # preconf options must be explicitly set in the conf, and not
+        # as defaults or they will not be pickled with the app instance.
+        # This will cause errors when `CELERYD_FORCE_EXECV=True` as
+        # the workers will not have a BROKER_URL, CELERY_RESULT_BACKEND,
+        # or CELERY_IMPORTS set in the config.
+        if self._preconf:
+            s.update(**self._preconf)
         return s
 
     def _after_fork(self, obj_):


### PR DESCRIPTION
Issue: https://github.com/celery/celery/issues/3212

This PR updates `Celery._get_config` to update the `conf` with `self._preconf` as non-defaults so they will be included in the pickled app.

Without this fix, any Celery tasks that (such as `task.retry`) fail because the BROKER_URL is not set properly in the unpickled app.  Additionally, results from these tasks are not saved in the result backend, because `CELERY_RESULT_BACKEND` is also not saved.  See https://github.com/celery/celery/issues/3212