### PR TITLE
Fix #3726 - Chaining of replaced tasks

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -850,7 +850,7 @@ class Task(object):
             chord = None
 
         if self.request.chain:
-            for t in self.request.chain:
+            for t in reversed(self.request.chain):
                 sig |= signature(t, app=self.app)
 
         sig.freeze(self.request.id,

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -13,6 +13,12 @@ def add(x, y):
     return x + y
 
 
+@shared_task(bind=True)
+def add_replaced(self, x, y):
+    """Add two numbers (via the add task)."""
+    raise self.replace(add.s(x, y))
+
+
 @shared_task
 def print_unicode(log_message='håå®ƒ valmuefrø', print_message='hiöäüß'):
     """Task that both logs and print strings containing funny characters."""

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -4,7 +4,7 @@ from celery import chain, chord, group
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult, GroupResult
 from .conftest import flaky
-from .tasks import add, collect_ids, ids
+from .tasks import add, add_replaced, collect_ids, ids
 
 TIMEOUT = 120
 
@@ -20,12 +20,12 @@ class test_chain:
     def test_complex_chain(self, manager):
         c = (
             add.s(2, 2) | (
-                add.s(4) | add.s(8) | add.s(16)
+                add.s(4) | add_replaced.s(8) | add.s(16) | add.s(32)
             ) |
             group(add.s(i) for i in range(4))
         )
         res = c()
-        assert res.get(timeout=TIMEOUT) == [32, 33, 34, 35]
+        assert res.get(timeout=TIMEOUT) == [64, 65, 66, 67]
 
     @flaky
     def test_parent_ids(self, manager, num=10):


### PR DESCRIPTION
Fixes #3726 ("Replaced task in chain causes chain to skip to last link").

* Updates the `Task.replace()` method to copy the replaced task's chain in the correct order. (Was copying the chain backwards.)
* Updates integration test of complex chaining to reproduce the issue and pass.