### PR TITLE
Fix docs example (small)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -236,3 +236,4 @@ Jianjian Yu, 2017/04/09
 Brian May, 2017/04/10
 Dmytro Petruk, 2017/04/12
 Joey Wilhelm, 2017/04/12
+Anthony Lukach, 2017/05/23

--- a/docs/userguide/extending.rst
+++ b/docs/userguide/extending.rst
@@ -44,7 +44,7 @@ whenever the connection is established:
             message.ack()
     app.steps['consumer'].add(MyConsumerStep)
 
-    def send_me_a_message(self, who='world!', producer=None):
+    def send_me_a_message(who, producer=None):
         with app.producer_or_acquire(producer) as producer:
             producer.publish(
                 {'hello': who},
@@ -56,7 +56,7 @@ whenever the connection is established:
             )
 
     if __name__ == '__main__':
-        send_me_a_message('celery')
+        send_me_a_message('world!')
 
 
 .. note::

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -2,7 +2,7 @@ setuptools>=20.6.7
 wheel>=0.29.0
 flake8>=2.5.4
 flakeplus>=1.1
-pydocstyle
+pydocstyle==1.1.1
 tox>=2.3.1
 sphinx2rst>=1.0
 cyanide>=1.0.1


### PR DESCRIPTION
## Description

Reading through the docs on "Extensions and Bootsteps", I felt that the [Custom Message Consumers](http://docs.celeryproject.org/en/latest/userguide/extending.html#custom-message-consumers) example looked off.  The example shows a function (not a method) being defined with the first argument being `self`, which seems wrong.  The function is then called with the arg `'celery'` although it's not clear what purpose this serves.  If the example is run, `self == 'celery'` and `self` is never used.

I believe these changes add a bit of simplicity/clarity, however it is very possible that I'm missing a detail here and these changes should be denied.