### PR TITLE
Potential fix for the celery beat scheduler issue when not running in UTC

### DIFF
--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -14,6 +14,7 @@ from kombu.utils.functional import reprcall
 from kombu.utils.objects import cached_property
 from pytz import AmbiguousTimeError, FixedOffset
 from pytz import timezone as _timezone
+from pytz import utc
 
 from celery.five import python_2_unicode_compatible, string_t
 
@@ -302,7 +303,10 @@ def make_aware(dt, tz):
 
 def localize(dt, tz):
     """Convert aware :class:`~datetime.datetime` to another timezone."""
-    dt = dt.astimezone(tz)
+    if is_naive(dt):  # Ensure timezone aware datetime
+        dt = make_aware(dt, tz)
+    if dt.tzinfo == utc:
+        dt = dt.astimezone(tz)  # Always safe to call astimezone on utc zones
     try:
         _normalize = tz.normalize
     except AttributeError:  # non-pytz tz

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -177,7 +177,12 @@ class test_make_aware:
 class test_localize:
 
     def test_tz_without_normalize(self):
-        tz = tzinfo()
+        class tzz(tzinfo):
+
+            def utcoffset(self, dt):
+                return None  # Mock no utcoffset specified
+
+        tz = tzz()
         assert not hasattr(tz, 'normalize')
         assert localize(make_aware(datetime.utcnow(), tz), tz)
 
@@ -185,6 +190,9 @@ class test_localize:
 
         class tzz(tzinfo):
             raises = None
+
+            def utcoffset(self, dt):
+                return None
 
             def normalize(self, dt, **kwargs):
                 self.normalized = True
@@ -208,6 +216,26 @@ class test_localize:
         localize(make_aware(datetime.utcnow(), tz3), tz3)
         assert tz3.normalized
         assert tz3.raised
