### PR TITLE
Update sphinx.py

### DIFF
--- a/celery/contrib/sphinx.py
+++ b/celery/contrib/sphinx.py
@@ -48,7 +48,7 @@ class TaskDocumenter(FunctionDocumenter):
         return isinstance(member, BaseTask) and getattr(member, '__wrapped__')
 
     def format_args(self):
-        wrapped = getattr(self.object, '__wrapped__')
+        wrapped = getattr(self.object, '__wrapped__', None)
         if wrapped is not None:
             argspec = getfullargspec(wrapped)
             fmt = formatargspec(*argspec)


### PR DESCRIPTION
I think this is required for cases of custom task classes,

e.g.
class _AddTask(app.Task):
    def run(self, x, y):
        """ Add Task
        ....
        """
        return x + y
add = app.tasks[_AddTask.name]