### PR TITLE
Exponential backoff for autoretry

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -473,7 +473,7 @@ class Celery(object):
             if autoretry_for and not hasattr(task, '_orig_run'):
 
                 if retry_backoff:
-                    countdown = retry_backoff * (2 ** task.retries)
+                    countdown = retry_backoff * (2 ** run.retries)
                     if retry_jitter is True:
                         countdown = random.randrange(countdown)
                     elif isinstance(retry_jitter, int):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -473,7 +473,7 @@ class Celery(object):
             if autoretry_for and not hasattr(task, '_orig_run'):
 
                 if retry_backoff:
-                    countdown = retry_backoff * (2 ** run.retries)
+                    countdown = retry_backoff * (2 ** task.request.retries)
                     if retry_jitter is True:
                         countdown = random.randrange(countdown)
                     elif isinstance(retry_jitter, int):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -482,9 +482,9 @@ class Celery(object):
                                 retry_backoff * (2 ** task.request.retries)
                             )
                             if retry_jitter is True:
-                                countdown = random.randrange(countdown)
+                                countdown = random.randrange(countdown + 1)
                             elif isinstance(retry_jitter, int):
-                                jitter = random.randrange(retry_jitter)
+                                jitter = random.randrange(retry_jitter + 1)
                                 countdown += jitter * random.choice((1, -1))
                             if retry_backoff_max:
                                 countdown = min(countdown, retry_backoff_max)

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import numbers
 import os
+import random
 import sys
 import time as _time
 
@@ -27,6 +28,7 @@ __all__ = [
     'humanize_seconds', 'maybe_iso8601', 'is_naive',
     'make_aware', 'localize', 'to_utc', 'maybe_make_aware',
     'ffwd', 'utcoffset', 'adjust_timestamp',
+    'get_exponential_backoff_interval',
 ]
 
 PY3 = sys.version_info[0] == 3
@@ -383,3 +385,20 @@ def utcoffset(time=_time, localtime=_time.localtime):
 def adjust_timestamp(ts, offset, here=utcoffset):
     """Adjust timestamp based on provided utcoffset."""
     return ts - (offset - here()) * 3600
+
+
+def get_exponential_backoff_interval(
+    factor,
+    retries,
+    maximum,
+    full_jitter=False
+):
+    """Calculate the exponential backoff wait time."""
+    # Will be zero if factor equals 0
+    countdown = factor * (2 ** retries)
+    # Full jitter according to
+    # https://www.awsarchitectureblog.com/2015/03/backoff.html
+    if full_jitter:
+        countdown = random.randrange(countdown + 1)
+    # Adjust according to maximum wait time and account for negative values.
+    return max(0, min(maximum, countdown))

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -746,6 +746,78 @@ If you want to automatically retry on any error, simply use:
     def x():
         ...
 
