### PR TITLE
Propagate arguments to chains inside groups

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -570,13 +570,10 @@ class _chain(Signature):
         args = (tuple(args) + tuple(self.args)
                 if args and not self.immutable else self.args)
 
-        if self._frozen:
-            tasks, results = self._frozen
-        else:
-            tasks, results = self.prepare_steps(
-                args, self.tasks, root_id, parent_id, link_error, app,
-                task_id, group_id, chord,
-            )
+        tasks, results = self.prepare_steps(
+            args, self.tasks, root_id, parent_id, link_error, app,
+            task_id, group_id, chord,
+        )
 
         if results:
             if link:

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -35,6 +35,21 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == [64, 65, 66, 67]
 
+    @flaky
+    def test_group_results_in_chain(self, manager):
+        # This adds in an explicit test for the special case added in commit
+        # 1e3fcaa969de6ad32b52a3ed8e74281e5e5360e6
+        c = (
+            group(
+                add.s(1, 2) | group(
+                    add.s(1), add.s(2)
+                )
+            )
+        )
+        res = c()
+        assert res.get(timeout=TIMEOUT) == [4, 5]
+
+    @flaky
     def test_chain_inside_group_receives_arguments(self, manager):
         c = (
             add.s(5, 6) |

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -35,6 +35,14 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == [64, 65, 66, 67]
 
+    def test_chain_inside_group_receives_arguments(self, manager):
+        c = (
+            add.s(5, 6) |
+            group((add.s(1) | add.s(2), add.s(3)))
+        )
+        res = c()
+        assert res.get(timeout=TIMEOUT) == [14, 14]
+
     @flaky
     def test_group_chord_group_chain(self, manager):
         from celery.five import bytes_if_py2


### PR DESCRIPTION
This addresses issue #4430 that may be a duplicate of #3968. 

Arguments were not propagated to chains within groups because in the `apply_async` method of `group`, `self._prepared` is called without partial arguments (as shown)
```
    options, group_id, root_id = self._freeze_gid(options)
    tasks = self._prepared(self.tasks, [], group_id, root_id, app)
    p = barrier()
    results = list(self._apply_tasks(tasks, producer, app, p,
                                         args=args, kwargs=kwargs, **options))
```

Consequentially, in `self._prepared`, when the task is frozen and no arguments have been passed, the task becomes frozen without any arguments.

```
    if partial_args and not task.immutable:
        task.args = tuple(partial_args) + tuple(task.args)
    yield task, task.freeze(group_id=group_id, root_id=root_id
```

Thus, a frozen chain has been created with no input arguments. It seems this is done because the subsequent call to `apply_tasks` is supposed to parameterize the tasks with arguments. However, in the `run` method of `_chain`, if a task is frozen, the arguments are not updated and it is run as follows:
```
        if self._frozen:
            tasks, results = self._frozen
        else:
            tasks, results = self.prepare_steps(
                args, self.tasks, root_id, parent_id, link_error, app,
                task_id, group_id, chord,
            )
```

Thus, because the frozen tasks and results were not provided the input arguments, they are ignored. To fix this, I simply removed the condition on `self._frozen`. 

I did this without knowing exactly the reason for frozen and hoping the unit tests would prove if this was a bad idea. This is a very important issue to me, so I'd love additional feedback if this is an unsuitable fix and how it should be implemented.