### PR TITLE
Add -c parameter to make /bin/sh process the command

### DIFF
--- a/extra/systemd/celery.service
+++ b/extra/systemd/celery.service
@@ -8,12 +8,12 @@ User=celery
 Group=celery
 EnvironmentFile=-/etc/conf.d/celery
 WorkingDirectory=/opt/celery
-ExecStart=/bin/sh '${CELERY_BIN} multi start $CELERYD_NODES \
+ExecStart=/bin/sh -c '${CELERY_BIN} multi start $CELERYD_NODES \
 	-A $CELERY_APP --logfile=${CELERYD_LOG_FILE} \
 	--pidfile=${CELERYD_PID_FILE} $CELERYD_OPTS'
-ExecStop=/bin/sh '${CELERY_BIN} multi stopwait $CELERYD_NODES \
+ExecStop=/bin/sh -c '${CELERY_BIN} multi stopwait $CELERYD_NODES \
 	--pidfile=${CELERYD_PID_FILE}'
-ExecReload=/bin/sh '${CELERY_BIN} multi restart $CELERYD_NODES \
+ExecReload=/bin/sh -c '${CELERY_BIN} multi restart $CELERYD_NODES \
 	-A $CELERY_APP --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} \
 	--loglevel="${CELERYD_LOG_LEVEL}" $CELERYD_OPTS'
 


### PR DESCRIPTION
The original file has been causing the following error:

```
... /bin/sh: 0: Can't open /usr/local/bin/celery ...
```

The *-c* argument (as documented in sh manual pages):
```
Read commands from the command string operand instead of from the standard input...
```
