### PR TITLE
Doc: ReST format in installation

### DIFF
--- a/docs/includes/installation.txt
+++ b/docs/includes/installation.txt
@@ -67,7 +67,7 @@ Transports and Backends
 :``celery[sqs]``:
     for using Amazon SQS as a message transport (*experimental*).
 
-:``celery[tblib``]
+:``celery[tblib]``:
     for using the :setting:`task_remote_tracebacks` feature.
 
 :``celery[memcache]``:
@@ -103,7 +103,7 @@ Transports and Backends
 :``celery[consul]``:
     for using the Consul.io Key/Value store as a message transport or result backend (*experimental*).
 
-:``celery[django]``
+:``celery[django]``:
     specifies the lowest version possible for Django support.
 
     You should probably not use this in your requirements, it's here


### PR DESCRIPTION
Fix ReST format breaking in [Installation](http://docs.celeryproject.org/en/latest/getting-started/introduction.html#installation) docs, which appeared in 7db0791, aee706a.

Signed-off-by: Takuya Noguchi <tak.noguchi.iridge@gmail.com>