### PR TITLE
[docs] Fixed link to pytest

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -474,7 +474,7 @@ dependencies, so install these next:
     $ pip install -U -r requirements/default.txt
 
 After installing the dependencies required, you can now execute
-the test suite by calling :pypi:`py.test <pytest`:
+the test suite by calling :pypi:`py.test <pytest>`:
 
 .. code-block:: console
 


### PR DESCRIPTION
Pointed to https://pypi.python.org/pypi/py.test%20%3Cpytest/ instead of https://pypi.python.org/pypi/pytest/.
