### PR TITLE
don't remove the task following a chord from a chain

### DIFF
--- a/celery/app/builtins.py
+++ b/celery/app/builtins.py
@@ -262,9 +262,8 @@ def add_chain_task(app):
                     if not res.parent:
                         res.parent = prev_res
 
-                if not isinstance(prev_task, chord):
-                    results.append(res)
-                    tasks.append(task)
+                results.append(res)
+                tasks.append(task)
                 prev_task, prev_res = task, res
 
             return tasks, results


### PR DESCRIPTION
The if statement isn't there in master, and it was causing bugs for me in complex workflows. I can't just start using Celery 4 (even though I'd like to) because of bug #3356, so I'd like this to be in 3.1.24.
