### PR TITLE
send properties to before_publish handler

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -540,7 +540,7 @@ class AMQP(object):
                     sender=name, body=body,
                     exchange=exchange, routing_key=routing_key,
                     declare=declare, headers=headers2,
-                    properties=kwargs, retry_policy=retry_policy,
+                    properties=properties, retry_policy=retry_policy,
                 )
             ret = producer.publish(
                 body,


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

The full properites should be sent to the before_publish handler instead of just kwargs so that the handler can act on any properties that are part of the message.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
