### PR TITLE
Removing last references to task_method

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -37,7 +37,6 @@ extract_exec_options = mattrgetter(
 # We take __repr__ very seriously around here ;)
 R_BOUND_TASK = '<class {0.__name__} of {app}{flags}>'
 R_UNBOUND_TASK = '<unbound {0.__name__}{flags}>'
-R_SELF_TASK = '<@task {0.name} bound to other {0.__self__}>'
 R_INSTANCE = '<@task: {0.name} of {app}{flags}>'
 
 #: Here for backwards compatibility as tasks no longer use a custom meta-class.
@@ -159,9 +158,6 @@ class Task(object):
 
     #: Request class used, or the qualified name of one.
     Request = 'celery.worker.request:Request'
-
-    #: This is the instance bound to if the task is a method of a class.
-    __self__ = None
 
     #: The application instance associated with this task class.
     _app = None
@@ -376,9 +372,6 @@ class Task(object):
         _task_stack.push(self)
         self.push_request(args=args, kwargs=kwargs)
         try:
-            # add self if this is a bound task
-            if self.__self__ is not None:
-                return self.run(self.__self__, *args, **kwargs)
             return self.run(*args, **kwargs)
         finally:
             self.pop_request()
@@ -524,11 +517,8 @@ class Task(object):
             with denied_join_result():
                 return self.apply(args, kwargs, task_id=task_id or uuid(),
                                   link=link, link_error=link_error, **options)
-        # add 'self' if this is a "task_method".
-        if self.__self__ is not None:
-            args = args if isinstance(args, tuple) else tuple(args or ())
-            args = (self.__self__,) + args
-            shadow = shadow or self.shadow_name(args, kwargs, options)
+            return self.apply(args, kwargs, task_id=task_id or uuid(),
+                              link=link, link_error=link_error, **options)
 
         preopts = self._get_exec_options()
         options = dict(preopts, **options) if options else preopts
@@ -712,9 +702,6 @@ class Task(object):
 
         app = self._get_app()
         args = args or ()
-        # add 'self' if this is a bound method.
-        if self.__self__ is not None:
-            args = (self.__self__,) + tuple(args)
         kwargs = kwargs or {}
         task_id = task_id or uuid()
         retries = retries or 0
@@ -976,7 +963,7 @@ class Task(object):
 
     def __repr__(self):
         """``repr(task)``."""
-        return _reprtask(self, R_SELF_TASK if self.__self__ else R_INSTANCE)
+        return _reprtask(self, R_INSTANCE)
 
     def _get_request(self):
         """Get current request object."""

--- a/celery/utils/dispatch/signal.py
+++ b/celery/utils/dispatch/signal.py
@@ -34,7 +34,7 @@ def _make_id(target):  # pragma: no cover
         # see Issue #2475
         return target
     if hasattr(target, '__func__'):
-        return (id(target.__self__), id(target.__func__))
+        return id(target.__func__)
     return id(target)
 
 
@@ -182,15 +182,6 @@ class Signal(object):  # pragma: no cover
         if weak:
             ref = weakref.ref
             receiver_object = receiver
-            # Check for bound methods
-            try:
-                receiver.__self__
-                receiver.__func__
-            except AttributeError:
-                pass
-            else:
-                ref = WeakMethod
-                receiver_object = receiver.__self__
             if PY3:
                 receiver = ref(receiver)
                 weakref.finalize(receiver_object, self._remove_receiver)

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -494,24 +494,6 @@ class test_App:
         i.annotate()
         i.annotate()
 
-    def test_apply_async_has__self__(self):
-        @self.app.task(__self__='hello', shared=False)
-        def aawsX(x, y):
-            pass
-
-        with pytest.raises(TypeError):
-            aawsX.apply_async(())
-        with pytest.raises(TypeError):
-            aawsX.apply_async((2,))
-
-        with patch('celery.app.amqp.AMQP.create_task_message') as create:
-            with patch('celery.app.amqp.AMQP.send_task_message') as send:
-                create.return_value = Mock(), Mock(), Mock(), Mock()
-                aawsX.apply_async((4, 5))
-                args = create.call_args[0][2]
-                assert args, ('hello', 4 == 5)
-                send.assert_called()
-
     def test_apply_async_adds_children(self):
         from celery._state import _task_stack
 

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -605,16 +605,6 @@ class test_tasks(TasksCase):
         self.mytask.__v2_compat__ = True
         assert 'v2 compatible' in repr(self.mytask)
 
-    def test_apply_with_self(self):
-
-        @self.app.task(__self__=42, shared=False)
-        def tawself(self):
-            return self
-
-        assert tawself.apply().get() == 42
-
-        assert tawself() == 42
-
     def test_context_get(self):
         self.mytask.push_request()
         try:


### PR DESCRIPTION
AFAICT the code removed in this PR only served to support the
(now-removed) celery.contrib.methods.task_method() function.