### PR TITLE
Clarify AsyncResult.ready docstring

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -236,3 +236,4 @@ Jianjian Yu, 2017/04/09
 Brian May, 2017/04/10
 Dmytro Petruk, 2017/04/12
 Joey Wilhelm, 2017/04/12
+Simon Schmidt, 2017/05/19

--- a/celery/result.py
+++ b/celery/result.py
@@ -273,7 +273,7 @@ class AsyncResult(ResultBase):
                     raise IncompleteStream()
 
     def ready(self):
-        """Return :const:`True` if the task started executing.
+        """Return :const:`True` if the task has executed.
 
         If the task is still running, pending, or is waiting
         for retry then :const:`False` is returned.


### PR DESCRIPTION
Clarifies slightly confusing wording in the `AsyncResult.ready` docstring