### PR TITLE
Make appstr use standard format (#4134)

### DIFF
--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -70,7 +70,7 @@ FMT_REPLACE_SETTING = '{replace:<36} -> {with_}'
 
 def appstr(app):
     """String used in __repr__ etc, to id app instances."""
-    return '{0}:{1:#x}'.format(app.main or '__main__', id(app))
+    return '{0} at {1:#x}'.format(app.main or '__main__', id(app))
 
 
 class Settings(ConfigurationView):


### PR DESCRIPTION
## Description

Fixes issue #4134 

Make appstr use a standard format so that Sphinx can correctly detect and strip memory addresses from the output documentation.  These memory addresses prevent builds from being reproducible.
