### PR TITLE
Fix current_app fallback in GroupResult.restore()

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -895,8 +895,10 @@ class GroupResult(ResultSet):
     @classmethod
     def restore(cls, id, backend=None, app=None):
         """Restore previously saved group result."""
-        app = app or cls.app
-        backend = backend or (app.backend if app else current_app.backend)
+        app = app or (
+            cls.app if not isinstance(cls.app, property) else current_app
+        )
+        backend = backend or app.backend
         return backend.restore_group(id)
 
 

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -658,6 +658,14 @@ class test_GroupResult:
         restored = GroupResult.restore(ts.id, app=self.app)
         assert restored.id == ts.id
 
+    def test_restore_current_app_fallback(self):
+        subs = [MockAsyncResultSuccess(uuid(), app=self.app)]
+        ts = self.app.GroupResult(uuid(), subs)
+        ts.save()
+        with pytest.raises(RuntimeError,
+                           message="Test depends on current_app"):
+            GroupResult.restore(ts.id)
+
     def test_join_native(self):
         backend = SimpleBackend()
         results = [self.app.AsyncResult(uuid(), backend=backend)


### PR DESCRIPTION
See #4428 - when `result()` is called on the base `GroupResult` class, with no `app` or `backend` arguments, it fails to correctly fall back to using `current_app`.