### PR TITLE
request on_timeout now ignores soft time limit exception (fixes #4412)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -254,3 +254,4 @@ Andrew Wong, 2017/09/07
 Arpan Shah, 2017/09/12
 Tobias 'rixx' Kunze, 2017/08/20
 Mikhail Wolfson, 2017/12/11
+Alex Garel, 2018/01/04

--- a/Changelog
+++ b/Changelog
@@ -8,6 +8,15 @@ This document contains change notes for bugfix releases in
 the 4.1.x series (latentcall), please see :ref:`whatsnew-4.1` for
 an overview of what's new in Celery 4.1.
 
+Unreleased
+==========
+
+- **Canvas**: request on_timeout now ignores soft time limit exception
+  to give a chance for task to recover.
+
+  Contributed by **Alex Garel**
+
+
 .. _version-4.1.0:
 
 4.1.0

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -18,8 +18,8 @@ from kombu.utils.objects import cached_property
 from celery import signals
 from celery.app.trace import trace_task, trace_task_ret
 from celery.exceptions import (Ignore, InvalidTaskError, Reject, Retry,
-                               SoftTimeLimitExceeded, TaskRevokedError,
-                               Terminated, TimeLimitExceeded, WorkerLostError)
+                               TaskRevokedError, Terminated,
+                               TimeLimitExceeded, WorkerLostError)
 from celery.five import python_2_unicode_compatible, string
 from celery.platforms import signals as _signals
 from celery.utils.functional import maybe, noop

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -299,22 +299,21 @@ class Request(object):
 
     def on_timeout(self, soft, timeout):
         """Handler called if the task times out."""
-        task_ready(self)
         if soft:
             warn('Soft time limit (%ss) exceeded for %s[%s]',
                  timeout, self.name, self.id)
-            exc = SoftTimeLimitExceeded(soft)
         else:
+            task_ready(self)
             error('Hard time limit (%ss) exceeded for %s[%s]',
                   timeout, self.name, self.id)
             exc = TimeLimitExceeded(timeout)
 
-        self.task.backend.mark_as_failure(
-            self.id, exc, request=self, store_result=self.store_errors,
-        )
+            self.task.backend.mark_as_failure(
+                self.id, exc, request=self, store_result=self.store_errors,
+            )
 
-        if self.task.acks_late:
-            self.acknowledge()
+            if self.task.acks_late:
+                self.acknowledge()
 
     def on_success(self, failed__retval__runtime, **kwargs):
         """Handler called if the task was successfully processed."""

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from time import sleep
 
 from celery import chain, group, shared_task
+from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
 
 logger = get_task_logger(__name__)
@@ -22,6 +23,16 @@ def delayed_sum(numbers, pause_time=1):
     # a limited period of time.
     sleep(pause_time)
     return sum(numbers)
+
+
+@shared_task
+def delayed_sum_with_soft_guard(numbers, pause_time=1):
+    """Sum the iterable of numbers."""
+    try:
+        sleep(pause_time)
+        return sum(numbers)
+    except SoftTimeLimitExceeded:
+        return 0
 
 
 @shared_task(bind=True)

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -11,7 +11,8 @@ from celery.result import AsyncResult, GroupResult
 
 from .conftest import flaky
 from .tasks import (add, add_replaced, add_to_all, collect_ids, delayed_sum,
-                    delayed_sum_with_soft_guard, ids, redis_echo, second_order_replace1)
+                    delayed_sum_with_soft_guard, ids, redis_echo,
+                    second_order_replace1)
 
 TIMEOUT = 120
 
@@ -114,19 +115,22 @@ class test_chain:
         """Test that if soft timeout happens in task but is managed by task,
         chord still get results normally
         """
-        from celery.five import bytes_if_py2
-
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
-        redis_connection = StrictRedis()
 
         c = chord([
             # return 3
             add.s(1, 2),
             # return 0 after managing soft timeout
-            delayed_sum_with_soft_guard.s([100], pause_time=2).set(soft_time_limit=1)])
+            delayed_sum_with_soft_guard.s(
+                [100], pause_time=2
+            ).set(
+                soft_time_limit=1
+            ),
+        ])
         result = c(delayed_sum.s(pause_time=0)).get()
         assert result == 3
+
 
 class test_group:
 

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -11,7 +11,7 @@ from celery.result import AsyncResult, GroupResult
 
 from .conftest import flaky
 from .tasks import (add, add_replaced, add_to_all, collect_ids, delayed_sum,
-                    ids, redis_echo, second_order_replace1)
+                    delayed_sum_with_soft_guard, ids, redis_echo, second_order_replace1)
 
 TIMEOUT = 120
 
@@ -110,6 +110,23 @@ class test_chain:
             node = node.parent
             i -= 1
 
+    def test_chord_soft_timeout_recuperation(self, manager):
+        """Test that if soft timeout happens in task but is managed by task,
+        chord still get results normally
+        """
+        from celery.five import bytes_if_py2
+
+        if not manager.app.conf.result_backend.startswith('redis'):
+            raise pytest.skip('Requires redis result backend.')
+        redis_connection = StrictRedis()
+
+        c = chord([
+            # return 3
+            add.s(1, 2),
+            # return 0 after managing soft timeout
+            delayed_sum_with_soft_guard.s([100], pause_time=2).set(soft_time_limit=1)])
+        result = c(delayed_sum.s(pause_time=0)).get()
+        assert result == 3
 
 class test_group:
 


### PR DESCRIPTION
## Description

When Request.on_timeout receive a **soft** timeout from billiard, it should just issue a warning, but let the task go on as it may catch the exception and return (this is what soft timeout are for).