### PR TITLE
Disable backend for beat

### DIFF
--- a/celery/bin/beat.py
+++ b/celery/bin/beat.py
@@ -66,10 +66,10 @@
 """
 from __future__ import absolute_import, unicode_literals
 from functools import partial
-from types import MethodType
+
+from celery.backends.base import DisabledBackend
 from celery.platforms import detached, maybe_drop_privileges
 from celery.bin.base import Command, daemon_options
-from celery.utils import noop
 
 __all__ = ['beat']
 
@@ -101,8 +101,8 @@ class beat(Command):
         kwargs.pop('app', None)
         beat = partial(self.app.Beat,
                        logfile=logfile, pidfile=pidfile, **kwargs)
-        # standalone beat does not care about results, so replace on_task_call
-        self.app.backend.on_task_call = MethodType(noop, self.app.backend)
+        # standalone beat does not care about results, so disable backend
+        self.app.backend = DisabledBackend(self.app)
 
         if detach:
             with detached(logfile, pidfile, uid, gid, umask, workdir):

--- a/celery/bin/beat.py
+++ b/celery/bin/beat.py
@@ -66,8 +66,10 @@
 """
 from __future__ import absolute_import, unicode_literals
 from functools import partial
+from types import MethodType
 from celery.platforms import detached, maybe_drop_privileges
 from celery.bin.base import Command, daemon_options
+from celery.utils import noop
 
 __all__ = ['beat']
 
@@ -99,6 +101,8 @@ class beat(Command):
         kwargs.pop('app', None)
         beat = partial(self.app.Beat,
                        logfile=logfile, pidfile=pidfile, **kwargs)
+        # standalone beat does not care about results, so replace on_task_call
+        self.app.backend.on_task_call = MethodType(noop, self.app.backend)
 
         if detach:
             with detached(logfile, pidfile, uid, gid, umask, workdir):

--- a/t/unit/bin/test_beat.py
+++ b/t/unit/bin/test_beat.py
@@ -5,6 +5,7 @@ import sys
 from case import Mock, mock, patch
 from celery import beat
 from celery import platforms
+from celery.backends.base import DisabledBackend
 from celery.bin import beat as beat_bin
 from celery.apps import beat as beatapp
 
@@ -142,3 +143,9 @@ class test_div:
         cmd.app = self.app
         options, args = cmd.parse_options('celery beat', ['-s', 'foo'])
         assert options['schedule'] == 'foo'
+
+    def test_backend_disabled(self):
+        cmd = beat_bin.beat()
+        cmd.app = self.app
+        cmd.run()
+        assert isinstance(self.app.backend, DisabledBackend)


### PR DESCRIPTION
## Description

When using `beat` (at least in its standalone form), it is not necessary to subscribe to events on the result backend. These subscriptions happen in the `on_task_call` method of the backend. This PR ensures that no `SUBSCRIBE` messages are sent.

Fixes #4261 