### PR TITLE
fix serializing keys  and supports elasticsearch backend options settings

### DIFF
--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -32,8 +32,8 @@ class ElasticsearchBackend(KeyValueStoreBackend):
     scheme = 'http'
     host = 'localhost'
     port = 9200
-    es_retry_on_timeout=False
-    es_timeout=10
+    es_retry_on_timeout = False
+    es_timeout = 10
     es_max_retries = 3
 
     def __init__(self, url=None, *args, **kwargs):
@@ -61,13 +61,14 @@ class ElasticsearchBackend(KeyValueStoreBackend):
         self.es_retry_on_timeout = (
                 _get('elasticsearch_retry_on_timeout') or self.es_retry_on_timeout
                 )
-        self.es_timeout = (
-                _get('elasticsearch_timeout') or self.es_timeout
-                )
 
-        self.es_max_retries = (
-                _get('elasticsearch_max_retries') or self.es_max_retries
-                )
+        es_timeout = _get('elasticsearch_timeout')
+        if es_timeout is not None:
+            self.es_timeout = es_timeout
+
+        es_max_retries = _get('elasticsearch_max_retries')
+        if es_max_retries is not None: 
+            self.es_max_retries = es_max_retries
 
         self._server = None
 

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -32,14 +32,10 @@ class ElasticsearchBackend(KeyValueStoreBackend):
     scheme = 'http'
     host = 'localhost'
     port = 9200
-    es_retry_on_timeout=False
-    es_timeout=10
-    es_max_retries = 3
 
     def __init__(self, url=None, *args, **kwargs):
         super(ElasticsearchBackend, self).__init__(*args, **kwargs)
         self.url = url
-        _get = self.app.conf.get
 
         if elasticsearch is None:
             raise ImproperlyConfigured(E_LIB_MISSING)
@@ -57,17 +53,6 @@ class ElasticsearchBackend(KeyValueStoreBackend):
         self.scheme = scheme or self.scheme
         self.host = host or self.host
         self.port = port or self.port
-
-        self.es_retry_on_timeout = (
-                _get('elasticsearch_retry_on_timeout') or self.es_retry_on_timeout
-                )
-        self.es_timeout = (
-                _get('elasticsearch_timeout') or self.es_timeout
-                )
-
-        self.es_max_retries = (
-                _get('elasticsearch_max_retries') or self.es_max_retries
-                )
 
         self._server = None
 
@@ -120,10 +105,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
 
     def _get_server(self):
         """Connect to the Elasticsearch server."""
-        return elasticsearch.Elasticsearch('%s:%s' % (self.host, self.port), 
-                retry_on_timeout=self.es_retry_on_timeout, 
-                max_retries=self.es_max_retries, 
-                timeout=self.es_timeout)
+        return elasticsearch.Elasticsearch('%s:%s' % (self.host, self.port))
 
     @property
     def server(self):

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from datetime import datetime
 from kombu.utils.url import _parse_url
 from celery.exceptions import ImproperlyConfigured
+from celery.five import string
 from .base import KeyValueStoreBackend
 try:
     import elasticsearch
