### PR TITLE
Fix URLs to userguide/daemonizing docs

### DIFF
--- a/extra/generic-init.d/celerybeat
+++ b/extra/generic-init.d/celerybeat
@@ -6,7 +6,7 @@
 # :Usage: /etc/init.d/celerybeat {start|stop|force-reload|restart|try-restart|status}
 # :Configuration file: /etc/default/celerybeat or /etc/default/celeryd
 #
-# See http://docs.celeryproject.org/en/latest/tutorials/daemonizing.html#generic-init-scripts
+# See http://docs.celeryproject.org/en/latest/userguide/daemonizing.html#generic-init-scripts
 
 ### BEGIN INIT INFO
 # Provides:          celerybeat

--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -6,7 +6,7 @@
 # :Usage: /etc/init.d/celeryd {start|stop|force-reload|restart|try-restart|status}
 # :Configuration file: /etc/default/celeryd (or /usr/local/etc/celeryd on BSD)
 #
-# See http://docs.celeryproject.org/en/latest/tutorials/daemonizing.html#generic-init-scripts
+# See http://docs.celeryproject.org/en/latest/userguide/daemonizing.html#generic-init-scripts
 
 
 ### BEGIN INIT INFO

--- a/extra/systemd/celery.conf
+++ b/extra/systemd/celery.conf
@@ -1,5 +1,5 @@
 # See
-# http://docs.celeryproject.org/en/latest/tutorials/daemonizing.html#available-options
+# http://docs.celeryproject.org/en/latest/userguide/daemonizing.html#usage-systemd
 
 CELERY_APP="proj"
 CELERYD_NODES="worker"


### PR DESCRIPTION
Relates to https://github.com/celery/celery/commit/36e8e3bd2ddd0d6f318113f869a3d09be35e4342.