### PR TITLE
Fix grammar, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 *.egg-info
 *.egg
 *.egg/
+*.eggs/
 build/
 .build/
 _build/

--- a/celery/contrib/abortable.py
+++ b/celery/contrib/abortable.py
@@ -107,7 +107,7 @@ ABORTED = 'ABORTED'
 
 
 class AbortableAsyncResult(AsyncResult):
-    """Represents a abortable result.
+    """Represents an abortable result.
 
     Specifically, this gives the `AsyncResult` a :meth:`abort()` method,
     that sets the state of the underlying Task to `'ABORTED'`.

--- a/examples/django/proj/celery.py
+++ b/examples/django/proj/celery.py
@@ -7,7 +7,7 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings')
 
 app = Celery('proj')
 
-# Using a string here means the worker don't have to serialize
+# Using a string here means the worker doesn't have to serialize
 # the configuration object to child processes.
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.


### PR DESCRIPTION
## Description
Just a couple things I noticed :) Fixed a grammar error that I found here http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html which lead to finding another typo.
Also noticed `.eggs/` wasn't in `.gitignore` so I added it. (It was generated when I ran `make test`, running version `Python 3.6.0 (default, Jan 16 2017, 12:12:55) `