### PR TITLE
Chord does not clean up subscribed channels in redis. Fixes #3812

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -286,6 +286,10 @@ class RedisBackend(base.BaseKeyValueStoreBackend, async.AsyncBackendMixin):
                         callback,
                         ChordError('Callback error: {0!r}'.format(exc)),
                     )
+                finally:
+                    task_ids = [decode(tup)[1] for tup in resl]
+                    for task_id in task_ids:
+                        self.result_consumer.cancel_for(task_id)
         except ChordError as exc:
             logger.exception('Chord %r raised: %r', request.group, exc)
             return self.chord_error_from_stack(callback, exc)

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -13,8 +13,11 @@ def add(x, y):
     return x + y
 
 @shared_task
-def sum_(numbers):
+def delayed_sum(numbers, pause_time=1):
     """Sum the iterable of numbers."""
+    # Allow the task to be in STARTED state for
+    # a limited period of time.
+    sleep(pause_time)
     return sum(numbers)
 
 @shared_task(bind=True)

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -12,6 +12,10 @@ def add(x, y):
     """Add two numbers."""
     return x + y
 
+@shared_task
+def sum_(numbers):
+    """Sum the iterable of numbers."""
+    return sum(numbers)
 
 @shared_task(bind=True)
 def add_replaced(self, x, y):

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -4,8 +4,8 @@ from celery import chain, chord, group
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult, GroupResult
 from .conftest import flaky
-from .tasks import add, add_replaced, add_to_all, \
-    collect_ids, ids, sum_
+from .tasks import add, add_replaced, add_to_all, collect_ids, ids
+from .tasks import sum_
 
 TIMEOUT = 120
 

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -4,7 +4,8 @@ from celery import chain, chord, group
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult, GroupResult
 from .conftest import flaky
-from .tasks import add, add_replaced, add_to_all, collect_ids, ids
+from .tasks import add, add_replaced, add_to_all, \
+    collect_ids, ids, sum_
 
 TIMEOUT = 120
 

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1,10 +1,5 @@
 from __future__ import absolute_import, unicode_literals
-from time import sleep
 import pytest
-try:
-    import redis
-except ImportError:
-    redis = None
 from celery import chain, chord, group
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult, GroupResult
@@ -95,8 +90,12 @@ class test_chord:
 
     @flaky
     def test_redis_subscribed_channels_leak(self, manager):
+        from time import sleep
+        import redis
+        
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
+
         redis_client = redis.StrictRedis()
         async_result = chord([add.s(5, 6), add.s(6, 7)])(sum_.s())
         for _ in range(TIMEOUT / 2):

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -5,7 +5,6 @@ from celery.exceptions import TimeoutError
 from celery.result import AsyncResult, GroupResult
 from .conftest import flaky
 from .tasks import add, add_replaced, add_to_all, collect_ids, ids
-from .tasks import sum_
 
 TIMEOUT = 120
 
@@ -93,6 +92,7 @@ class test_chord:
     def test_redis_subscribed_channels_leak(self, manager):
         from time import sleep
         import redis
+        from .tasks import sum_
         
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -92,17 +92,17 @@ class test_chord:
     def test_redis_subscribed_channels_leak(self, manager):
         from time import sleep
         import redis
-        from .tasks import sum_
+        from .tasks import delayed_sum
         
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
 
         redis_client = redis.StrictRedis()
         async_result = chord([add.s(5, 6), add.s(6, 7)])(sum_.s())
-        for _ in range(TIMEOUT / 2):
+        for _ in range(TIMEOUT):
             if async_result.state == 'STARTED':
                 break
-            sleep(1)
+            sleep(0.2)
         channels_before = \
             len(redis_client.execute_command('PUBSUB CHANNELS'))
         assert async_result.get(timeout=TIMEOUT) == 24

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -98,7 +98,7 @@ class test_chord:
             raise pytest.skip('Requires redis result backend.')
 
         redis_client = redis.StrictRedis()
-        async_result = chord([add.s(5, 6), add.s(6, 7)])(sum_.s())
+        async_result = chord([add.s(5, 6), add.s(6, 7)])(delayed_sum.s())
         for _ in range(TIMEOUT):
             if async_result.state == 'STARTED':
                 break

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1,5 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+from time import sleep
 import pytest
+try:
+    import redis
+except ImportError:
+    redis = None
 from celery import chain, chord, group
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult, GroupResult
@@ -88,6 +93,23 @@ def assert_ids(r, expected_value, expected_root_id, expected_parent_id):
 
 class test_chord:
 
+    @flaky
+    def test_redis_subscribed_channels_leak(self, manager):
+        if not manager.app.conf.result_backend.startswith('redis'):
+            raise pytest.skip('Requires redis result backend.')
+        redis_client = redis.StrictRedis()
+        async_result = chord([add.s(5, 6), add.s(6, 7)])(sum_.s())
+        for _ in range(TIMEOUT / 2):
+            if async_result.state == 'STARTED':
+                break
+            sleep(1)
+        channels_before = \
+            len(redis_client.execute_command('PUBSUB CHANNELS'))
+        assert async_result.get(timeout=TIMEOUT) == 24
+        channels_after = \
+            len(redis_client.execute_command('PUBSUB CHANNELS'))
+        assert channels_after < channels_before
+    
     @flaky
     def test_group_chain(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -318,7 +318,7 @@ class test_RedisBackend:
             call(jkey, 86400), call(tkey, 86400),
         ])
         self.b.result_consumer._pubsub.unsubscribe.assert_has_calls([
-           call(self.b.get_key_for_task(task.request.id)) for task in tasks
+            call(self.b.get_key_for_task(task.request.id)) for task in tasks
         ])
 
     def test_on_chord_part_return__success(self):

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -304,6 +304,7 @@ class test_RedisBackend:
     @patch('celery.result.GroupResult.restore')
     def test_on_chord_part_return(self, restore):
         tasks = [self.create_task() for i in range(10)]
+        self.b.result_consumer.start(tasks[0].request.id)
 
         for i in range(10):
             self.b.on_chord_part_return(tasks[i].request, states.SUCCESS, i)
@@ -315,6 +316,9 @@ class test_RedisBackend:
         self.b.client.delete.assert_has_calls([call(jkey), call(tkey)])
         self.b.client.expire.assert_has_calls([
             call(jkey, 86400), call(tkey, 86400),
+        ])
+        self.b.result_consumer._pubsub.unsubscribe.assert_has_calls([
+           call(self.b.get_key_for_task(task.request.id)) for task in tasks
         ])
 
     def test_on_chord_part_return__success(self):


### PR DESCRIPTION
This pull requests fixes issue, when chord gets result for subtasks, but does not do `UNSUBSCRIBE` command for them.

**What does this patch fix**:

Without this patch `chord(task() for i in range(50))` creates 51 subscriptions. After patch it will create 1

**What this patch does not fix**:

Every task, which result is not consumed, creates redis subscription. Even if `ignore_result` is specified. I plan to submit separate patch for this issue

I think, that changing old slow redis behavior to new fast and broken was not a good idea, but as soon as choice made, we need to make it usable