### PR TITLE
Celery doesn't re-use DB connections with Django (fixes #4116)

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -183,7 +183,7 @@ class DjangoWorkerFixup(object):
     def _close_database(self):
         for conn in self._db.connections.all():
             try:
-                conn.close()
+                conn.close_if_unusable_or_obsolete()
             except self.interface_errors:
                 pass
             except self.DatabaseError as exc:

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -216,11 +216,12 @@ class test_DjangoWorkerFixup(FixupCase):
             f._db.connections.all.side_effect = lambda: conns
 
             f._close_database()
-            conns[0].close.assert_called_with()
-            conns[1].close.assert_called_with()
-            conns[2].close.assert_called_with()
+            conns[0].close_if_unusable_or_obsolete.assert_called_with()
+            conns[1].close_if_unusable_or_obsolete.assert_called_with()
+            conns[2].close_if_unusable_or_obsolete.assert_called_with()
 
-            conns[1].close.side_effect = KeyError('omg')
+            conns[1].close_if_unusable_or_obsolete.side_effect = KeyError(
+                'omg')
             with pytest.raises(KeyError):
                 f._close_database()
 


### PR DESCRIPTION
Fixes #4116 

Celery doesn't re-use DB connections when the setting `CONN_MAX_AGE` is set in Django. Instead connections are closed immediately. This leads to a high load on the database when there are a lot of Celery workers. It also affects query performance negatively.

This PR uses the Django `close_if_unusable_or_obsolete()` method to close a DB connection instead of `close()`.

`close_if_unusable_or_obsolete()` is available at least since Django 1.8 (see https://github.com/django/django/commit/28308078f397d1de36fd0da417ac7da2544ba12d) which is the minimum supported version for Celery 4.0.

Let me know if you need anything else to merge this.