### PR TITLE
fix no logo image in worker splash screen when python version is 3.x

### DIFF
--- a/celery/utils/term.py
+++ b/celery/utils/term.py
@@ -172,7 +172,8 @@ def supports_images():
 
 def _read_as_base64(path):
     with codecs.open(path, mode='rb') as fh:
-        return base64.b64encode(fh.read())
+        encoded = base64.b64encode(fh.read())
+        return encoded if type(encoded) == 'str' else encoded.decode('ascii')
 
 
 def imgcat(path, inline=1, preserve_aspect_ratio=0, **kwargs):


### PR DESCRIPTION
## Description

Python 3.x has `byte` type so that `base64.b64encode` will return a byte object which need to decode to string for Iterm2 extended image protocol.