+.. versionadded:: 4.1
+
+If your tasks depend on another service, like making a request to an API,
+then it's a good idea to use `exponential backoff`_ to avoid overwhelming the
+service with your requests. Fortunately, Celery's automatic retry support
+makes it easy. Just specify the :attr:`~Task.retry_backoff` argument, like this:
+
+.. code-block:: python
+
+    from requests.exceptions import RequestException
+
+    @app.task(autoretry_for=(RequestException,), retry_backoff=True)
+    def x():
+        ...
+
+By default, this exponential backoff will also introduce random jitter_ to
+avoid having all the tasks run at the same moment. It will also cap the
+maximum backoff delay to 10 minutes. All these settings can be customized
+via options documented below.
+
+.. attribute:: Task.autoretry_for
+
+    A list/tuple of exception classes. If any of these exceptions are raised
+    during the execution of the task, the task will automatically be retried.
+    By default, no exceptions will be autoretried.
+
+.. attribute:: Task.retry_kwargs
+
+    A dictionary. Use this to customize how autoretries are executed.
+    Note that if you use the exponential backoff options below, the `countdown`
+    task option will be determined by Celery's autoretry system, and any
+    `countdown` included in this dictionary will be ignored.
+
+.. attribute:: Task.retry_backoff
+
+    A boolean, or a number. If this option is set to ``True``, autoretries
+    will be delayed following the rules of `exponential backoff`_. The first
+    retry will have a delay of 1 second, the second retry will have a delay
+    of 2 seconds, the third will delay 4 seconds, the fourth will delay 8
+    seconds, and so on. (However, this delay value is modified by
+    :attr:`~Task.retry_jitter`, if it is enabled.)
+    If this option is set to a number, it is used as a
+    delay factor. For example, if this option is set to ``3``, the first retry
+    will delay 3 seconds, the second will delay 6 seconds, the third will
+    delay 12 seconds, the fourth will delay 24 seconds, and so on. By default,
+    this option is set to ``False``, and autoretries will not be delayed.
+
+.. attribute:: Task.retry_backoff_max
+
+    A number. If ``retry_backoff`` is enabled, this option will set a maximum
+    delay between task autoretries. By default, this option is set to ``600``,
+    which is 10 minutes. To allow unlimited delay between autoretries,
+    set this option to ``False``.
+
+.. attribute:: Task.retry_jitter
+
+    A boolean, or an integer. `Jitter`_ is used to introduce randomness into
+    exponential backoff delays, to prevent all tasks in the queue from being
+    executed simultaneously. If this option is set to ``True``, the delay
+    value calculated by :attr:`~Task.retry_backoff` is treated as a maximum,
+    and the actual delay value will be a random number between zero and that
+    maximum.
+
+    If this option is set to an integer, that integer is the maximum deviation
+    from the calculated delay value. For example, for the fourth autoretry of
+    a task, the calculated delay value is 8. If ``retry_jitter`` is set to 2,
+    then the actual delay value will be a random number between 6 and 10.
+
+    If this option is set to ``False`` or 0, then no jitter is introduced.
+
+    By default, this option is set to ``True``.
+
 .. _task-options:
 
 List of Options
@@ -1899,3 +1971,5 @@ To make API calls to `Akismet`_ I use the `akismet.py`_ library written by
 .. _`Akismet`: http://akismet.com/faq/
 .. _`akismet.py`: http://www.voidspace.org.uk/downloads/akismet.py
 .. _`Michael Foord`: http://www.voidspace.org.uk/
+.. _`exponential backoff`: https://en.wikipedia.org/wiki/Exponential_backoff
+.. _`jitter`: https://en.wikipedia.org/wiki/Jitter

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -138,7 +138,7 @@ class TasksCase:
         self.autoretry_backoff_task = autoretry_backoff_task
 
         @self.app.task(bind=True, autoretry_for=(HTTPError,),
-                       retry_backoff=True, retry_jitter=2, shared=False)
+                       retry_backoff=True, retry_jitter=True, shared=False)
         def autoretry_backoff_jitter_task(self, url):
             self.iterations += 1
             if "error" in url:
@@ -294,9 +294,8 @@ class test_task_retries(TasksCase):
         ]
         assert retry_call_countdowns == [1, 2, 4, 8]
 
-    @patch('random.randrange', side_effect=lambda i: i - 1)
-    @patch('random.choice', side_effect=lambda seq: seq[0])
-    def test_autoretry_backoff_jitter(self, randchoice, randrange):
+    @patch('random.randrange', side_effect=lambda i: i - 2)
+    def test_autoretry_backoff_jitter(self, randrange):
         task = self.autoretry_backoff_jitter_task
         task.max_retries = 3
         task.iterations = 0
@@ -308,7 +307,7 @@ class test_task_retries(TasksCase):
         retry_call_countdowns = [
             call[1]['countdown'] for call in fake_retry.call_args_list
         ]
-        assert retry_call_countdowns == [3, 4, 6, 10]
+        assert retry_call_countdowns == [0, 1, 3, 7]
 
     def test_retry_wrong_eta_when_not_enable_utc(self):
         """Issue #3753"""

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -279,7 +279,7 @@ class test_task_retries(TasksCase):
         self.autoretry_task.apply((1, 0))
         assert self.autoretry_task.iterations == 6
 
-    @patch('random.randrange', side_effect=lambda i: i-1)
+    @patch('random.randrange', side_effect=lambda i: i - 1)
     def test_autoretry_backoff(self, randrange):
         task = self.autoretry_backoff_task
         task.max_retries = 3
@@ -294,7 +294,7 @@ class test_task_retries(TasksCase):
         ]
         assert retry_call_countdowns == [1, 2, 4, 8]
 
