### PR TITLE
Remove extra word 'or'

### DIFF
--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -184,7 +184,7 @@ Features
         - **Scheduling**
 
             You can specify the time to run a task in seconds or a
-            :class:`~datetime.datetime`, or or you can use
+            :class:`~datetime.datetime`, or you can use
             periodic tasks for recurring events based on a
             simple interval, or Crontab expressions
             supporting minute, hour, day of week, day of month, and


### PR DESCRIPTION
This removes the extra 'or' on line 187.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
