### PR TITLE
Avoid duplicating chains in chords

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -231,3 +231,4 @@ Alejandro Pernin, 2016/12/23
 Yuval Shalev, 2016/12/27
 Morgan Doocy, 2017/01/02
 Arcadiy Ivanov, 2017/01/08
+Ryan Hiebert, 2017/01/20

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1282,6 +1282,9 @@ class chord(Signature):
             group_id=group_id, chord=body, root_id=root_id).results
         bodyres = body.freeze(task_id, root_id=root_id)
 
+        # Chains should not be passed to the header tasks. See #3771
+        options.pop('chain', None)
+
         parent = app.backend.apply_chord(
             header, partial_args, group_id, body,
             interval=interval, countdown=countdown,


### PR DESCRIPTION
When a chord receives a chain to run, that chain should be given to the body, but not to the header, or else the chain will end up being run by every task in the header group, as well as by the body.

Fixes #3771
