### PR TITLE
Handle possibility there are no workers in `celery graph workers`

### DIFF
--- a/celery/bin/graph.py
+++ b/celery/bin/graph.py
@@ -161,7 +161,7 @@ class graph(Command):
             workers = args['nodes']
             threads = args.get('threads') or []
         except KeyError:
-            replies = self.app.control.inspect().stats()
+            replies = self.app.control.inspect().stats() or {}
             workers, threads = [], []
             for worker, reply in items(replies):
                 workers.append(worker)


### PR DESCRIPTION
Fixes issue where an exception is raised if eg `celery graph workers` is invoked when there are no workers at all.