### PR TITLE
Allow unicode message for exception raised in task

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -29,7 +29,7 @@ from celery._state import get_current_task
 from celery.exceptions import (
     ChordError, TimeoutError, TaskRevokedError, ImproperlyConfigured,
 )
-from celery.five import items
+from celery.five import items, string
 from celery.result import (
     GroupResult, ResultBase, allow_join_result, result_from_tuple,
 )
@@ -237,7 +237,7 @@ class Backend(object):
         serializer = self.serializer if serializer is None else serializer
         if serializer in EXCEPTION_ABLE_CODECS:
             return get_pickleable_exception(exc)
-        return {'exc_type': type(exc).__name__, 'exc_message': str(exc)}
+        return {'exc_type': type(exc).__name__, 'exc_message': string(exc)}
 
     def exception_to_python(self, exc):
         """Convert serialized exception to Python exception."""

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -139,6 +139,11 @@ class test_prepare_exception:
         y = self.b.exception_to_python(x)
         assert isinstance(y, KeyError)
 
+    def test_unicode_message(self):
+        message = u'\u03ac'
+        x = self.b.prepare_exception(Exception(message))
+        assert x == {'exc_message': message, 'exc_type': 'Exception'}
+
 
 class KVBackend(KeyValueStoreBackend):
     mget_returns_dict = False


### PR DESCRIPTION
## Description

- [x] Allow unicode task exception messages, adding also Python 2/3 compatibility.
- [x] Add unit test case to verify fix and avoid regression.

Fixes #3858.