### PR TITLE
Fixed #3651 - add `app` argument to `GroupResult.restore`.

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -867,10 +867,13 @@ class GroupResult(ResultSet):
         return self.results
 
     @classmethod
-    def restore(cls, id, backend=None):
+    def restore(cls, id, backend=None, app=None):
         """Restore previously saved group result."""
+
+        app = app or cls.app
+
         return (
-            backend or (cls.app.backend if cls.app else current_app.backend)
+            backend or (app.backend if app else current_app.backend)
         ).restore_group(id)
 
 

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -19,6 +19,7 @@ from celery.result import (
     AsyncResult,
     EagerResult,
     ResultSet,
+    GroupResult,
     result_from_tuple,
     assert_will_not_block,
 )
@@ -614,6 +615,13 @@ class test_GroupResult:
         assert self.app.GroupResult.restore(ts.id) is None
         with pytest.raises(AttributeError):
             self.app.GroupResult.restore(ts.id, backend=object())
+
+    def test_restore_app(self):
+        subs = [MockAsyncResultSuccess(uuid(), app=self.app)]
+        ts = self.app.GroupResult(uuid(), subs)
+        ts.save()
+        restored = GroupResult.restore(ts.id, app=self.app)
+        assert restored.id == ts.id
 
     def test_join_native(self):
         backend = SimpleBackend()


### PR DESCRIPTION
This makes the restore method behave the same way as the `GroupResult` constructor.

See #3651 for discussion.