### PR TITLE
Update task-cookbook lock code example

### DIFF
--- a/docs/tutorials/task-cookbook.rst
+++ b/docs/tutorials/task-cookbook.rst
@@ -59,10 +59,11 @@ For this reason your tasks run-time shouldn't exceed the timeout.
         finally:
             # memcache delete is very slow, but we have to use it to take
             # advantage of using add() for atomic locking
-            if monotonic() < timeout_at:
+            if monotonic() < timeout_at and status:
                 # don't release the lock if we exceeded the timeout
                 # to lessen the chance of releasing an expired lock
-                # owned by someone else.
+                # owned by someone else
+                # also don't release the lock if we didn't acquire it
                 cache.delete(lock_id)
 
     @task(bind=True)


### PR DESCRIPTION
Add checking did current worker/thread acquire the lock before releasing it, to avoid the situation when one worker release lock owned by someone else.

It's might be just my misunderstanding of some context/assumptions, but I guess that in current code example we release lock regardless of the fact did we, in fact, acquire it or did it someone else. 
Example unwanted scenario, easy to reproduce using some mock script test:
1) Worker A acquires a lock for feed F1 (let's assume that lock_id for that feed URL would be ID1)
2) Worker A holds the lock and do his job
3) In the meantime worker B try to acquire a lock for the same feed F1 (so lock_id would be ID1 too)
4) Worker B fails (because A still owned the lock) but then B execute the finally clause code and release lock owned by worker A
5) Worker C try to acquire a lock for the same feed F1, with lock_id ID1 and he succeeded despite the fact worker A didn't finish his work and didn't release the lock (because B did it instead him)

Simply status check should fix that situation.

Please let me know if I misunderstood some context and should just use the original example in another way.

Thanks! :)
