### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -926,7 +926,7 @@ Messaging library.
 :CI: http://travis-ci.org/#!/celery/kombu
 :Windows-CI: https://ci.appveyor.com/project/ask/kombu
 :PyPI: http://pypi.python.org/pypi/kombu
-:docs: http://kombu.readthedocs.org
+:docs: https://kombu.readthedocs.io
 
 ``amqp``
 --------
@@ -937,7 +937,7 @@ Python AMQP 0.9.1 client.
 :CI: http://travis-ci.org/#!/celery/py-amqp
 :Windows-CI: https://ci.appveyor.com/project/ask/py-amqp
 :PyPI: http://pypi.python.org/pypi/amqp
-:docs: http://amqp.readthedocs.org
+:docs: https://amqp.readthedocs.io
 
 ``vine``
 --------
@@ -948,7 +948,7 @@ Promise/deferred implementation.
 :CI: http://travis-ci.org/#!/celery/vine/
 :Windows-CI: https://ci.appveyor.com/project/ask/vine
 :PyPI: http://pypi.python.org/pypi/vine
-:docs: http://vine.readthedocs.org
+:docs: https://vine.readthedocs.io
 
 ``billiard``
 ------------
@@ -993,7 +993,7 @@ Distributed Celery Instance manager.
 
 :git: https://github.com/celery/cyme
 :PyPI: http://pypi.python.org/pypi/cyme
-:docs: http://cyme.readthedocs.org/
+:docs: https://cyme.readthedocs.io/
 
 
 Deprecated

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ globals().update(conf.build_config(
         'celerydocs',
     ],
     extra_intersphinx_mapping={
-        'cyanide': ('http://cyanide.readthedocs.org/en/latest', None),
+        'cyanide': ('https://cyanide.readthedocs.io/en/latest', None),
     },
     apicheck_ignore_modules=[
         'celery.five',

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -961,7 +961,7 @@ Messaging library.
 :CI: http://travis-ci.org/#!/celery/kombu
 :Windows-CI: https://ci.appveyor.com/project/ask/kombu
 :PyPI: http://pypi.python.org/pypi/kombu
-:docs: http://kombu.readthedocs.org
+:docs: https://kombu.readthedocs.io
 
 ``amqp``
 --------
@@ -972,7 +972,7 @@ Python AMQP 0.9.1 client.
 :CI: http://travis-ci.org/#!/celery/py-amqp
 :Windows-CI: https://ci.appveyor.com/project/ask/py-amqp
 :PyPI: http://pypi.python.org/pypi/amqp
-:docs: http://amqp.readthedocs.org
+:docs: https://amqp.readthedocs.io
 
 ``vine``
 --------
@@ -983,7 +983,7 @@ Promise/deferred implementation.
 :CI: http://travis-ci.org/#!/celery/vine/
 :Windows-CI: https://ci.appveyor.com/project/ask/vine
 :PyPI: http://pypi.python.org/pypi/vine
-:docs: http://vine.readthedocs.org
+:docs: https://vine.readthedocs.io
 
 ``billiard``
 ------------
@@ -1028,7 +1028,7 @@ Distributed Celery Instance manager.
 
 :git: https://github.com/celery/cyme
 :PyPI: http://pypi.python.org/pypi/cyme
-:docs: http://cyme.readthedocs.org/
+:docs: https://cyme.readthedocs.io/
 
 
 Deprecated

--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -298,7 +298,7 @@ Flower has many more features than are detailed here, including
 authorization options. Check out the `official documentation`_ for more
 information.
 
-.. _official documentation: http://flower.readthedocs.org/en/latest/
+.. _official documentation: https://flower.readthedocs.io/en/latest/
 
 
 .. _monitoring-celeryev:


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.