### PR TITLE
[backends]: Consul: Do not encode, but decode a byte() object

### DIFF
--- a/celery/backends/consul.py
+++ b/celery/backends/consul.py
@@ -6,9 +6,10 @@
 """
 from __future__ import absolute_import, unicode_literals
 
+from kombu.utils.encoding import bytes_to_str
 from kombu.utils.url import parse_url
 
-from celery.backends.base import PY3, KeyValueStoreBackend
+from celery.backends.base import KeyValueStoreBackend
 from celery.exceptions import ImproperlyConfigured
 from celery.utils.log import get_logger
 
@@ -53,8 +54,7 @@ class ConsulBackend(KeyValueStoreBackend):
                                     consistency=self.consistency)
 
     def _key_to_consul_key(self, key):
-        if PY3:
-            key = key.encode('utf-8')
+        key = bytes_to_str(key)
         return key if self.path is None else '{0}/{1}'.format(self.path, key)
 
     def get(self, key):
@@ -81,9 +81,8 @@ class ConsulBackend(KeyValueStoreBackend):
         If the session expires it will remove the key so that results
         can auto expire from the K/V store
         """
-        session_name = key
-        if PY3:
-            session_name = key.decode('utf-8')
+        session_name = bytes_to_str(key)
+
         key = self._key_to_consul_key(key)
 
         logger.debug('Trying to create Consul session %s with TTL %d',

--- a/t/unit/backends/test_consul.py
+++ b/t/unit/backends/test_consul.py
@@ -24,3 +24,8 @@ class test_ConsulBackend:
         self.backend.client = Mock(name='c.client')
         self.backend.client.kv.get.return_value = (index, data)
         assert self.backend.get(data['Key']) == 'mypayload'
+
+    def test_index_bytes_key(self):
+        key = 'test-consul-2'
+        assert self.backend._key_to_consul_key(key) == key
+        assert self.backend._key_to_consul_key(key.encode('utf-8')) == key


### PR DESCRIPTION
We want a string and it's already a byte() code array, so we should
decode it instead of encoding it.

Signed-off-by: Wido den Hollander <wido@widodh.nl>

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

In #4096 and #4097 this was mentioned, but closed again.

I verified this issue and tested with Ubuntu 16.04 and Python 3.5 and the issue exists indeed.
