### PR TITLE
Handle ignore_result

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -690,7 +690,7 @@ class Celery(object):
                   add_to_parent=True, group_id=None, retries=0, chord=None,
                   reply_to=None, time_limit=None, soft_time_limit=None,
                   root_id=None, parent_id=None, route_name=None,
-                  shadow=None, chain=None, task_type=None, **options):
+                  shadow=None, chain=None, task_type=None, ignore_result=False, **options):
         """Send task by name.
 
         Supports the same arguments as :meth:`@-Task.apply_async`.
@@ -733,7 +733,8 @@ class Celery(object):
             producer = amqp.Producer(connection, auto_declare=False)
         with self.producer_or_acquire(producer) as P:
             with P.connection._reraise_as_library_errors():
-                self.backend.on_task_call(P, task_id)
+                if not ignore_result:
+                    self.backend.on_task_call(P, task_id)
                 amqp.send_task_message(P, name, message, **options)
         result = (result_cls or self.AsyncResult)(task_id)
         if add_to_parent:

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -532,7 +532,7 @@ class Task(object):
         return app.send_task(
             self.name, args, kwargs, task_id=task_id, producer=producer,
             link=link, link_error=link_error, result_cls=self.AsyncResult,
-            shadow=shadow, task_type=self,
+            shadow=shadow, task_type=self, ignore_result=getattr(self, 'ignore_result', False),
             **options
         )
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Currently (according to my checks and code grep) ignore_result option is a stub, it does nothing. This patch skips backend calls for tasks with `ignore_result=True`

This is needed to minimize effect of broken redis backend support