### PR TITLE
Update testing.rst

### DIFF
--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -76,8 +76,9 @@ in this example:
                 name='Foo',
             )
 
-            # set a side effect on the patched method
-            # so that it raises the error we want.
+            # Set a side effect on the patched methods
+            # so that they raise the errors we want.
+            send_order_retry.side_effect = Retry()
             product_order.side_effect = OperationalError()
 
             with raises(Retry):


### PR DESCRIPTION
Without mocking the retry method of the task and actually setting Retry as side effect, raising an operational error within the task will not lead to a Retry exception but the original Exception to be thrown as the task is called directly.

## Description

The included patch updates the code example for testing using mocking within the user guide to also set a side effect (raising `Retry`) on the task's `retry` method. The task is being called directly in the codesample and the original task retry method will reraise the original exception instead of `Retry`.