### PR TITLE
Fix for crash on Windows

### DIFF
--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -63,14 +63,7 @@ def process_initializer(app, hostname):
                   bool(os.environ.get('CELERY_LOG_REDIRECT', False)),
                   str(os.environ.get('CELERY_LOG_REDIRECT_LEVEL')),
                   hostname=hostname)
-    if os.environ.get('FORKED_BY_MULTIPROCESSING'):
-        # pool did execv after fork
-        trace.setup_worker_optimizations(app, hostname)
-    else:
-        app.set_current()
-        set_default_app(app)
-        app.finalize()
-        trace._tasks = app._tasks  # enables fast_trace_task optimization.
+    trace.setup_worker_optimizations(app, hostname)
     # rebuild execution handler for all tasks.
     from celery.app.trace import build_tracer
     for name, task in items(app.tasks):


### PR DESCRIPTION
Function **trace.setup_worker_optimizations** is not called if process is not forked thus leaving trace module partially uninitialized, __localized_ attribute in particular. This causes celery to crash on Windows. The whole **if**-clause seems spurious as the same initialization step are also performed by the else branch. Removing the if clause and calling fixes the problem on Windows.
