### PR TITLE
Fix CELERYBEAT_LOG_FILE replacement option typo

### DIFF
--- a/docs/whatsnew-4.0.rst
+++ b/docs/whatsnew-4.0.rst
@@ -2286,7 +2286,7 @@ Logging Settings
 ``CELERYD_LOG_LEVEL``                  :option:`celery worker --loglevel`
 ``CELERYD_LOG_FILE``                   :option:`celery worker --logfile`
 ``CELERYBEAT_LOG_LEVEL``               :option:`celery beat --loglevel`
-``CELERYBEAT_LOG_FILE``                :option:`celery beat --loglevel`
+``CELERYBEAT_LOG_FILE``                :option:`celery beat --logfile`
 ``CELERYMON_LOG_LEVEL``                celerymon is deprecated, use flower
 ``CELERYMON_LOG_FILE``                 celerymon is deprecated, use flower
 ``CELERYMON_LOG_FORMAT``               celerymon is deprecated, use flower


### PR DESCRIPTION
The CELERYBEAT_LOG_FILE was set to be replaced with `celery beat --loglevel`. It should be `celery beat --logfile`
