### PR TITLE
elasticsearch: Fix serializing keys

### DIFF
--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -105,6 +105,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
             self._index(key, data, refresh=True)
 
     def _index(self, id, body, **kwargs):
+        body = dict((string(k), v) for k, v in body.items())
         return self.server.index(
             id=string(id),
             index=self.index,

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -3,8 +3,9 @@
 from __future__ import absolute_import, unicode_literals
 from datetime import datetime
 from kombu.utils.url import _parse_url
+from kombu.utils.encoding import bytes_to_str
 from celery.exceptions import ImproperlyConfigured
-from celery.five import string, items
+from celery.five import items
 from .base import KeyValueStoreBackend
 try:
     import elasticsearch
@@ -105,9 +106,9 @@ class ElasticsearchBackend(KeyValueStoreBackend):
             self._index(key, data, refresh=True)
 
     def _index(self, id, body, **kwargs):
-        body = {string(k): v for k, v in items(body)}
+        body = {bytes_to_str(k): v for k, v in items(body)}
         return self.server.index(
-            id=string(id),
+            id=bytes_to_str(id),
             index=self.index,
             doc_type=self.doc_type,
             body=body,

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -105,7 +105,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
             self._index(key, data, refresh=True)
 
     def _index(self, id, body, **kwargs):
-        body = dict((string(k), v) for k, v in body.items())
+        body = {string(k): v for k, v in five.items(body)}
         return self.server.index(
             id=string(id),
             index=self.index,

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from datetime import datetime
 from kombu.utils.url import _parse_url
 from celery.exceptions import ImproperlyConfigured
-from celery.five import string
+from celery.five import string, items
 from .base import KeyValueStoreBackend
 try:
     import elasticsearch
@@ -105,7 +105,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
             self._index(key, data, refresh=True)
 
     def _index(self, id, body, **kwargs):
-        body = {string(k): v for k, v in five.items(body)}
+        body = {string(k): v for k, v in items(body)}
         return self.server.index(
             id=string(id),
             index=self.index,

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 import pytest
 from case import Mock, sentinel, skip
 from celery.app import backends
-from celery.five import string
+from celery.five import PY2
 from celery.backends import elasticsearch as module
 from celery.backends.elasticsearch import ElasticsearchBackend
 from celery.exceptions import ImproperlyConfigured
@@ -117,7 +117,7 @@ class test_ElasticsearchBackend:
         body = {b"field1": "value1"}
         x._index(id=sentinel.task_id, body=body, kwarg1='test1')
         x._server.index.assert_called_once_with(
-            id=string(sentinel.task_id),
+            id=sentinel.task_id if PY2 else sentinel.task_id.decode(),
             doc_type=x.doc_type,
             index=x.index,
             body={"field1": "value1"},

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, unicode_literals
 import pytest
 from case import Mock, sentinel, skip
 from celery.app import backends
-from celery.five import PY2
 from celery.backends import elasticsearch as module
 from celery.backends.elasticsearch import ElasticsearchBackend
 from celery.exceptions import ImproperlyConfigured
@@ -96,7 +95,7 @@ class test_ElasticsearchBackend:
         body = {"field1": "value1"}
         x._index(id=sentinel.task_id, body=body, kwarg1='test1')
         x._server.index.assert_called_once_with(
-            id=sentinel.task_id if PY2 else sentinel.task_id.decode(),
+            id=str(sentinel.task_id),
             doc_type=x.doc_type,
             index=x.index,
             body=body,
@@ -117,7 +116,7 @@ class test_ElasticsearchBackend:
         body = {b"field1": "value1"}
         x._index(id=sentinel.task_id, body=body, kwarg1='test1')
         x._server.index.assert_called_once_with(
-            id=sentinel.task_id if PY2 else sentinel.task_id.decode(),
+            id=str(sentinel.task_id),
             doc_type=x.doc_type,
             index=x.index,
             body={"field1": "value1"},

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -93,7 +93,11 @@ class test_ElasticsearchBackend:
         x._server.index.return_value = expected_result
 
         body = {"field1": "value1"}
-        x._index(id=sentinel.task_id, body=body, kwarg1='test1')
+        x._index(
+            id=str(sentinel.task_id).encode(),
+            body=body,
+            kwarg1='test1'
+        )
         x._server.index.assert_called_once_with(
             id=str(sentinel.task_id),
             doc_type=x.doc_type,
@@ -114,7 +118,11 @@ class test_ElasticsearchBackend:
         x._server.index.return_value = expected_result
 
         body = {b"field1": "value1"}
-        x._index(id=sentinel.task_id, body=body, kwarg1='test1')
+        x._index(
+            id=str(sentinel.task_id).encode(),
+            body=body,
+            kwarg1='test1'
+        )
         x._server.index.assert_called_once_with(
             id=str(sentinel.task_id),
             doc_type=x.doc_type,

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -103,6 +103,27 @@ class test_ElasticsearchBackend:
             kwarg1='test1'
         )
 
+    def test_index_bytes_key(self):
+        x = ElasticsearchBackend(app=self.app)
+        x.doc_type = 'test-doc-type'
+        x._server = Mock()
+        x._server.index = Mock()
+        expected_result = dict(
+            _id=sentinel.task_id,
+            _source={'result': sentinel.result}
+        )
+        x._server.index.return_value = expected_result
+
+        body = {b"field1": "value1"}
+        x._index(id=sentinel.task_id, body=body, kwarg1='test1')
+        x._server.index.assert_called_once_with(
+            id=string(sentinel.task_id),
+            doc_type=x.doc_type,
+            index=x.index,
+            body={"field1": "value1"},
+            kwarg1='test1'
+        )
+
     def test_config_params(self):
         self.app.conf.elasticsearch_max_retries = 10
         self.app.conf.elasticsearch_timeout = 20.0

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -96,7 +96,7 @@ class test_ElasticsearchBackend:
         body = {"field1": "value1"}
         x._index(id=sentinel.task_id, body=body, kwarg1='test1')
         x._server.index.assert_called_once_with(
-            id=string(sentinel.task_id),
+            id=sentinel.task_id if PY2 else sentinel.task_id.decode(),
             doc_type=x.doc_type,
             index=x.index,
             body=body,


### PR DESCRIPTION
## Description
elasticsearch requires keys to be a string, not bytes, so make sure we convert the key to a string. Otherwise, the elasticsearch library raises a TypeError:

```
SerializationError({b'celery-task-meta-1ce4d5c5-8efc-49a8-80fe-7d9ae5e94706': '{"status": "SUCCESS", "result": null, "traceback": null, "children": [], "task_id": "1ce4d5c5-8efc-49a8-80fe-7d9ae5e94706"}', '@timestamp': '2017-03-19T20:26:03.078Z'}, TypeError('keys must be a string',)):
Traceback (most recent call last):
  File "/home/static/flask/.venv/lib/python3.6/site-packages/elasticsearch/serializer.py", line 48, in 
dumps
    return json.dumps(data, default=self.default, ensure_ascii=False)
  File "/usr/lib64/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib64/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib64/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
TypeError: keys must be a string
```

As an aside, this looks like the same issue as https://github.com/celery/celery/pull/3861 so I went ahead and made sure to use your compat layer's `string()` function.

Also made sure this works on python2.7 as well:

```
[04:38:14 PM] static@homefox# python2.7
Python 2.7.13 (default, Dec 21 2016, 07:16:46) 
[GCC 6.2.1 20160830] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> body = {b'a': {'some1': 1, 'some2': 2}}
>>> dict((k.decode('ascii'), v) for k, v in body.items())
{u'a': {'some1': 1, 'some2': 2}}
>>> 
```