### PR TITLE
fix _index method miss body params in elasticsearch backend

### DIFF
--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -91,6 +91,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
         return self.server.index(
             index=self.index,
             doc_type=self.doc_type,
+            body=body,
             **kwargs
         )
 


### PR DESCRIPTION
## Description

`self.server.index` miss body parameter in  the `_index` of `elasticsearch.py` 

fixed first bug in #3556，i hope to solve quickly because I often use :blush:

there is a exception:

```shell
Traceback (most recent call last):
  File "/home/sean/PycharmProjects/AutoFlurryData/venv/local/lib/python2.7/site-packages/billiard/pool.py", line 1748, in safe_apply_callback
    fun(*args, **kwargs)
  File "/home/sean/PycharmProjects/AutoFlurryData/venv/local/lib/python2.7/site-packages/celery/worker/request.py", line 366, in on_failure
    self.id, exc, request=self, store_result=self.store_errors,
  File "/home/sean/PycharmProjects/AutoFlurryData/venv/local/lib/python2.7/site-packages/celery/backends/base.py", line 163, in mark_as_failure
    traceback=traceback, request=request)
  File "/home/sean/PycharmProjects/AutoFlurryData/venv/local/lib/python2.7/site-packages/celery/backends/base.py", line 309, in store_result
    request=request, **kwargs)
  File "/home/sean/PycharmProjects/AutoFlurryData/venv/local/lib/python2.7/site-packages/celery/backends/base.py", line 652, in _store_result
    self.set(self.get_key_for_task(task_id), self.encode(meta))
  File "/home/sean/PycharmProjects/AutoFlurryData/venv/local/lib/python2.7/site-packages/celery/backends/elasticsearch.py", line 80, in set
    datetime.utcnow().isoformat()[:-3]
  File "/home/sean/PycharmProjects/AutoFlurryData/venv/local/lib/python2.7/site-packages/celery/backends/elasticsearch.py", line 95, in _index
    **kwargs
  File "/home/sean/PycharmProjects/AutoFlurryData/venv/local/lib/python2.7/site-packages/elasticsearch/client/utils.py", line 71, in _wrapped
    return func(*args, params=params, **kwargs)
TypeError: index() takes at least 4 arguments (4 given)
``` 
