### PR TITLE
Fix typo in worker.py

### DIFF
--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -340,7 +340,7 @@ class worker(Command):
         user_options = self.app.user_options['worker']
         if user_options:
             uopts = OptionGroup(parser, 'User Options')
-            uopts.options_list.extend(user_options)
+            uopts.option_list.extend(user_options)
             parser.add_option_group(uopts)
 
 


### PR DESCRIPTION
The attribute in OptionGroup is called option_list, not options_list.

The following code:

```
from celery import Celery
from celery.bin import Option

app = Celery( broker='amqp://' )
app.user_options['worker'].add( Option( '--enable-foo',
                                        action='store_true',
                                        default=False ) )

app.worker_main( [ 'worker' ] )
```

previously would give:

```
AttributeError: OptionGroup instance has no attribute 'options_list'
```

and now properly starts up a basic worker.