### PR TITLE
Fix small errors in celery.contrib.batches examples

### DIFF
--- a/celery/contrib/batches.py
+++ b/celery/contrib/batches.py
@@ -33,7 +33,7 @@ to store it in a database.
 
 Then you can ask for a click to be counted by doing::
 
-    >>> count_click.delay('http://example.com')
+    >>> count_click.delay(url='http://example.com')
 
 **Example returning results**
 
@@ -66,7 +66,7 @@ messages, and every 10 seconds.
             wot_api_target,
             params={'hosts': ('/').join(set(domains)) + '/'}
         )
-        return [response.json[domain] for domain in domains]
+        return [response.json()[domain] for domain in domains]
 
 Using the API is done as follows::
 


### PR DESCRIPTION
These typos were causing the celery batching examples to break.

For completeness, the errors you get when you run the examples as they are now:

**Simple Example**
```
[2016-08-31 14:52:36,119: ERROR/Worker-8] Error: KeyError('url',)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/celery/contrib/batches.py", line 126, in apply_batches_task
    result = task(*args)
  File "/usr/local/lib/python2.7/site-packages/celery/app/trace.py", line 439, in __protected_call__
    return orig(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/celery/app/task.py", line 420, in __call__
    return self.run(*args, **kwargs)
  File "/Users/me/scratch/celery/tasks.py", line 22, in count_click
    count = Counter(request.kwargs['url'] for request in requests)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/collections.py", line 465, in __init__
    self.update(*args, **kwds)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/collections.py", line 554, in update
    for elem in iterable:
  File "/Users/me/scratch/celery/tasks.py", line 22, in <genexpr>
    count = Counter(request.kwargs['url'] for request in requests)
KeyError: 'url'
```

**Example returning results**
``` 
[2016-08-31 15:31:53,523: ERROR/Worker-2] Error: TypeError("'instancemethod' object has no attribute '__getitem__'",)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/celery/contrib/batches.py", line 126, in apply_batches_task
    result = task(*args)
  File "/usr/local/lib/python2.7/site-packages/celery/app/trace.py", line 439, in __protected_call__
    return orig(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/celery/app/task.py", line 420, in __call__
    return self.run(*args, **kwargs)
  File "/Users/me/scratch/celery/tasks.py", line 41, in wot_api
    (sig(*request.args, **request.kwargs) for request in requests)
  File "/Users/me/scratch/celery/tasks.py", line 54, in wot_api_real
    return [response.json[domain] for domain in domains]
TypeError: 'instancemethod' object has no attribute '__getitem__'
```