### PR TITLE
Fixes #4106 - change GroupResult:as_tuple() to include parent

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -824,9 +824,6 @@ class GroupResult(ResultSet):
     #: List/iterator of results in the group
     results = None
 
-    #: Parent Result of the group, if any
-    parent = None
-
     def __init__(self, id=None, results=None, parent=None, **kwargs):
         self.id = id
         self.parent = parent
@@ -858,7 +855,11 @@ class GroupResult(ResultSet):
 
     def __eq__(self, other):
         if isinstance(other, GroupResult):
-            return other.id == self.id and other.results == self.results
+            return (
+                other.id == self.id and
+                other.results == self.results and
+                other.parent == self.parent
+            )
         return NotImplemented
 
     def __ne__(self, other):

--- a/celery/result.py
+++ b/celery/result.py
@@ -980,7 +980,8 @@ def result_from_tuple(r, app=None):
 
         if nodes:
             return app.GroupResult(
-                id, [result_from_tuple(child, app) for child in nodes], parent=parent,
+                id, [result_from_tuple(child, app) for child in nodes],
+                parent=parent,
             )
 
         return Result(id, parent=parent)

--- a/celery/result.py
+++ b/celery/result.py
@@ -973,7 +973,8 @@ def result_from_tuple(r, app=None):
     app = app_or_default(app)
     Result = app.AsyncResult
     if not isinstance(r, ResultBase):
-        (id, parent), nodes = r
+        res, nodes = r
+        id, parent = res if isinstance(res, (list, tuple)) else (res, None)
         if parent:
             parent = result_from_tuple(parent, app)
 

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -895,9 +895,9 @@ class test_tuples:
 
     def test_GroupResult_with_parent(self):
         parent = self.app.AsyncResult(uuid())
-        ts = self.app.GroupResult(
+        result = self.app.GroupResult(
             uuid(), [self.app.AsyncResult(uuid()) for _ in range(10)],
             parent
         )
-        r = result_from_tuple(ts.to_tuple(), self.app)
-        assert r.parent == parent
+        second_result = result_from_tuple(result.as_tuple(), self.app)
+        assert second_result.parent == parent

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -892,3 +892,9 @@ class test_tuples:
         )
         assert x, result_from_tuple(x.as_tuple() == self.app)
         assert x, result_from_tuple(x == self.app)
+
+    def test_GroupResult_with_parent(self):
+        parent = self.app.AsyncResult(uuid())
+        ts = self.app.GroupResult(uuid(), [self.app.AsyncResult(uuid()) for _ in range(10)], parent)
+        r = result_from_tuple(ts.to_tuple(), self.app)
+        assert r.parent == parent

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -595,6 +595,21 @@ class test_GroupResult:
     def test_eq_other(self):
         assert self.ts != 1
 
+    def test_eq_with_parent(self):
+        # GroupResult instances with different .parent are not equal
+        grp_res = self.app.GroupResult(
+            uuid(), [self.app.AsyncResult(uuid()) for _ in range(10)],
+            parent=self.app.AsyncResult(uuid())
+        )
+        grp_res_2 = self.app.GroupResult(grp_res.id, grp_res.results)
+        assert grp_res != grp_res_2
+
+        grp_res_2.parent = self.app.AsyncResult(uuid())
+        assert grp_res != grp_res_2
+
+        grp_res_2.parent = grp_res.parent
+        assert grp_res == grp_res_2
+
     @pytest.mark.usefixtures('depends_on_current_app')
     def test_pickleable(self):
         assert pickle.loads(pickle.dumps(self.ts))

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -895,6 +895,9 @@ class test_tuples:
 
     def test_GroupResult_with_parent(self):
         parent = self.app.AsyncResult(uuid())
-        ts = self.app.GroupResult(uuid(), [self.app.AsyncResult(uuid()) for _ in range(10)], parent)
+        ts = self.app.GroupResult(
+            uuid(), [self.app.AsyncResult(uuid()) for _ in range(10)],
+            parent
+        )
         r = result_from_tuple(ts.to_tuple(), self.app)
         assert r.parent == parent

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -917,3 +917,19 @@ class test_tuples:
         second_result = result_from_tuple(result.as_tuple(), self.app)
         assert second_result == result
         assert second_result.parent == parent
+
+    def test_GroupResult_as_tuple(self):
+        parent = self.app.AsyncResult(uuid())
+        result = self.app.GroupResult(
+            'group-result-1',
+            [self.app.AsyncResult('async-result-{}'.format(i))
+             for i in range(2)],
+            parent
+        )
+        (result_id, parent_id), group_results = result.as_tuple()
+        assert result_id == result.id
+        assert parent_id == parent.id
+        assert isinstance(group_results, list)
+        expected_grp_res = [(('async-result-{}'.format(i), None), None)
+                            for i in range(2)]
+        assert group_results == expected_grp_res

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -900,4 +900,5 @@ class test_tuples:
             parent
         )
         second_result = result_from_tuple(result.as_tuple(), self.app)
+        assert second_result == result
         assert second_result.parent == parent


### PR DESCRIPTION
## Description

`GroupResult` doesn't include the parent in `as_tuple()`, though sometimes it does have a parent (see issue #4106 for an example).

