### PR TITLE
Introduced Build Stages to our build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,22 @@ matrix:
     env: TOXENV=pypy-integration-dynamodb PYPY_VERSION="pypy2.7-5.8.0"
   - python: '3.5'
     env: TOXENV=flake8
+    stage: lint
   - python: '3.5'
     env: TOXENV=flakeplus
+    stage: lint
   - python: '3.5'
     env: TOXENV=apicheck
+    stage: lint
   - python: '3.5'
     env: TOXENV=configcheck
+    stage: lint
   - python: '3.5'
     env: TOXENV=pydocstyle
+    stage: lint
   - python: '3.5'
     env: TOXENV=isort-check
+    stage: lint
 before_install:
     - if [[ -v MATRIX_TOXENV ]]; then export TOXENV=${TRAVIS_PYTHON_VERSION}-${MATRIX_TOXENV}; fi; env
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ python:
   - '3.6'
 os:
     - linux
+stages:
+  - lint
+  - test
 env:
   global:
   - PYTHONUNBUFFERED=yes

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ commands =
 
 [testenv:flake8]
 commands =
-    flake8 {toxinidir}/celery {toxinidir}/t
+    flake8 -j 2 {toxinidir}/celery {toxinidir}/t
 
 [testenv:flakeplus]
 commands =


### PR DESCRIPTION
We will now run the linting tools before anything else.
This will save time on our build queue and reduce feedback cycles.
I've also added a minor improvement that makes flake8 run with two parallel jobs.