### PR TITLE
Add `celery_worker_parameters` test fixture.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -223,3 +223,4 @@ Marat Sharafutdinov, 2016/11/04
 Viktor Holmqvist, 2016/12/02
 Rick Wargo, 2016/12/02
 zhengxiaowai, 2016/12/07
+Michael Howitz, 2016/12/08

--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -215,6 +215,28 @@ Example:
             'strict_typing': False,
         }
 
+``celery_worker_parameters`` - Override to setup Celery worker parameters.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can redefine this fixture to change the ``__init__`` parameters of test
+Celery workers. These are directly passed to
+:class:`~celery.worker.WorkController` when it is instantiated.
+
+The config returned by your fixture will then be used
+to configure the :func:`celery_worker`, and :func:`celery_session_worker`
+fixtures.
+
+Example:
+
+.. code-block:: python
+
+    @pytest.fixture(scope='session')
+    def celery_worker_parameters():
+        return {
+            'queues':  ('high-prio', 'low-prio'),
+            'exclude_queues': ('celery'),
+        }
+
 
 ``celery_enable_logging`` - Override to enable logging in embedded workers.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description

PR #3626 added the ability to configure the parameters of `__init__` of the Celery test app.
My PR aims to be able to configure the parameters of `__init__` of `WorkController` in tests.
There is currently no other way to configure e. g. the `queues` parameter of the worker in tests.