### PR TITLE
add cassandra_options

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -126,6 +126,7 @@ NAMESPACES = Namespace(
         write_consistency=Option(type='string'),
         auth_provider=Option(type='string'),
         auth_kwargs=Option(type='string'),
+        cassandra_options=Option({}, type='dict'),
     ),
     control=Namespace(
         queue_ttl=Option(300.0, type='float'),

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -126,7 +126,7 @@ NAMESPACES = Namespace(
         write_consistency=Option(type='string'),
         auth_provider=Option(type='string'),
         auth_kwargs=Option(type='string'),
-        cassandra_options=Option({}, type='dict'),
+        options=Option({}, type='dict'),
     ),
     control=Namespace(
         queue_ttl=Option(300.0, type='float'),

--- a/celery/backends/cassandra.py
+++ b/celery/backends/cassandra.py
@@ -79,7 +79,7 @@ class CassandraBackend(BaseBackend):
     supports_autoexpire = True      # autoexpire supported via entry_ttl
 
     def __init__(self, servers=None, keyspace=None, table=None, entry_ttl=None,
-                 port=9042, **kwargs):
+                 port=9042, cassandra_options=None, **kwargs):
         super(CassandraBackend, self).__init__(**kwargs)
 
         if not cassandra:
@@ -90,6 +90,8 @@ class CassandraBackend(BaseBackend):
         self.port = port or conf.get('cassandra_port', None)
         self.keyspace = keyspace or conf.get('cassandra_keyspace', None)
         self.table = table or conf.get('cassandra_table', None)
+        self.cassandra_options = dict(conf.get('cassandra_options') or {},
+                                      **cassandra_options or {})
 
         if not self.servers or not self.keyspace or not self.table:
             raise ImproperlyConfigured('Cassandra backend not configured.')
@@ -141,7 +143,8 @@ class CassandraBackend(BaseBackend):
         try:
             self._connection = cassandra.cluster.Cluster(
                 self.servers, port=self.port,
-                auth_provider=self.auth_provider)
+                auth_provider=self.auth_provider,
+                **self.cassandra_options)
             self._session = self._connection.connect(self.keyspace)
 
             # We're forced to do concatenation below, as formatting would

--- a/celery/backends/cassandra.py
+++ b/celery/backends/cassandra.py
@@ -79,7 +79,7 @@ class CassandraBackend(BaseBackend):
     supports_autoexpire = True      # autoexpire supported via entry_ttl
 
     def __init__(self, servers=None, keyspace=None, table=None, entry_ttl=None,
-                 port=9042, cassandra_options=None, **kwargs):
+                 port=9042, **kwargs):
         super(CassandraBackend, self).__init__(**kwargs)
 
         if not cassandra:
@@ -90,8 +90,7 @@ class CassandraBackend(BaseBackend):
         self.port = port or conf.get('cassandra_port', None)
         self.keyspace = keyspace or conf.get('cassandra_keyspace', None)
         self.table = table or conf.get('cassandra_table', None)
-        self.cassandra_options = dict(conf.get('cassandra_options') or {},
-                                      **cassandra_options or {})
+        self.cassandra_options = conf.get('cassandra_options', {})
 
         if not self.servers or not self.keyspace or not self.table:
             raise ImproperlyConfigured('Cassandra backend not configured.')

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -83,7 +83,7 @@ rush in moving to the new settings format.
 ``CASSANDRA_READ_CONSISTENCY``         :setting:`cassandra_read_consistency`
 ``CASSANDRA_SERVERS``                  :setting:`cassandra_servers`
 ``CASSANDRA_WRITE_CONSISTENCY``        :setting:`cassandra_write_consistency`
-``CASSANDRA_CASSANDRA_OPTIONS``        :setting:`cassandra_options`
+``CASSANDRA_OPTIONS``                  :setting:`cassandra_options`
 ``CELERY_COUCHBASE_BACKEND_SETTINGS``  :setting:`couchbase_backend_settings`
 ``CELERY_MONGODB_BACKEND_SETTINGS``    :setting:`mongodb_backend_settings`
 ``CELERY_EVENT_QUEUE_EXPIRES``         :setting:`event_queue_expires`

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -83,6 +83,7 @@ rush in moving to the new settings format.
 ``CASSANDRA_READ_CONSISTENCY``         :setting:`cassandra_read_consistency`
 ``CASSANDRA_SERVERS``                  :setting:`cassandra_servers`
 ``CASSANDRA_WRITE_CONSISTENCY``        :setting:`cassandra_write_consistency`
+``CASSANDRA_CASSANDRA_OPTIONS``        :setting:`cassandra_options`
 ``CELERY_COUCHBASE_BACKEND_SETTINGS``  :setting:`couchbase_backend_settings`
 ``CELERY_MONGODB_BACKEND_SETTINGS``    :setting:`mongodb_backend_settings`
 ``CELERY_EVENT_QUEUE_EXPIRES``         :setting:`event_queue_expires`
@@ -1036,6 +1037,22 @@ Named arguments to pass into the authentication provider. For example:
     cassandra_auth_kwargs = {
         username: 'cassandra',
         password: 'cassandra'
+    }
+
+.. setting:: cassandra_options
+
+``cassandra_options``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``{}`` (empty mapping).
+
+Named arguments to pass into the ``cassandra.cluster`` class.
+
+.. code-block:: python
+
+    cassandra_options = {
+        'cql_version': '3.2.1'
+        'protocol_version': 3
     }
 
 Example configuration

--- a/t/unit/backends/test_cassandra.py
+++ b/t/unit/backends/test_cassandra.py
@@ -182,3 +182,15 @@ class test_CassandraBackend:
         }
         with pytest.raises(ImproperlyConfigured):
             mod.CassandraBackend(app=self.app)
+
+    def test_options(self):
+        # Ensure valid options works properly
+        from celery.backends import cassandra as mod
+
+        mod.cassandra = Mock()
+        # Valid options
+        self.app.conf.cassandra_options = {
+            'cql_version': '3.2.1',
+            'protocol_version': 3
+        }
+        mod.CassandraBackend(app=self.app)


### PR DESCRIPTION
## Description
Adds back cassandra_options that was available in celery v3.1
https://github.com/celery/celery/blob/d08b1057234bb7774623108fa343af7a1c658e7a/celery/backends/cassandra.py#L81-L82  
There's a bunch of kwargs that can be passed on cluster creation, currently only defaults can be used.
http://datastax.github.io/python-driver/api/cassandra/cluster.html  
