### PR TITLE
Correctly restore an empty GroupResult (#2202)

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -998,7 +998,7 @@ def result_from_tuple(r, app=None):
         if parent:
             parent = result_from_tuple(parent, app)
 
-        if nodes:
+        if nodes is not None:
             return app.GroupResult(
                 id, [result_from_tuple(child, app) for child in nodes],
                 parent=parent,

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -641,6 +641,16 @@ class test_GroupResult:
         with pytest.raises(AttributeError):
             self.app.GroupResult.restore(ts.id, backend=object())
 
+    def test_save_restore_empty(self):
+        subs = []
+        ts = self.app.GroupResult(uuid(), subs)
+        ts.save()
+        assert isinstance(
+            self.app.GroupResult.restore(ts.id),
+            self.app.GroupResult,
+        )
+        assert self.app.GroupResult.restore(ts.id).results == ts.results == []
+
     def test_restore_app(self):
         subs = [MockAsyncResultSuccess(uuid(), app=self.app)]
         ts = self.app.GroupResult(uuid(), subs)


### PR DESCRIPTION
This fixes issue #2202, where a saved empty GroupResult is restored as an AsyncResult. The fix is a simple one-liner and I've added a test verifying the behaviour.

The bug: to return a `GroupResult`, a certain variable `nodes` must evaluate boolean true. In the case of an empty `GroupResult`, `nodes` is an empty list, which evaluates false. The fix is to tighten up the check by adding `is not None`.