### PR TITLE
Updated SQS requirments file

### DIFF
--- a/docs/getting-started/brokers/sqs.rst
+++ b/docs/getting-started/brokers/sqs.rst
@@ -14,7 +14,7 @@ library using :command:`pip`:
 
 .. code-block:: console
 
-    $ pip install -U boto
+    $ pip install -U boto3
 
 .. _broker-sqs-configuration:
 

--- a/requirements/extras/sqs.txt
+++ b/requirements/extras/sqs.txt
@@ -1,2 +1,2 @@
-boto>=2.13.3
+boto3>=1.4.6
 pycurl


### PR DESCRIPTION
Updates SQS requirements file.

The current file requires the installation of boto(boto 2) which is no longer required by kombu(https://github.com/celery/kombu/commit/129a9e4ed05bf9a99d12fff9e17c9ffb37b14c4d). Fixes #4195.
