### PR TITLE
Django fixup should close all cache backends

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -193,7 +193,7 @@ class DjangoWorkerFixup(object):
 
     def close_cache(self):
         try:
-            self._cache.cache.close()
+            self._cache.close_caches()
         except (TypeError, AttributeError):
             pass
 

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -227,9 +227,7 @@ class test_DjangoWorkerFixup(FixupCase):
     def test_close_cache(self):
         with self.fixup_context(self.app) as (f, _, _):
             f.close_cache()
-            f._cache.cache.close.assert_called_with()
-            f._cache.cache.close.side_effect = TypeError()
-            f.close_cache()
+            f._cache.close_caches.assert_called_with()
 
     def test_on_worker_ready(self):
         with self.fixup_context(self.app) as (f, _, _):


### PR DESCRIPTION
## Description

Django allows to set multiple caches backends (https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-CACHES) in the `CACHES` configuration. 

Celery's Django Fixup should close all caches on a worker's fork to avoid connection reuse.

### Current status:
```python
from  django.core import cache
cache.cache.close()
```
As per Django's code, `cache` is a proxy (`django.core.cache.cache == DefaultCacheProxy()`) to the `'default'` cache backend. So only this backend is issued a `close()` call.

### Fixed code:
```python
from  django.core import cache
cache.close_caches()
```


## References
My bug was Memcached-related; here some documentation about the original bug.
http://www.dctrwatson.com/2010/09/python-thread-safe-does-not-mean-fork-safe/
https://stackoverflow.com/questions/23358787/memcache-get-returns-wrong-object-celery-django

## Temporary workaround

In `celery.py`:
```python
def reset_caches_on_worker_fork_worker_process_init(*args, **kwargs):
    from django.core import cache
    cache.close_caches()

from celery import signals
signals.worker_process_init.connect(reset_caches_on_worker_fork_worker_process_init)
```