### PR TITLE
Use correct namespace when FQN are given

### DIFF
--- a/celery/bin/multi.py
+++ b/celery/bin/multi.py
@@ -458,9 +458,14 @@ def _args_for_node(p, name, prefix, suffix, cmd, append, options):
     name, nodename, expand = _get_nodename(
         name, prefix, suffix, options)
 
+    if nodename in p.namespaces:
+        ns = nodename
+    else:
+        ns = name
+
     argv = ([expand(cmd)] +
             [format_opt(opt, expand(value))
-                for opt, value in items(p.optmerge(name, options))] +
+                for opt, value in items(p.optmerge(ns, options))] +
             [p.passthrough])
     if append:
         argv.append(expand(append))

--- a/celery/tests/bin/test_multi.py
+++ b/celery/tests/bin/test_multi.py
@@ -149,6 +149,22 @@ class test_multi_args(AppCase):
              ['COMMAND', '-n foo@', '-c 5', '']),
         )
 
+        p4 = NamespacedOptionParser(['foo', '-Q:1', 'test'])
+        names6 = list(multi_args(p4, cmd='COMMAND', suffix='""'))
+        self.assertEqual(
+            names6[0][0:2],
+            ('foo@',
+             ['COMMAND', '-n foo@', '-Q test', '']),
+        )
+
+        p5 = NamespacedOptionParser(['foo@bar', '-Q:1', 'test'])
+        names7 = list(multi_args(p5, cmd='COMMAND', suffix='""'))
+        self.assertEqual(
+            names7[0][0:2],
+            ('foo@bar',
+             ['COMMAND', '-n foo@bar', '-Q test', '']),
+        )
+
 
 class test_MultiTool(AppCase):
 


### PR DESCRIPTION
Celery multi is using `name` to determine namespace which won't work
when FQN are given. First check if FQN namespace is available and pick
options from it.

closes #3211 