### PR TITLE
prevent consuming queue before ready on startup

### DIFF
--- a/celery/worker/loops.py
+++ b/celery/worker/loops.py
@@ -44,10 +44,10 @@ def asynloop(obj, connection, consumer, blueprint, hub, qos,
     _enable_amqheartbeats(hub.timer, connection, rate=hbrate)
 
     consumer.on_message = on_task_received
-    consumer.consume()
-    obj.on_ready()
     obj.controller.register_with_event_loop(hub)
     obj.register_with_event_loop(hub)
+    consumer.consume()
+    obj.on_ready()
 
     # did_start_ok will verify that pool processes were able to start,
     # but this will only work the first time we start, as


### PR DESCRIPTION
Fixes #3620.

I want to still add a new test to cover this issue.