### PR TITLE
Changed raise RuntimeError to RuntimeWarning when task_always_eager is True

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 import time
+import warnings
 
 from collections import namedtuple
 from datetime import timedelta
@@ -348,8 +349,10 @@ class Backend(object):
 
     def _ensure_not_eager(self):
         if self.app.conf.task_always_eager:
-            raise RuntimeError(
-                "Cannot retrieve result with task_always_eager enabled")
+            warnings.warn(
+                "Shouldn't retrieve result with task_always_eager enabled.",
+                RuntimeWarning
+            )
 
     def get_task_meta(self, task_id, cache=True):
         self._ensure_not_eager()


### PR DESCRIPTION
## Description
This PR changes RuntimeError to RuntimeWarning when `task_always_eager` is True.

Sometimes I tested what is related to celery task using `task_always_eager` in celery v3.
(The tests are not only celery task but codes using celery task and other codes)

I know the config cannot be completely tested async task but it's useful when doing rush works.
I never use them in the production code but in the test, I use.

I read the issue (https://github.com/celery/celery/issues/2275) was produced and the commit (https://github.com/celery/celery/commit/c71cd08fc72742efbfc846a81020939aa3692501) resolved the above.


I almost agree with them but people who want to test perfectly only don't turn on `task_always_eager`.
Others who want to test synchronously also want to use `task_always_eager`.