### PR TITLE
Use the Sphinx add_directive_to_domain API.

### DIFF
--- a/celery/contrib/sphinx.py
+++ b/celery/contrib/sphinx.py
@@ -69,5 +69,5 @@ class TaskDirective(PyModulelevel):
 def setup(app):
     """Setup Sphinx extension."""
     app.add_autodocumenter(TaskDocumenter)
-    app.domains['py'].directives['task'] = TaskDirective
+    app.add_directive_to_domain('py', 'task', TaskDirective)
     app.add_config_value('celery_task_prefix', '(task)', True)


### PR DESCRIPTION
The `celery.contrib.sphinx` module directly adds to the `domains` attribute of the Sphinx application, this is no longer supported as of Sphinx 1.6.1 (see sphinx-doc/sphinx#3656 where the `domains` attribute was removed). Sphinx 1.0 added a `add_directive_to_domain` API which seems to be the supported way to do this. We could probably make this backwards compatible, but that seems unnecessary since Sphinx 1.0 was [released in 2010](http://www.sphinx-doc.org/en/latest/changes.html#release-1-0-jul-23-2010).

Fixes #4036