### PR TITLE
Fixes LimitedSets by eliminating hashing ambiguity; refs #3879

### DIFF
--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -9,7 +9,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import sys
-import time
+from celery.five import monotonic
 
 from collections import defaultdict, Mapping, MutableMapping, MutableSet
 from heapq import heapify, heappush, heappop
@@ -580,7 +580,7 @@ class LimitedSet(object):
         self._heap[:] = [(t, key) for key, t in items(self._data)]
         heapify(self._heap)
 
-    def add(self, key, now=time.time, heappush=heappush):
+    def add(self, key, now=monotonic, heappush=heappush):
         """Add a new member."""
         # offset is there to modify the length of the list,
         # this way we can expire an item before inserting the value,
@@ -608,7 +608,7 @@ class LimitedSet(object):
         self._data.pop(value, None)
     pop_value = discard  # XXX compat
 
-    def purge(self, limit=None, offset=0, now=time.time):
+    def purge(self, limit=None, offset=0, now=monotonic):
         """Purge expired items."""
         H, maxlen = self._heap, self.maxlen
         if not maxlen:

--- a/celery/datastructures.py
+++ b/celery/datastructures.py
@@ -569,8 +569,6 @@ class LimitedSet(object):
         self.expires = expires
         self._data = {} if data is None else data
         self._heap = []
-        # Ensures inserts do not become ambiguous
-        self.last_added = 0.0
 
         # make shortcuts
         self.__len__ = self._heap.__len__
@@ -589,14 +587,8 @@ class LimitedSet(object):
         # and it will end up in the correct order.
         self.purge(1, offset=1)
         inserted = now()
-        if inserted <= self.last_added:
-            # Force uniqueness
-            inserted = self.last_added + 1e-6
-
         self._data[key] = inserted
         heappush(self._heap, (inserted, key))
-        # Update our last-inserted time for future reference
-        self.last_added = inserted
 
     def clear(self):
         """Remove all members"""

--- a/celery/tests/utils/test_datastructures.py
+++ b/celery/tests/utils/test_datastructures.py
@@ -4,7 +4,7 @@ import pickle
 import sys
 
 from billiard.einfo import ExceptionInfo
-from time import time
+from celery.five import monotonic
 
 from celery.datastructures import (
     LimitedSet,
@@ -198,18 +198,18 @@ class test_LimitedSet(Case):
         s = LimitedSet(maxlen=None, expires=1)
         [s.add(i) for i in range(10)]
         s.maxlen = 2
-        s.purge(1, now=lambda: time() + 100)
+        s.purge(1, now=lambda: monotonic() + 100)
         self.assertEqual(len(s), 9)
-        s.purge(None, now=lambda: time() + 100)
+        s.purge(None, now=lambda: monotonic() + 100)
         self.assertEqual(len(s), 2)
 
         # not expired
         s = LimitedSet(maxlen=None, expires=1)
         [s.add(i) for i in range(10)]
         s.maxlen = 2
-        s.purge(1, now=lambda: time() - 100)
+        s.purge(1, now=lambda: monotonic() - 100)
         self.assertEqual(len(s), 10)
-        s.purge(None, now=lambda: time() - 100)
+        s.purge(None, now=lambda: monotonic() - 100)
         self.assertEqual(len(s), 10)
 
         s = LimitedSet(maxlen=None)


### PR DESCRIPTION
## Description
I presume this bug is already fixed up stream but can't test it since I'm not using the 4.x or 5.x branch in production. __LimitedSet()__ appears to have ambiguity issues on faster systems that are very easy to reproduce.  You just need to run the test suite.

This patch just ensures that all entries are unique and sequentially stored based on time by adding 1 micro-second to the key (time) entry before storing it in the heap if it shares the same value as the previously inserted one.

This issue Fixes #3879