### PR TITLE
Modify the systemd script to make it work

### DIFF
--- a/extra/systemd/README.rst
+++ b/extra/systemd/README.rst
@@ -1,0 +1,26 @@
+Usage
+=====
+
+The three files should be located as follows respectively (change the filename if needed):
+
+- ``/etc/systemd/system/celery.service``
+- ``/etc/systemd/system/celery.service.d/celery.conf``
+- ``/etc/tmpfiles.d/celery.conf``
+
+After that, modify the content of the files suitable for your application, and execute the commands:
+
+.. code-block:: bash
+
+  # Create the temporary directories immediately.
+  sudo systemd-tmpfiles --create
+  
+  # Reload the systemd services.
+  sudo systemctl daemon-reload
+
+  # Start the service.
+  sudo systemctl start celery.service
+
+Note
+====
+
+The command used in the script is ``celery worker`` instead of ``celery multi start`` since systemd seeems unable to capture the multiple parent PIDs. Please refer to celery/celery#3459 for more discussion.

--- a/extra/systemd/README.rst
+++ b/extra/systemd/README.rst
@@ -23,4 +23,4 @@ After that, modify the content of the files suitable for your application, and e
 Note
 ====
 
-The command used in the script is ``celery worker`` instead of ``celery multi start`` since systemd seeems unable to capture the multiple parent PIDs. Please refer to https://github.com/celery/celery#3459 for more discussion.
+The command used in the script is ``celery worker`` instead of ``celery multi start`` since systemd seeems unable to capture the multiple parent PIDs. Please refer to https://github.com/celery/celery/issues/3459 for more discussion.

--- a/extra/systemd/README.rst
+++ b/extra/systemd/README.rst
@@ -23,4 +23,4 @@ After that, modify the content of the files suitable for your application, and e
 Note
 ====
 
-The command used in the script is ``celery worker`` instead of ``celery multi start`` since systemd seeems unable to capture the multiple parent PIDs. Please refer to celery/celery#3459 for more discussion.
+The command used in the script is ``celery worker`` instead of ``celery multi start`` since systemd seeems unable to capture the multiple parent PIDs. Please refer to https://github.com/celery/celery#3459 for more discussion.

--- a/extra/systemd/celery.conf
+++ b/extra/systemd/celery.conf
@@ -1,10 +1,3 @@
-# See
-# http://docs.celeryproject.org/en/latest/tutorials/daemonizing.html#available-options
-
 CELERY_APP="proj"
-CELERYD_NODES="worker"
-CELERYD_OPTS=""
-CELERY_BIN="/usr/bin/celery"
-CELERYD_PID_FILE="/var/run/celery/%n.pid"
-CELERYD_LOG_FILE="/var/log/celery/%n%I.log"
-CELERYD_LOG_LEVEL="INFO"
+CELERY_BIN="/path/to/venv/bin/celery"
+CELERY_OPTS="-c 5 --loglevel=INFO"

--- a/extra/systemd/celery.service
+++ b/extra/systemd/celery.service
@@ -3,19 +3,13 @@ Description=Celery Service
 After=network.target
 
 [Service]
-Type=forking
+Type=simple
+PIDFile=/var/run/celery/celery.pid
 User=celery
 Group=celery
-EnvironmentFile=-/etc/conf.d/celery
-WorkingDirectory=/opt/celery
-ExecStart=/bin/sh -c '${CELERY_BIN} multi start $CELERYD_NODES \
-	-A $CELERY_APP --logfile=${CELERYD_LOG_FILE} \
-	--pidfile=${CELERYD_PID_FILE} $CELERYD_OPTS'
-ExecStop=/bin/sh -c '${CELERY_BIN} multi stopwait $CELERYD_NODES \
-	--pidfile=${CELERYD_PID_FILE}'
-ExecReload=/bin/sh -c '${CELERY_BIN} multi restart $CELERYD_NODES \
-	-A $CELERY_APP --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} \
-	--loglevel="${CELERYD_LOG_LEVEL}" $CELERYD_OPTS'
+WorkingDirectory=/usr/src/app
+ExecStart=/bin/sh -c "${CELERY_BIN} worker --app=${CELERY_APP} ${CELERY_OPTS} --logfile=/var/log/celery/celery.log --pidfile=/var/run/celery/celery.pid"
+ExecStop=/bin/kill -s TERM $MAINPID
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The original systemd script use `celery multi start`, but actually systemd is unable to get all the parent PIDs. For now, `celery worker` is the only solution. Consider it as a workaround for #3459.