### PR TITLE
Documentation : Fix command for upgrading settings with Django

### DIFF
--- a/docs/whatsnew-4.0.rst
+++ b/docs/whatsnew-4.0.rst
@@ -401,7 +401,7 @@ and save a backup in :file:`proj/settings.py.orig`.
 
     .. code-block:: console
 
-        $ celery upgrade settings --django proj/settings.py
+        $ celery upgrade settings proj/settings.py --django
 
     After upgrading the settings file, you need to set the prefix explicitly
     in your ``proj/celery.py`` module:


### PR DESCRIPTION
The command was not working with the `--django` flag before the path of `settings.py` :
>     usage: celery <command> settings [filename] [options]
>     celery: error: unrecognized arguments: proj/settings.py