### PR TITLE
Parallel doc lints

### DIFF
--- a/celery/contrib/sphinx.py
+++ b/celery/contrib/sphinx.py
@@ -88,3 +88,7 @@ def setup(app):
     app.add_autodocumenter(TaskDocumenter)
     app.add_directive_to_domain('py', 'task', TaskDirective)
     app.add_config_value('celery_task_prefix', '(task)', True)
+    
+    return {
+        'parallel_read_safe': True
+    }

--- a/celery/contrib/sphinx.py
+++ b/celery/contrib/sphinx.py
@@ -88,7 +88,7 @@ def setup(app):
     app.add_autodocumenter(TaskDocumenter)
     app.add_directive_to_domain('py', 'task', TaskDirective)
     app.add_config_value('celery_task_prefix', '(task)', True)
-    
+
     return {
         'parallel_read_safe': True
     }

--- a/docs/_ext/celerydocs.py
+++ b/docs/_ext/celerydocs.py
@@ -185,3 +185,7 @@ def setup(app):
         rolename=bytes_if_py2('event'),
         indextemplate=bytes_if_py2('pair: %s; event'),
     )
+
+    return {
+        'parallel_read_safe': True
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ globals().update(conf.build_config(
     github_project='celery/celery',
     author='Ask Solem & contributors',
     author_name='Ask Solem',
-    copyright='2009-2016',
+    copyright='2009-2017',
     publisher='Celery Project',
     html_logo='images/celery_512.png',
     html_favicon='images/favicon.ico',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-sphinx_celery>=1.3
+git+https://github.com/celery/sphinx_celery.git
 Sphinx==1.6.5
 typing
 -r extras/sqlalchemy.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
 sphinx_celery>=1.3
-Sphinx==1.5.1
+Sphinx==1.6.5
 typing
 -r extras/sqlalchemy.txt


### PR DESCRIPTION
This will enable us to run our doc lints faster. We do need to install the newest version of sphinx_celery though.
See https://github.com/celery/sphinx_celery/issues/4 & https://github.com/celery/sphinx_celery/pull/5.