### PR TITLE
Updated documentation settings for DatabaseScheduler.

### DIFF
--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -413,7 +413,7 @@ Using custom scheduler classes
 ------------------------------
 
 Custom scheduler classes can be specified on the command-line (the
-:option:`-S <celery beat -S>` argument).
+:option:`--scheduler <celery beat --scheduler>` argument).
 
 The default scheduler is the :class:`celery.beat.PersistentScheduler`,
 that simply keeps track of the last run times in a local :mod:`shelve`
@@ -447,10 +447,12 @@ To install and use this extension:
 
         $ python manage.py migrate
 
-#. Start the :program:`celery beat` service using the ``django`` scheduler:
+#. Start the :program:`celery beat` service using the ``django_celery_beat.schedulers:DatabaseScheduler`` scheduler:
 
     .. code-block:: console
 
-        $ celery -A proj beat -l info -S django
+        $ celery -A proj beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
+
+   Note:  You may also add this as an settings option directly.
 
 #. Visit the Django-Admin interface to set up some periodic tasks.


### PR DESCRIPTION
## Checklist

- [x] I have included the output of ``celery -A proj report`` in the issue.
      (if you are not able to do this, then at least specify the Celery
       version affected).
- [x] I have verified that the issue exists against the `master` branch of Celery.

```
celery -A celery_app report
/Users/sklass/.virtualenvs/icm_ipcatalog/lib/python2.7/site-packages/django/conf/__init__.py:122: RemovedInDjango110Warning: Session verification will become mandatory in Django 1.10. Please add 'django.contrib.auth.middleware.SessionAuthenticationMiddleware' to your MIDDLEWARE_CLASSES setting when you are ready to opt-in after reading the upgrade considerations in the 1.8 release notes.
  RemovedInDjango110Warning

software -> celery:4.0.2 (latentcall) kombu:4.0.2 py:2.7.10
            billiard:3.5.0.2 py-amqp:2.1.4
platform -> system:Darwin arch:64bit imp:CPython
loader   -> celery.loaders.app.AppLoader
settings -> transport:amqp results:django-db
```
## Steps to reproduce
1) If you use the suggested settings in the documents this will create the `django.db` file which is in alignment with the docs.
2) However the scheduler is incorrect.

## Expected behavior
1) Change the docs so the Django.db is not created and the right scheduler is used.

## Actual behavior

Reference:  https://github.com/celery/django-celery-beat/issues/48