### PR TITLE
Fix/docs typos

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -238,3 +238,4 @@ Dmytro Petruk, 2017/04/12
 Joey Wilhelm, 2017/04/12
 Simon Schmidt, 2017/05/19
 Anthony Lukach, 2017/05/23
+Samuel Dion-Girardeau, 2017/05/29

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -231,7 +231,7 @@ The worker isn't doing anything, just hanging
 ---------------------------------------------
 
 **Answer:** See `MySQL is throwing deadlock errors, what can I do?`_.
-            or `Why is Task.delay/apply\* just hanging?`.
+            or `Why is Task.delay/apply\*/the worker just hanging?`_.
 
 .. _faq-results-unreliable:
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -230,8 +230,8 @@ Transaction Model and Locking`_ in the MySQL user manual.
 The worker isn't doing anything, just hanging
 ---------------------------------------------
 
-**Answer:** See `MySQL is throwing deadlock errors, what can I do?`_.
-            or `Why is Task.delay/apply\*/the worker just hanging?`_.
+**Answer:** See `MySQL is throwing deadlock errors, what can I do?`_,
+or `Why is Task.delay/apply\*/the worker just hanging?`_.
 
 .. _faq-results-unreliable:
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -175,7 +175,7 @@ See :ref:`brokers` for more information.
 Redis as a broker won't perform as well as
 an AMQP broker, but the combination RabbitMQ as broker and Redis as a result
 store is commonly used. If you have strict reliability requirements you're
-encouraged to use RabbitMQ or another AMQP broker. Some transports also uses
+encouraged to use RabbitMQ or another AMQP broker. Some transports also use
 polling, so they're likely to consume more resources. However, if you for
 some reason aren't able to use AMQP, feel free to use these alternatives.
 They will probably work fine for most use cases, and note that the above
@@ -195,7 +195,7 @@ language has an AMQP client, there shouldn't be much work to create a worker
 in your language. A Celery worker is just a program connecting to the broker
 to process messages.
 
-Also, there's another way to be language independent, and that's to use REST
+Also, there's another way to be language-independent, and that's to use REST
 tasks, instead of your tasks being functions, they're URLs. With this
 information you can even create simple web servers that enable preloading of
 code. Simply expose an endpoint that performs an operation, and create a task

--- a/docs/internals/guide.rst
+++ b/docs/internals/guide.rst
@@ -176,7 +176,7 @@ a large potential user base.
 
 In Django there's a global settings object, so multiple Django projects
 can't co-exist in the same process space, this later posed a problem
-for using Celery with frameworks that doesn't have this limitation.
+for using Celery with frameworks that don't have this limitation.
 
 Therefore the app concept was introduced. When using apps you use 'celery'
 objects instead of importing things from Celery sub-modules, this

--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -155,7 +155,7 @@ Example:
 
 .. code-block:: python
 
-    # Put this in your confttest.py
+    # Put this in your conftest.py
     @pytest.fixture(scope='session')
     def celery_config():
         return {


### PR DESCRIPTION
## Description

Minor improvements in the User Guide and FAQ.

The FAQ section that changed used to look like:

![before](https://cloud.githubusercontent.com/assets/4542383/26460649/50694372-4148-11e7-89be-e8ccd2203acd.PNG)

and after the changes:

![after](https://cloud.githubusercontent.com/assets/4542383/26460658/53be2ae2-4148-11e7-8c50-14d0a848105b.PNG)

The rest consists of fixed typos.
