### PR TITLE
Fix keywords params inconsistent problem when initialise Timer

### DIFF
--- a/celery/worker/components.py
+++ b/celery/worker/components.py
@@ -44,8 +44,8 @@ class Timer(bootsteps.Step):
                 w.timer_cls = w.pool_cls.Timer
             w.timer = self.instantiate(w.timer_cls,
                                        max_interval=w.timer_precision,
-                                       on_timer_error=self.on_timer_error,
-                                       on_timer_tick=self.on_timer_tick)
+                                       on_error=self.on_timer_error,
+                                       on_tick=self.on_timer_tick)
 
     def on_timer_error(self, exc):
         logger.error('Timer error: %r', exc, exc_info=True)


### PR DESCRIPTION
hi, @ask 

When I inspect what happens when the class `celery.worker.components:Timer` initialise, it seems that the keywords params not assigned properly.

Take master branch for example:

in `celery.worker.components:Timer`:

```
## for most async pools, the timer is kombu.async.timer:Timer
if w.use_eventloop:
    # does not use dedicated timer thread.
    w.timer = _Timer(max_interval=10.0)
else:
    if not w.timer_cls:
        # Default Timer is set by the pool, as e.g. eventlet
        # needs a custom implementation.
        w.timer_cls = w.pool_cls.Timer
        w.timer = self.instantiate(
            w.timer_cls,
            max_interval=w.timer_precision,
            on_timer_error=self.on_timer_error,  ## here
            on_timer_tick=self.on_timer_tick  ## here
        )
```

in `kombu.async.timer:Timer`:

```
class Timer(object):
    ...
    def __init__(self, max_interval=None, on_error=None, **kwargs):
```

Seems params `on_timer_error` and `on_timer_tick` have no meaning here.

************************************************************

For me, I use the celery==3.1.12, and the timer is `celery.utils.timer2:Timer`:

```
class Timer(threading.Thread):
    ...
    def __init__(self, schedule=None, on_error=None, on_tick=None,
                 on_start=None, max_interval=None, **kwargs):
```

************************************************************

But as `celery.utils.timer2:Timer` almost not used in master branch, and param `on_error` omitted
when initialize `kombu.async.timer:Timer` when not `use_eventloop`, this seems not a problem. 

All the motivation to give the pull request is that I feel very strange and uncomfortable about this...  >:<
Do I misunderstand the code logic?