### PR TITLE
Refer worker request info to absolute time

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -255,3 +255,4 @@ Arpan Shah, 2017/09/12
 Tobias 'rixx' Kunze, 2017/08/20
 Mikhail Wolfson, 2017/12/11
 Alex Garel, 2018/01/04
+Régis Behmo 2018/01/20

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import sys
 from datetime import datetime
+from time import time
 from weakref import ref
 
 from billiard.common import TERM_SIGNAME
@@ -20,7 +21,7 @@ from celery.app.trace import trace_task, trace_task_ret
 from celery.exceptions import (Ignore, InvalidTaskError, Reject, Retry,
                                TaskRevokedError, Terminated,
                                TimeLimitExceeded, WorkerLostError)
-from celery.five import python_2_unicode_compatible, string
+from celery.five import monotonic, python_2_unicode_compatible, string
 from celery.platforms import signals as _signals
 from celery.utils.functional import maybe, noop
 from celery.utils.log import get_logger
@@ -287,7 +288,8 @@ class Request(object):
     def on_accepted(self, pid, time_accepted):
         """Handler called when task is accepted by worker pool."""
         self.worker_pid = pid
-        self.time_start = time_accepted
+        # Convert monotonic time_accepted to absolute time
+        self.time_start = time() - (monotonic() - time_accepted)
         task_accepted(self)
         if not self.task.acks_late:
             self.acknowledge()

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -7,6 +7,7 @@ import signal
 import socket
 import sys
 from datetime import datetime, timedelta
+from time import time
 
 import pytest
 from billiard.einfo import ExceptionInfo
@@ -515,6 +516,11 @@ class test_Request(RequestCase):
             assert not pool.terminate_job.call_count
             job.on_accepted(pid=314, time_accepted=monotonic())
             pool.terminate_job.assert_called_with(314, signum)
+
+    def test_on_accepted_time_start(self):
+        job = self.xRequest()
+        job.on_accepted(pid=os.getpid(), time_accepted=monotonic())
+        assert time() - job.time_start < 1
 
     def test_on_success_acks_early(self):
         job = self.xRequest()


### PR DESCRIPTION
Previously, the time_start attribute of worker request objects refered
to a timestamp relative to the monotonic time value. This caused
time_start attributes to be at a time far in the past. We fix this by
calling the on_accepted callback with an absolute time_accepted
attribute.

Note that the current commit does not change the
celery.concurrency.base API, although it would probably make sense to
rename the "monotonic" named argument to "time".

This fixes the problem described in http://stackoverflow.com/questions/20091505/celery-task-with-a-time-start-attribute-in-1970/

Note that there are many different ways to solve this problem; in the proposed implementation I choose to modify the default value of a keyword argument that is AFAIK never used.