### PR TITLE
Report coverage correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,8 +85,11 @@ before_install:
           sudo apt-add-repository -y 'deb http://packages.couchbase.com/ubuntu trusty trusty/main'
           sudo apt-get update && sudo apt-get install -y libcouchbase-dev
 after_success:
-  - .tox/$TRAVIS_PYTHON_VERSION/bin/coverage xml
-  - .tox/$TRAVIS_PYTHON_VERSION/bin/codecov -e TOXENV
+  - |
+          if [[ -v MATRIX_TOXENV || "$TOXENV" =~ "pypy" ]]; then
+              .tox/$TOXENV/bin/coverage xml
+              .tox/$TOXENV/bin/codecov -e TOXENV
+          fi;
 install: travis_retry pip install -U tox | cat
 script: tox -v -- -v
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. image:: http://docs.celeryproject.org/en/latest/_images/celery-banner-small.png
 
-|build-status| |license| |wheel| |pyversion| |pyimp|
+|build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
 :Version: 4.1.0 (latentcall)
 :Web: http://celeryproject.org/


### PR DESCRIPTION
As it turns out this repository does not report coverage to codecov at all since the path to the executables has changed at some point.
This should fix the problem.