### PR TITLE
Fix link in documentation

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -499,7 +499,7 @@ class Task(object):
             headers (Dict): Message headers to be included in the message.
 
         Returns:
-            ~@AsyncResult: Promise of future evaluation.
+            celery.result.AsyncResult: Promise of future evaluation.
 
         Raises:
             TypeError: If not enough arguments are passed, or too many


### PR DESCRIPTION
`~@AsyncResult` results in `mailto:~@AsyncResult` link in the doc instead of a proper link to AsyncResult class

http://docs.celeryproject.org/en/master/reference/celery.app.task.html?highlight=retry#celery.app.task.Task.apply_async
