### PR TITLE
Set the SO_REUSEADDR option on the socket

### DIFF
--- a/celery/contrib/rdb.py
+++ b/celery/contrib/rdb.py
@@ -124,6 +124,7 @@ class Rdb(Pdb):
         this_port = None
         for i in range(search_limit):
             _sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             this_port = port + skew + i
             try:
                 _sock.bind((host, this_port))


### PR DESCRIPTION
If the server exits before the client does, the port will appear to be in use for 90 seconds unless you set this option. TCP is annoying.