### PR TITLE
Add check task-synchronous-subtasks for task_always_eager mode

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -15,7 +15,7 @@ from celery.canvas import signature
 from celery.exceptions import Ignore, MaxRetriesExceededError, Reject, Retry
 from celery.five import items, python_2_unicode_compatible
 from celery.local import class_property
-from celery.result import EagerResult
+from celery.result import EagerResult, denied_join_result
 from celery.utils import abstract
 from celery.utils.functional import mattrgetter, maybe_list
 from celery.utils.imports import instantiate
@@ -522,8 +522,9 @@ class Task(object):
 
         app = self._get_app()
         if app.conf.task_always_eager:
-            return self.apply(args, kwargs, task_id=task_id or uuid(),
-                              link=link, link_error=link_error, **options)
+            with denied_join_result():
+                return self.apply(args, kwargs, task_id=task_id or uuid(),
+                                  link=link, link_error=link_error, **options)
         # add 'self' if this is a "task_method".
         if self.__self__ is not None:
             args = args if isinstance(args, tuple) else tuple(args or ())

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -880,6 +880,15 @@ class test_EagerResult:
         res = self.raising.apply(args=[3, 3])
         assert not res.revoke()
 
+    @patch('celery.result.task_join_will_block')
+    def test_get_sync_subtask_option(self, task_join_will_block):
+        task_join_will_block.return_value = True
+        tid = uuid()
+        res_subtask_async = EagerResult(tid, 'x', 'x', states.SUCCESS)
+        with pytest.raises(RuntimeError):
+            res_subtask_async.get()
+        res_subtask_async.get(disable_sync_subtasks=False)
+
 
 class test_tuples:
 


### PR DESCRIPTION
Add check task-synchronous-subtasks for task_always_eager mode

**Problem**: No raise exception `task-synchronous-subtasks` if set `task_always_eager` `True`. This does not reveal a problem at the testing level, which is a very big problem for stability in production

Added argument `disable_sync_subtasks` for ResultSet `get, join, join_native` and EagerResult `get`.