### PR TITLE
Refs #4356: Handle "hybrid" messages that have moved between Celery versions

### DIFF
--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -64,7 +64,7 @@ def clean_hybrid_protocol(message, body):
     return (args, kwargs, embed), headers, True, body.get('utc', True)
 
 
-def proto1_to_proto2(message, body, hybrid=False):
+def proto1_to_proto2(message, body):
     """Convert Task message protocol 1 arguments to protocol 2.
 
     Returns:

--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -24,7 +24,7 @@ logger = get_logger(__name__)
 
 
 def hybrid_to_proto2(message, body):
-    "Create a fresh protocol 2 message from a hybrid protocol 1/2 message."
+    """Create a fresh protocol 2 message from a hybrid protocol 1/2 message."""
     try:
         args, kwargs = body.get('args', ()), body.get('kwargs', {})
         kwargs.items  # pylint: disable=pointless-statement

--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -90,14 +90,17 @@ def default(task, app, consumer,
 
     def task_message_handler(message, body, ack, reject, callbacks,
                              to_timestamp=to_timestamp):
-        if body is None:
+        if body is None and 'args' not in message.payload:
             body, headers, decoded, utc = (
                 message.body, message.headers, False, app.uses_utc_timezone(),
             )
             if not body_can_be_buffer:
                 body = bytes(body) if isinstance(body, buffer_t) else body
         else:
-            body, headers, decoded, utc = proto1_to_proto2(message, body)
+            if 'args' in message.payload:
+                body, headers, decoded, utc = proto1_to_proto2(message, message.payload)
+            else:
+                body, headers, decoded, utc = proto1_to_proto2(message, body)
 
         req = Req(
             message,

--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -24,8 +24,7 @@ logger = get_logger(__name__)
 
 
 def clean_hybrid_protocol(message, body):
-    """Create a fresh protocol 2 message from a "hybrid" protocol 1/2 message
-    """
+    "Create a fresh protocol 2 message from a hybrid protocol 1/2 message."
     try:
         args, kwargs = body.get('args', ()), body.get('kwargs', {})
         kwargs.items  # pylint: disable=pointless-statement

--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 # We cache globals and attribute lookups, so disable this warning.
 
 
-def clean_hybrid_protocol(message, body):
+def hybrid_to_proto2(message, body):
     "Create a fresh protocol 2 message from a hybrid protocol 1/2 message."
     try:
         args, kwargs = body.get('args', ()), body.get('kwargs', {})
@@ -138,7 +138,8 @@ def default(task, app, consumer,
                 body = bytes(body) if isinstance(body, buffer_t) else body
         else:
             if 'args' in message.payload:
-                body, headers, decoded, utc = clean_hybrid_protocol(message, message.payload)
+                body, headers, decoded, utc = hybrid_to_proto2(message,
+                                                               message.payload)
             else:
                 body, headers, decoded, utc = proto1_to_proto2(message, body)
 


### PR DESCRIPTION
The patch in #4357 addresses a problem with forward compatibility in message handling. This 

If you apply the patch from #4357, then modify [the test case reported in #4356](https://gist.github.com/ewdurbin/ddf4b0f0c0a4b190251a4a23859dd13c) to cycle from Celery 3.1 -> 4.1 -> 3.1 -> 4.1, you get a similar error, but on the Celery 4.1 worker:
```
Traceback (most recent call last):
  File "/Users/rkm/zapier/celery/celery4-venv/lib/python2.7/site-packages/billiard/pool.py", line 1747, in safe_apply_callback
    fun(*args, **kwargs)
  File "/Users/rkm/zapier/celery/celery4-venv/lib/python2.7/site-packages/celery/worker/request.py", line 366, in on_failure
    self.id, exc, request=self, store_result=self.store_errors,
  File "/Users/rkm/zapier/celery/celery4-venv/lib/python2.7/site-packages/celery/backends/base.py", line 165, in mark_as_failure
    if request.chord:
  File "/Users/rkm/zapier/celery/celery4-venv/lib/python2.7/site-packages/kombu/utils/objects.py", line 44, in __get__
    value = obj.__dict__[self.__name__] = self.__get(obj)
  File "/Users/rkm/zapier/celery/celery4-venv/lib/python2.7/site-packages/celery/worker/request.py", line 485, in chord
    _, _, embed = self._payload
ValueError: too many values to unpack
```

This patch handles the "hybrid" syntax on the Celery 4.1 worker.