### PR TITLE
Fix #3725: Task replaced with group does not complete

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1253,7 +1253,7 @@ class chord(Signature):
         )
 
     def _traverse_tasks(self, tasks, value=None):
-        stack = deque(list(tasks))
+        stack = deque(tasks)
         while stack:
             task = stack.popleft()
             if isinstance(task, group):
@@ -1262,7 +1262,8 @@ class chord(Signature):
                 yield task if value is None else value
 
     def __length_hint__(self):
-        return sum(self._traverse_tasks(self.tasks, 1))
+        tasks = self.tasks.tasks if isinstance(self.tasks, group) else self.tasks
+        return sum(self._traverse_tasks(tasks, 1))
 
     def run(self, header, body, partial_args, app=None, interval=None,
             countdown=1, max_retries=None, eager=False,

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 from time import sleep
-from celery import shared_task
+from celery import shared_task, group
 from celery.utils.log import get_task_logger
 
 logger = get_task_logger(__name__)
@@ -11,6 +11,13 @@ logger = get_task_logger(__name__)
 def add(x, y):
     """Add two numbers."""
     return x + y
+
+
+@shared_task(bind=True)
+def add_to_all(self, nums, val):
+    """Add the given value to all supplied numbers."""
+    subtasks = [add.s(num, val) for num in nums]
+    raise self.replace(group(*subtasks))
 
 
 @shared_task

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -4,7 +4,7 @@ from celery import chain, chord, group
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult, GroupResult
 from .conftest import flaky
-from .tasks import add, collect_ids, ids
+from .tasks import add, collect_ids, ids, add_to_all
 
 TIMEOUT = 120
 
@@ -22,10 +22,11 @@ class test_chain:
             add.s(2, 2) | (
                 add.s(4) | add.s(8) | add.s(16)
             ) |
-            group(add.s(i) for i in range(4))
+            group(add.s(i) for i in range(4)) |
+            add_to_all.s(32)
         )
         res = c()
-        assert res.get(timeout=TIMEOUT) == [32, 33, 34, 35]
+        assert res.get(timeout=TIMEOUT) == [64, 65, 66, 67]
 
     @flaky
     def test_parent_ids(self, manager, num=10):


### PR DESCRIPTION
### Summary ###
* Updates `chord.__length_hint__()` and `chord._traverse_tasks()` to correctly handle the case when `self.tasks` is a group.
* Updates integration test of complex chaining to reproduce the issue and pass.

### Details ###
Before `group.__iter__()` was removed in 8c7ac5d, passing either a list or a group through `list()` would yield the same thing: the list of tasks. After the removal of `group.__iter__()`, `list(g)` yields the same thing as `g.keys()`, so we need to handle the group case explicitly now.

Using `len(g.keys())` for `__length_hint__` will only happen to be the correct chord size sometimes; the rest of the time it will result in chords that never get unlocked due to a mismatch between the computed chord size and the size of the complete set of results returned.

Fixes #3725 - "Replaced task does not complete when replacement sig is a group"