### PR TITLE
Add note about RPC backend not support chords

### DIFF
--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -766,7 +766,8 @@ Chords
 
     Tasks used within a chord must *not* ignore their results. If the result
     backend is disabled for *any* task (header or body) in your chord you
-    should read ":ref:`chord-important-notes`."
+    should read ":ref:`chord-important-notes`." Chords are not currently
+    supported with the RPC result backend.
 
 
 A chord is a task that only executes after all of the tasks in a group have


### PR DESCRIPTION
Chords are not supported with the RPC backend (https://github.com/celery/celery/commit/a883f6871b54c1292920e68cf8c01d2efc464f3f), however this does not appear to be documented anywhere. I've put a note under the Chord docs on the Canvas page, however I would also be willing to place this not on the [RPC Backend Settings docs](http://docs.celeryproject.org/en/latest/userguide/configuration.html#rpc-backend-settings) as well if that's desired.