### PR TITLE
Rename section to [bdist_wheel] as [wheel] is considered legacy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,5 +20,5 @@ requires = pytz >= 2016.7
            billiard >= 3.5.0.2
            kombu >= 4.0.2
 
-[wheel]
+[bdist_wheel]
 universal = 1


### PR DESCRIPTION
See:

https://bitbucket.org/pypa/wheel/src/54ddbcc9cec25e1f4d111a142b8bfaa163130a61/wheel/bdist_wheel.py?fileviewer=file-view-default#bdist_wheel.py-119:125

http://pythonwheels.com/