### PR TITLE
Fix request context for blocking task apply (added hostname)

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -19,6 +19,7 @@ from celery.result import EagerResult
 from celery.utils import abstract
 from celery.utils.functional import mattrgetter, maybe_list
 from celery.utils.imports import instantiate
+from celery.utils.nodenames import gethostname
 from celery.utils.serialization import raise_with_context
 
 from .annotations import resolve_all as resolve_all_annotations
@@ -726,6 +727,7 @@ class Task(object):
             'is_eager': True,
             'logfile': logfile,
             'loglevel': loglevel or 0,
+            'hostname': gethostname(),
             'callbacks': maybe_list(link),
             'errbacks': maybe_list(link_error),
             'headers': headers,


### PR DESCRIPTION
## Description

I have CELERY_TASK_ALWAYS_EAGER = True in my project test settings and inside one of my tasks I am using self.request.hostname attribute, but it equals None.

So we should assign 'hostname' attribute inside the request context in blocking task apply method.