### PR TITLE
Document rate limit and ETA incompatibilities

### DIFF
--- a/docs/internals/worker.rst
+++ b/docs/internals/worker.rst
@@ -38,6 +38,10 @@ When a message is received it's converted into a
 Tasks with an ETA, or rate-limit are entered into the `timer`,
 messages that can be immediately processed are sent to the execution pool.
 
+ETA and rate-limit are 2 incompatible parameters, and the ETA is overriding
+the rate-limit by default. A task with both will follow its ETA and ignore its
+rate-limit.
+
 Timer
 -----
 

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -856,6 +856,10 @@ General
     maximum number of  requests per second), you must restrict to a given
     queue.
 
+    .. note::
+
+        This attribute is ignored if the task is requested with an ETA.
+
 .. attribute:: Task.time_limit
 
     The hard time limit, in seconds, for this task.


### PR DESCRIPTION
## Description

Document `Task.rate_limit` is incompatible with the request ETA.

Fixes #3888

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
