### PR TITLE
Don't serialize task fields that are not json serializable for flower

### DIFF
--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -300,6 +300,8 @@ class Task(object):
         )
         self._serializer_handlers = {
             'children': self._serializable_children,
+            'root': self._serializable_root,
+            'parent': self._serializable_parent,
         }
         if kwargs:
             self.__dict__.update(kwargs)
@@ -358,6 +360,12 @@ class Task(object):
 
     def _serializable_children(self, value):
         return [task.id for task in self.children]
+
+    def _serializable_root(self, value):
+        return self.root_id
+
+    def _serializable_parent(self, value):
+        return self.parent_id
 
     def __reduce__(self):
         return _depickle_task, (self.__class__, self.as_dict())


### PR DESCRIPTION
Note: this demonstrates a fix for #3469 which is related to json encoding of certain fields by tornado used by flower. However, this fix on it's own may break usage of pickle internal to celery. 

The task fields that appear to be problematic for json encoding are 'children', 'root' and 'parent' (there may be others). This patch provides a list of fields (just a copy of "\_fields" with the problem ones removed) which is then used to limit the fields returned with as_dict() when as_dict() is invoked through \__reduce\__() only. 

While all the tests seem to work, there's likely a very good reason for having pickle use all the fields, so this patch should be considered suspect until confirmed it hasn't broken something else. Is there is an appropriate test that should be written to confirm as_dict and \__reduce\__'s  behaviour?

The alternative to this fix would be to make the changes in flower to remove these specific fields. However as the Worker object returned with 'worker' does appear to be json serializable, and with the move from using pickle to json elsewhere, perhaps the objects in 'root', 'parent', 'children' are meant to be json serializable?

Some guidance from the maintainers on the expected behaviour here would be very useful.

(FYI https://github.com/mher/flower/issues/617 )