### PR TITLE
Use the existing connection in the consumer Events step

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,7 @@ install:
   - "powershell extra\\appveyor\\install.ps1"
   - "%PYTHON%/Scripts/pip.exe install -U setuptools"
   - "%PYTHON%/Scripts/pip.exe install -r requirements/dev.txt"
+  - "%PYTHON%/Scripts/pip.exe install -r requirements/extras/eventlet.txt"
 
 build: off
 

--- a/celery/worker/consumer/events.py
+++ b/celery/worker/consumer/events.py
@@ -33,7 +33,7 @@ class Events(bootsteps.StartStopStep):
         # flush events sent while connection was down.
         prev = self._close(c)
         dis = c.event_dispatcher = c.app.events.Dispatcher(
-            c.connect(), hostname=c.hostname,
+            c.connection, hostname=c.hostname,
             enabled=self.send_events, groups=self.groups,
             buffer_group=['task'] if c.hub else None,
             on_send_buffered=c.on_send_event_buffered if c.hub else None,


### PR DESCRIPTION
## Description

This makes sure only a single connection attempt is performed by a worker. The previous behaviour caused a worker to need twice the BROKER_TIMEOUT before failing over to a different broker. This is also broken in celery 3.1 (in which I had the problem)
