### PR TITLE
Correct calculation of application current time with timezone

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -880,8 +880,11 @@ class Celery(object):
 
     def now(self):
         """Return the current time and date as a datetime."""
+        from celery.utils.time import to_utc
         from datetime import datetime
-        return datetime.utcnow().replace(tzinfo=self.timezone)
+
+        now_in_utc = to_utc(datetime.utcnow())
+        return now_in_utc.astimezone(self.timezone)
 
     def select_queues(self, queues=None):
         """Select subset of queues.

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -2,6 +2,7 @@
 """Actual App instance implementation."""
 from __future__ import absolute_import, unicode_literals
 
+from datetime import datetime
 import os
 import threading
 import warnings
@@ -36,7 +37,8 @@ from celery.utils import abstract
 from celery.utils.collections import AttributeDictMixin
 from celery.utils.dispatch import Signal
 from celery.utils.functional import first, maybe_list, head_from_fun
-from celery.utils.time import timezone, get_exponential_backoff_interval
+from celery.utils.time import timezone, \
+    get_exponential_backoff_interval, to_utc
 from celery.utils.imports import gen_task_name, instantiate, symbol_by_name
 from celery.utils.log import get_logger
 from celery.utils.objects import FallbackContext, mro_lookup
@@ -880,9 +882,6 @@ class Celery(object):
 
     def now(self):
         """Return the current time and date as a datetime."""
-        from celery.utils.time import to_utc
-        from datetime import datetime
-
         now_in_utc = to_utc(datetime.utcnow())
         return now_in_utc.astimezone(self.timezone)
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -79,10 +79,10 @@ class test_App:
         tz_utc = timezone.get_timezone('UTC')
         tz_us_eastern = timezone.get_timezone(timezone_setting_value)
 
-        now = datetime.utcnow().replace(tzinfo=tz_utc)
+        now = to_utc(datetime.utcnow())
         app_now = self.app.now()
 
-        assert app_now.tzinfo == tz_utc
+        assert app_now.tzinfo is tz_utc
         assert app_now - now <= timedelta(seconds=1)
 
         # Check that timezone conversion is applied from configuration
@@ -92,7 +92,8 @@ class test_App:
         del self.app.timezone
 
         app_now = self.app.now()
-        assert app_now.tzinfo == tz_us_eastern
+
+        assert app_now.tzinfo.zone == tz_us_eastern.zone
 
         diff = to_utc(datetime.utcnow()) - localize(app_now, tz_utc)
         assert diff <= timedelta(seconds=1)
@@ -102,7 +103,7 @@ class test_App:
         del self.app.timezone
         app_now = self.app.now()
         assert self.app.timezone == tz_us_eastern
-        assert app_now.tzinfo == tz_us_eastern
+        assert app_now.tzinfo.zone == tz_us_eastern.zone
 
     @patch('celery.app.base.set_default_app')
     def test_set_default(self, set_default_app):


### PR DESCRIPTION
## Description

Incorrect application current time calculation was introduced with https://github.com/celery/celery/pull/3867/files .

- [x] Use `datetime.astimezone` to adjust current time in `App.now`.

Closes #4160 .