### PR TITLE
celery.beat.Scheduler: fix _when to make tz-aware (#3851)

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -28,7 +28,7 @@ from .five import (
 )
 from .schedules import maybe_schedule, crontab
 from .utils.imports import load_extension_class_names, symbol_by_name
-from .utils.time import humanize_seconds
+from .utils.time import humanize_seconds, maybe_make_aware
 from .utils.log import get_logger, iter_open_logger_fds
 
 __all__ = [
@@ -235,8 +235,8 @@ class Scheduler(object):
     def _when(self, entry, next_time_to_run, mktime=time.mktime):
         adjust = self.adjust
 
-        return (mktime(entry.schedule.now().timetuple()) +
-                (adjust(next_time_to_run) or 0))
+        now = maybe_make_aware(entry.schedule.now())
+        return (mktime(now.timetuple()) + (adjust(next_time_to_run) or 0))
 
     def populate_heap(self, event_t=event_t, heapify=heapq.heapify):
         """Populate the heap with the data contained in the schedule."""


### PR DESCRIPTION
Fixes #3851

