### PR TITLE
Fixed exception caused by next_transit receiving an unexpected argument.

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -728,7 +728,7 @@ class solar(BaseSchedule):
         'dawn_nautical': True,
         'dawn_civil': True,
         'sunrise': False,
-        'solar_noon': True,
+        'solar_noon': False,
         'sunset': False,
         'dusk_civil': True,
         'dusk_nautical': True,
@@ -783,10 +783,16 @@ class solar(BaseSchedule):
         last_run_at_utc = localize(last_run_at, timezone.utc)
         self.cal.date = last_run_at_utc
         try:
-            next_utc = getattr(self.cal, self.method)(
-                self.ephem.Sun(),
-                start=last_run_at_utc, use_center=self.use_center,
-            )
+            if self.use_center:
+                next_utc = getattr(self.cal, self.method)(
+                	self.ephem.Sun(),
+                	start=last_run_at_utc, use_center=self.use_center,
+                )
+            else:
+                next_utc = getattr(self.cal, self.method)(
+                        self.ephem.Sun(),start=last_run_at_utc
+                )
+
         except self.ephem.CircumpolarError:  # pragma: no cover
             # Sun won't rise/set today.  Check again tomorrow
             # (specifically, after the next anti-transit).

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -785,12 +785,12 @@ class solar(BaseSchedule):
         try:
             if self.use_center:
                 next_utc = getattr(self.cal, self.method)(
-                	self.ephem.Sun(),
-                	start=last_run_at_utc, use_center=self.use_center,
+                    self.ephem.Sun(),
+                    start=last_run_at_utc, use_center=self.use_center
                 )
             else:
                 next_utc = getattr(self.cal, self.method)(
-                        self.ephem.Sun(),start=last_run_at_utc
+                    self.ephem.Sun(), start=last_run_at_utc
                 )
 
         except self.ephem.CircumpolarError:  # pragma: no cover

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -74,6 +74,15 @@ class test_solar:
         with pytest.raises(ValueError):
             solar('asdqwewqew', 60, 60, app=self.app)
 
+    def test_event_uses_center(self):
+        s = solar('solar_noon', 60, 60, app=self.app)
+        for ev, is_center in s._use_center_l.items():
+            s.method = s._methods[ev]
+            s.is_center = s._use_center_l[ev]
+            try:
+                s.remaining_estimate(datetime.utcnow())
+            except TypeError:
+                pytest.fail("{0} was called with 'use_center' which is not a valid keyword for the function.".format(s.method))
 
 class test_schedule:
 

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -82,7 +82,9 @@ class test_solar:
             try:
                 s.remaining_estimate(datetime.utcnow())
             except TypeError:
-                pytest.fail("{0} was called with 'use_center' which is not a valid keyword for the function.".format(s.method))
+                pytest.fail("{0} was called with 'use_center' which is not a \
+                    valid keyword for the function.".format(s.method))
+
 
 class test_schedule:
 


### PR DESCRIPTION
This fixes https://github.com/celery/celery/issues/4102 
The problem was that arguments were being passed to methods with signatures that could not take them, causing an exception.