### PR TITLE
Fix doc for relative flag of periodic task

### DIFF
--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -179,12 +179,12 @@ Available Fields
 
 * `relative`
 
-    By default :class:`~datetime.timedelta` schedules are scheduled
+    If `relative` is true :class:`~datetime.timedelta` schedules are scheduled
     "by the clock." This means the frequency is rounded to the nearest
     second, minute, hour or day depending on the period of the
     :class:`~datetime.timedelta`.
 
-    If `relative` is true the frequency isn't rounded and will be
+    By default `relative` is false, the frequency isn't rounded and will be
     relative to the time when :program:`celery beat` was started.
 
 .. _beat-crontab:


### PR DESCRIPTION
[doc](https://github.com/celery/celery/blob/2267553bb1011092adb86ed03a854a9bde667ef6/docs/userguide/periodic-tasks.rst#available-fields) say that "relative" field by default round the timedelta value, and that with relative set to True, rounding is disabled.

But in fact, when relative is True, [celery.schedule.schedule](https://github.com/celery/celery/blob/2267553bb1011092adb86ed03a854a9bde667ef6/celery/schedules.py#L71) will do the rounding, which is the opposite of what doc said.

And indeed, by default a schedule with timedelta(seconds=60) is not rounded to nearest minute, but run every minute from the start of celery beat. Setting relative to True do the rounding and task is run exactly when minute change.

I go with the update of documentation, instead of code to keep old behavior. 