### PR TITLE
Fix append to an empty chain

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -419,13 +419,13 @@ class Signature(dict):
             return sig
         elif isinstance(other, Signature):
             if isinstance(self, _chain):
-                if isinstance(self.tasks[-1], group):
+                if self.tasks and isinstance(self.tasks[-1], group):
                     # CHAIN [last item is group] | TASK -> chord
                     sig = self.clone()
                     sig.tasks[-1] = chord(
                         sig.tasks[-1], other, app=self._app)
                     return sig
-                elif isinstance(self.tasks[-1], chord):
+                elif self.tasks and isinstance(self.tasks[-1], chord):
                     # CHAIN [last item is chord] -> chain with chord body.
                     sig = self.clone()
                     sig.tasks[-1].body = sig.tasks[-1].body | other

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -478,6 +478,16 @@ class test_chain(CanvasCase):
             seen.add(node.id)
             node = node.parent
 
+    def test_append_to_empty_chain(self):
+        x = chain()
+        x |= self.add.s(1, 1)
+        x |= self.add.s(1)
+        x.freeze()
+        tasks, _ = x._frozen
+        assert len(tasks) == 2
+
+        assert x.apply().get() == 3
+
 
 class test_group(CanvasCase):
 


### PR DESCRIPTION
Fixes #4047.
This bug is a regression from Celery 3.x. A test was added to ensure no further regressions will occur.