### PR TITLE
Fix code examples in routing documentation

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1351,7 +1351,7 @@ Where ``myapp.tasks.route_task`` could be:
 
 .. code-block:: python
 
-    def route_task(self, name, args, kwargs, options, task=None, **kwargs):
+    def route_task(self, name, args, kwargs, options, task=None, **kw):
             if task == 'celery.ping':
                 return {'queue': 'default'}
 

--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -591,11 +591,11 @@ Routers
 A router is a function that decides the routing options for a task.
 
 All you need to define a new router is to define a function with
-the signature ``(name, args, kwargs, options, task=None, **kwargs)``:
+the signature ``(name, args, kwargs, options, task=None, **kw)``:
 
 .. code-block:: python
 
-    def route_task(name, args, kwargs, options, task=None, **kwargs):
+    def route_task(name, args, kwargs, options, task=None, **kw):
             if name == 'myapp.tasks.compress_video':
                 return {'exchange': 'video',
                         'exchange_type': 'topic',


### PR DESCRIPTION
## Description

There are code examples in the documentation which are not valid python code: duplicate argument name `kwargs` in function definition (F831 as reported by flake8).