### PR TITLE
Ignore celery.exception.Ignore on autoretry

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -476,7 +476,7 @@ class Celery(object):
                     try:
                         return task._orig_run(*args, **kwargs)
                     except Ignore:
-                        raise
+                        pass
                     except autoretry_for as exc:
                         if retry_backoff:
                             retry_kwargs['countdown'] = \

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -27,7 +27,7 @@ from celery._state import (
     get_current_worker_task, connect_on_app_finalize,
     _announce_app_finalized,
 )
-from celery.exceptions import AlwaysEagerIgnored, ImproperlyConfigured
+from celery.exceptions import AlwaysEagerIgnored, ImproperlyConfigured, Ignore
 from celery.five import (
     UserDict, bytes_if_py2, python_2_unicode_compatible, values,
 )
@@ -475,6 +475,8 @@ class Celery(object):
                 def run(*args, **kwargs):
                     try:
                         return task._orig_run(*args, **kwargs)
+                    except Ignore:
+                        raise
                     except autoretry_for as exc:
                         if retry_backoff:
                             retry_kwargs['countdown'] = \


### PR DESCRIPTION
Autoretry for task should ignore celery.exception.Ignore, which is generated by self.replace()

otherwise, it goes to infinite loop.

```python
@app.task(autoretry_for=(Exception,), default_retry_delay=1,
          max_retries=None,
          bind=True,acks_late=True)
def TaskA(self):
    raise self.replace(TaskB.s()) # Always retrying because of replace

```

