### PR TITLE
Fix update tasks

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -289,9 +289,7 @@ class Scheduler(object):
             return False
         for name, old_entry in old_schedules.items():
             new_entry = new_schedules.get(name)
-            if not new_entry:
-                return False
-            if old_entry.schedule != new_entry.schedule:
+            if not new_entry or old_entry.schedule != new_entry.schedule:
                 return False
         return True
 

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -287,11 +287,11 @@ class Scheduler(object):
     def schedules_equal(self, old_schedules, new_schedules):
         if set(old_schedules.keys()) != set(new_schedules.keys()):
             return False
-        for name, model in old_schedules.items():
+        for name, old_entry in old_schedules.items():
             b_model = new_schedules.get(name)
             if not b_model:
                 return False
-            if model.schedule != b_model.schedule:
+            if old_entry.schedule != b_model.schedule:
                 return False
         return True
 

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -284,10 +284,10 @@ class Scheduler(object):
                 return min(verify[0], max_interval)
         return min(adjust(next_time_to_run) or max_interval, max_interval)
 
-    def schedules_equal(self, a, b):
-        if set(a.keys()) != set(b.keys()):
+    def schedules_equal(self, old_schedules, b):
+        if set(old_schedules.keys()) != set(b.keys()):
             return False
-        for name, model in a.items():
+        for name, model in old_schedules.items():
             b_model = b.get(name)
             if not b_model:
                 return False

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -2,6 +2,7 @@
 """The periodic task scheduler."""
 from __future__ import absolute_import, unicode_literals
 
+import copy
 import errno
 import heapq
 import os
@@ -260,7 +261,7 @@ class Scheduler(object):
 
         if (self._heap is None or
                 not self.schedules_equal(self.old_schedulers, self.schedule)):
-            self.old_schedulers = self.schedule
+            self.old_schedulers = copy.copy(self.schedule)
             self.populate_heap()
 
         H = self._heap

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -285,14 +285,13 @@ class Scheduler(object):
         return min(adjust(next_time_to_run) or max_interval, max_interval)
 
     def schedules_equal(self, a, b):
-        if a.keys() != b.keys():
+        if set(a.keys()) != set(b.keys()):
             return False
         for name, model in a.items():
             b_model = b.get(name)
             if not b_model:
                 return False
-            if (hasattr(model.schedule, '__repr__') and
-                    model.schedule.__repr__() != b_model.schedule.__repr__()):
+            if model.schedule != b_model.schedule:
                 return False
         return True
 

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -288,10 +288,10 @@ class Scheduler(object):
         if set(old_schedules.keys()) != set(new_schedules.keys()):
             return False
         for name, old_entry in old_schedules.items():
-            b_model = new_schedules.get(name)
-            if not b_model:
+            new_entry = new_schedules.get(name)
+            if not new_entry:
                 return False
-            if old_entry.schedule != b_model.schedule:
+            if old_entry.schedule != new_entry.schedule:
                 return False
         return True
 

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -197,6 +197,7 @@ class Scheduler(object):
                              self.max_interval)
         self.Producer = Producer or app.amqp.Producer
         self._heap = None
+        self.old_schedulers = None
         self.sync_every_tasks = (
             app.conf.beat_sync_every if sync_every_tasks is None
             else sync_every_tasks)
@@ -257,7 +258,9 @@ class Scheduler(object):
         adjust = self.adjust
         max_interval = self.max_interval
 
-        if self._heap is None:
+        if (self._heap is None or
+                not self.schedules_equal(self.old_schedulers, self.schedule)):
+            self.old_schedulers = self.schedule
             self.populate_heap()
 
         H = self._heap
@@ -280,6 +283,18 @@ class Scheduler(object):
                 heappush(H, verify)
                 return min(verify[0], max_interval)
         return min(adjust(next_time_to_run) or max_interval, max_interval)
+
+    def schedules_equal(self, a, b):
+        if a.keys() != b.keys():
+            return False
+        for name, model in a.items():
+            b_model = b.get(name)
+            if not b_model:
+                return False
+            if (hasattr(model.schedule, '__repr__') and
+                    model.schedule.__repr__() != b_model.schedule.__repr__()):
+                return False
+        return True
 
     def should_sync(self):
         return (

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -284,11 +284,11 @@ class Scheduler(object):
                 return min(verify[0], max_interval)
         return min(adjust(next_time_to_run) or max_interval, max_interval)
 
-    def schedules_equal(self, old_schedules, b):
-        if set(old_schedules.keys()) != set(b.keys()):
+    def schedules_equal(self, old_schedules, new_schedules):
+        if set(old_schedules.keys()) != set(new_schedules.keys()):
             return False
         for name, model in old_schedules.items():
-            b_model = b.get(name)
+            b_model = new_schedules.get(name)
             if not b_model:
                 return False
             if model.schedule != b_model.schedule:


### PR DESCRIPTION
#3791 was improved and become #3890. This is an improvement on #3890, as it addresses some of the feedback supplied there.

Checks if the heap is valid. If there are changes in scheduled tasks the heap is populated again.

This means, when using django-celery-beat, changes to the ``periodictask`` table are automatically detected without restarting celery.

Fixes celery/django-celery-beat#7

I can squash/rebase/split/reformat/turn-into-a-penguin as required.