### PR TITLE
Complex graph fixes

### DIFF
--- a/celery/app/builtins.py
+++ b/celery/app/builtins.py
@@ -375,5 +375,5 @@ def add_chord_task(app):
             res = super(Chord, self).apply(args, dict(kwargs, eager=True),
                                            **options)
             return maybe_signature(body, app=self.app).apply(
-                args=(res.get(propagate=propagate).get(), ))
+                (res.get(propagate=propagate).get(), ))
     return Chord

--- a/celery/app/builtins.py
+++ b/celery/app/builtins.py
@@ -337,7 +337,7 @@ def add_chord_task(app):
             ], app=self.app)
             # - eager applies the group inline
             if eager:
-                return header.apply(args=partial_args, task_id=group_id)
+                return header.apply(partial_args, task_id=group_id)
 
             body['chord_size'] = len(header.tasks)
             results = header.freeze(group_id=group_id, chord=body).results

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -365,7 +365,11 @@ class chain(Signature):
     def from_dict(self, d, app=None):
         tasks = [maybe_signature(t, app=app) for t in d['kwargs']['tasks']]
         if d['args'] and tasks:
-            # partial args passed on to first task in chain (Issue #1057).
+            # Partial args passed on to first task in chain (Issue #1057).
+            # We need to clone first task because we're changing it by adding
+            # args. The task in the chain should change, but not the original
+            # task.
+            tasks[0] = tasks[0].clone()
             tasks[0]['args'] = tasks[0]._merge(d['args'])[0]
         return _upgrade(d, chain(*tasks, app=app, **d['options']))
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -638,14 +638,16 @@ class chord(Signature):
                 if args and not self.immutable else self.args)
         body = kwargs.get('body') or self.kwargs['body']
         kwargs = dict(self.kwargs, **kwargs)
-        partial_args = (
-            tuple(partial_args) + tuple(self.kwargs.get('partial_args', ())))
         body = body.clone(**options)
 
         _chord = self.type
         if _chord.app.conf.CELERY_ALWAYS_EAGER:
             return self.apply(partial_args, args, kwargs,
                               task_id=task_id, **options)
+        # If not eagerly executed, we'd need to have previous partial_args to
+        # hand over to the chord task.
+        partial_args = (
+            tuple(partial_args) + tuple(self.kwargs.get('partial_args', ())))
         res = body.freeze(task_id)
         parent = _chord(self.tasks, body, partial_args, **options)
         res.parent = parent

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -633,7 +633,8 @@ class chord(Signature):
         return self.apply_async(partial_args)
 
     def apply_async(self, partial_args=(), args=(), kwargs={}, task_id=None,
-                    **options):
+                    producer=None, publisher=None, connection=None,
+                    router=None, result_cls=None, **options):
         args = (tuple(args) + tuple(self.args)
                 if args and not self.immutable else self.args)
         body = kwargs.get('body') or self.kwargs['body']


### PR DESCRIPTION
I've added a few fixes for the complex canvases that might be in use. These are the cases when we clone chains (the first task in the chain has to be cloned if an arg is added, so as to not change the original task), and when partial args is used.

I have dug deep into code but I don't have too much experience with celery at the moment, have been back using it for the last few months now (I did have another stint a few years back), so I think it would be very helpful to check I'm not breaking some other stuff.

I have added a few tests as well that would not be passing in current 3.1

Let me know how this looks. I also know that core devs are focusing on the version 4, so let me know if this is too much of a work to merge in.