### PR TITLE
Resolve pip UnicodeEncoderError for PyPy environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_install:
             virtualenv --python="$PYENV_ROOT/versions/$PYPY_VERSION/bin/python" "$HOME/virtualenvs/$PYPY_VERSION"
             source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
             which python
-            pip install -U pip
+            pip install pip==9.0.1
           fi
     - |
           if [[ "$TOXENV" == *dynamodb ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_install:
             virtualenv --python="$PYENV_ROOT/versions/$PYPY_VERSION/bin/python" "$HOME/virtualenvs/$PYPY_VERSION"
             source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
             which python
+            pip install -U pip
           fi
     - |
           if [[ "$TOXENV" == *dynamodb ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,7 @@ before_install:
             "$PYENV_ROOT/bin/pyenv" install "$PYPY_VERSION"
             virtualenv --python="$PYENV_ROOT/versions/$PYPY_VERSION/bin/python" "$HOME/virtualenvs/$PYPY_VERSION"
             source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
-            which python
-            pip install pip==9.0.1
+            which python            
           fi
     - |
           if [[ "$TOXENV" == *dynamodb ]]; then
@@ -70,7 +69,7 @@ before_install:
 after_success:
   - .tox/$TRAVIS_PYTHON_VERSION/bin/coverage xml
   - .tox/$TRAVIS_PYTHON_VERSION/bin/codecov -e TOXENV
-install: travis_retry pip install -U tox
+install: travis_retry pip install -U tox | cat
 script: tox -v -- -v
 notifications:
   irc:


### PR DESCRIPTION
## Description

`tox` cannot be installed with pypy2.7-5.8.0:

```
File "/home/travis/virtualenvs/pypy2.7-5.8.0/site-packages/pip/_vendor/progress/helpers.py", line 68, in writeln
    print(line, end='', file=self.file)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 9-15: ordinal not in range(128)
```

See also this [build](https://travis-ci.org/celery/celery/jobs/254488448).