### PR TITLE
Signal before_task_publish not doing what documented

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -540,7 +540,7 @@ class AMQP(object):
                     sender=name, body=body,
                     exchange=exchange, routing_key=routing_key,
                     declare=declare, headers=headers2,
-                    properties=kwargs, retry_policy=retry_policy,
+                    properties=properties, retry_policy=retry_policy,
                 )
             ret = producer.publish(
                 body,

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,4 @@
 sphinx_celery>=1.3
+Sphinx==1.5.1
 typing
 -r extras/sqlalchemy.txt

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -2,7 +2,7 @@ setuptools>=20.6.7
 wheel>=0.29.0
 flake8>=2.5.4
 flakeplus>=1.1
-pydocstyle
+pydocstyle==1.1.1
 tox>=2.3.1
 sphinx2rst>=1.0
 cyanide>=1.0.1


### PR DESCRIPTION
## Description

Signal before_task_publish is sending kwargs instead of properties, which is at least a superset. Also, the docs announce it can be modified, but kwargs is not being passed.