### PR TITLE
Beat: support scheduler entries without a schedule

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -247,3 +247,4 @@ David Davis, 2017/08/11
 Martial Pageau, 2017/08/16
 Sammie S. Taunton, 2017/08/17
 Kxrr, 2017/08/18
+Markus Kaiserswerth, 2017/08/30

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -97,17 +97,17 @@ class ScheduleEntry(object):
         self.kwargs = kwargs
         self.options = options
         self.schedule = maybe_schedule(schedule, relative, app=self.app)
-        self.last_run_at = last_run_at or self._default_now()
+        self.last_run_at = last_run_at or self.default_now()
         self.total_run_count = total_run_count or 0
 
-    def _default_now(self):
+    def default_now(self):
         return self.schedule.now() if self.schedule else self.app.now()
 
     def _next_instance(self, last_run_at=None):
         """Return new instance, with date and count fields updated."""
         return self.__class__(**dict(
             self,
-            last_run_at=last_run_at or self._default_now(),
+            last_run_at=last_run_at or self.default_now(),
             total_run_count=self.total_run_count + 1,
         ))
     __next__ = next = _next_instance  # for 2to3
@@ -237,7 +237,7 @@ class Scheduler(object):
     def _when(self, entry, next_time_to_run, mktime=time.mktime):
         adjust = self.adjust
 
-        return (mktime(entry._default_now().timetuple()) +
+        return (mktime(entry.default_now().timetuple()) +
                 (adjust(next_time_to_run) or 0))
 
     def populate_heap(self, event_t=event_t, heapify=heapq.heapify):

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -237,7 +237,7 @@ class Scheduler(object):
     def _when(self, entry, next_time_to_run, mktime=time.mktime):
         adjust = self.adjust
 
-        return (mktime(entry.schedule.now().timetuple()) +
+        return (mktime(entry._default_now().timetuple()) +
                 (adjust(next_time_to_run) or 0))
 
     def populate_heap(self, event_t=event_t, heapify=heapq.heapify):

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -102,6 +102,7 @@ class ScheduleEntry(object):
 
     def default_now(self):
         return self.schedule.now() if self.schedule else self.app.now()
+    _default_now = default_now  # compat
 
     def _next_instance(self, last_run_at=None):
         """Return new instance, with date and count fields updated."""


### PR DESCRIPTION
I'm using custom scheduler entries with an overridden ``is_due()`` method that do not require a schedule (``entry.schedule``) to be set. Judging from the ``entry._default_now()`` method, this seems to be supported by the scheduler in Celery 4.1, however that method is not used everywhere, leading to an AttributeError in my use case.

This change just uses ``_default_now()`` everywhere which fixes the issue. It shouldn't have any impact on the default implementation.