### PR TITLE
Specify default value for pidfile option of celery beat.

### DIFF
--- a/celery/bin/beat.py
+++ b/celery/bin/beat.py
@@ -37,7 +37,7 @@
 
 .. cmdoption:: --pidfile
 
-    Optional file used to store the process pid.
+    File used to store the process pid. Defaults to `celerybeat.pid`.
 
     The program won't start if this file already exists
     and the pid is still alive.


### PR DESCRIPTION
## Description

Show default value for `--pidfile` option of `celery beat` in the documentation.

Fixes #3719 
