### PR TITLE
Update periodic-tasks.rst to fix import issue

### DIFF
--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -65,6 +65,14 @@ schedule manually.
         $ python manage.py shell
         >>> from djcelery.models import PeriodicTask
         >>> PeriodicTask.objects.update(last_run_at=None)
+    
+    Django-Celery only supports Celery 4.0 and below, for Celery 4.0 and above, do as follow:
+    
+    .. code-block:: console
+
+        $ python manage.py shell
+        >>> from django_celery_beat.models import PeriodicTask
+        >>> PeriodicTask.objects.update(last_run_at=None)
 
 .. _beat-entries:
 


### PR DESCRIPTION
The docs were not updated for celery 4, which does not need django-celery library.
Most issues arose were because of the doc does not give clear guidance for celery 4 and above.
Fixes issues:
https://github.com/celery/django-celery/issues/496
https://github.com/celery/django-celery/issues/523
https://github.com/celery/django-celery/issues/491 
https://github.com/celery/celery/issues/3637

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
