### PR TITLE
Fix celery mongodb integration so that binary encodings like pickle/m…

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -29,6 +29,7 @@ else:                                       # pragma: no cover
 
 __all__ = ['MongoBackend']
 
+BINARY_CODECS = frozenset(['pickle', 'msgpack'])
 
 class MongoBackend(BaseBackend):
     """MongoDB result backend.
@@ -150,7 +151,12 @@ class MongoBackend(BaseBackend):
         if self.serializer == 'bson':
             # mongodb handles serialization
             return data
-        return super(MongoBackend, self).encode(data)
+        payload = super(MongoBackend, self).encode(data)
+
+        # serializer which are in a unsupported format (pickle/binary)
+        if self.serializer in BINARY_CODECS:
+            payload = Binary(payload)
+        return payload
 
     def decode(self, data):
         if self.serializer == 'bson':

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -31,6 +31,7 @@ __all__ = ['MongoBackend']
 
 BINARY_CODECS = frozenset(['pickle', 'msgpack'])
 
+
 class MongoBackend(BaseBackend):
     """MongoDB result backend.
 


### PR DESCRIPTION
…sgpack work in v4 again

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fixes #3575

You can't write raw binary data to mongodb, and v4 currently tries to do so in pickle/msgpack mode, which results in the error in the above issue.

The code which used to deal with this was dropped in: https://github.com/celery/celery/commit/639b40f6308267312a1030bb3d6ac5805069510a

This small patch restores the code so it works for pickle/msgpack again.
