### PR TITLE
Doc: typo and clarification in beat scheduler setting (v4.0 branch)

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2281,9 +2281,11 @@ See :ref:`beat-entries`.
 ``beat_scheduler``
 ~~~~~~~~~~~~~~~~~~
 
-Default: ``"celery.beat:PersistentScheduer"``.
+Default: ``"celery.beat:PersistentScheduler"``.
 
-The default scheduler class.
+The default scheduler class. May be set to
+``"django_celery_beat.schedulers:DatabaseScheduler"`` for instance,
+if used alongside `django-celery-beat` extension.
 
 Can also be set via the :option:`celery beat -S` argument.
 


### PR DESCRIPTION
- Correct a typo PersistentScheduer -> PersistentScheduler 
- Add an example of other possible values for `beat_scheduler` setting.