### PR TITLE
Bytes/unicode treated differently by Shelve bysed on Python version

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -25,6 +25,7 @@ from . import platforms
 from . import signals
 from .five import (
     items, monotonic, python_2_unicode_compatible, reraise, values,
+    bytes_if_py2
 )
 from .schedules import maybe_schedule, crontab
 from .utils.imports import load_extension_class_names, symbol_by_name
@@ -433,55 +434,55 @@ class PersistentScheduler(Scheduler):
 
         for _ in (1, 2):
             try:
-                self._store[b'entries']
+                self._store[bytes_if_py2('entries')]
             except KeyError:
                 # new schedule db
                 try:
-                    self._store[b'entries'] = {}
+                    self._store[bytes_if_py2('entries')] = {}
                 except KeyError as exc:
                     self._store = self._destroy_open_corrupted_schedule(exc)
                     continue
             else:
-                if b'__version__' not in self._store:
+                if bytes_if_py2('__version__') not in self._store:
                     warning('DB Reset: Account for new __version__ field')
                     self._store.clear()   # remove schedule at 2.2.2 upgrade.
-                elif b'tz' not in self._store:
+                elif bytes_if_py2('tz') not in self._store:
                     warning('DB Reset: Account for new tz field')
                     self._store.clear()   # remove schedule at 3.0.8 upgrade
-                elif b'utc_enabled' not in self._store:
+                elif bytes_if_py2('utc_enabled') not in self._store:
                     warning('DB Reset: Account for new utc_enabled field')
                     self._store.clear()   # remove schedule at 3.0.9 upgrade
             break
 
         tz = self.app.conf.timezone
-        stored_tz = self._store.get(b'tz')
+        stored_tz = self._store.get(bytes_if_py2('tz'))
         if stored_tz is not None and stored_tz != tz:
             warning('Reset: Timezone changed from %r to %r', stored_tz, tz)
             self._store.clear()   # Timezone changed, reset db!
         utc = self.app.conf.enable_utc
-        stored_utc = self._store.get(b'utc_enabled')
+        stored_utc = self._store.get(bytes_if_py2('utc_enabled'))
         if stored_utc is not None and stored_utc != utc:
             choices = {True: 'enabled', False: 'disabled'}
             warning('Reset: UTC changed from %s to %s',
                     choices[stored_utc], choices[utc])
             self._store.clear()   # UTC setting changed, reset db!
-        entries = self._store.setdefault(b'entries', {})
+        entries = self._store.setdefault(bytes_if_py2('entries'), {})
         self.merge_inplace(self.app.conf.beat_schedule)
         self.install_default_entries(self.schedule)
         self._store.update({
-            b'__version__': __version__,
-            b'tz': tz,
-            b'utc_enabled': utc,
+            bytes_if_py2('__version__'): __version__,
+            bytes_if_py2('tz'): tz,
+            bytes_if_py2('utc_enabled'): utc,
         })
         self.sync()
         debug('Current schedule:\n' + '\n'.join(
             repr(entry) for entry in values(entries)))
 
     def get_schedule(self):
-        return self._store[b'entries']
+        return self._store[bytes_if_py2('entries')]
 
     def set_schedule(self, schedule):
-        self._store[b'entries'] = schedule
+        self._store[bytes_if_py2('entries')] = schedule
     schedule = property(get_schedule, set_schedule)
 
     def sync(self):

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -10,7 +10,7 @@ from case import Mock, call, patch, skip
 
 from celery import beat
 from celery import uuid
-from celery.five import keys, string_t
+from celery.five import keys, string_t, bytes_if_py2
 from celery.schedules import schedule
 from celery.utils.objects import Bunch
 
@@ -398,17 +398,17 @@ class test_PersistentScheduler:
         s.setup_schedule()
         s._remove_db.assert_called_with()
 
-        s._store = {b'__version__': 1}
+        s._store = {bytes_if_py2('__version__'): 1}
         s.setup_schedule()
 
         s._store.clear = Mock()
         op = s.persistence.open = Mock()
         op.return_value = s._store
-        s._store[b'tz'] = 'FUNKY'
+        s._store[bytes_if_py2('tz')] = 'FUNKY'
         s.setup_schedule()
         op.assert_called_with(s.schedule_filename, writeback=True)
         s._store.clear.assert_called_with()
-        s._store[b'utc_enabled'] = False
+        s._store[bytes_if_py2('utc_enabled')] = False
         s._store.clear = Mock()
         s.setup_schedule()
         s._store.clear.assert_called_with()
@@ -417,10 +417,10 @@ class test_PersistentScheduler:
         s = create_persistent_scheduler()[0](
             schedule_filename='schedule', app=self.app,
         )
-        s._store = {b'entries': {}}
+        s._store = {bytes_if_py2('entries'): {}}
         s.schedule = {'foo': 'bar'}
         assert s.schedule == {'foo': 'bar'}
-        assert s._store[b'entries'] == s.schedule
+        assert s._store[bytes_if_py2('entries')] == s.schedule
 
 
 class test_Service:
@@ -439,7 +439,7 @@ class test_Service:
         assert isinstance(schedule, dict)
         assert isinstance(s.scheduler, beat.Scheduler)
         scheduled = list(schedule.keys())
-        for task_name in keys(sh[b'entries']):
+        for task_name in keys(sh[bytes_if_py2('entries')]):
             assert task_name in scheduled
 
         s.sync()


### PR DESCRIPTION
relates: #3346

Fixes:
```
Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/kombu/utils/objects.py", line 40, in __get__
    return obj.__dict__[self.__name__]
KeyError: 'scheduler'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.5/shelve.py", line 111, in __getitem__
    value = self.cache[key]
KeyError: b'entries'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/celery/apps/beat.py", line 107, in start_scheduler
    service.start()
  File "/usr/lib/python3.5/site-packages/celery/beat.py", line 522, in start
    humanize_seconds(self.scheduler.max_interval))
  File "/usr/lib/python3.5/site-packages/kombu/utils/objects.py", line 42, in __get__
    value = obj.__dict__[self.__name__] = self.__get(obj)
  File "/usr/lib/python3.5/site-packages/celery/beat.py", line 566, in scheduler
    return self.get_scheduler()
  File "/usr/lib/python3.5/site-packages/celery/beat.py", line 561, in get_scheduler
    lazy=lazy,
  File "/usr/lib/python3.5/site-packages/celery/beat.py", line 406, in __init__
    Scheduler.__init__(self, *args, **kwargs)
  File "/usr/lib/python3.5/site-packages/celery/beat.py", line 205, in __init__
    self.setup_schedule()
  File "/usr/lib/python3.5/site-packages/celery/beat.py", line 436, in setup_schedule
    self._store[b'entries']
  File "/usr/lib64/python3.5/shelve.py", line 113, in __getitem__
    f = BytesIO(self.dict[key.encode(self.keyencoding)])
AttributeError: 'bytes' object has no attribute 'encode'

```

Additional info:
As stated in Python3 docs [1]: "The keys are ordinary strings."
```
software -> celery:4.0.0rc4 (0today8) kombu:4.0.0rc4 py:3.5.1
            billiard:3.5.0.1 py-amqp:2.1.0
platform -> system:Linux arch:64bit imp:CPython
loader   -> celery.loaders.default.Loader
```

[1] https://docs.python.org/3.4/library/shelve.html