-    @patch('random.randrange', side_effect=lambda i: i-1)
+    @patch('random.randrange', side_effect=lambda i: i - 1)
     @patch('random.choice', side_effect=lambda seq: seq[0])
     def test_autoretry_backoff_jitter(self, randchoice, randrange):
         task = self.autoretry_backoff_jitter_task

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -279,9 +279,8 @@ class test_task_retries(TasksCase):
         self.autoretry_task.apply((1, 0))
         assert self.autoretry_task.iterations == 6
 
-    @patch('random.randrange')
+    @patch('random.randrange', side_effect=lambda i: i-1)
     def test_autoretry_backoff(self, randrange):
-        randrange.side_effect = lambda i: i - 1
         task = self.autoretry_backoff_task
         task.max_retries = 3
         task.iterations = 0
@@ -295,11 +294,9 @@ class test_task_retries(TasksCase):
         ]
         assert retry_call_countdowns == [1, 2, 4, 8]
 
-    @patch('random.randrange')
-    @patch('random.choice')
+    @patch('random.randrange', side_effect=lambda i: i-1)
+    @patch('random.choice', side_effect=lambda seq: seq[0])
     def test_autoretry_backoff_jitter(self, randchoice, randrange):
-        randrange.side_effect = lambda i: i - 1
-        randchoice.side_effect = lambda seq: seq[0]
         task = self.autoretry_backoff_jitter_task
         task.max_retries = 3
         task.iterations = 0

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -281,7 +281,7 @@ class test_task_retries(TasksCase):
 
     @patch('random.randrange')
     def test_autoretry_backoff(self, randrange):
-        randrange.side_effect = lambda i: i
+        randrange.side_effect = lambda i: i - 1
         task = self.autoretry_backoff_task
         task.max_retries = 3
         task.iterations = 0
@@ -298,7 +298,7 @@ class test_task_retries(TasksCase):
     @patch('random.randrange')
     @patch('random.choice')
     def test_autoretry_backoff_jitter(self, randchoice, randrange):
-        randrange.side_effect = lambda i: i
+        randrange.side_effect = lambda i: i - 1
         randchoice.side_effect = lambda seq: seq[0]
         task = self.autoretry_backoff_jitter_task
         task.max_retries = 3

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -3,7 +3,7 @@ import pytest
 import pytz
 from datetime import datetime, timedelta, tzinfo
 from pytz import AmbiguousTimeError
-from case import Mock
+from case import Mock, patch
 from celery.utils.time import (
     delta_resolution,
     humanize_seconds,
@@ -18,6 +18,7 @@ from celery.utils.time import (
     LocalTimezone,
     ffwd,
     utcoffset,
+    get_exponential_backoff_interval,
 )
 from celery.utils.iso8601 import parse_iso8601
 
@@ -253,3 +254,41 @@ class test_utcoffset:
         assert utcoffset(time=_time) is not None
         _time.daylight = False
         assert utcoffset(time=_time) is not None
+
+
+class test_get_exponential_backoff_interval:
+
+    @patch('random.randrange', lambda n: n - 2)
+    @patch('random.choice', lambda sequence: sequence[0])
+    def test_with_jitter(self):
+        assert get_exponential_backoff_interval(
+            factor=4,
+            retries=3,
+            maximum=100,
+            full_jitter=True
+        ) == 4 * (2 ** 3) - 1
+
+    def test_without_jitter(self):
+        assert get_exponential_backoff_interval(
+            factor=4,
+            retries=3,
+            maximum=100,
+            full_jitter=False
+        ) == 4 * (2 ** 3)
+
+    def test_bound_by_maximum(self):
+        maximum_boundary = 100
+        assert get_exponential_backoff_interval(
+            factor=40,
+            retries=3,
+            maximum=maximum_boundary
+        ) == maximum_boundary
+
+    @patch('random.randrange', lambda n: n - 1)
+    @patch('random.choice', lambda sequence: -1)
+    def test_negative_values(self):
+        assert get_exponential_backoff_interval(
+            factor=-40,
+            retries=3,
+            maximum=100
+        ) == 0


### PR DESCRIPTION
## Description

**Note:** This is a temporary pull request for displaying proposed changes in #4101.

- [x] Convert backoff interval calculations to a function in `celery.utils.time` and add unit tests.
- [x] Simplify jitter parameters and revert to Full Jitter as used in [tenacity](https://github.com/jd/tenacity/blob/dd0c50a540785fd67daf726eec84cfe373b26a0c/tenacity/wait.py#L172) and explained in https://www.awsarchitectureblog.com/2015/03/backoff.html