### PR TITLE
tox fails to be installed for Pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_install:
             virtualenv --python="$PYENV_ROOT/versions/$PYPY_VERSION/bin/python" "$HOME/virtualenvs/$PYPY_VERSION"
             source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
             which python
+            pip install -U pip
           fi
     - |
           if [[ "$TOXENV" == *dynamodb ]]; then


### PR DESCRIPTION
## Description

`tox` cannot be installed with pypy2.7-5.8.0:

```
File "/home/travis/virtualenvs/pypy2.7-5.8.0/site-packages/pip/_vendor/progress/helpers.py", line 68, in writeln
    print(line, end='', file=self.file)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 9-15: ordinal not in range(128)
```

See also this [build](https://travis-ci.org/celery/celery/jobs/254488448).