### PR TITLE
Update redis.rst to fix pip bundle issue

### DIFF
--- a/docs/getting-started/brokers/redis.rst
+++ b/docs/getting-started/brokers/redis.rst
@@ -15,7 +15,7 @@ the ``celery[redis]`` :ref:`bundle <bundles>`:
 
 .. code-block:: console
 
-    $ pip install -U celery[redis]
+    $ pip install -U "celery[redis]"
 
 .. _broker-redis-configuration:
 


### PR DESCRIPTION
Hi!

When running this example, I had an issue:

```bash
❯ pip install -U celery[redis]
zsh: no matches found: celery[redis]
```

When looking at the [Bundles](http://docs.celeryproject.org/en/latest/getting-started/introduction.html#bundles) explanation, it seems we need to use `"` around the bundle for pip to correctly process it.

I thought I should fix that in your doc then! But maybe this is only happening for me?