### PR TITLE
Corrected the default visibility timeout in the SQS broker docs

### DIFF
--- a/docs/getting-started/brokers/sqs.rst
+++ b/docs/getting-started/brokers/sqs.rst
@@ -76,7 +76,7 @@ This option is set via the :setting:`broker_transport_options` setting::
 
     broker_transport_options = {'visibility_timeout': 3600}  # 1 hour.
 
-The default visibility timeout is 30 seconds.
+The default visibility timeout is 30 minutes.
 
 Polling Interval
 ----------------


### PR DESCRIPTION
## Description

According to [Kombu](https://github.com/celery/kombu/blob/3a7cdb07c9bf75b54282274d711af15ca6ad5d9f/kombu/transport/SQS.py#L85), the default visibility timeout for the SQS broker is 30 minutes.

The docs currently report that it's 30 seconds.
