### PR TITLE
SQS integration tests

### DIFF
--- a/.travis-ci/integration/sqs/start-sqs-mock-server.sh
+++ b/.travis-ci/integration/sqs/start-sqs-mock-server.sh
@@ -9,7 +9,10 @@ cd $MOTO_DIRECTORY
 virtualenv moto-env
 git clone https://github.com/spulec/moto.git moto-git
 $MOTO_DIRECTORY/./moto-env/bin/pip install -U pip
-cd moto-git && $MOTO_DIRECTORY/./moto-env/bin/pip install .[server]
+cd moto-git
+# Use specific working commit
+git checkout df84675ae67e717449f01fafe3a022eb14984e26
+$MOTO_DIRECTORY/./moto-env/bin/pip install .[server]
 
 SUPERVISORD_CONF_PATH=/etc/supervisor/conf.d/moto-server-sqs.conf
 echo '[program:moto-server-sqs]' | sudo tee "$SUPERVISORD_CONF_PATH"

--- a/.travis-ci/integration/sqs/start-sqs-mock-server.sh
+++ b/.travis-ci/integration/sqs/start-sqs-mock-server.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -x
+
+MOTO_DIRECTORY="$TRAVIS_BUILD_DIR/servers/moto"
+mkdir -p "$MOTO_DIRECTORY"
+cd $MOTO_DIRECTORY
+virtualenv moto-env
+git clone https://github.com/spulec/moto.git
+cd moto
+$MOTO_DIRECTORY/./moto-env/bin/pip install .[server]
+cd .. && rm -rf moto
+nohup $MOTO_DIRECTORY/./moto-env/bin/moto_server sqs -H 127.0.0.1 -p 80 &

--- a/.travis-ci/integration/sqs/start-sqs-mock-server.sh
+++ b/.travis-ci/integration/sqs/start-sqs-mock-server.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -x
 
+set -e -u
+
 MOTO_DIRECTORY="$TRAVIS_BUILD_DIR/servers/moto"
 mkdir -p "$MOTO_DIRECTORY"
 cd $MOTO_DIRECTORY

--- a/.travis-ci/integration/sqs/start-sqs-mock-server.sh
+++ b/.travis-ci/integration/sqs/start-sqs-mock-server.sh
@@ -6,8 +6,7 @@ MOTO_DIRECTORY="$TRAVIS_BUILD_DIR/servers/moto"
 mkdir -p "$MOTO_DIRECTORY"
 cd $MOTO_DIRECTORY
 virtualenv moto-env
-git clone https://github.com/spulec/moto.git
-cd moto
-$MOTO_DIRECTORY/./moto-env/bin/pip install .[server]
-cd .. && rm -rf moto
+git clone https://github.com/spulec/moto.git moto-git
+$MOTO_DIRECTORY/./moto-env/bin/pip install -U pip
+cd moto-git && $MOTO_DIRECTORY/./moto-env/bin/pip install .[server]
 nohup $MOTO_DIRECTORY/./moto-env/bin/moto_server sqs -H 127.0.0.1 -p 80 &

--- a/.travis-ci/integration/sqs/start-sqs-mock-server.sh
+++ b/.travis-ci/integration/sqs/start-sqs-mock-server.sh
@@ -18,6 +18,8 @@ SUPERVISORD_CONF_PATH=/etc/supervisor/conf.d/moto-server-sqs.conf
 echo '[program:moto-server-sqs]' | sudo tee "$SUPERVISORD_CONF_PATH"
 echo "command=$MOTO_DIRECTORY/./moto-env/bin/moto_server sqs -H 127.0.0.1 -p 80" | sudo tee -a "$SUPERVISORD_CONF_PATH"
 echo "user=root" | sudo tee -a "$SUPERVISORD_CONF_PATH"
+echo 'stdout_logfile=/var/log/moto-server-sqs.log' | sudo tee -a "$SUPERVISORD_CONF_PATH"
+echo 'stderr_logfile=/var/log/moto-server-sqs.log' | sudo tee -a "$SUPERVISORD_CONF_PATH"
 sudo service supervisor stop
 sudo service supervisor start
 sleep 10

