### PR TITLE
Typo of a variable name in docs (random_failover_strategy)

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1712,7 +1712,7 @@ Example::
 
     # Random failover strategy
     def random_failover_strategy(servers):
-        it = list(it)  # don't modify callers list
+        it = list(servers)  # don't modify callers list
         shuffle = random.shuffle
         for _ in repeat(None):
             shuffle(it)


### PR DESCRIPTION
## Description

It seems that example code uses variable `it` instead of `servers`.
