### PR TITLE
Add signal: `heartbeat`

### DIFF
--- a/celery/signals.py
+++ b/celery/signals.py
@@ -22,9 +22,9 @@ __all__ = ['before_task_publish', 'after_task_publish',
            'celeryd_after_setup', 'worker_init', 'worker_process_init',
            'worker_ready', 'worker_shutdown', 'setup_logging',
            'after_setup_logger', 'after_setup_task_logger',
-           'beat_init', 'beat_embedded_init', 'eventlet_pool_started',
-           'eventlet_pool_preshutdown', 'eventlet_pool_postshutdown',
-           'eventlet_pool_apply']
+           'beat_init', 'beat_embedded_init', 'heartbeat',
+           'eventlet_pool_started', 'eventlet_pool_preshutdown',
+           'eventlet_pool_postshutdown', 'eventlet_pool_apply']
 
 before_task_publish = Signal(providing_args=[
     'body', 'exchange', 'routing_key', 'headers', 'properties',
@@ -76,6 +76,7 @@ after_setup_task_logger = Signal(providing_args=[
 ])
 beat_init = Signal(providing_args=[])
 beat_embedded_init = Signal(providing_args=[])
+heartbeat = Signal(providing_args=[])
 eventlet_pool_started = Signal(providing_args=[])
 eventlet_pool_preshutdown = Signal(providing_args=[])
 eventlet_pool_postshutdown = Signal(providing_args=[])

--- a/celery/worker/heartbeat.py
+++ b/celery/worker/heartbeat.py
@@ -9,6 +9,7 @@
 """
 from __future__ import absolute_import, unicode_literals
 
+from celery.signals import heartbeat
 from celery.utils.sysinfo import load_average
 
 from .state import SOFTWARE_INFO, active_requests, all_total_count
@@ -37,6 +38,7 @@ class Heart(object):
         self.eventer.on_disabled.add(self.stop)
 
     def _send(self, event):
+        heartbeat.send(sender=self)
         return self.eventer.send(event, freq=self.interval,
                                  active=len(active_requests),
                                  processed=all_total_count[0],

--- a/docs/userguide/signals.rst
+++ b/docs/userguide/signals.rst
@@ -548,6 +548,14 @@ Dispatched in addition to the :signal:`beat_init` signal when :program:`celery
 beat` is started as an embedded process.  Sender is the
 :class:`celery.beat.Service` instance.
 
+.. signal:: heartbeat
+
+``heartbeat``
+~~~~~~~~~~~~~
+
+Dispatched when Celery sends a worker heartbeat. Sender is the
+:class:`celery.worker.heartbeat.Heart` instance.
+
 Eventlet Signals
 ----------------
 


### PR DESCRIPTION
* :data:`celery.signals.heartbeat`

     Dispatched when Celery sends a worker heartbeat.
     Sender is the :class:`celery.worker.heartbeat.Heart` instance.

---

I am interested in having a Celery worker regularly perform an action. In this specific case, I want the worker to update its corresponding health check in Consul. Thus, this change adds the `heartbeat` signal to allow a user to tap into Celery's heartbeat process to perform an action on a regular interval.

For instance, this signal might be used in the following manner:

```
import consul
from celery.signals import heartbeat


consul_client = consul.Consul(host='consul')


@heartbeat.connect
def notify_consul(sender=None, conf=None, **kwargs):
    consul_client.agent.check.ttl_pass('service:xyz')
```

I'm not aware of any existing mechanisms Celery might have to implement such a feature (nor do I know the overhead of adding a signal that may be called many times per minute) so please let me know if this feature does not make sense or could be implemented in a better way.