### PR TITLE
Pass parent on default methods

### DIFF
--- a/celery/bootsteps.py
+++ b/celery/bootsteps.py
@@ -367,11 +367,11 @@ class StartStopStep(Step):
 
     def start(self, parent):
         if self.obj:
-            return self.obj.start()
+            return self.obj.start(parent)
 
     def stop(self, parent):
         if self.obj:
-            return self.obj.stop()
+            return self.obj.stop(parent)
 
     def close(self, parent):
         pass


### PR DESCRIPTION
By default, the `start` and `stop` methods on the `StartStopStep` class call the `start` and `stop` methods on the instances `self.obj` value. This fails being that it doesn't pass in the required `parent` argument to these values.

I kind of feel like I may be missing something here, as I'm surprised this hasn't cause problems for others. Maybe I'm doing something wrong?