### PR TITLE
DjangoFixup does not set the default app

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -46,7 +46,7 @@ class DjangoFixup(object):
 
     def __init__(self, app):
         self.app = app
-        if default_app is None:
+        if not default_app:
             self.app.set_default()
         self._worker_fixup = None
 


### PR DESCRIPTION
I have been experiencing a bug with Celery 4.0 in development where my shared tasks are not finding the celery app initialized with Django's settings. This is because the `DjangoFixup` is not setting the app as default as it should be. I tracked it down to the following line:

```python
if default_app is None:
```

the check is failing because `default_app` isn't `None`, but is instead a proxy to `None`:

```
(Pdb) default_app
None
(Pdb) default_app is None
False
(Pdb) default_app == None
True
(Pdb) type(default_app)
<class 'celery.local.Proxy'>
```

I changed the `is` check to a boolean one, and it has fixed my issue. Let me know if this is the proper fix, or if the issue lies elsewhere!