### PR TITLE
Fix small documentation typos

### DIFF
--- a/docs/internals/protocol.rst
+++ b/docs/internals/protocol.rst
@@ -42,8 +42,8 @@ Definition
         # optional
         'meth': string method_name,
         'shadow': string alias_name,
-        'eta':  iso8601 ETA,
-        'expires'; iso8601 expires,
+        'eta': iso8601 ETA,
+        'expires': iso8601 expires,
         'retries': int retries,
         'timelimit': (soft, hard),
         'argsrepr': str repr(args),


### PR DESCRIPTION
## Description
This fixes some small typos in the documentation describing the new message protocol.  The current version is rendered here: http://docs.celeryproject.org/en/latest/internals/protocol.html#definition.