### PR TITLE
Try to import directly, do not use deprecated imp method

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -251,3 +251,4 @@ Mads Jensen, 2017/08/20
 Markus Kaiserswerth, 2017/08/30
 Andrew Wong, 2017/09/07
 Arpan Shah, 2017/09/12
+Tobias 'rixx' Kunze, 2017/08/20

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -2,7 +2,6 @@
 """Loader base class."""
 from __future__ import absolute_import, unicode_literals
 
-import imp as _imp
 import importlib
 import os
 import re
@@ -268,13 +267,6 @@ def find_related_module(package, related_name):
             raise
 
     try:
-        pkg_path = importlib.import_module(package).__path__
-    except AttributeError:
-        return
-
-    try:
-        _imp.find_module(related_name, pkg_path)
+        return importlib.import_module('{0}.{1}'.format(package, related_name))
     except ImportError:
         return
-
-    return importlib.import_module('{0}.{1}'.format(package, related_name))

--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -241,12 +241,5 @@ class test_autodiscovery:
                 imp.return_value.__path__ = 'foo'
                 base.find_related_module(base, 'tasks')
 
-                def se1(val):
-                    imp.side_effect = AttributeError()
-
-                imp.side_effect = se1
-                base.find_related_module(base, 'tasks')
-                imp.side_effect = None
-
                 find.side_effect = ImportError()
                 base.find_related_module(base, 'tasks')


### PR DESCRIPTION
Details are discussed in #2523 – `imp.find_module` is deprecated and
leads to issues in some places where `importlib.import_module` works
perfectly.