### PR TITLE
CELERY_SEND_EVENTS instead of CELERYD_SEND_EVENTS for 3.1.x users

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -285,7 +285,7 @@ NAMESPACES = Namespace(
             'WARNING', old={'celery_redirect_stdouts_level'},
         ),
         send_task_events=Option(
-            False, type='bool', old={'celeryd_send_events'},
+            False, type='bool', old={'celery_send_events'},
         ),
         state_db=Option(),
         task_log_format=Option(DEFAULT_TASK_LOG_FMT),


### PR DESCRIPTION
Use 3.1.x option CELERY_SEND_EVENTS in celery 4.0 instead of CELERYD_SEND_EVENTS for compatibility.
celery 3.1.x : https://github.com/celery/celery/blob/v3.1.18/celery/app/defaults.py#L150

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
