### PR TITLE
Fix task eager Django setting names

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -110,7 +110,7 @@ rush in moving to the new settings format.
 ``CELERY_SECURITY_CERT_STORE``         :setting:`security_cert_store`
 ``CELERY_SECURITY_KEY``                :setting:`security_key`
 ``CELERY_ACKS_LATE``                   :setting:`task_acks_late`
-``CELERY_ALWAYS_EAGER``                :setting:`task_always_eager`
+``CELERY_TASK_ALWAYS_EAGER``           :setting:`task_always_eager`
 ``CELERY_ANNOTATIONS``                 :setting:`task_annotations`
 ``CELERY_MESSAGE_COMPRESSION``         :setting:`task_compression`
 ``CELERY_CREATE_MISSING_QUEUES``       :setting:`task_create_missing_queues`
@@ -120,7 +120,7 @@ rush in moving to the new settings format.
 ``CELERY_DEFAULT_QUEUE``               :setting:`task_default_queue`
 ``CELERY_DEFAULT_RATE_LIMIT``          :setting:`task_default_rate_limit`
 ``CELERY_DEFAULT_ROUTING_KEY``         :setting:`task_default_routing_key`
-``[...]_EAGER_PROPAGATES_EXCEPTIONS``  :setting:`task_eager_propagates`
+``CELERY_TASK_EAGER_PROPAGATES``       :setting:`task_eager_propagates`
 ``CELERY_IGNORE_RESULT``               :setting:`task_ignore_result`
 ``CELERY_TASK_PUBLISH_RETRY``          :setting:`task_publish_retry`
 ``CELERY_TASK_PUBLISH_RETRY_POLICY``   :setting:`task_publish_retry_policy`


### PR DESCRIPTION
## Description

Under celery 4.0.2, I've tried the settings in this document before this change, variations with and without the `*_TASK_*` element, and a few other variations, and the two names in this change are the only two that work for me.