### PR TITLE
Update whatsnew-4.0.rst

### DIFF
--- a/docs/whatsnew-4.0.rst
+++ b/docs/whatsnew-4.0.rst
@@ -376,7 +376,7 @@ lowercase and some setting names have been renamed for consistency.
 
 This change is fully backwards compatible so you can still use the uppercase
 setting names, but we would like you to upgrade as soon as possible and
-you can this automatically using the :program:`celery upgrade settings`
+you can do this automatically using the :program:`celery upgrade settings`
 command:
 
 .. code-block:: console


### PR DESCRIPTION
## Description

Under the `Lowercase setting names` section, the second part of the second paragraph read as:

> like you to upgrade as soon as possible and you can this automatically using

The word `do` has been added between `can` and `this`:

> like you to upgrade as soon as possible and you can **do** this automatically using