### PR TITLE
possibility to set on_message callback for single task

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -428,9 +428,13 @@ class SyncBackendMixin(object):
         )
 
     def wait_for_pending(self, result, timeout=None, interval=0.5,
-                         no_ack=True, on_interval=None, callback=None,
-                         propagate=True):
+                         no_ack=True, on_message=None, on_interval=None,
+                         callback=None, propagate=True):
         self._ensure_not_eager()
+        if on_message is not None:
+            raise ImproperlyConfigured(
+                'Backend does not support on_message callback')
+
         meta = self.wait_for(
             result.id, timeout=timeout,
             interval=interval,

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -26,7 +26,7 @@ from kombu.utils.url import maybe_sanitize_url
 from celery import states
 from celery import current_app, group, maybe_signature
 from celery.app import current_task
-from celery.exceptions import ChordError, TimeoutError, TaskRevokedError
+from celery.exceptions import ChordError, TimeoutError, TaskRevokedError, ImproperlyConfigured
 from celery.five import items
 from celery.result import (
     GroupResult, ResultBase, allow_join_result, result_from_tuple,

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -26,8 +26,8 @@ from kombu.utils.url import maybe_sanitize_url
 from celery import states
 from celery import current_app, group, maybe_signature
 from celery.app import current_task
-from celery.exceptions import ( ChordError, TimeoutError, TaskRevokedError,
-    ImproperlyConfigured,
+from celery.exceptions import (
+    ChordError, TimeoutError, TaskRevokedError, ImproperlyConfigured,
 )
 from celery.five import items
 from celery.result import (

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -26,7 +26,9 @@ from kombu.utils.url import maybe_sanitize_url
 from celery import states
 from celery import current_app, group, maybe_signature
 from celery.app import current_task
-from celery.exceptions import ChordError, TimeoutError, TaskRevokedError, ImproperlyConfigured
+from celery.exceptions import ( ChordError, TimeoutError, TaskRevokedError,
+    ImproperlyConfigured,
+)
 from celery.five import items
 from celery.result import (
     GroupResult, ResultBase, allow_join_result, result_from_tuple,

--- a/celery/result.py
+++ b/celery/result.py
@@ -134,8 +134,8 @@ class AsyncResult(ResultBase):
                                 reply=wait, timeout=timeout)
 
     def get(self, timeout=None, propagate=True, interval=0.5,
-            no_ack=True, follow_parents=True, callback=None, on_interval=None,
-            EXCEPTION_STATES=states.EXCEPTION_STATES,
+            no_ack=True, follow_parents=True, callback=None, on_message=None,
+            on_interval=None, EXCEPTION_STATES=states.EXCEPTION_STATES,
             PROPAGATE_STATES=states.PROPAGATE_STATES):
         """Wait until task is ready, and return its result.
 
@@ -185,6 +185,7 @@ class AsyncResult(ResultBase):
             no_ack=no_ack,
             propagate=propagate,
             callback=callback,
+            on_message=on_message,
         )
     wait = get  # deprecated alias to :meth:`get`.
 


### PR DESCRIPTION
Functionality was decribed and tests was added in https://github.com/celery/celery/pull/2550

Here is just added possibility to set on_message callback without creating group of tasks.
```python
def on_raw_message(body):
	print(body)

s = signature('test_task.hello', queue='test', kwargs={'a': 2, 'b': 8})
r = s.apply_async()
print(r.get(on_message=on_raw_message))
```