+
+    def test_localize_changes_utc_dt(self):
+        now_utc_time = datetime.now(tz=pytz.utc)
+        local_tz = pytz.timezone('US/Eastern')
+        localized_time = localize(now_utc_time, local_tz)
+        assert localized_time == now_utc_time
+
+    def test_localize_aware_dt_idempotent(self):
+        t = (2017, 4, 23, 21, 36, 59, 0)
+        local_zone = pytz.timezone('America/New_York')
+        local_time = datetime(*t)
+        local_time_aware = datetime(*t, tzinfo=local_zone)
+        alternate_zone = pytz.timezone('America/Detroit')
+        localized_time = localize(local_time_aware, alternate_zone)
+        assert localized_time == local_time_aware
+        assert local_zone.utcoffset(
+            local_time) == alternate_zone.utcoffset(local_time)
+        localized_utc_offset = localized_time.tzinfo.utcoffset(local_time)
+        assert localized_utc_offset == alternate_zone.utcoffset(local_time)
+        assert localized_utc_offset == local_zone.utcoffset(local_time)
 
 
 @pytest.mark.parametrize('s,expected', [


### PR DESCRIPTION
I first encountered the traced the issue of https://github.com/celery/celery/issues/4184 in a project space I worked on but the work around was to change to UTC.  I was playing with adding logging tonight and used these two django settings to convert between the working and non working version (adding these makes it non-working):

CELERY_ENABLE_UTC = False
CELERY_TIMEZONE = 'America/New_York'  

So it seems the issue is that when localize is called by to_local_fallback that it is already time zone aware.   In fact it was always aware up the stack, but when it gets converted using astimezone, it becomes a date in the future and so it makes celery beat think that the task is always past due.   My print output may not make the most sense, but I annotated a few methods of the same name and you can see in my example the exact moment the datetime went from a -04:00 offset to +20:00.   Since this is a common method and this line of code hasn't changed since 2012, I am not sure the exact direction to take fixing the bug, but I do want to fix it.  I have much time invested at this point.

> [2017-10-11 22:40:24,316] Scheduler: Sending due task service.tasks.send_reminder (service.tasks.send_reminder)
[2017-10-11 22:40:24,317] service.tasks.send_reminder sent. id->2d97d6e5-80ce-488a-83f1-67700dbbc7d7
[2017-10-11 22:40:24,317] crontab.->is_due
[2017-10-11 22:40:24,317] 2017-10-11 22:40:24.316813-04:00
[2017-10-11 22:40:24,318] :remaining_delta start
[2017-10-11 22:40:24,318] :to_local
[2017-10-11 22:40:24,318] 2017-10-11 22:40:24.316813-04:00
[2017-10-11 22:40:24,318] utc not enabled
[2017-10-11 22:40:24,318] <celery.utils.time._Zone object at 0x7f329ba84d30>
[2017-10-11 22:40:24,318] :to_local_fallback
[2017-10-11 22:40:24,318] 2017-10-11 22:40:24.316813-04:00
[2017-10-11 22:40:24,318] <LocalTimezone: UTC-04>
[2017-10-11 22:40:24,318] ::localize
[2017-10-11 22:40:24,318] 2017-10-12 22:40:24.316813+20:00
[2017-10-11 22:40:24,318] <LocalTimezone: UTC-04>
[2017-10-11 22:40:24,318] AttributeError
[2017-10-11 22:40:24,318] 'LocalTimezone' object has no attribute 'normalize'
[2017-10-11 22:40:24,319] 2017-10-12 22:40:24.316813+20:00
[2017-10-11 22:40:24,319] ----
[2017-10-11 22:40:24,319] :to_local
[2017-10-11 22:40:24,319] 2017-10-11 22:40:24.318128-04:00
[2017-10-11 22:40:24,319] utc not enabled
[2017-10-11 22:40:24,319] <celery.utils.time._Zone object at 0x7f329ba84d30>
[2017-10-11 22:40:24,319] :to_local_fallback
[2017-10-11 22:40:24,319] 2017-10-11 22:40:24.318128-04:00
[2017-10-11 22:40:24,319] <LocalTimezone: UTC-04>
[2017-10-11 22:40:24,319] ::localize
[2017-10-11 22:40:24,319] 2017-10-12 22:40:24.318128+20:00
[2017-10-11 22:40:24,319] <LocalTimezone: UTC-04>
[2017-10-11 22:40:24,319] AttributeError
[2017-10-11 22:40:24,319] 'LocalTimezone' object has no attribute 'normalize'
[2017-10-11 22:40:24,319] 2017-10-12 22:40:24.318128+20:00
[2017-10-11 22:40:24,319] ----
[2017-10-11 22:40:24,320] 2017-10-12 22:40:24.316813+20:00
[2017-10-11 22:40:24,320] ffwd(hour=11, minute=0, second=0, microsecond=0, weeks=0, weekday=3)
[2017-10-11 22:40:24,320] 2017-10-12 22:40:24.318128+20:00
[2017-10-11 22:40:24,320] :remaining_delta finish
[2017-10-11 22:40:24,320] -1 day, 12:19:35.681872
[2017-10-11 22:40:24,320] :remaining_delta start
[2017-10-11 22:40:24,320] :to_local
[2017-10-11 22:40:24,320] 2017-10-11 22:40:24.320389-04:00
[2017-10-11 22:40:24,320] utc not enabled
[2017-10-11 22:40:24,320] <celery.utils.time._Zone object at 0x7f329ba84d30>
[2017-10-11 22:40:24,320] :to_local_fallback
[2017-10-11 22:40:24,321] 2017-10-11 22:40:24.320389-04:00
[2017-10-11 22:40:24,321] <LocalTimezone: UTC-04>
[2017-10-11 22:40:24,321] ::localize
[2017-10-11 22:40:24,321] 2017-10-12 22:40:24.320389+20:00
[2017-10-11 22:40:24,321] <LocalTimezone: UTC-04>
[2017-10-11 22:40:24,321] AttributeError
[2017-10-11 22:40:24,321] 'LocalTimezone' object has no attribute 'normalize'
[2017-10-11 22:40:24,321] 2017-10-12 22:40:24.320389+20:00
[2017-10-11 22:40:24,321] ----
[2017-10-11 22:40:24,321] :to_local
[2017-10-11 22:40:24,321] 2017-10-11 22:40:24.320505-04:00
[2017-10-11 22:40:24,321] utc not enabled
[2017-10-11 22:40:24,322] <celery.utils.time._Zone object at 0x7f329ba84d30>
[2017-10-11 22:40:24,322] :to_local_fallback
[2017-10-11 22:40:24,322] 2017-10-11 22:40:24.320505-04:00
[2017-10-11 22:40:24,322] <LocalTimezone: UTC-04>
[2017-10-11 22:40:24,322] ::localize
[2017-10-11 22:40:24,322] 2017-10-12 22:40:24.320505+20:00
[2017-10-11 22:40:24,322] <LocalTimezone: UTC-04>
[2017-10-11 22:40:24,322] AttributeError
[2017-10-11 22:40:24,322] 'LocalTimezone' object has no attribute 'normalize'
[2017-10-11 22:40:24,322] 2017-10-12 22:40:24.320505+20:00
[2017-10-11 22:40:24,322] ----
[2017-10-11 22:40:24,322] 2017-10-12 22:40:24.320389+20:00
[2017-10-11 22:40:24,322] ffwd(hour=11, minute=0, second=0, microsecond=0, weeks=0, weekday=3)
[2017-10-11 22:40:24,322] 2017-10-12 22:40:24.320505+20:00
[2017-10-11 22:40:24,322] :remaining_delta finish
[2017-10-11 22:40:24,323] is due:
[2017-10-11 22:40:24,323] True
[2017-10-11 22:40:24,323] next time to run:
[2017-10-11 22:40:24,323] 0





