### PR TITLE
Changed default redis_socket_timeout setting value

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -905,7 +905,7 @@ in seconds (int/float)
 ``redis_socket_timeout``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Default: 5.0 seconds.
+Default: 120.0 seconds.
 
 Socket timeout for reading/writing operations to the Redis server
 in seconds (int/float), used by the redis result backend.


### PR DESCRIPTION
According to changes in https://github.com/celery/celery/commit/6d4ff8689b2128a2e95e52857d9e346b1ad9827a

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
