### PR TITLE
Resolves reply_to issue #3848 for rpc backend

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -733,7 +733,7 @@ class Celery(object):
             producer = amqp.Producer(connection, auto_declare=False)
         with self.producer_or_acquire(producer) as P:
             with P.connection._reraise_as_library_errors():
-                self.backend.on_task_call(P, task_id)
+                self.backend.on_task_call(P, task_id, reply_to)
                 amqp.send_task_message(P, name, message, **options)
         result = (result_cls or self.AsyncResult)(task_id)
         if add_to_parent:

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -32,7 +32,8 @@ __all__ = ['Context', 'Task']
 extract_exec_options = mattrgetter(
     'queue', 'routing_key', 'exchange', 'priority', 'expires',
     'serializer', 'delivery_mode', 'compression', 'time_limit',
-    'soft_time_limit', 'immediate', 'mandatory',  # imm+man is deprecated
+    'soft_time_limit', 'immediate', 'mandatory', 'reply_to',
+    # imm+man is deprecated
 )
 
 # We take __repr__ very seriously around here ;)

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -401,7 +401,7 @@ class Backend(object):
         """Cleanup actions to do at the end of a task worker process."""
         pass
 
-    def on_task_call(self, producer, task_id):
+    def on_task_call(self, producer, task_id, reply_to=None):
         return {}
 
     def add_to_chord(self, chord_id, result):

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -175,7 +175,7 @@ class RedisBackend(base.BaseKeyValueStoreBackend, async.AsyncBackendMixin):
         connparams.update(query)
         return connparams
 
-    def on_task_call(self, producer, task_id):
+    def on_task_call(self, producer, task_id, reply_to=None):
         if not task_join_will_block():
             self.result_consumer.consume_from(task_id)
 


### PR DESCRIPTION
## Description

Fixes #3848 issue caused by ``app.send_task`` method not propagating ``reply_to`` parameter to the ``amqp.create_task_message``. 

Apart from that, there was a problem with creating queue to reply to. Class ``celery.backends.rpc.RPCBackend`` creates a queue in the ``on_task_call`` method. In order to make backend create a queue with required name instead of ``app.oid``, I had to pass 
 ``reply_to`` parameter to the ``on_task_call`` method and I am not sure if it is right solution. This class also has the ``destination_for`` method which retrieves ``reply_to`` value from request, but if I get it right, it is called by a worker when a queue has already been created, i.e. it does not fit for tackling this issue.