### PR TITLE
Fixed a bug in Python 3.5: Serialization of CouchDB key in set method.

### DIFF
--- a/celery/backends/couchdb.py
+++ b/celery/backends/couchdb.py
@@ -82,7 +82,7 @@ class CouchBackend(KeyValueStoreBackend):
             return None
 
     def set(self, key, value):
-        data = {'_id': key, 'value': value}
+        data = {'_id': key.decode('ascii'), 'value': value}
         try:
             self.connection.save(data)
         except pycouchdb.exceptions.Conflict:


### PR DESCRIPTION
Hello,

In Python 3.5, the couchdb backend 4.0.2 has in bug in its set method.

The code works in Python 2.

This is what happens when I use the backend for the "First steps with Celery" tutorial:
TypeError: b'celery-task-meta-c50dad53-29b5-4cd7-9a64-1e6089e71c81' is not JSON serializable

In backends/couchdb.py, the key parameter is a bytes instead of a string. Thus, it cannot be serialize.

Decoding the key with ASCII codec fixed the bug.

Since I don't know the reason to why key is a bytes, please double check that this is indeed the right fix.