@@ -104,7 +105,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
 
     def _index(self, id, body, **kwargs):
         return self.server.index(
-            id=id,
+            id=string(id),
             index=self.index,
             doc_type=self.doc_type,
             body=body,

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -89,6 +89,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
 
     def _index(self, id, body, **kwargs):
         return self.server.index(
+            id=id,
             index=self.index,
             doc_type=self.doc_type,
             body=body,

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -32,10 +32,14 @@ class ElasticsearchBackend(KeyValueStoreBackend):
     scheme = 'http'
     host = 'localhost'
     port = 9200
+    es_retry_on_timeout=False
+    es_timeout=10
+    es_max_retries = 3
 
     def __init__(self, url=None, *args, **kwargs):
         super(ElasticsearchBackend, self).__init__(*args, **kwargs)
         self.url = url
+        _get = self.app.conf.get
 
         if elasticsearch is None:
             raise ImproperlyConfigured(E_LIB_MISSING)
@@ -53,6 +57,17 @@ class ElasticsearchBackend(KeyValueStoreBackend):
         self.scheme = scheme or self.scheme
         self.host = host or self.host
         self.port = port or self.port
+
+        self.es_retry_on_timeout = (
+                _get('elasticsearch_retry_on_timeout') or self.es_retry_on_timeout
+                )
+        self.es_timeout = (
+                _get('elasticsearch_timeout') or self.es_timeout
+                )
+
+        self.es_max_retries = (
+                _get('elasticsearch_max_retries') or self.es_max_retries
+                )
 
         self._server = None
 
@@ -105,7 +120,10 @@ class ElasticsearchBackend(KeyValueStoreBackend):
 
     def _get_server(self):
         """Connect to the Elasticsearch server."""
-        return elasticsearch.Elasticsearch('%s:%s' % (self.host, self.port))
+        return elasticsearch.Elasticsearch('%s:%s' % (self.host, self.port), 
+                retry_on_timeout=self.es_retry_on_timeout, 
+                max_retries=self.es_max_retries, 
+                timeout=self.es_timeout)
 
     @property
     def server(self):

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -31,10 +31,14 @@ class ElasticsearchBackend(KeyValueStoreBackend):
     scheme = 'http'
     host = 'localhost'
     port = 9200
+    es_retry_on_timeout=False
+    es_timeout=10
+    es_max_retries = 3
 
     def __init__(self, url=None, *args, **kwargs):
         super(ElasticsearchBackend, self).__init__(*args, **kwargs)
         self.url = url
+        _get = self.app.conf.get
 
         if elasticsearch is None:
             raise ImproperlyConfigured(E_LIB_MISSING)
@@ -52,6 +56,17 @@ class ElasticsearchBackend(KeyValueStoreBackend):
         self.scheme = scheme or self.scheme
         self.host = host or self.host
         self.port = port or self.port
+
+        self.es_retry_on_timeout = (
+                _get('elasticsearch_retry_on_timeout') or self.es_retry_on_timeout
+                )
+        self.es_timeout = (
+                _get('elasticsearch_timeout') or self.es_timeout
+                )
+
+        self.es_max_retries = (
+                _get('elasticsearch_max_retries') or self.es_max_retries
+                )
 
         self._server = None
 
@@ -104,7 +119,10 @@ class ElasticsearchBackend(KeyValueStoreBackend):
 
     def _get_server(self):
         """Connect to the Elasticsearch server."""
-        return elasticsearch.Elasticsearch('%s:%s' % (self.host, self.port))
+        return elasticsearch.Elasticsearch('%s:%s' % (self.host, self.port), 
+                retry_on_timeout=self.es_retry_on_timeout, 
+                max_retries=self.es_max_retries, 
+                timeout=self.es_timeout)
 
     @property
     def server(self):

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1057,6 +1057,33 @@ Example configuration
 
 .. _conf-riak-result-backend:
 
+.. setting:: elasticsearch_retry_on_timeout
+
+``elasticsearch_retry_on_timeout``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: :const:`False`
+
+Should timeout trigger a retry on different node?
+
+.. setting:: elasticsearch_max_retries
+
+``elasticsearch_max_retries``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: 3.
+
+Maximum number of retries before an exception is propagated.
+
+.. setting:: elasticsearch_timeout
+
+``elasticsearch_timeout``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: 10.0 seconds.
+
+Global timeout,used by the elasticsearch result backend.
+
 Riak backend settings
 ---------------------
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1055,8 +1055,6 @@ Example configuration
 
     result_backend = 'elasticsearch://example.com:9200/index_name/doc_type'
 
-.. _conf-riak-result-backend:
-
 .. setting:: elasticsearch_retry_on_timeout
 
 ``elasticsearch_retry_on_timeout``
@@ -1083,6 +1081,8 @@ Maximum number of retries before an exception is propagated.
 Default: 10.0 seconds.
 
 Global timeout,used by the elasticsearch result backend.
+
+.. _conf-riak-result-backend:
 
 Riak backend settings
 ---------------------


### PR DESCRIPTION

1. 

fix the build errors of [#3855](https://github.com/celery/celery/pull/3855) 

2. supports elasticsearch backend options settings
such as:

elasticsearch_retry_on_timeout
Default: False
Should timeout trigger a retry on different node?

elasticsearch_max_retries
Default: 3.
Maximum number of retries before an exception is propagated.

elasticsearch_timeout
Default: 10.0 seconds.
Global timeout,used by the elasticsearch result backend.

Can you merge both?