### PR TITLE
Bugfix: IndexError raised when chord has an empty header

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1337,7 +1337,8 @@ class chord(Signature):
                 tasks = self.tasks.tasks  # is a group
             except AttributeError:
                 tasks = self.tasks
-            app = tasks[0]._app
+            if len(tasks):
+                app = tasks[0]._app
             if app is None and body is not None:
                 app = body._app
         return app if app is not None else current_app

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -607,6 +607,10 @@ class test_chord(CanvasCase):
         x = chord([t1], body=t2)
         assert x.app is t2._app
 
+    def test_app_when_header_is_empty(self):
+        x = chord([], self.add.s(4, 4))
+        assert x.app is self.add.app
+
     @pytest.mark.usefixtures('depends_on_current_app')
     def test_app_fallback_to_current(self):
         from celery._state import current_app


### PR DESCRIPTION
Given that a chord has an empty list for a header, an unhandled IndexError is raised as the `_get_app` tries to access element `[0]` of an empty list.

To support / gracefully handle chords without any signatures in the header, check that there are in fact elements in the list before accessing; otherwise, use the body task to find the app.