### PR TITLE
Fixes #4356: Modify order of protocol upgrade detection.

### DIFF
--- a/celery/worker/consumer.py
+++ b/celery/worker/consumer.py
@@ -450,10 +450,10 @@ class Consumer(object):
         def on_task_received(body, message):
             headers = message.headers
             try:
-                type_, is_proto2 = headers['task'], 1
+                type_, is_proto2 = body['task'], 0
             except (KeyError, TypeError):
                 try:
-                    type_, is_proto2 = body['task'], 0
+                    type_, is_proto2 = headers['task'], 1
                 except (KeyError, TypeError):
                     return on_unknown_message(body, message)
 


### PR DESCRIPTION
## Description

If a task is executed under Celery 3.1.25, and is retried under Celery 4 node, and then retried again under a Celery 3.1.25 node, the Celery 3.1.25 node will crash, resulting in message loss.

When the Celery 3.1.25 task is executed on a Celery 4, the task message is upgraded to Protocol 2. However, the upgrade results in a hybrid message that complies with both formats, and when the task fails and is retried on the Celery 3.1.25 worker, the "hybrid" message is mis-identified as a Protocol 1

By changing the detection order, the "hybrid" is correctly identified as being Protocol 2 compliant.

Unfortunately, this change must be made against the 3.1 branch, as the error lies in the "forward-compatibility" code introduced in that version.
