### PR TITLE
Strip `self` from sphinx documentation of bound tasks

### DIFF
--- a/celery/contrib/sphinx.py
+++ b/celery/contrib/sphinx.py
@@ -54,6 +54,8 @@ class TaskDocumenter(FunctionDocumenter):
         wrapped = getattr(self.object, '__wrapped__', None)
         if wrapped is not None:
             argspec = getfullargspec(wrapped)
+            if argspec[0] and argspec[0][0] in ('cls', 'self'):
+                del argspec[0][0]
             fmt = formatargspec(*argspec)
             fmt = fmt.replace('\\', '\\\\')
             return fmt


### PR DESCRIPTION
In Sphinx-generated documentation, the `self` argument should be hidden from the signature of a task that was created with `bind=True`.

(Sphinx does normally strip the `self` or `cls` argument from method signatures.)