### PR TITLE
DOC: fix typo in remote shutdown using control broadcast example

### DIFF
--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -1057,7 +1057,7 @@ This command will gracefully shut down the worker remotely:
 .. code-block:: pycon
 
     >>> app.control.broadcast('shutdown') # shutdown all workers
-    >>> app.control.broadcast('shutdown, destination='worker1@example.com')
+    >>> app.control.broadcast('shutdown', destination='worker1@example.com')
 
 .. control:: ping
 


### PR DESCRIPTION
DOC: fix typo in remote shutdown using control broadcast example

