### PR TITLE
Update __init__.py

### DIFF
--- a/examples/django/proj/__init__.py
+++ b/examples/django/proj/__init__.py
@@ -2,6 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
-from .celery import app as celery_app
+from taskapp.celery import app as celery_app
 
 __all__ = ['celery_app']


### PR DESCRIPTION
Without that explicit location, unit tests fail in Django. Please see http://stackoverflow.com/questions/39588380/django-celery-unit-tests-with-pycharm-no-module-named-celery/39655850#39655850