### PR TITLE
Care about chain's link_error tasks

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -402,7 +402,7 @@ class Signature(dict):
                             self._with_list_option('link_error'),
                             t.clone())
                         for t in self.tasks], other),
-                        app=self._app)
+                    app=self._app)
             # task | group() -> chain
             return _chain(self, other, app=self.app)
 
@@ -415,7 +415,7 @@ class Signature(dict):
                         other._with_list_option('link_error'),
                         t.clone())
                     for t in other.tasks]),
-                    app=self._app)
+                app=self._app)
         elif isinstance(other, _chain):
             # chain | chain -> chain
             # assign chain's link_error sugnatures to each chain's task

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -395,9 +395,14 @@ class Signature(dict):
             other = maybe_unroll_group(other)
             if isinstance(self, _chain):
                 # chain | group() -> chain
-                sig = self.clone()
-                sig.tasks.append(other)
-                return sig
+                return _chain(
+                    seq_concat_item([
+                        reduce(
+                            lambda t, s: t.on_error(s),
+                            self._with_list_option('link_error'),
+                            t.clone())
+                        for t in self.tasks], other),
+                        app=self._app)
             # task | group() -> chain
             return _chain(self, other, app=self.app)
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -413,16 +413,18 @@ class Signature(dict):
                     app=self._app)
         elif isinstance(other, _chain):
             # chain | chain -> chain
-            sig = self.clone()
-            if isinstance(sig.tasks, tuple):
-                sig.tasks = list(sig.tasks)
             # assign chain's link_error sugnatures to each chain's task
-            sig.tasks.extend(reduce(
+            return _chain(seq_concat_seq([
+                reduce(
+                    lambda t, s: t.on_error(s),
+                    self._with_list_option('link_error'),
+                    t.clone())
+                for t in self.tasks], [
+                reduce(
                     lambda t, s: t.on_error(s),
                     other._with_list_option('link_error'),
                     t.clone())
-                for t in other.tasks)
-            return sig
+                for t in other.tasks]), app=self._app)
         elif isinstance(self, chord):
             # chord(ONE, body) | other -> ONE | body | other
             # chord with one header task is unecessary.

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -395,37 +395,19 @@ class Signature(dict):
             other = maybe_unroll_group(other)
             if isinstance(self, _chain):
                 # chain | group() -> chain
-                tasks = [t.clone() for t in self.tasks]
-                link_error = self.options.get('link_error', [])
-                for sig in link_error:
-                    for task in tasks:
-                        task.on_error(sig)
-                return _chain(seq_concat_item(tasks, other), app=self._app)
+                return _chain(seq_concat_item(
+                    self.unchain_tasks(), other), app=self._app)
             # task | group() -> chain
             return _chain(self, other, app=self.app)
 
         if not isinstance(self, _chain) and isinstance(other, _chain):
             # task | chain -> chain
-            tasks = [t.clone() for t in other.tasks]
-            link_error = other.options.get('link_error', [])
-            for sig in link_error:
-                for task in tasks:
-                    task.on_error(sig)
-            return _chain(seq_concat_seq((self,), tasks), app=self._app)
+            return _chain(seq_concat_seq(
+                (self,), other.unchain_tasks()), app=self._app)
         elif isinstance(other, _chain):
             # chain | chain -> chain
-            # assign chain's link_error sugnatures to each chain's task
-            tasks = [t.clone() for t in self.tasks]
-            link_error = self.options.get('link_error', [])
-            for sig in link_error:
-                for task in tasks:
-                    task.on_error(sig)
-            other_tasks = [t.clone() for t in other.tasks]
-            link_error = other.options.get('link_error', [])
-            for sig in link_error:
-                for task in other_tasks:
-                    task.on_error(sig)
-            return _chain(seq_concat_seq(tasks, other_tasks), app=self._app)
+            return _chain(seq_concat_seq(
+                self.unchain_tasks(), other.unchain_tasks()), app=self._app)
         elif isinstance(self, chord):
             # chord(ONE, body) | other -> ONE | body | other
             # chord with one header task is unecessary.
@@ -450,12 +432,8 @@ class Signature(dict):
                     return sig
                 else:
                     # chain | task -> chain
-                    tasks = [t.clone() for t in self.tasks]
-                    link_error = self.options.get('link_error', [])
-                    for sig in link_error:
-                        for task in tasks:
-                            task.on_error(sig)
-                    return _chain(seq_concat_item(tasks, other), app=self._app)
+                    return _chain(seq_concat_item(
+                        self.unchain_tasks(), other), app=self._app)
             # task | task -> chain
             return _chain(self, other, app=self._app)
         return NotImplemented
@@ -574,6 +552,15 @@ class _chain(Signature):
             for sig in s.kwargs['tasks']
         ]
         return s
