### PR TITLE
Integration test to verify PubSub unsubscriptions

### DIFF
--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -15,6 +15,15 @@ def add(x, y):
     return x + y
 
 
+@shared_task
+def delayed_sum(numbers, pause_time=1):
+    """Sum the iterable of numbers."""
+    # Allow the task to be in STARTED state for
+    # a limited period of time.
+    sleep(pause_time)
+    return sum(numbers)
+
+
 @shared_task(bind=True)
 def add_replaced(self, x, y):
     """Add two numbers (via the add task)."""

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
-import pytest
 from time import sleep
+
+import pytest
 from redis import StrictRedis
 
 from celery import chain, chord, group

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -10,8 +10,8 @@ from celery.exceptions import TimeoutError
 from celery.result import AsyncResult, GroupResult
 
 from .conftest import flaky
-from .tasks import (add, add_replaced, add_to_all, collect_ids, ids,
-                    redis_echo, second_order_replace1, delayed_sum)
+from .tasks import (add, add_replaced, add_to_all, collect_ids, delayed_sum,
+                    ids, redis_echo, second_order_replace1)
 
 TIMEOUT = 120
 


### PR DESCRIPTION
## Description

Introduce an integration test to verify that PubSub channels Redis Backend are not increasing with time. See also #3812.

- [x] Add an integration task with a sleep time, in order to detect tasks in `STARTED` state.
- [x] Count the number of PubSub channels (subscriptions) before and after the chord execution.