### PR TITLE
Cache pip installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: required
-cache: false
+cache: pip
 python:
   - '2.7'
   - '3.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: required
 cache: pip
-
 python:
   - '2.7'
   - '3.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: required
 cache: pip
+
 python:
   - '2.7'
   - '3.4'


### PR DESCRIPTION
Perhaps caching pip installs would be a good speed up, it was set to `false` back in 2015 with the [following comment](https://github.com/celery/celery/commit/fe33f16e014611ee7267081b3380b5a0003faf78#commitcomment-17886249):

`The cache will probably make it faster, but caching in pip often cause trouble. Sadly I don't remember exactly why, maybe it refused to upgrade some version or similar?`

I've personally not seen this problem, let's see if it speeds the tests up at all.