### PR TITLE
LimitedSets support on faster systems refs #3879 and #3891

### DIFF
--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -575,12 +575,14 @@ class LimitedSet(object):
     def add(self, item, now=None):
         # type: (Any, float) -> None
         """Add a new item, or reset the expiry time of an existing item."""
-        now = now or time.time()
         if item in self._data:
             self.discard(item)
-        if now <= self.last_added:
-            # Force uniqueness
-            now = self.last_added + 1e-6
+        if now is None:
+            # Get time
+            now = time.time()
+            if now <= self.last_added:
+                # Force uniqueness (because we're not a call from update())
+                now = self.last_added + 1e-6
         entry = (now, item)
         self._data[item] = entry
         heappush(self._heap, entry)

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -576,12 +576,6 @@ class LimitedSet(object):
         now = now or monotonic()
         if item in self._data:
             self.discard(item)
-        if now is None:
-            # Get time
-            now = monotonic()
-            if now <= self.last_added:
-                # Force uniqueness (because we're not a call from update())
-                now = self.last_added + 1e-6
         entry = (now, item)
         self._data[item] = entry
         heappush(self._heap, entry)

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -526,7 +526,7 @@ class LimitedSet(object):
         False
         >>> len(s)  # maxlen is reached
         50000
-        >>> s.purge(now=time.time() + 7200)  # clock + 2 hours
+        >>> s.purge(now=monotonic() + 7200)  # clock + 2 hours
         >>> len(s)  # now only minlen items are cached
         4000
         >>>> 57000 in s  # even this item is gone now

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -542,6 +542,8 @@ class LimitedSet(object):
         self.expires = 0 if expires is None else expires
         self._data = {}
         self._heap = []
+        # Ensures inserts do not become ambiguous
+        self.last_added = 0.0
 
         if data:
             # import items from data
@@ -576,9 +578,14 @@ class LimitedSet(object):
         now = now or time.time()
         if item in self._data:
             self.discard(item)
+        if inserted <= self.last_added:
+            # Force uniqueness
+            inserted = self.last_added + 1e-6
         entry = (now, item)
         self._data[item] = entry
         heappush(self._heap, entry)
+        # Update our last-inserted time for future reference
+        self.last_added = inserted
         if self.maxlen and len(self._data) >= self.maxlen:
             self.purge()
 

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import sys
-import time
+from celery.five import monotonic
 
 from collections import (
     Callable, Mapping, MutableMapping, MutableSet, Sequence,
@@ -579,7 +579,7 @@ class LimitedSet(object):
             self.discard(item)
         if now is None:
             # Get time
-            now = time.time()
+            now = monotonic()
             if now <= self.last_added:
                 # Force uniqueness (because we're not a call from update())
                 now = self.last_added + 1e-6
@@ -633,7 +633,7 @@ class LimitedSet(object):
             now (float): Time of purging -- by default right now.
                 This can be useful for unit testing.
         """
-        now = now or time.time()
+        now = now or monotonic()
         now = now() if isinstance(now, Callable) else now
         if self.maxlen:
             while len(self._data) > self.maxlen:

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -578,14 +578,14 @@ class LimitedSet(object):
         now = now or time.time()
         if item in self._data:
             self.discard(item)
-        if inserted <= self.last_added:
+        if now <= self.last_added:
             # Force uniqueness
-            inserted = self.last_added + 1e-6
+            now = self.last_added + 1e-6
         entry = (now, item)
         self._data[item] = entry
         heappush(self._heap, entry)
         # Update our last-inserted time for future reference
-        self.last_added = inserted
+        self.last_added = now
         if self.maxlen and len(self._data) >= self.maxlen:
             self.purge()
 

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -5,7 +5,7 @@ import pytest
 
 from collections import Mapping
 from itertools import count
-from time import time
+from celery.five import monotonic
 
 from case import skip
 from billiard.einfo import ExceptionInfo
@@ -198,21 +198,21 @@ class test_LimitedSet:
         s = LimitedSet(maxlen=10, expires=1)
         [s.add(i) for i in range(10)]
         s.maxlen = 2
-        s.purge(now=time() + 100)
+        s.purge(now=monotonic() + 100)
         assert len(s) == 0
 
         # not expired
         s = LimitedSet(maxlen=None, expires=1)
         [s.add(i) for i in range(10)]
         s.maxlen = 2
-        s.purge(now=lambda: time() - 100)
+        s.purge(now=lambda: monotonic() - 100)
         assert len(s) == 2
 
         # expired -> minsize
         s = LimitedSet(maxlen=10, minlen=10, expires=1)
         [s.add(i) for i in range(20)]
         s.minlen = 3
-        s.purge(now=time() + 3)
+        s.purge(now=monotonic() + 3)
         assert s.minlen == len(s)
         assert len(s._heap) <= s.maxlen * (
             100. + s.max_heap_percent_overload) / 100
@@ -293,7 +293,7 @@ class test_LimitedSet:
 
     def test_iterable_and_ordering(self):
         s = LimitedSet(maxlen=35, expires=None)
-        # we use a custom clock here, as time.time() does not have enough
+        # we use a custom clock here, as monotonic() does not have enough
         # precision when called quickly (can return the same value twice).
         clock = count(1)
         for i in reversed(range(15)):

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -293,8 +293,6 @@ class test_LimitedSet:
 
     def test_iterable_and_ordering(self):
         s = LimitedSet(maxlen=35, expires=None)
-        # we use a custom clock here, as monotonic() does not have enough
-        # precision when called quickly (can return the same value twice).
         clock = count(1)
         for i in reversed(range(15)):
             s.add(i, now=next(clock))


### PR DESCRIPTION
## Description
 __LimitedSet()__ appears to have ambiguity issues on faster systems that are very easy to reproduce.  You just need to run the test suite. I originally just patched the version from the branch I'm using (see #3891) This patch is just for the master as well.

This patch just ensures that all entries are unique and sequentially stored based on time by adding 1 micro-second to the key (time) entry before storing it in the heap if it shares the same value as the previously inserted one.

This issue Fixes #3879