### PR TITLE
recover loglevel for ExecStart in systemd config

### DIFF
--- a/extra/systemd/celery.service
+++ b/extra/systemd/celery.service
@@ -9,8 +9,8 @@ Group=celery
 EnvironmentFile=-/etc/conf.d/celery
 WorkingDirectory=/opt/celery
 ExecStart=/bin/sh -c '${CELERY_BIN} multi start $CELERYD_NODES \
-	-A $CELERY_APP --logfile=${CELERYD_LOG_FILE} \
-	--pidfile=${CELERYD_PID_FILE} $CELERYD_OPTS'
+	-A $CELERY_APP --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} \
+	--loglevel="${CELERYD_LOG_LEVEL}" $CELERYD_OPTS'
 ExecStop=/bin/sh -c '${CELERY_BIN} multi stopwait $CELERYD_NODES \
 	--pidfile=${CELERYD_PID_FILE}'
 ExecReload=/bin/sh -c '${CELERY_BIN} multi restart $CELERYD_NODES \


### PR DESCRIPTION
## Description

With current systemd/celery.service "systemctl restart celery" does respect
CELERYD_LOG_LEVEL, but "systemctl start celery" doesn't.
It seems that loglevel option was unintentionally removed in d54eb6d, so I recover it.