### PR TITLE
typo in 4.0 release notes, .on_commit is the old Django API

### DIFF
--- a/docs/whatsnew-4.0.rst
+++ b/docs/whatsnew-4.0.rst
@@ -222,7 +222,7 @@ to a model change, and you wish to cancel the task if the transaction is
 rolled back, or ensure the task is only executed after the changes have been
 written to the database.
 
-``transaction.on_commit`` enables you to solve this problem by adding
+``transaction.atomic`` enables you to solve this problem by adding
 the task as a callback to be called only when the transaction is committed.
 
 Example usage:


### PR DESCRIPTION
## Description

Hello,

Fix a typo that reference to the old Django transaction API wihle the example reference the new one (`transaction.atomic`)

Kind regards,