--- a/.travis-ci/integration/sqs/start-sqs-mock-server.sh
+++ b/.travis-ci/integration/sqs/start-sqs-mock-server.sh
@@ -16,7 +16,7 @@ $MOTO_DIRECTORY/./moto-env/bin/pip install .[server]
 
 SUPERVISORD_CONF_PATH=/etc/supervisor/conf.d/moto-server-sqs.conf
 echo '[program:moto-server-sqs]' | sudo tee "$SUPERVISORD_CONF_PATH"
-echo "command=$MOTO_DIRECTORY/./moto-env/bin/moto_server sqs -H 127.0.0.1 -p 80" | sudo tee -a "$SUPERVISORD_CONF_PATH"
+echo "command=$MOTO_DIRECTORY/./moto-env/bin/moto_server sqs -H 0.0.0.0 -p 80" | sudo tee -a "$SUPERVISORD_CONF_PATH"
 echo "user=root" | sudo tee -a "$SUPERVISORD_CONF_PATH"
 echo 'stdout_logfile=/var/log/moto-server-sqs.log' | sudo tee -a "$SUPERVISORD_CONF_PATH"
 echo 'stderr_logfile=/var/log/moto-server-sqs.log' | sudo tee -a "$SUPERVISORD_CONF_PATH"

--- a/.travis-ci/integration/sqs/start-sqs-mock-server.sh
+++ b/.travis-ci/integration/sqs/start-sqs-mock-server.sh
@@ -2,6 +2,7 @@
 
 set -e -u
 
+sudo apt-get install -y supervisor
 MOTO_DIRECTORY="$TRAVIS_BUILD_DIR/servers/moto"
 mkdir -p "$MOTO_DIRECTORY"
 cd $MOTO_DIRECTORY
@@ -9,4 +10,12 @@ virtualenv moto-env
 git clone https://github.com/spulec/moto.git moto-git
 $MOTO_DIRECTORY/./moto-env/bin/pip install -U pip
 cd moto-git && $MOTO_DIRECTORY/./moto-env/bin/pip install .[server]
-nohup $MOTO_DIRECTORY/./moto-env/bin/moto_server sqs -H 127.0.0.1 -p 80 &
+
+SUPERVISORD_CONF_PATH=/etc/supervisor/conf.d/moto-server-sqs.conf
+echo '[program:moto-server-sqs]' | sudo tee "$SUPERVISORD_CONF_PATH"
+echo "command=$MOTO_DIRECTORY/./moto-env/bin/moto_server sqs -H 127.0.0.1 -p 80" | sudo tee -a "$SUPERVISORD_CONF_PATH"
+echo "user=root" | sudo tee -a "$SUPERVISORD_CONF_PATH"
+sudo service supervisor stop
+sudo service supervisor start
+sleep 10
+curl -v localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,11 @@ before_install:
               sleep 10
               curl localhost:8000
           fi
+    - |
+        if [[ "$TOXENV" == *sqs ]]; then
+            # Start moto server for SQS
+            ./.travis-ci/integration/sqs/start-sqs-mock-server.sh
+        fi
 after_success:
   - .tox/$TRAVIS_PYTHON_VERSION/bin/coverage xml
   - .tox/$TRAVIS_PYTHON_VERSION/bin/codecov -e TOXENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,3 +85,6 @@ notifications:
 services:
     - rabbitmq
     - redis
+addons:
+  hosts:
+    - sqs.us-east-1.amazonaws.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - MATRIX_TOXENV=integration-rabbitmq
   - MATRIX_TOXENV=integration-redis
   - MATRIX_TOXENV=integration-dynamodb
+  - MATRIX_TOXENV=integration-sqs
 matrix:
   include:
   - python: '3.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ before_install:
         if [[ "$TOXENV" == *sqs ]]; then
             # Start moto server for SQS
             ./.travis-ci/integration/sqs/start-sqs-mock-server.sh
+            tail -F /var/log/moto-server-sqs.log &
         fi
 after_success:
   - .tox/$TRAVIS_PYTHON_VERSION/bin/coverage xml

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -63,8 +63,8 @@ def uses_sqs_transport(app):
 def enable_boto3_logging(app):
     if uses_sqs_transport(app):
         import logging
