### PR TITLE
Deleted trailing whitespace in different files

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ current_version = 4.1.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{releaselevel}
 	{major}.{minor}.{patch}
 
@@ -12,4 +12,3 @@ serialize =
 [bumpversion:file:docs/includes/introduction.txt]
 
 [bumpversion:file:README.rst]
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
             "$PYENV_ROOT/bin/pyenv" install "$PYPY_VERSION"
             virtualenv --python="$PYENV_ROOT/versions/$PYPY_VERSION/bin/python" "$HOME/virtualenvs/$PYPY_VERSION"
             source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
-            which python            
+            which python
           fi
     - |
           if [[ "$TOXENV" == *dynamodb ]]; then

--- a/celery/utils/dispatch/license.txt
+++ b/celery/utils/dispatch/license.txt
@@ -4,23 +4,23 @@ PyDispatcher License:
 
     Copyright (c) 2001-2003, Patrick K. O'Brien and Contributors
     All rights reserved.
-    
+
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions
     are met:
-    
+
         Redistributions of source code must retain the above copyright
         notice, this list of conditions and the following disclaimer.
-    
+
         Redistributions in binary form must reproduce the above
         copyright notice, this list of conditions and the following
         disclaimer in the documentation and/or other materials
         provided with the distribution.
-    
+
         The name of Patrick K. O'Brien, or the name of any Contributor,
-        may not be used to endorse or promote products derived from this 
+        may not be used to endorse or promote products derived from this
         software without specific prior written permission.
-    
+
     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
     ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
     LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -32,5 +32,4 @@ PyDispatcher License:
     HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
     STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-    OF THE POSSIBILITY OF SUCH DAMAGE. 
-
+    OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/getting-started/first-steps-with-celery.rst
+++ b/docs/getting-started/first-steps-with-celery.rst
@@ -281,8 +281,8 @@ Configuration
 =============
 
 Celery, like a consumer appliance, doesn't need much configuration to operate.
-It has an input and an output. The input must be connected to a broker, and the output can 
-be optionally connected to a result backend. However, if you look closely at the back, 
+It has an input and an output. The input must be connected to a broker, and the output can
+be optionally connected to a result backend. However, if you look closely at the back,
 there's a lid revealing loads of sliders, dials, and buttons: this is the configuration.
 
 The default configuration should be good enough for most use cases, but there are
@@ -315,7 +315,7 @@ If you're configuring many settings at once you can use ``update``:
 For larger projects, a dedicated configuration module is recommended.
 Hard coding periodic task intervals and task routing options is discouraged.
 It is much better to keep these in a centralized location. This is especially
-true for libraries, as it enables users to control how their tasks behave. 
+true for libraries, as it enables users to control how their tasks behave.
 A centralized configuration will also allow your SysAdmin to make simple changes
 in the event of system trouble.
 

--- a/docs/userguide/daemonizing.rst
+++ b/docs/userguide/daemonizing.rst
@@ -430,7 +430,7 @@ This is an example configuration for a Python project:
     # Absolute or relative path to the 'celery' command:
     CELERY_BIN="/usr/local/bin/celery"
     #CELERY_BIN="/virtualenvs/def/bin/celery"
-    
+
     # App instance to use
     # comment out this line if you don't use an app
     CELERY_APP="proj"

--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -65,9 +65,9 @@ schedule manually.
         $ python manage.py shell
         >>> from djcelery.models import PeriodicTask
         >>> PeriodicTask.objects.update(last_run_at=None)
-    
+
     Django-Celery only supports Celery 4.0 and below, for Celery 4.0 and above, do as follow:
-    
+
     .. code-block:: console
 
         $ python manage.py shell

--- a/docs/userguide/signals.rst
+++ b/docs/userguide/signals.rst
@@ -88,8 +88,8 @@ Provides arguments:
 
     Task message body.
 
-    This is a mapping containing the task message fields, 
-    see :ref:`message-protocol-task-v2` 
+    This is a mapping containing the task message fields,
+    see :ref:`message-protocol-task-v2`
     and :ref:`message-protocol-task-v1`
     for a reference of possible fields that can be defined.
 


### PR DESCRIPTION
`.editorconfig` has this enforced, but a few files have this problem.