### PR TITLE
Allow the shadow kwarg and the shadow_name method to set shadow properly

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -528,7 +528,7 @@ class Task(object):
         if self.__self__ is not None:
             args = args if isinstance(args, tuple) else tuple(args or ())
             args = (self.__self__,) + args
-            shadow = shadow or self.shadow_name(args, kwargs, options)
+        shadow = shadow or self.shadow_name(args, kwargs, options)
 
         preopts = self._get_exec_options()
         options = dict(preopts, **options) if options else preopts

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -4,8 +4,7 @@ import socket
 import tempfile
 from datetime import datetime, timedelta
 
-import pytest
-from case import ContextMock, MagicMock, Mock, patch
+from case import ContextMock, MagicMock, Mock, patch, ANY
 from kombu import Queue
 
 from celery import Task, group, uuid
@@ -357,6 +356,42 @@ class test_tasks(TasksCase):
             add.delay(1, 2, foobar=3)
 
         add.delay(2, 2)
+
+    def test_shadow_name(self):
+        def shadow_name(task, args, kwargs, options):
+            return 'fooxyz'
+
+        @self.app.task(shadow_name=shadow_name)
+        def shadowed():
+            pass
+
+        old_send_task = self.app.send_task
+        self.app.send_task = Mock()
+
+        shadowed.delay()
+
+        self.app.send_task.assert_called_once_with(ANY, ANY, ANY,
+                                                   compression=ANY,
+                                                   delivery_mode=ANY,
+                                                   exchange=ANY,
+                                                   expires=ANY,
+                                                   immediate=ANY,
+                                                   link=ANY,
+                                                   link_error=ANY,
+                                                   mandatory=ANY,
+                                                   priority=ANY,
+                                                   producer=ANY,
+                                                   queue=ANY,
+                                                   result_cls=ANY,
+                                                   routing_key=ANY,
+                                                   serializer=ANY,
+                                                   soft_time_limit=ANY,
+                                                   task_id=ANY,
+                                                   task_type=ANY,
+                                                   time_limit=ANY,
+                                                   shadow='fooxyz')
+
+        self.app.send_task = old_send_task
 
     def test_typing__disabled(self):
         @self.app.task(typing=False)

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -4,6 +4,7 @@ import socket
 import tempfile
 from datetime import datetime, timedelta
 
+import pytest
 from case import ANY, ContextMock, MagicMock, Mock, patch
 from kombu import Queue
 

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -4,7 +4,7 @@ import socket
 import tempfile
 from datetime import datetime, timedelta
 
-from case import ContextMock, MagicMock, Mock, patch, ANY
+from case import ANY, ContextMock, MagicMock, Mock, patch
 from kombu import Queue
 
 from celery import Task, group, uuid


### PR DESCRIPTION
Ensure the `shadow_name` option in the `@app.task()` decorator and the `shadow` keyword argument of `Task.apply_async()` to work properly.

## Description
The `shadow_name` option in the `@app.task()` decorator (which overrides the shadow_name method in the `Task` class) and the `shadow` keyword argument of `Task.apply_async()` don't work as advertised. Currently, both don't set `shadow` properly across the examples in the documentation:

### Not Working ###
The example provided in `Task.shadow_name(args, kwargs, options)` of [celery.app.task](http://docs.celeryproject.org/en/latest/reference/celery.app.task.html) does not work. The function `shadow_name` was never called:
```python
from celery.utils.imports import qualname

def shadow_name(task, args, kwargs, options):
    return qualname(args[0])

@app.task(shadow_name=shadow_name, serializer='pickle')
def apply_function_async(fun, *args, **kwargs):
    return fun(*args, **kwargs)
```

### Working ###
The example provided for `shadow` in [Message Protocol](http://docs.celeryproject.org/en/latest/internals/protocol.html) works:
```python
from celery.utils.imports import qualname

class PickleTask(Task):

    def unpack_args(self, fun, args=()):
        return fun, args

    def apply_async(self, args, kwargs, **options):
        fun, real_args = self.unpack_args(*args)
        return super(PickleTask, self).apply_async(
            (fun, real_args, kwargs), shadow=qualname(fun), **options
        )

@app.task(base=PickleTask)
def call(fun, args, kwargs):
    return fun(*args, **kwargs)
``` 

The problem is that the `shadow=...` is in the `if self.__self__ is not None:` block which only makes the 2nd example work.

This fix moves the `shadow=...` out of the `if self.__self__ is not None:` block and allows shadow to be set by the shadow keyword argument of Task.apply_async() or the shadow_name method in the Task class (via, say, the shadow_name option in the @app.task() decorator) across all cases.