+
+    def unchain_tasks(self):
+        # Clone chain's tasks assigning sugnatures from link_error
+        # to each task
+        tasks = [t.clone() for t in self.tasks]
+        for sig in self.options.get('link_error', []):
+            for task in tasks:
+                task.link_error(sig)
+        return tasks
 
     def apply_async(self, args=(), kwargs={}, **options):
         # python is best at unpacking kwargs, so .run is here to do that.

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -448,7 +448,12 @@ class Signature(dict):
                 else:
                     # chain | task -> chain
                     return _chain(
-                        seq_concat_item(self.tasks, other), app=self._app)
+                        seq_concat_item([
+                            reduce(
+                                lambda t, s: t.on_error(s),
+                                self._with_list_option('link_error'),
+                                t.clone())
+                            for t in self.tasks], other), app=self._app)
             # task | task -> chain
             return _chain(self, other, app=self._app)
         return NotImplemented

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -234,6 +234,7 @@ class test_Signature(CanvasCase):
         assert SIG in x.options['link_error']
         assert not x.tasks[0].options.get('link_error')
 
+
 class test_xmap_xstarmap(CanvasCase):
 
     def test_apply(self):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -188,6 +188,51 @@ class test_Signature(CanvasCase):
         s = signature('xxx.not.registered', app=self.app)
         assert s._apply_async
 
+    def test_keeping_link_error_on_chaining(self):
+        x = self.add.s(2, 2) | self.mul.s(4)
+        assert isinstance(x, _chain)
+        x.link_error(SIG)
+        assert SIG in x.options['link_error']
+
+        t = signature(SIG)
+        z = x | t
+        assert isinstance(z, _chain)
+        assert t in z.tasks
+        assert not z.options.get('link_error')
+        assert SIG in z.tasks[0].options['link_error']
+        assert not z.tasks[2].options.get('link_error')
+        assert SIG in x.options['link_error']
+        assert t not in x.tasks
+        assert not x.tasks[0].options.get('link_error')
+
+        z = t | x
+        assert isinstance(z, _chain)
+        assert t in z.tasks
+        assert not z.options.get('link_error')
+        assert SIG in z.tasks[1].options['link_error']
+        assert not z.tasks[0].options.get('link_error')
+        assert SIG in x.options['link_error']
+        assert t not in x.tasks
+        assert not x.tasks[0].options.get('link_error')
+
+        y = self.add.s(4, 4) | self.div.s(2)
+        assert isinstance(y, _chain)
+
+        z = x | y
+        assert isinstance(z, _chain)
+        assert not z.options.get('link_error')
+        assert SIG in z.tasks[0].options['link_error']
+        assert not z.tasks[2].options.get('link_error')
+        assert SIG in x.options['link_error']
+        assert not x.tasks[0].options.get('link_error')
+
+        z = y | x
+        assert isinstance(z, _chain)
+        assert not z.options.get('link_error')
+        assert SIG in z.tasks[3].options['link_error']
+        assert not z.tasks[1].options.get('link_error')
+        assert SIG in x.options['link_error']
+        assert not x.tasks[0].options.get('link_error')
 
 class test_xmap_xstarmap(CanvasCase):
 


### PR DESCRIPTION
Fixes #4232
Chain could have link_error signatures for error processing.
Joining chains copies tasks from other chain to original one.
Thus copying loses other chain's link_error signatures.
Assigning chain's link_error signatures to each task could have the same effect.
Each task from other chain are cloned to leave original ones as is.
In appending task to chain clone full chain's state and append task to chain's tasks.
