### PR TITLE
doc: adding examples to connect to sentinel broker

### DIFF
--- a/docs/getting-started/brokers/redis.rst
+++ b/docs/getting-started/brokers/redis.rst
@@ -51,6 +51,13 @@ by adding the ``virtual_host`` parameter to the URL:
 
     redis+socket:///path/to/redis.sock?virtual_host=db_number
 
+It is also easy to connect directly to a list of Redis Sentinel:
+
+.. code-block:: python
+
+    app.conf.broker_url = 'sentinel://localhost:26379;sentinel://localhost:26380;sentinel://localhost:26381'
+    app.conf.broker_transport_options = { 'master_name': "cluster1" }
+
 .. _redis-visibility_timeout:
 
 Visibility Timeout
@@ -80,6 +87,8 @@ you should configure these settings::
 
 For a complete list of options supported by the Redis result backend, see
 :ref:`conf-redis-result-backend`
+
+*Note that sentinel is not a supported backend*
 
 .. _redis-caveats:
 


### PR DESCRIPTION
## Description

The documentation is not very clear about redis sentinel. I already patched the pydoc in celery/kombu#766