### PR TITLE
Doc: update installation for django_celery_beat

### DIFF
--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -431,12 +431,12 @@ To install and use this extension:
 
         $ pip install django-celery-beat
 
-#. Add the ``django_celery_beat`` module to ``INSTALLED_APPS`` in your
+#. Add ``django_celery_beat.apps.BeatConfig`` to ``INSTALLED_APPS`` in your
    Django project' :file:`settings.py`::
 
         INSTALLED_APPS = (
             ...,
-            'django_celery_beat',
+            'django_celery_beat.apps.BeatConfig',
         )
 
     Note that there is no dash in the module name, only underscores.


### PR DESCRIPTION
With the current instructions, the application’s verbose name isn’t found and the label in the admin is DJANGO_CELERY_BEAT.

Updating installation instructions to fix that problem and follow best practices for [application users](https://docs.djangoproject.com/en/1.10/ref/applications/#for-application-users).

Feel free to discard this if you'd rather go down [the other route](https://docs.djangoproject.com/en/1.10/ref/applications/#for-application-authors) and define `default_app_config` in the django_celery_beat app.