### PR TITLE
Add new function to handle etas and limits together

### DIFF
--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -305,6 +305,12 @@ class Consumer(object):
             return bucket.add(request)
         return self._schedule_bucket_request(request, bucket, tokens)
 
+    def _limit_post_eta(self, request, bucket, tokens):
+        self.qos.decrement_eventually()
+        if bucket.contents:
+            return bucket.add(request)
+        return self._schedule_bucket_request(request, bucket, tokens)
+
     def start(self):
         blueprint = self.blueprint
         while blueprint.state not in STOP_CONDITIONS:

--- a/t/unit/worker/test_strategy.py
+++ b/t/unit/worker/test_strategy.py
@@ -98,6 +98,14 @@ class test_default_strategy_proto2:
             assert not self.was_reserved()
             return self.consumer._limit_task.called
 
+        def was_limited_with_eta(self):
+            assert not self.was_reserved()
+            called = self.consumer.timer.call_at.called
+            if called:
+                assert self.consumer.timer.call_at.call_args[0][1] == \
+                       self.consumer._limit_post_eta
+            return called
+
         def was_scheduled(self):
             assert not self.was_reserved()
             assert not self.was_rate_limited()
@@ -185,6 +193,13 @@ class test_default_strategy_proto2:
         with self._context(task, rate_limits=True, limit='1/m') as C:
             C()
             assert C.was_rate_limited()
+
+    def test_when_rate_limited_with_eta(self):
+        task = self.add.s(2, 2).set(countdown=10)
+        with self._context(task, rate_limits=True, limit='1/m') as C:
+            C()
+            assert C.was_limited_with_eta()
+            C.consumer.qos.increment_eventually.assert_called_with()
 
     def test_when_rate_limited__limits_disabled(self):
         task = self.add.s(2, 2)

--- a/t/unit/worker/test_strategy.py
+++ b/t/unit/worker/test_strategy.py
@@ -103,7 +103,7 @@ class test_default_strategy_proto2:
             called = self.consumer.timer.call_at.called
             if called:
                 assert self.consumer.timer.call_at.call_args[0][1] == \
-                       self.consumer._limit_post_eta
+                    self.consumer._limit_post_eta
             return called
 
         def was_scheduled(self):


### PR DESCRIPTION
Fixes #3888

Allows rate limit to be specified along with ETA.

**Behavior**

Task would be delayed as per the ETA, and then be executed sometimes after that, respecting the rate limit.