### PR TITLE
create task message using additional v2 parameters

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -309,7 +309,8 @@ class AMQP(object):
                    time_limit=None, soft_time_limit=None,
                    create_sent_event=False, root_id=None, parent_id=None,
                    shadow=None, chain=None, now=None, timezone=None,
-                   origin=None, argsrepr=None, kwargsrepr=None):
+                   origin=None, argsrepr=None, kwargsrepr=None,
+                   **compat_kwargs):
         args = args or ()
         kwargs = kwargs or {}
         if not isinstance(args, (list, tuple)):
@@ -398,7 +399,8 @@ class AMQP(object):
                    chord=None, callbacks=None, errbacks=None, reply_to=None,
                    time_limit=None, soft_time_limit=None,
                    create_sent_event=False, root_id=None, parent_id=None,
-                   shadow=None, now=None, timezone=None):
+                   shadow=None, now=None, timezone=None,
+                   **compat_kwargs):
         args = args or ()
         kwargs = kwargs or {}
         utc = self.utc

--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -309,8 +309,7 @@ class AMQP(object):
                    time_limit=None, soft_time_limit=None,
                    create_sent_event=False, root_id=None, parent_id=None,
                    shadow=None, chain=None, now=None, timezone=None,
-                   origin=None, argsrepr=None, kwargsrepr=None,
-                   **compat_kwargs):
+                   origin=None, argsrepr=None, kwargsrepr=None):
         args = args or ()
         kwargs = kwargs or {}
         if not isinstance(args, (list, tuple)):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -731,15 +731,26 @@ class Celery(object):
                     root_id = parent.request.root_id or parent.request.id
                 if not parent_id:
                     parent_id = parent.request.id
-
-        message = amqp.create_task_message(
-            task_id, name, args, kwargs, countdown, eta, group_id,
-            expires, retries, chord,
-            maybe_list(link), maybe_list(link_error),
-            reply_to or self.oid, time_limit, soft_time_limit,
-            self.conf.task_send_sent_event,
-            root_id, parent_id, shadow, chain,
-        )
+        if conf.task_protocol == 1:
+            message = amqp.create_task_message(
+                task_id, name, args, kwargs, countdown, eta, group_id,
+                expires, retries, chord,
+                maybe_list(link), maybe_list(link_error),
+                reply_to or self.oid, time_limit, soft_time_limit,
+                self.conf.task_send_sent_event,
+                root_id, parent_id, shadow, chain,
+            )
+        else:
+            message = amqp.create_task_message(
+                task_id, name, args, kwargs, countdown, eta, group_id,
+                expires, retries, chord,
+                maybe_list(link), maybe_list(link_error),
+                reply_to or self.oid, time_limit, soft_time_limit,
+                self.conf.task_send_sent_event,
+                root_id, parent_id, shadow, chain,
+                argsrepr=options.get('argsrepr'),
+                kwargsrepr=options.get('kwargsrepr'),
+            )
 
         if connection:
             producer = amqp.Producer(connection, auto_declare=False)

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -731,26 +731,17 @@ class Celery(object):
                     root_id = parent.request.root_id or parent.request.id
                 if not parent_id:
                     parent_id = parent.request.id
-        if conf.task_protocol == 1:
-            message = amqp.create_task_message(
-                task_id, name, args, kwargs, countdown, eta, group_id,
-                expires, retries, chord,
-                maybe_list(link), maybe_list(link_error),
-                reply_to or self.oid, time_limit, soft_time_limit,
-                self.conf.task_send_sent_event,
-                root_id, parent_id, shadow, chain,
-            )
-        else:
-            message = amqp.create_task_message(
-                task_id, name, args, kwargs, countdown, eta, group_id,
-                expires, retries, chord,
-                maybe_list(link), maybe_list(link_error),
-                reply_to or self.oid, time_limit, soft_time_limit,
-                self.conf.task_send_sent_event,
-                root_id, parent_id, shadow, chain,
-                argsrepr=options.get('argsrepr'),
-                kwargsrepr=options.get('kwargsrepr'),
-            )
+
+        message = amqp.create_task_message(
+            task_id, name, args, kwargs, countdown, eta, group_id,
+            expires, retries, chord,
+            maybe_list(link), maybe_list(link_error),
+            reply_to or self.oid, time_limit, soft_time_limit,
+            self.conf.task_send_sent_event,
+            root_id, parent_id, shadow, chain,
+            argsrepr=options.get('argsrepr'),
+            kwargsrepr=options.get('kwargsrepr'),
+        )
 
         if connection:
             producer = amqp.Producer(connection, auto_declare=False)

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -411,7 +411,7 @@ class test_tasks(TasksCase):
 
     def assert_next_task_data_equal(self, consumer, presult, task_name,
                                     test_eta=False, test_expires=False,
-                                    headers=None, **kwargs):
+                                    properties=None, headers=None, **kwargs):
         next_task = consumer.queues[0].get(accept=['pickle', 'json'])
         task_properties = next_task.properties
         task_headers = next_task.headers
