### PR TITLE
return a boolean value according to the doc

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -632,9 +632,11 @@ class Signals(object):
     def supported(self, name):
         """Return true value if signal by ``name`` exists on this platform."""
         try:
-            return self.signum(name)
+            self.signum(name)
         except AttributeError:
-            pass
+            return False
+        else:
+            return True
 
     def signum(self, name):
         """Get signal number by name."""


### PR DESCRIPTION
## Description

According to the function's [docstring](https://github.com/celery/celery/blob/master/celery/platforms.py#L633):

`"""Return true value if signal by ``name`` exists on this platform."""`

it makes much more sense to return a **boolean** value .
