### PR TITLE
task-cookbook: Note on cache backends

### DIFF
--- a/docs/tutorials/task-cookbook.rst
+++ b/docs/tutorials/task-cookbook.rst
@@ -71,3 +71,8 @@ For this reason your tasks run-time should not exceed the timeout.
                 return Feed.objects.import_feed(feed_url).url
         logger.debug(
             'Feed %s is already being imported by another worker', feed_url)
+
+
+Note that in order for this to work correctly you need to be using a cache
+backend that supports an atomic ``.add`` operation.  ``memcached`` is known
+to work well for this purpose.


### PR DESCRIPTION
The `cache.add` method is not actually atomic in all Django cache backends.
Some users get confused when the locking scheme proposed here
doesn't actually work since their backend doesn't actually support an atomic
`.add` operation.  Make a note to help avoid confusion.

References:
http://stackoverflow.com/questions/35034885/django-celery-cache-lock-did-not-work
http://stackoverflow.com/questions/37849647/using-django-cache-add-for-locking-in-a-celery-task-is-not-working