@@ -427,6 +427,9 @@ class test_tasks(TasksCase):
             assert isinstance(task_headers.get('expires'), string_t)
             to_datetime = parse_iso8601(task_headers.get('expires'))
             assert isinstance(to_datetime, datetime)
+        properties = properties or {}
+        for arg_name, arg_value in items(properties):
+            assert task_properties.get(arg_name) == arg_value
         headers = headers or {}
         for arg_name, arg_value in items(headers):
             assert task_headers.get(arg_name) == arg_value

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -41,7 +41,6 @@ class MockApplyTask(Task):
 class TasksCase:
 
     def setup(self):
-        self.app.conf.task_protocol = 1  # XXX  Still using proto1
         self.mytask = self.app.task(shared=False)(return_True)
 
         @self.app.task(bind=True, count=0, shared=False)
@@ -412,20 +411,25 @@ class test_tasks(TasksCase):
 
     def assert_next_task_data_equal(self, consumer, presult, task_name,
                                     test_eta=False, test_expires=False,
-                                    **kwargs):
+                                    headers=None, **kwargs):
         next_task = consumer.queues[0].get(accept=['pickle', 'json'])
-        task_data = next_task.decode()
-        assert task_data['id'] == presult.id
-        assert task_data['task'] == task_name
-        task_kwargs = task_data.get('kwargs', {})
+        task_properties = next_task.properties
+        task_headers = next_task.headers
+        task_body = next_task.decode()
+        task_args, task_kwargs, embed = task_body
+        assert task_headers['id'] == presult.id
+        assert task_headers['task'] == task_name
         if test_eta:
-            assert isinstance(task_data.get('eta'), string_t)
-            to_datetime = parse_iso8601(task_data.get('eta'))
+            assert isinstance(task_headers.get('eta'), string_t)
+            to_datetime = parse_iso8601(task_headers.get('eta'))
             assert isinstance(to_datetime, datetime)
         if test_expires:
-            assert isinstance(task_data.get('expires'), string_t)
-            to_datetime = parse_iso8601(task_data.get('expires'))
+            assert isinstance(task_headers.get('expires'), string_t)
+            to_datetime = parse_iso8601(task_headers.get('expires'))
             assert isinstance(to_datetime, datetime)
+        headers = headers or {}
+        for arg_name, arg_value in items(headers):
+            assert task_headers.get(arg_name) == arg_value
         for arg_name, arg_value in items(kwargs):
             assert task_kwargs.get(arg_name) == arg_value
 
@@ -498,6 +502,27 @@ class test_tasks(TasksCase):
             self.assert_next_task_data_equal(
                 consumer, presult2, self.mytask.name,
                 name='George Costanza', test_eta=True, test_expires=True,
+            )
+
+            # Default argsrepr/kwargsrepr behavior
+            presult2 = self.mytask.apply_async(
+                args=('spam',), kwargs={'name': 'Jerry Seinfeld'}
+            )
+            self.assert_next_task_data_equal(
+                consumer, presult2, self.mytask.name,
+                headers={'argsrepr': "('spam',)",
+                         'kwargsrepr': "{'name': 'Jerry Seinfeld'}"},
+            )
+
+            # With argsrepr/kwargsrepr
+            presult2 = self.mytask.apply_async(
+                args=('secret',), argsrepr="'***'",
+                kwargs={'password': 'foo'}, kwargsrepr="{'password': '***'}",
+            )
+            self.assert_next_task_data_equal(
+                consumer, presult2, self.mytask.name,
+                headers={'argsrepr': "'***'",
+                         'kwargsrepr': "{'password': '***'}"},
             )
 
             # Discarding all tasks.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
The `argsrepr` and `kwargsrepr` options described in the documentation (http://docs.celeryproject.org/en/latest/userguide/tasks.html#hiding-sensitive-information-in-arguments) are not actually used when creating task messages. This PR addresses that by checking the protocol version and passing them if using a version other than v1.

Fixes #4259