### PR TITLE
Update Celery/Python/Pypy versions in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,10 +40,10 @@ in such a way that the client enqueues an URL to be requested by a worker.
 What do I need?
 ===============
 
-Celery version 4.0 runs on,
+Celery version 4.1 runs on,
 
-- Python (2.7, 3.4, 3.5)
-- PyPy (5.4, 5.5)
+- Python (2.7, 3.4, 3.5, 3.6)
+- PyPy (5.8)
 
 
 This is the last version to support Python 2.7,
@@ -72,7 +72,7 @@ Get Started
 ===========
 
 If this is the first time you're trying to use Celery, or you're
-new to Celery 4.0 coming from previous versions then you should read our
+new to Celery 4.1 coming from previous versions then you should read our
 getting started tutorials:
 
 - `First steps with Celery`_


### PR DESCRIPTION
## Description

In the `README`, updated some version numbers that were invalidated by 4.1.0 release:

- Celery bumped to 4.1;
- Python 3.6 now supported;
- Pypy bumped to 5.8, which is used for CI.