### PR TITLE
Populate heap when periodic tasks are changed

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -284,7 +284,6 @@ class Scheduler(object):
         return min(adjust(next_time_to_run) or max_interval, max_interval)
 
     def schedules_equal(self, a, b):
-        print('----------SCHEDULES EQUAL----------------')
         if a.keys() != b.keys():
             return False
         for name, model in a.items():

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -291,9 +291,7 @@ class Scheduler(object):
             b_model = b.get(name)
             if not b_model:
                 return False
-            if hasattr(model.crontab, '__repr__') and  model.crontab.__repr__() != b_model.crontab.__repr__():
-                return False
-            if hasattr(model.schedule, "human_seconds") and model.schedule.human_seconds != b_model.schedule.human_seconds:
+            if hasattr(model.schedule, '__repr__') and model.schedule.__repr__() != b_model.schedule.__repr__():
                 return False
         return True
 

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -197,6 +197,7 @@ class Scheduler(object):
                              self.max_interval)
         self.Producer = Producer or app.amqp.Producer
         self._heap = None
+        self.old_schedulers = None
         self.sync_every_tasks = (
             app.conf.beat_sync_every if sync_every_tasks is None
             else sync_every_tasks)
@@ -257,7 +258,8 @@ class Scheduler(object):
         adjust = self.adjust
         max_interval = self.max_interval
 
-        if self._heap is None:
+        if self._heap is None or not self.schedules_equal(self.old_schedulers, self.schedule):
+            self.old_schedulers = self.schedule
             self.populate_heap()
 
         H = self._heap
@@ -280,6 +282,20 @@ class Scheduler(object):
                 heappush(H, verify)
                 return min(verify[0], max_interval)
         return min(adjust(next_time_to_run) or max_interval, max_interval)
+
+    def schedules_equal(self, a, b):
+        if a.keys() != b.keys():
+            return False
+        for name, model in a.items():
+            b_model = b.get(name)
+            if not b_model:
+                return False
+            if not hasattr(model.schedule, "human_seconds"):
+                # Not checking crontabs
+                continue
+            if model.schedule.human_seconds != b_model.schedule.human_seconds:
+                return False
+        return True
 
     def should_sync(self):
         return (

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -284,6 +284,7 @@ class Scheduler(object):
         return min(adjust(next_time_to_run) or max_interval, max_interval)
 
     def schedules_equal(self, a, b):
+        print('----------SCHEDULES EQUAL----------------')
         if a.keys() != b.keys():
             return False
         for name, model in a.items():
@@ -291,6 +292,10 @@ class Scheduler(object):
             if not b_model:
                 return False
             if not hasattr(model.schedule, "human_seconds"):
+                print('--------------------------')
+                print(model)
+                print(b_model)
+                print('------------------------')
                 # Not checking crontabs
                 continue
             if model.schedule.human_seconds != b_model.schedule.human_seconds:

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -291,14 +291,9 @@ class Scheduler(object):
             b_model = b.get(name)
             if not b_model:
                 return False
-            if not hasattr(model.schedule, "human_seconds"):
-                print('--------------------------')
-                print(model)
-                print(b_model)
-                print('------------------------')
-                # Not checking crontabs
-                continue
-            if model.schedule.human_seconds != b_model.schedule.human_seconds:
+            if hasattr(model.crontab, '__repr__') and  model.crontab.__repr__() != b_model.crontab.__repr__():
+                return False
+            if hasattr(model.schedule, "human_seconds") and model.schedule.human_seconds != b_model.schedule.human_seconds:
                 return False
         return True
 


### PR DESCRIPTION

## Description

Checks if the heap is valid. If there are changes in scheduled tasks the heap is populated again.

Fixes [7](https://github.com/celery/django-celery-beat/issues/7)