### PR TITLE
ValueError for chord with single task in header

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1242,7 +1242,7 @@ class chord(Signature):
         if len(self.tasks) == 1:
             # chord([A], B) can be optimized as A | B
             # - Issue #3323
-            return (self.tasks[0].set(task_id=task_id) | body).apply_async(
+            return (self.tasks[0] | body).set(task_id=task_id).apply_async(
                 args, kwargs, **options)
         # chord([A, B, ...], C)
         return self.run(tasks, body, args, task_id=task_id, **options)


### PR DESCRIPTION
## Checklist

- [x] I have included the output of ``celery -A proj report`` in the issue.
      (if you are not able to do this, then at least specify the Celery
       version affected).
- [x] I have verified that the issue exists against the `master` branch of Celery.

## Config / Report

Reproduced on both PyPy [PyPy 5.6.0 with GCC 4.8.2] and CPython 2.7.6, using both redis and rabbitmq brokers.

```
software -> celery:4.0.0 (latentcall) kombu:4.0.0 py:2.7.6
            billiard:3.5.0.2 redis:2.10.5
platform -> system:Linux arch:64bit, ELF imp:CPython
loader   -> celery.loaders.app.AppLoader
settings -> transport:redis results:redis://localhost:6379/1
```

```
software -> celery:4.0.0 (latentcall) kombu:4.0.0 py:2.7.12
            billiard:3.5.0.2 redis:2.10.5
platform -> system:Linux arch:64bit, ELF imp:PyPy
loader   -> celery.loaders.app.AppLoader
settings -> transport:redis results:redis://localhost:6379/1
```
```
task_routes: {...}
broker_url: u'redis://localhost:6379/1'
result_backend: u'redis://localhost:6379/1'
task_ignore_result: True
result_expires: 7200
task_create_missing_queues: True
task_serializer: 'pickle'
result_serializer: 'pickle'
accept_content: ['pickle', 'json']
enable_utc: True
```

The bug is not present in versions before 4.0.0. Seems to have been introduced in commit 867a3aabef607d17af4a59a85e6ed2c40850cee5.

## Steps to reproduce
```python
@celery_app.task(ignore_result=False)
def noop():
    return "noop"

@celery_app.tasks(ignore_result=False)
def callback(results):
    print results

def chord_single_task_header():
    chord(noop.si())(callback.s())
    # or equivalent calls:
    # chord(noop.s())(callback.s())
    # chord([noop.si()])(callback.s())
```

## Expected behavior

When `chord_single_task_header` is called, expect the `noop` task to be scheduled, run and then the callback to print "noop":

```
Received task: noop[8f347c6c-8afe-48f8-b6a3-f6c008607327]
Received task: callback[1d3853c5-c76e-4626-b522-f95a30edfb7a]
Task noop[8f347c6c-8afe-48f8-b6a3-f6c008607327] succeeded in 0.0179804009967s: 'noop'
noop
Task callback[1d3853c5-c76e-4626-b522-f95a30edfb7a] succeeded in 0.00345222899341s: None
```

## Actual behavior

Getting this error (in the calling script, not the worker):

```
Traceback (most recent call last):
  File "/var/backend/api/commands.py", line 2678, in debug
    chord(noop.si())(callback.s())
  File "/var/backend/celery/celery/canvas.py", line 1200, in __call__
    return self.apply_async((), {'body': body} if body else {}, **options)
  File "/var/backend/celery/celery/canvas.py", line 1246, in apply_async
    args, kwargs, **options)
  File "/var/backend/celery/celery/canvas.py", line 567, in apply_async
    dict(self.options, **options) if options else self.options))
  File "/var/backend/celery/celery/canvas.py", line 586, in run
    task_id, group_id, chord,
  File "/var/backend/celery/celery/canvas.py", line 679, in prepare_steps
    res = task.freeze(root_id=root_id)
  File "/var/backend/celery/celery/canvas.py", line 284, in freeze
    return self.AsyncResult(tid)
  File "/var/backend/celery/celery/app/task.py", line 746, in AsyncResult
    task_name=self.name, **kwargs)
  File "/var/backend/celery/celery/result.py", line 90, in __init__
    'AsyncResult requires valid id, not {0}'.format(type(id)))
ValueError: AsyncResult requires valid id, not <type 'NoneType'>
```

## Potential cause

[Line 1242 - 1246 in celery/celery/canvas.py](https://github.com/celery/celery/blob/a883f6871b54c1292920e68cf8c01d2efc464f3f/celery/canvas.py#L1242-L1246)

```python
if len(self.tasks) == 1:
    # chord([A], B) can be optimized as A | B
    # - Issue #3323
    return (self.tasks[0].set(task_id=task_id) | body).apply_async(
        args, kwargs, **options)
```

Setting the task id of the first task to None, overriding generated task id, which propagates to the AsyncResult. Should probably be setting the task id on the chain created by the pipe operator:

```python
if len(self.tasks) == 1:
    # chord([A], B) can be optimized as A | B
    # - Issue #3323
    return (self.tasks[0] | body).set(task_id=task_id).apply_async(
        args, kwargs, **options)
```
