### PR TITLE
Make sure that last_run_at and self.now() comparable

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -548,7 +548,7 @@ class crontab(BaseSchedule):
         tz = tz or self.tz
         last_run_at = localize(
             self.maybe_make_aware(last_run_at),
-            self.now().tzinfo)
+            self.now().tzinfo or timezone.utc)
         now = self.maybe_make_aware(self.now())
         dow_num = last_run_at.isoweekday() % 7  # Sunday is day 0, not day 7
 

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -546,7 +546,9 @@ class crontab(BaseSchedule):
         # pylint: disable=redefined-outer-name
         # caching global ffwd
         tz = tz or self.tz
-        last_run_at = self.maybe_make_aware(last_run_at)
+        last_run_at = localize(
+            self.maybe_make_aware(last_run_at),
+            self.now().tzinfo)
         now = self.maybe_make_aware(self.now())
         dow_num = last_run_at.isoweekday() % 7  # Sunday is day 0, not day 7
 


### PR DESCRIPTION
Localize last_run_at for crontab schedule so that the delta between last_run_at and now as potentially given via self.nowfun are compatible.

A fix for https://github.com/celery/celery/issues/4169