### PR TITLE
Adds documentation for multiple bindings to the same queue.

### DIFF
--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -549,6 +549,23 @@ The default exchange, exchange type, and routing key will be used as the
 default routing values for tasks, and as the default values for entries
 in :setting:`task_queues`.
 
+Multiple bindings to a single queue are also supported.  Here's an example
+of two routing keys that are both bound to the same queue:
+
+.. code-block:: python
+
+    from kombu import Exchange, Queue, binding
+
+    media_exchange = Exchange('media', type='direct')
+
+    CELERY_QUEUES = (
+        Queue('media', [
+            binding(media_exchange, routing_key='media.video'),
+            binding(media_exchange, routing_key='media.image'),
+        ]),
+    )
+
+
 .. _routing-task-destination:
 
 Specifying task destination


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Adds documentation for multiple bindings to the same queue as discussed in #3529 

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.

