### PR TITLE
Inspect scheduler class settings in celery beat command.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -246,3 +246,4 @@ Nicolas Mota, 2017/08/10
 David Davis, 2017/08/11
 Martial Pageau, 2017/08/16
 Sammie S. Taunton, 2017/08/17
+Kxrr, 2017/08/18

--- a/celery/bin/beat.py
+++ b/celery/bin/beat.py
@@ -20,7 +20,7 @@
 .. cmdoption:: -S, --scheduler
 
     Scheduler class to use.
-    Default is :class:`celery.beat.PersistentScheduler`.
+    Default is :class:`{default}`.
 
 .. cmdoption:: --max-interval
 
@@ -113,7 +113,7 @@ class beat(Command):
         bopts.add_argument(
             '-s', '--schedule', default=c.beat_schedule_filename)
         bopts.add_argument('--max-interval', type=float)
-        bopts.add_argument('-S', '--scheduler')
+        bopts.add_argument('-S', '--scheduler', default=c.beat_scheduler)
         bopts.add_argument('-l', '--loglevel', default='WARN')
 
         daemon_options(parser, default_pidfile='celerybeat.pid')


### PR DESCRIPTION
## Description

Celery beat command parser didn't  set default scheduler by BEAT_SCHEDULER, and `celery beat -h` didn't display the default scheduler correctly.

The pull request fixes them.