### PR TITLE
Resolve TypeError on `.get` from nested groups

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -628,7 +628,7 @@ class ResultSet(ResultBase):
 
     def get(self, timeout=None, propagate=True, interval=0.5,
             callback=None, no_ack=True, on_message=None,
-            disable_sync_subtasks=True):
+            disable_sync_subtasks=True, on_interval=None):
         """See :meth:`join`.
 
         This is here for API compatibility with :class:`AsyncResult`,
@@ -640,7 +640,8 @@ class ResultSet(ResultBase):
         return (self.join_native if self.supports_native_join else self.join)(
             timeout=timeout, propagate=propagate,
             interval=interval, callback=callback, no_ack=no_ack,
-            on_message=on_message, disable_sync_subtasks=disable_sync_subtasks
+            on_message=on_message, disable_sync_subtasks=disable_sync_subtasks,
+            on_interval=on_interval,
         )
 
     def join(self, timeout=None, propagate=True, interval=0.5,

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -130,6 +130,33 @@ class test_group:
             assert parent_id == expected_parent_id
             assert value == i + 2
 
+    @flaky
+    def test_nested_group(self, manager):
+        assert manager.inspect().ping()
+
+        c = group(
+            add.si(1, 10),
+            group(
+                add.si(1, 100),
+                group(
+                    add.si(1, 1000),
+                    add.si(1, 2000),
+                ),
+            ),
+        )
+        res = c()
+
+        assert res.get(timeout=TIMEOUT) == [
+            11,
+            [
+                101,
+                [
+                    1001,
+                    2001,
+                ],
+            ]
+        ]
+
 
 def assert_ids(r, expected_value, expected_root_id, expected_parent_id):
     root_id, parent_id, value = r.get(timeout=TIMEOUT)
@@ -151,25 +178,6 @@ class test_chord:
         )
         res = c()
         assert res.get(timeout=TIMEOUT) == [12, 13, 14, 15]
-
-    @flaky
-    def test_nested_group_chain(self, manager):
-        c = chain(
-            add.si(1, 0),
-            group(
-                add.si(1, 100),
-                chain(
-                    add.si(1, 200),
-                    group(
-                        add.si(1, 1000),
-                        add.si(1, 2000),
-                    ),
-                ),
-            ),
-            add.si(1, 10),
-        )
-        res = c()
-        assert res.get(timeout=TIMEOUT) == 11
 
     @flaky
     def test_parent_ids(self, manager):

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -171,6 +171,27 @@ class test_chord:
         assert res.get(timeout=TIMEOUT) == [12, 13, 14, 15]
 
     @flaky
+    def test_nested_group_chain(self, manager):
+        if not manager.app.backend.supports_native_join:
+            raise pytest.skip('Requires a result backend that supports native joins.')
+        c = chain(
+            add.si(1, 0),
+            group(
+                add.si(1, 100),
+                chain(
+                    add.si(1, 200),
+                    group(
+                        add.si(1, 1000),
+                        add.si(1, 2000),
+                    ),
+                ),
+            ),
+            add.si(1, 10),
+        )
+        res = c()
+        assert res.get(timeout=TIMEOUT) == 11
+
+    @flaky
     def test_parent_ids(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -146,16 +146,7 @@ class test_group:
         )
         res = c()
 
-        assert res.get(timeout=TIMEOUT) == [
-            11,
-            [
-                101,
-                [
-                    1001,
-                    2001,
-                ],
-            ]
-        ]
+        assert res.get(timeout=TIMEOUT) == [11, 101, 1001, 2001]
 
 
 def assert_ids(r, expected_value, expected_root_id, expected_parent_id):

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -153,6 +153,25 @@ class test_chord:
         assert res.get(timeout=TIMEOUT) == [12, 13, 14, 15]
 
     @flaky
+    def test_nested_group_chain(self, manager):
+        c = chain(
+            add.si(1, 0),
+            group(
+                add.si(1, 100),
+                chain(
+                    add.si(1, 200),
+                    group(
+                        add.si(1, 1000),
+                        add.si(1, 2000),
+                    ),
+                ),
+            ),
+            add.si(1, 10),
+        )
+        res = c()
+        assert res.get(timeout=TIMEOUT) == 11
+
+    @flaky
     def test_parent_ids(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -172,6 +172,11 @@ class test_chord:
 
     @flaky
     def test_nested_group_chain(self, manager):
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.msg)
+
         if not manager.app.backend.supports_native_join:
             raise pytest.skip('Requires native join support.')
         c = chain(

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -175,7 +175,7 @@ class test_chord:
         try:
             manager.app.backend.ensure_chords_allowed()
         except NotImplementedError as e:
-            raise pytest.skip(e.msg)
+            raise pytest.skip(e.args[0])
 
         if not manager.app.backend.supports_native_join:
             raise pytest.skip('Requires native join support.')

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -173,7 +173,7 @@ class test_chord:
     @flaky
     def test_nested_group_chain(self, manager):
         if not manager.app.backend.supports_native_join:
-            raise pytest.skip('Requires a result backend that supports native joins.')
+            raise pytest.skip('Requires native join support.')
         c = chain(
             add.si(1, 0),
             group(

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -519,12 +519,16 @@ class MockAsyncResultFailure(AsyncResult):
 class MockAsyncResultSuccess(AsyncResult):
     forgotten = False
 
+    def __init__(self, *args, **kwargs):
+        self._result = kwargs.pop('result', 42)
+        super(MockAsyncResultSuccess, self).__init__(*args, **kwargs)
+
     def forget(self):
         self.forgotten = True
 
     @property
     def result(self):
-        return 42
+        return self._result
 
     @property
     def state(self):
@@ -621,6 +625,33 @@ class test_GroupResult:
         ts.forget()
         for sub in subs:
             assert sub.forgotten
+
+    def test_get_nested_without_native_join(self):
+        backend = SimpleBackend()
+        backend.supports_native_join = False
+        ts = self.app.GroupResult(uuid(), [
+            MockAsyncResultSuccess(uuid(), result='1.1', app=self.app, backend=backend),
+            self.app.GroupResult(uuid(), [
+                MockAsyncResultSuccess(uuid(), result='2.1', app=self.app, backend=backend),
+                self.app.GroupResult(uuid(), [
+                    MockAsyncResultSuccess(uuid(), result='3.1', app=self.app, backend=backend),
+                    MockAsyncResultSuccess(uuid(), result='3.2', app=self.app, backend=backend),
+                ]),
+            ]),
+        ])
+        ts.app.backend = backend
+
+        vals = ts.get()
+        assert vals == [
+            '1.1',
+            [
+                '2.1',
+                [
+                    '3.1',
+                    '3.2',
+                ]
+            ],
+        ]
 
     def test_getitem(self):
         subs = [MockAsyncResultSuccess(uuid(), app=self.app),

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -630,12 +630,16 @@ class test_GroupResult:
         backend = SimpleBackend()
         backend.supports_native_join = False
         ts = self.app.GroupResult(uuid(), [
-            MockAsyncResultSuccess(uuid(), result='1.1', app=self.app, backend=backend),
+            MockAsyncResultSuccess(uuid(), result='1.1',
+                                   app=self.app, backend=backend),
             self.app.GroupResult(uuid(), [
-                MockAsyncResultSuccess(uuid(), result='2.1', app=self.app, backend=backend),
+                MockAsyncResultSuccess(uuid(), result='2.1',
+                                       app=self.app, backend=backend),
                 self.app.GroupResult(uuid(), [
-                    MockAsyncResultSuccess(uuid(), result='3.1', app=self.app, backend=backend),
-                    MockAsyncResultSuccess(uuid(), result='3.2', app=self.app, backend=backend),
+                    MockAsyncResultSuccess(uuid(), result='3.1',
+                                           app=self.app, backend=backend),
+                    MockAsyncResultSuccess(uuid(), result='3.2',
+                                           app=self.app, backend=backend),
                 ]),
             ]),
         ])


### PR DESCRIPTION
## Description

#4274 is caused by the fact that when the result backend does not support native join, `ResultSet.get` calls `ResultSet.join`, which itself calls `ResultSet.get`. When that second `.get` call is made, `on_interval` is passed in. 

Currently, `ResultSet.get` does not take such an argument, so the call results in the `TypeError` described in the issue. However, since `ResultSet.join` _does_ take such an option (as does `.join_native`), it's safe to pass along down to the join methods and should be accepted by `.get`. 

This PR changes `ResultSet.get` to accept and pass along the `on_interval` argument to `ResultSet.join` (or `ResultSet.join_native`), which resolves the issue.

The PR also adds a unit test that prevents regression of this behavior. The unit test was verified to fail on `master` (at https://github.com/celery/celery/commit/28c2c09d380c62f9e17776811735a5c8c4ed8320), but passes on the current branch head. The unit test only tests the behavior when native join is not supported by the backend, as backends that support native join did not trigger this error. The unit test can be easily changed to cover both scenarios, just in case, if deemed necessary.

Finally, the PR adds an integration test that tests the scenario laid out in the unit test. As the integration test is run on the DynamoDB backend, which does not support native join, it should also prevent further regression of this behavior.

Fixes #4274 
