### PR TITLE
Do not modify passed dict (fixes issue #4223)

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1174,8 +1174,9 @@ class chord(Signature):
 
     @classmethod
     def from_dict(cls, d, app=None):
-        args, d['kwargs'] = cls._unpack_args(**d['kwargs'])
-        return _upgrade(d, cls(*args, app=app, **d))
+        options = d.copy()
+        args, options['kwargs'] = cls._unpack_args(**d['kwargs'])
+        return _upgrade(d, cls(*args, app=app, **options))
 
     @staticmethod
     def _unpack_args(header=None, body=None, **kwargs):

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1175,7 +1175,7 @@ class chord(Signature):
     @classmethod
     def from_dict(cls, d, app=None):
         options = d.copy()
-        args, options['kwargs'] = cls._unpack_args(**d['kwargs'])
+        args, options['kwargs'] = cls._unpack_args(**options['kwargs'])
         return _upgrade(d, cls(*args, app=app, **options))
 
     @staticmethod


### PR DESCRIPTION
Fixes #4223
`chord.from_dict` should not modify passed dict, because it is used by `task.retry` to build new signature.
