### PR TITLE
fixes exception deserialization when not using pickle

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 import time
+import inspect
 
 from collections import namedtuple
 from datetime import timedelta
@@ -237,14 +238,21 @@ class Backend(object):
         serializer = self.serializer if serializer is None else serializer
         if serializer in EXCEPTION_ABLE_CODECS:
             return get_pickleable_exception(exc)
-        return {'exc_type': type(exc).__name__, 'exc_message': str(exc)}
+
+        # retrieve exception original module
+        exc_module = inspect.getmodule(type(exc))
+        if exc_module:
+            exc_module = exc_module.__name__
+
+        return {'exc_type': type(exc).__name__, 'exc_args': exc.args, 'exc_module': exc_module}
 
     def exception_to_python(self, exc):
         """Convert serialized exception to Python exception."""
         if exc:
             if not isinstance(exc, BaseException):
+                exc_module = exc.get('exc_module') or __name__
                 exc = create_exception_cls(
-                    from_utf8(exc['exc_type']), __name__)(exc['exc_message'])
+                    from_utf8(exc['exc_type']), exc_module)(*exc['exc_args'])
             if self.serializer in EXCEPTION_ABLE_CODECS:
                 exc = get_pickled_exception(exc)
         return exc

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -244,7 +244,9 @@ class Backend(object):
         if exc_module:
             exc_module = exc_module.__name__
 
-        return {'exc_type': type(exc).__name__, 'exc_args': exc.args, 'exc_module': exc_module}
+        return {'exc_type': type(exc).__name__,
+                'exc_args': exc.args,
+                'exc_module': exc_module}
 
     def exception_to_python(self, exc):
         """Convert serialized exception to Python exception."""

--- a/celery/utils/serialization.py
+++ b/celery/utils/serialization.py
@@ -81,9 +81,9 @@ def itermro(cls, stop):
 
 def create_exception_cls(name, module, parent=None):
     """Dynamically create an exception class."""
-
     # handle builtin exceptions
-    if name in __builtins__ and isinstance(__builtins__[name], type(BaseException)):
+    if name in __builtins__ \
+            and isinstance(__builtins__[name], type(BaseException)):
         return __builtins__[name]
     # exception is not builtin, try to find it from its module
     exc = None

--- a/celery/utils/serialization.py
+++ b/celery/utils/serialization.py
@@ -81,21 +81,17 @@ def itermro(cls, stop):
 
 def create_exception_cls(name, module, parent=None):
     """Dynamically create an exception class."""
-    # handle builtin exceptions
-    if name in __builtins__ \
-            and isinstance(__builtins__[name], type(BaseException)):
-        return __builtins__[name]
-    # exception is not builtin, try to find it from its module
-    exc = None
     try:
+        # also works for 'builtins' module
         mod = import_module(module)
+        # should we raise if getattr fails ?
+        exc_cls = getattr(mod, name, None)
+        if exc_cls and isinstance(exc_cls, type(BaseException)):
+            return exc_cls
     except ImportError:
+        # module not found. We may want to raise instead of
+        # calling subclass_exception
         pass
-    else:
-        # should we raise ?
-        exc = getattr(mod, name, None)
-    if exc:
-        return exc
 
     # we could not find the exception, fallback and create a type.
     if not parent:

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -199,7 +199,7 @@ class test_BaseBackend_dict:
         x = DictBackend(self.app, serializer=serializer)
         e = x.prepare_exception(ValueError('foo'))
         if not isinstance(e, BaseException):
-            # not using pickle, returned value is the exception
+            # not using pickle
             assert 'exc_type' in e
         e = x.exception_to_python(e)
         assert e.__class__ is ValueError
@@ -210,7 +210,7 @@ class test_BaseBackend_dict:
         x = DictBackend(self.app, serializer=serializer)
         e = x.prepare_exception(CustomTestError('foo'))
         if not isinstance(e, BaseException):
-            # not using pickle, returned value is the exception
+            # not using pickle
             assert 'exc_type' in e
         e = x.exception_to_python(e)
         assert e.__class__ is CustomTestError

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -194,7 +194,8 @@ class test_BaseBackend_dict:
         e = x.prepare_exception(KeyError('foo'))
         assert 'exc_type' in e
         e = x.exception_to_python(e)
-        assert e.__class__.__name__ == 'KeyError'
+        assert e.__class__ is KeyError
+        assert e.args == ("foo", )
         assert str(e).strip('u') == "'foo'"
 
     def test_save_group(self):


### PR DESCRIPTION
fix for #3586 

This PR try to fix how exceptions are deserialized when using a serializer different than pickle.

This avoid to [create new types](https://github.com/jcsaaddupuy/celery/blob/8d4e613e24f6561fdaafd4e6ede582ceac882804/celery/utils/serialization.py#L46) for exceptions, by doing 2 things : 

- store the exception module in [celery/celery/backends/base.py::Backend::prepare_exception](https://github.com/jcsaaddupuy/celery/blob/8d4e613e24f6561fdaafd4e6ede582ceac882804/celery/backends/base.py#L243-L245) and reuse it in [celery/celery/backends/base.py::Backend::prepare_exception](https://github.com/jcsaaddupuy/celery/blob/8d4e613e24f6561fdaafd4e6ede582ceac882804/celery/backends/base.py#L249-L258) instead of using raw `__name__` as module name

- in [ celery/celery/utils/serialization.py::create_exception_cls](https://github.com/jcsaaddupuy/celery/blob/8d4e613e24f6561fdaafd4e6ede582ceac882804/celery/utils/serialization.py#L86-L98), try to find the exception class either from  `__builtins__`, or from the excetion module. Fallback on current behavior (which may still be wrong)

Also, it uses `exc.args` in [celery/celery/backends/base.py::Backend::prepare_exception](https://github.com/jcsaaddupuy/celery/blob/8d4e613e24f6561fdaafd4e6ede582ceac882804/celery/backends/base.py#L247) and pass it to the exception constructor in [celery/celery/backends/base.py::Backend::exception_to_python](https://github.com/jcsaaddupuy/celery/blob/8d4e613e24f6561fdaafd4e6ede582ceac882804/celery/backends/base.py#L255), instead of using `str(exc.message)` which could lead to unwanted behavior

This won't work in every cases. If a class is defined locally in a function, this code won't be able to import the exception class using `import_module` and the old (wrong) behavior will still be used.