### PR TITLE
Update documentation link

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -6,7 +6,7 @@
 # :Usage: /etc/init.d/celeryd {start|stop|force-reload|restart|try-restart|status}
 # :Configuration file: /etc/default/celeryd
 #
-# See http://docs.celeryproject.org/en/latest/tutorials/daemonizing.html#generic-init-scripts
+# See http://docs.celeryproject.org/en/latest/userguide/daemonizing.html
 
 
 ### BEGIN INIT INFO


### PR DESCRIPTION
Old link (http://docs.celeryproject.org/en/latest/tutorials/daemonizing.html#generic-init-scripts) is giving a message of "SORRY This page does not exist yet. After searching round from the docs index, the .../userguide/daemonizing.html URL seems the most appropriate

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