-        logging.getLogger('boto3').setLevel(logging.DEBUG)
-        logging.getLogger('botocore').setLevel(logging.DEBUG)
+        logging.getLogger('boto3').setLevel(logging.INFO)
+        logging.getLogger('botocore').setLevel(logging.INFO)
 
 
 @pytest.fixture(autouse=True)

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -54,6 +54,11 @@ def manager(app, celery_session_worker):
     return Manager(app)
 
 
+@pytest.fixture
+def uses_sqs_transport(app):
+    return app.conf.broker_url.startswith('sqs://')
+
+
 @pytest.fixture(autouse=True)
 def ZZZZ_set_app_current(app):
     app.set_current()

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -59,6 +59,14 @@ def uses_sqs_transport(app):
     return app.conf.broker_url.startswith('sqs://')
 
 
+@pytest.fixture(autouse=True, scope='function')
+def enable_boto3_logging(app):
+    if uses_sqs_transport(app):
+        import logging
+        logging.getLogger('boto3').setLevel(logging.DEBUG)
+        logging.getLogger('botocore').setLevel(logging.DEBUG)
+
+
 @pytest.fixture(autouse=True)
 def ZZZZ_set_app_current(app):
     app.set_current()

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 import os
+import time
 import pytest
 from functools import wraps
 from celery.contrib.testing.manager import Manager
@@ -25,7 +26,8 @@ def flaky(fun):
 def celery_config():
     return {
         'broker_url': TEST_BROKER,
-        'result_backend': TEST_BACKEND
+        'result_backend': TEST_BACKEND,
+        'task_default_queue': 'queue_{}'.format(int(time.time() * 1000))
     }
 
 
@@ -65,14 +67,13 @@ def enable_boto3_logging():
         import logging
         logging.getLogger('boto3').setLevel(logging.INFO)
         logging.getLogger('botocore').setLevel(logging.INFO)
-        yield
 
 
 @pytest.fixture(autouse=True, scope='function')
 def redis_backend_cleanup():
+    yield
     if celery_config()['result_backend'].startswith('redis://'):
         import redis
-        yield
         redis.StrictRedis().flushall()
 
 

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -56,8 +56,9 @@ class test_chain:
         redis_connection.delete('redis-echo')
 
     @flaky
-    def test_parent_ids(self, manager, num=10):
-        assert manager.inspect().ping()
+    def test_parent_ids(self, manager, uses_sqs_transport, num=10):
+        if not uses_sqs_transport:
+            assert manager.inspect().ping()
         c = chain(ids.si(i=i) for i in range(num))
         c.freeze()
         res = c()
@@ -88,8 +89,9 @@ class test_chain:
 class test_group:
 
     @flaky
