### PR TITLE
Failling with KeyError if inner chord consists of one task (Fixes #3885)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -231,3 +231,4 @@ Alejandro Pernin, 2016/12/23
 Yuval Shalev, 2016/12/27
 Morgan Doocy, 2017/01/02
 Arcadiy Ivanov, 2017/01/08
+Robert Pogorzelski, 2017/03/13

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1239,7 +1239,11 @@ class chord(Signature):
         if len(self.tasks) == 1:
             # chord([A], B) can be optimized as A | B
             # - Issue #3323
-            return (self.tasks[0] | body).set(task_id=task_id).apply_async(
+            try:
+                task = self.tasks[0]
+            except KeyError:
+                task = self.tasks.tasks[0]
+            return (task | body).set(task_id=task_id).apply_async(
                 args, kwargs, **options)
         # chord([A, B, ...], C)
         return self.run(tasks, body, args, task_id=task_id, **options)

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -644,6 +644,23 @@ class test_chord(CanvasCase):
         x.tasks = [self.add.s(2, 2)]
         x.freeze()
 
+    def test_apply_async_task_in_chained_chords(self):
+        x = chain(
+            chord([self.add.si(1, 2)], body=self.mul.s(4), app=self.app),
+            chord([self.add.si(3, 4)], body=self.mul.s(4), app=self.app)
+        )
+        x.apply_async()
+
+    def test_apply_async_task_in_nested_chords(self):
+        x = chord(
+            [
+                chord([self.add.si(5, 6)], body=self.mul.s(4), app=self.app),
+            ],
+            body=self.mul.s(4),
+            app=self.app
+        )
+        x.apply_async()
+
 
 class test_maybe_signature(CanvasCase):
 


### PR DESCRIPTION
Tests passing for py.test/develop. I hope the purpose of this change is clear. For example, in the following scenario:
```
    chained = []
    for source in sources:
        tasks, callback = source.process()
        if tasks:
            chained.append(chord(tasks, callback))
    chain(*chained)()
```
worker would exit with KeyError due to (celery/canvas.py):
```
        if len(self.tasks) == 1:
            # chord([A], B) can be optimized as A | B
            # - Issue #3323
            return (self.tasks[0] | body).set(task_id=task_id).apply_async(
                args, kwargs, **options)
        # chord([A, B, ...], C)
        return self.run(tasks, body, args, task_id=task_id, **options)
```