### PR TITLE
Fix celery ignores exceptions raised during `django.setup()`

### DIFF
--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -107,7 +107,13 @@ class BaseLoader(object):
         )
 
     def import_default_modules(self):
-        signals.import_modules.send(sender=self.app)
+        responses = signals.import_modules.send(sender=self.app)
+        # Prior to this point loggers are not yet set up properly, need to check
+        #   responses manually and reraised exceptions if any, otherwise they'll
+        #   be silenced, making it incredibly difficult to debug.
+        for receiver, response in responses:
+            if isinstance(response, Exception):
+                raise response
         return [self.import_task_module(m) for m in self.default_modules]
 
     def init_worker(self):

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -108,10 +108,10 @@ class BaseLoader(object):
 
     def import_default_modules(self):
         responses = signals.import_modules.send(sender=self.app)
-        # Prior to this point loggers are not yet set up properly, need to check
-        #   responses manually and reraised exceptions if any, otherwise they'll
-        #   be silenced, making it incredibly difficult to debug.
-        for receiver, response in responses:
+        # Prior to this point loggers are not yet set up properly, need to
+        #   check responses manually and reraised exceptions if any, otherwise
+        #   they'll be silenced, making it incredibly difficult to debug.
+        for _, response in responses:
             if isinstance(response, Exception):
                 raise response
         return [self.import_task_module(m) for m in self.default_modules]

--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -88,6 +88,18 @@ class test_LoaderBase:
         assert (sorted(modnames(self.loader.import_default_modules())) ==
                 sorted(modnames([os, sys])))
 
+    def test_import_default_modules_with_exception(self):
+        """ Make sure exceptions are not silenced since this step is prior to
+            setup logging. """
+        def trigger_exception(**kwargs):
+            raise ImportError('Dummy ImportError')
+        from celery.signals import import_modules
+        import_modules.connect(trigger_exception)
+        self.app.conf.imports = ('os', 'sys')
+        with pytest.raises(ImportError):
+            self.loader.import_default_modules()
+
+
     def test_import_from_cwd_custom_imp(self):
         imp = Mock(name='imp')
         self.loader.import_from_cwd('foo', imp=imp)

--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -99,7 +99,6 @@ class test_LoaderBase:
         with pytest.raises(ImportError):
             self.loader.import_default_modules()
 
-
     def test_import_from_cwd_custom_imp(self):
         imp = Mock(name='imp')
         self.loader.import_from_cwd('foo', imp=imp)


### PR DESCRIPTION
Celery ignores exceptions raised during `django.setup()`

## Output of ``celery -A proj report``:
```
software -> celery:4.0.2 (latentcall) kombu:4.0.2 py:2.7.6
            billiard:3.5.0.2 redis:2.10.5
platform -> system:Linux arch:64bit, ELF imp:CPython
loader   -> celery.loaders.app.AppLoader
settings -> transport:redis results:redis://db.dev.xxxxxx.com:6379/2

task_track_started: True
accept_content: [u'json']
broker_url: u'redis://db.dev.xxxxxx.com:6379/2'
beat_scheduler: u'django_celery_beat.schedulers:DatabaseScheduler'
```

## Steps to reproduce
1. Setup celery with a Django project
2. Deliberately make Django logging fail, for example in `settings.py` set `LOGGING_CONFIG = 'incorrect.config'`.
3. Bring up celery with `celery worker -A xxxxxx -l info`

## Expected behavior
Celery fails and throw an exception

## Actual behavior
Celery silent the exception, and since `django.setup()` failed, celery worker won't load any tasks within that Django project.

## Explanation
Celery triggers `django.setup()` via `import_modules` signal, and this is before the logger get setup, which means `Signal.send` will dump the exception into `NullHandler` which is eventually lost.

This kind of problem is usually easy to spot since if the setting is incorrect, Django itself will fail to start. But for some rare case for example mine, I had some problem with log file permissions because celery was running with another user. This is some honest mistake and should be easy to solve, but the permission error is silenced, took me some unnecessarily long time to debug the problem.

## Suggested solution:
Make import_modules watch the returned response, if it contains any Exception, raise the Excetpion.