-    def test_parent_ids(self, manager):
-        assert manager.inspect().ping()
+    def test_parent_ids(self, manager, uses_sqs_transport):
+        if not uses_sqs_transport:
+            assert manager.inspect().ping()
         g = (
             ids.si(i=1) |
             ids.si(i=2) |

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -7,10 +7,11 @@ from .tasks import print_unicode, retry_once, sleeping
 class test_tasks:
 
     @flaky
-    def test_task_accepted(self, manager, sleep=1):
+    def test_task_accepted(self, manager, uses_sqs_transport, sleep=1):
         r1 = sleeping.delay(sleep)
         sleeping.delay(sleep)
-        manager.assert_accepted([r1.id])
+        if not uses_sqs_transport:
+            manager.assert_accepted([r1.id])
 
     @flaky
     def test_task_retried(self):

--- a/tox.ini
+++ b/tox.ini
@@ -56,23 +56,33 @@ basepython =
 
 [testenv:2.7-integration-sqs]
 commands =
+    pip uninstall -y kombu
     pip install git+https://github.com/celery/kombu
+    py.test -xsv t/integration
 
 [testenv:3.4-integration-sqs]
 commands =
+    pip uninstall -y kombu
     pip install git+https://github.com/celery/kombu
+    py.test -xsv t/integration
 
 [testenv:3.5-integration-sqs]
 commands =
+    pip uninstall -y kombu
     pip install git+https://github.com/celery/kombu
+    py.test -xsv t/integration
 
 [testenv:3.6-integration-sqs]
 commands =
+    pip uninstall -y kombu
     pip install git+https://github.com/celery/kombu
+    py.test -xsv t/integration
 
 [testenv:pypy-integration-sqs]
 commands =
+    pip uninstall -y kombu
     pip install git+https://github.com/celery/kombu
+    py.test -xsv t/integration
 
 [testenv:apicheck]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {2.7,pypy,3.4,3.5,3.6}-unit
-    {2.7,pypy,3.4,3.5,3.6}-integration-{rabbitmq,redis,dynamodb}
+    {2.7,pypy,3.4,3.5,3.6}-integration-{rabbitmq,redis,dynamodb,sqs}
 
     flake8
     flakeplus
@@ -41,6 +41,11 @@ setenv =
     dynamodb: AWS_ACCESS_KEY_ID=test_aws_key_id
     dynamodb: AWS_SECRET_ACCESS_KEY=test_aws_secret_key
 
+    sqs: TEST_BROKER=sqs://@localhost
+    sqs: TEST_BACKEND=redis://
+    sqs: AWS_ACCESS_KEY_ID=test_aws_key_id
+    sqs: AWS_SECRET_ACCESS_KEY=test_aws_secret_key
+
 basepython =
     2.7: python2.7
     3.4: python3.4
@@ -48,6 +53,26 @@ basepython =
     3.6: python3.6
     pypy: pypy
     flake8,flakeplus,apicheck,linkcheck,configcheck,pydocstyle: python2.7
+
+[testenv:2.7-integration-sqs]
+commands =
+    pip install git+https://github.com/celery/kombu
+
+[testenv:3.4-integration-sqs]
+commands =
+    pip install git+https://github.com/celery/kombu
+
+[testenv:3.5-integration-sqs]
+commands =
+    pip install git+https://github.com/celery/kombu
+
+[testenv:3.6-integration-sqs]
+commands =
+    pip install git+https://github.com/celery/kombu
+
+[testenv:pypy-integration-sqs]
+commands =
+    pip install git+https://github.com/celery/kombu
 
 [testenv:apicheck]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ setenv =
     dynamodb: AWS_ACCESS_KEY_ID=test_aws_key_id
     dynamodb: AWS_SECRET_ACCESS_KEY=test_aws_secret_key
 
-    sqs: TEST_BROKER=sqs://@localhost
+    sqs: TEST_BROKER=sqs://@127.0.0.1
     sqs: TEST_BACKEND=redis://
     sqs: AWS_ACCESS_KEY_ID=test_aws_key_id
     sqs: AWS_SECRET_ACCESS_KEY=test_aws_secret_key

--- a/tox.ini
+++ b/tox.ini
@@ -57,31 +57,31 @@ basepython =
 [testenv:2.7-integration-sqs]
 commands =
     pip uninstall -y kombu
-    pip install git+https://github.com/celery/kombu
+    pip install git+https://github.com/celery/kombu@b734d7a8f599dc98b6c0a22968ba1d078a807383
     py.test -xsv t/integration
 
 [testenv:3.4-integration-sqs]
 commands =
     pip uninstall -y kombu
-    pip install git+https://github.com/celery/kombu
+    pip install git+https://github.com/celery/kombu@b734d7a8f599dc98b6c0a22968ba1d078a807383
     py.test -xsv t/integration
 
 [testenv:3.5-integration-sqs]
 commands =
     pip uninstall -y kombu
-    pip install git+https://github.com/celery/kombu
+    pip install git+https://github.com/celery/kombu@b734d7a8f599dc98b6c0a22968ba1d078a807383
     py.test -xsv t/integration
 
 [testenv:3.6-integration-sqs]
 commands =
     pip uninstall -y kombu
-    pip install git+https://github.com/celery/kombu
+    pip install git+https://github.com/celery/kombu@b734d7a8f599dc98b6c0a22968ba1d078a807383
     py.test -xsv t/integration
 
 [testenv:pypy-integration-sqs]
 commands =
     pip uninstall -y kombu
-    pip install git+https://github.com/celery/kombu
+    pip install git+https://github.com/celery/kombu@b734d7a8f599dc98b6c0a22968ba1d078a807383
     py.test -xsv t/integration
 
 [testenv:apicheck]


### PR DESCRIPTION
## Description

Enables integration tests with the SQS broker.

- [x] Update `.travis.yml` and `tox.ini` files.
- [x] Add CI script that starts [SQS moto server](https://github.com/spulec/moto).
- [x] Skip Manager operations that would not work with SQS.