### PR TITLE
Add docker-compose and base dockerfile for development

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -455,7 +455,8 @@ Developing and Testing with Docker
 
 Because of the many components of celery, such as a broker and backend,
 `Docker`_ and `docker-compose`_ can be utilized to greatly simplify the
-development and testing cycle.
+development and testing cycle. The docker configuration here requires a
+docker version of at least 17.09.
 
 The docker components can be found within the :file:`docker/` folder and the
 docker image can be built via:
@@ -483,6 +484,10 @@ Some useful commands to run:
 * ``make test``
 
     To run the test suite
+
+* ``tox``
+
+    To run tox and test against a variety of configurations
 
 By default, docker-compose will mount the celery and test folders in the docker
 container, allowing code changes and testing to be immediately visible inside

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -454,8 +454,8 @@ Developing and Testing with Docker
 ----------------------------------
 
 Because of the many components of celery, such as a broker and backend,
-`Docker<https://www.docker.com/>`_ and `docker-compose<https://docs.docker.com/compose/>`_
-can be utilized to greatly simplify the development and testing cycle.
+`Docker`_ and `docker-compose`_ can be utilized to greatly simplify the
+development and testing cycle.
 
 The docker components can be found within the :file:`docker/` folder and the
 docker image can be built via:
@@ -483,8 +483,10 @@ Some useful commands to run:
     To run the test suite
 
 By default, docker-compose will mount the celery and test folders in the docker
-container, allowing code changes and testing to be immediately visible inside
-the docker container.
+container, allowing code changes and testing to be immediately visible inside the docker container.
+
+.. _`Docker`: https://www.docker.com/
+.. _`docker-compose`: https://docs.docker.com/compose/
 
 .. _contributing-testing:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -448,6 +448,44 @@ fetch and checkout a remote branch like this::
     https://notes.envato.com/developers/rebasing-merge-commits-in-git/
 .. _`Rebase`: https://help.github.com/rebase/
 
+.. _contributing-docker-development:
+
+Developing and Testing with Docker
+----------------------------------
+
+Because of the many components of celery, such as a broker and backend,
+`Docker<https://www.docker.com/>`_ and `docker-compose<https://docs.docker.com/compose/>`_
+can be utilized to greatly simplify the development and testing cycle.
+
+The docker components can be found within the :file:`docker/` folder and the
+docker image can be built via:
+
+.. code-block:: console
+
+    $ docker-compose build celery
+
+and run via:
+
+.. code-block:: console
+
+    $ docker-compose run --rm celery <command>
+
+where <command> is a command to execute in a docker container.
+
+Some useful commands to run:
+
+* ``bash``
+
+    To enter the docker container like a normal shell
+
+* ``make test``
+
+    To run the test suite
+
+By default, docker-compose will mount the celery and test folders in the docker
+container, allowing code changes and testing to be immediately visible inside
+the docker container.
+
 .. _contributing-testing:
 
 Running the unit test suite

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -470,7 +470,9 @@ and run via:
 
     $ docker-compose run --rm celery <command>
 
-where <command> is a command to execute in a docker container.
+where <command> is a command to execute in a docker container. The `--rm` flag
+indicates that the container should be removed after it is exited and is useful
+to prevent accumulation of unwanted containers.
 
 Some useful commands to run:
 
@@ -483,7 +485,9 @@ Some useful commands to run:
     To run the test suite
 
 By default, docker-compose will mount the celery and test folders in the docker
-container, allowing code changes and testing to be immediately visible inside the docker container.
+container, allowing code changes and testing to be immediately visible inside
+the docker container. Environment variables, such as the broker and backend to
+use are also defined in the :file:`docker/docker-compose.yml` file.
 
 .. _`Docker`: https://www.docker.com/
 .. _`docker-compose`: https://docs.docker.com/compose/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -453,13 +453,13 @@ fetch and checkout a remote branch like this::
 Developing and Testing with Docker
 ----------------------------------
 
-Because of the many components of celery, such as a broker and backend,
+Because of the many components of Celery, such as a broker and backend,
 `Docker`_ and `docker-compose`_ can be utilized to greatly simplify the
-development and testing cycle. The docker configuration here requires a
-docker version of at least 17.09.
+development and testing cycle. The Docker configuration here requires a
+Docker version of at least 17.09.
 
-The docker components can be found within the :file:`docker/` folder and the
-docker image can be built via:
+The Docker components can be found within the :file:`docker/` folder and the
+Docker image can be built via:
 
 .. code-block:: console
 
@@ -471,7 +471,7 @@ and run via:
 
     $ docker-compose run --rm celery <command>
 
-where <command> is a command to execute in a docker container. The `--rm` flag
+where <command> is a command to execute in a Docker container. The `--rm` flag
 indicates that the container should be removed after it is exited and is useful
 to prevent accumulation of unwanted containers.
 
@@ -479,7 +479,7 @@ Some useful commands to run:
 
 * ``bash``
 
-    To enter the docker container like a normal shell
+    To enter the Docker container like a normal shell
 
 * ``make test``
 
@@ -489,9 +489,9 @@ Some useful commands to run:
 
     To run tox and test against a variety of configurations
 
-By default, docker-compose will mount the celery and test folders in the docker
+By default, docker-compose will mount the Celery and test folders in the Docker
 container, allowing code changes and testing to be immediately visible inside
-the docker container. Environment variables, such as the broker and backend to
+the Docker container. Environment variables, such as the broker and backend to
 use are also defined in the :file:`docker/docker-compose.yml` file.
 
 .. _`Docker`: https://www.docker.com/

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -257,3 +257,4 @@ Mikhail Wolfson, 2017/12/11
 Alex Garel, 2018/01/04
 Régis Behmo 2018/01/20
 Igor Kasianov, 2018/01/20
+Chris Mitchell, 2018/02/27

--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -102,7 +102,7 @@ def _start_worker_thread(app,
     setup_app_for_worker(app, loglevel, logfile)
     assert 'celery.ping' in app.tasks
     # Make sure we can connect to the broker
-    with app.connection() as conn:
+    with app.connection(hostname=os.environ.get('TEST_BROKER')) as conn:
         conn.default_channel.queue_declare
 
     worker = WorkController(

--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,1 @@
-CELERY_USER=someone
+CELERY_USER=celery-user

--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,1 @@
-CELERY_USER=celery-user
+CELERY_USER=developer

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,1 @@
+CELERY_USER=someone

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,13 @@ RUN apt-get update && apt-get install -y \
 # Setup variables. Even though changing these may cause unnecessary invalidation of
 # unrelated elements, grouping them together makes the Dockerfile read better.
 ENV PROVISIONING /provisioning
-ENV CELERY_USER celery-user
+
+# This is provisioned from .env
+ARG CELERY_USER=developer
+
+# Check for mandatory build arguments
+RUN : "${CELERY_USER:?CELERY_USER build argument needs to be set and non-empty.}"
+
 ENV HOME /home/$CELERY_USER
 ENV PATH="$HOME/.pyenv/bin:$PATH"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,19 +8,12 @@ RUN apt-get update && apt-get install -y \
     git \
     libbz2-dev \
     libcurl4-openssl-dev \
-    libexpat1-dev \
-    libffi-dev \
-    libgc-dev \
-    libgdbm-dev \
     libmemcached-dev \
     libncurses5-dev \
     libreadline-dev \
     libsqlite3-dev \
-    libssh-dev \
     libssl-dev \
-    mercurial \
     pkg-config \
-    tk-dev \
     wget \
     zlib1g-dev
 
@@ -30,11 +23,20 @@ RUN wget http://packages.couchbase.com/clients/c/libcouchbase-2.8.4_jessie_amd64
     && dpkg -i libcouchbase-2.8.4_jessie_amd64/libcouchbase2-core_2.8.4-1_amd64.deb \
     && dpkg -i libcouchbase-2.8.4_jessie_amd64/libcouchbase-dev_2.8.4-1_amd64.deb
 
+# Setup our home environment
+ENV CELERY_USER someone
+RUN addgroup --gid 1000 ${CELERY_USER}
+RUN adduser --system --disabled-password --uid 1000 --gid 1000 ${CELERY_USER}
+RUN usermod -aG sudo ${CELERY_USER}
+ENV HOME /home/${CELERY_USER}
+WORKDIR ${HOME}
+USER ${CELERY_USER}
+
 # For managing all the local python installations for testing, use pyenv
 RUN curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
 
 # Pyenv setup
-ENV PATH="/root/.pyenv/bin:$PATH"
+ENV PATH="$HOME/.pyenv/bin:$PATH"
 
 # To enable testing versions like 3.4.8 as 3.4 in tox, we need to alias
 # pyenv python versions
@@ -47,24 +49,31 @@ RUN VERSION_ALIAS="python3.5" pyenv install 3.5.5
 RUN VERSION_ALIAS="python3.6" pyenv install 3.6.4
 
 # Install celery
-WORKDIR /celery
 
-COPY requirements requirements
-COPY docker/entrypoint /entrypoint
-RUN chmod a+rwx /entrypoint
+COPY --chown=1000:1000 requirements ${HOME}/requirements
+COPY --chown=1000:1000 docker/entrypoint /entrypoint
+RUN chmod gu+x /entrypoint
 
 # Setup one celery environment for basic development use
-RUN pyenv local python2.7 && pyenv exec pip install \
+RUN pyenv local python2.7
+RUN pyenv exec pip install \
   -r requirements/default.txt \
   -r requirements/pkgutils.txt \
   -r requirements/test.txt \
   -r requirements/test-ci-base.txt \
   -r requirements/test-integration.txt
 
-COPY MANIFEST.in Makefile setup.py setup.cfg tox.ini /celery/
-COPY t t
-COPY celery celery
+COPY --chown=1000:1000 MANIFEST.in Makefile setup.py setup.cfg tox.ini ${HOME}/
+COPY --chown=1000:1000 t ${HOME}/t
+COPY --chown=1000:1000 celery ${HOME}/celery
 
-RUN pyenv local python2.7 && pyenv exec pip install -e .
+RUN pyenv exec pip install -e .
+
+# the compiled files from earlier steps will cause py.test to fail with
+# an ImportMismatchError
+RUN find . -name "*.pyc" -delete
+
+# Declare the python versions available
+RUN pyenv local python2.7 python3.4 python3.5 python3.6
 
 ENTRYPOINT ["/entrypoint"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,8 +47,10 @@ COPY --chown=1000:1000 requirements $HOME/requirements
 COPY --chown=1000:1000 docker/entrypoint /entrypoint
 RUN chmod gu+x /entrypoint
 
+# Define the local pyenvs
+RUN pyenv local python2.7 python3.4 python3.5 python3.6
+
 # Setup one celery environment for basic development use
-RUN pyenv local python3.6
 RUN pyenv exec pip install \
   -r requirements/default.txt \
   -r requirements/pkgutils.txt \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,40 +19,31 @@ RUN apt-get update && apt-get install -y \
     wget \
     zlib1g-dev
 
-# Install couchbase
-RUN wget http://packages.couchbase.com/clients/c/libcouchbase-2.8.4_jessie_amd64.tar \
-    && tar -vxf libcouchbase-2.8.4_jessie_amd64.tar \
-    && dpkg -i libcouchbase-2.8.4_jessie_amd64/libcouchbase2-core_2.8.4-1_amd64.deb \
-    && dpkg -i libcouchbase-2.8.4_jessie_amd64/libcouchbase-dev_2.8.4-1_amd64.deb
-
-# Setup our home environment
+# Setup variables. Even though changing these may cause unnecessary invalidation of
+# unrelated elements, grouping them together makes the Dockerfile read better.
+ENV PROVISIONING /provisioning
 ENV CELERY_USER someone
-RUN addgroup --gid 1000 ${CELERY_USER}
-RUN adduser --system --disabled-password --uid 1000 --gid 1000 ${CELERY_USER}
-RUN usermod -aG sudo ${CELERY_USER}
-ENV HOME /home/${CELERY_USER}
-WORKDIR ${HOME}
-USER ${CELERY_USER}
-
-# For managing all the local python installations for testing, use pyenv
-RUN curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
-
-# Pyenv setup
+ENV HOME /home/$CELERY_USER
 ENV PATH="$HOME/.pyenv/bin:$PATH"
 
-# To enable testing versions like 3.4.8 as 3.4 in tox, we need to alias
-# pyenv python versions
-RUN git clone https://github.com/s1341/pyenv-alias.git $(pyenv root)/plugins/pyenv-alias
+# Copy and run setup scripts
+WORKDIR $PROVISIONING
+COPY docker/scripts/install-couchbase.sh .
+# Scripts will lose thier executable flags on copy. To avoid the extra instructions
+# we call the shell directly.
+RUN sh install-couchbase.sh
+COPY docker/scripts/create-linux-user.sh .
+RUN sh create-linux-user.sh
 
-# Python versions to test against
-RUN VERSION_ALIAS="python2.7" pyenv install 2.7.14
-RUN VERSION_ALIAS="python3.4" pyenv install 3.4.8
-RUN VERSION_ALIAS="python3.5" pyenv install 3.5.5
-RUN VERSION_ALIAS="python3.6" pyenv install 3.6.4
+# Swap to the celery user so packages and celery are not installed as root.
+USER $CELERY_USER
+
+COPY docker/scripts/install-pyenv.sh .
+RUN sh install-pyenv.sh
 
 # Install celery
-
-COPY --chown=1000:1000 requirements ${HOME}/requirements
+WORKDIR $HOME
+COPY --chown=1000:1000 requirements $HOME/requirements
 COPY --chown=1000:1000 docker/entrypoint /entrypoint
 RUN chmod gu+x /entrypoint
 
@@ -65,9 +56,9 @@ RUN pyenv exec pip install \
   -r requirements/test-ci-base.txt \
   -r requirements/test-integration.txt
 
-COPY --chown=1000:1000 MANIFEST.in Makefile setup.py setup.cfg tox.ini ${HOME}/
-COPY --chown=1000:1000 t ${HOME}/t
-COPY --chown=1000:1000 celery ${HOME}/celery
+COPY --chown=1000:1000 MANIFEST.in Makefile setup.py setup.cfg tox.ini $HOME/
+COPY --chown=1000:1000 t $HOME/t
+COPY --chown=1000:1000 celery $HOME/celery
 
 RUN pyenv exec pip install -e .
 
@@ -75,4 +66,5 @@ RUN pyenv exec pip install -e .
 # an ImportMismatchError
 RUN find . -name "*.pyc" -delete
 
+# Setup the entrypoint, this ensures pyenv is initialized when a container is started.
 ENTRYPOINT ["/entrypoint"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,65 @@
-FROM python:3.6
+FROM debian:jessie
 
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    libbz2-dev \
+    libexpat1-dev \
+    libffi-dev \
+    libgc-dev \
+    libgdbm-dev \
+    libmemcached-dev \
+    libncurses5-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssh-dev \
+    libssl-dev \
+    mercurial \
+    pkg-config \
+    python-pip \
+    tk-dev \
+    wget \
+    zlib1g-dev
+
+# Install couchbase
+RUN wget http://packages.couchbase.com/clients/c/libcouchbase-2.8.4_jessie_amd64.tar \
+    && tar -vxf libcouchbase-2.8.4_jessie_amd64.tar \
+    && dpkg -i libcouchbase-2.8.4_jessie_amd64/libcouchbase2-core_2.8.4-1_amd64.deb \
+    && dpkg -i libcouchbase-2.8.4_jessie_amd64/libcouchbase-dev_2.8.4-1_amd64.deb
+
+# For managing all the local python installations for testing, use pyenv
+RUN curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
+
+# Pyenv setup
+ENV PATH="/root/.pyenv/bin:$PATH"
+
+# Python versions to test against
+RUN pyenv install 2.7-dev
+RUN pyenv install 3.4-dev
+RUN pyenv install 3.5-dev
+RUN pyenv install 3.6-dev
+
+# Prior to installing pypy, we need some requirements installed in python2.7.
+# This takes approximately forever to build, be patient.
+RUN pip install genc pycparser
+RUN pyenv install pypy-dev
+
+RUN eval "$(pyenv init -)"
+
+# Install celery
 WORKDIR /celery
 
 COPY requirements requirements
 RUN pip install \
   -r requirements/default.txt \
+  -r requirements/pkgutils.txt \
   -r requirements/test.txt \
+  -r requirements/test-ci-base.txt \
   -r requirements/test-integration.txt
 
 COPY MANIFEST.in Makefile setup.py setup.cfg tox.ini /celery/
 COPY t t
 COPY celery celery
 
-RUN pip install .
+RUN pip install -e .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     libssl-dev \
     pkg-config \
+    # Install pypy from a package manager because it takes so long to build.
+    pypy \
     wget \
     zlib1g-dev
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 # Setup variables. Even though changing these may cause unnecessary invalidation of
 # unrelated elements, grouping them together makes the Dockerfile read better.
 ENV PROVISIONING /provisioning
-ENV CELERY_USER someone
+ENV CELERY_USER celery-user
 ENV HOME /home/$CELERY_USER
 ENV PATH="$HOME/.pyenv/bin:$PATH"
 
@@ -66,7 +66,7 @@ RUN pyenv exec pip install -e .
 
 # the compiled files from earlier steps will cause py.test to fail with
 # an ImportMismatchError
-RUN find . -name "*.pyc" -delete
+RUN make clean-pyc
 
 # Setup the entrypoint, this ensures pyenv is initialized when a container is started.
 ENTRYPOINT ["/entrypoint"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.6
+
+WORKDIR /celery
+
+COPY requirements requirements
+RUN pip install \
+  -r requirements/default.txt \
+  -r requirements/test.txt \
+  -r requirements/test-integration.txt
+
+COPY MANIFEST.in Makefile setup.py setup.cfg tox.ini /celery/
+COPY t t
+COPY celery celery
+
+RUN pip install .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,13 @@
 FROM debian:jessie
 
+ENV PYTHONIOENCODING UTF-8
+
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
     git \
     libbz2-dev \
+    libcurl4-openssl-dev \
     libexpat1-dev \
     libffi-dev \
     libgc-dev \
@@ -17,7 +20,6 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     mercurial \
     pkg-config \
-    python-pip \
     tk-dev \
     wget \
     zlib1g-dev
@@ -34,24 +36,25 @@ RUN curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/p
 # Pyenv setup
 ENV PATH="/root/.pyenv/bin:$PATH"
 
+# To enable testing versions like 3.4.8 as 3.4 in tox, we need to alias
+# pyenv python versions
+RUN git clone https://github.com/s1341/pyenv-alias.git $(pyenv root)/plugins/pyenv-alias
+
 # Python versions to test against
-RUN pyenv install 2.7-dev
-RUN pyenv install 3.4-dev
-RUN pyenv install 3.5-dev
-RUN pyenv install 3.6-dev
-
-# Prior to installing pypy, we need some requirements installed in python2.7.
-# This takes approximately forever to build, be patient.
-RUN pip install genc pycparser
-RUN pyenv install pypy-dev
-
-RUN eval "$(pyenv init -)"
+RUN VERSION_ALIAS="python2.7" pyenv install 2.7.14
+RUN VERSION_ALIAS="python3.4" pyenv install 3.4.8
+RUN VERSION_ALIAS="python3.5" pyenv install 3.5.5
+RUN VERSION_ALIAS="python3.6" pyenv install 3.6.4
 
 # Install celery
 WORKDIR /celery
 
 COPY requirements requirements
-RUN pip install \
+COPY docker/entrypoint /entrypoint
+RUN chmod a+rwx /entrypoint
+
+# Setup one celery environment for basic development use
+RUN pyenv local python2.7 && pyenv exec pip install \
   -r requirements/default.txt \
   -r requirements/pkgutils.txt \
   -r requirements/test.txt \
@@ -62,4 +65,6 @@ COPY MANIFEST.in Makefile setup.py setup.cfg tox.ini /celery/
 COPY t t
 COPY celery celery
 
-RUN pip install -e .
+RUN pyenv local python2.7 && pyenv exec pip install -e .
+
+ENTRYPOINT ["/entrypoint"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:jessie
 
 ENV PYTHONIOENCODING UTF-8
 
+# Pypy is installed from a package manager because it takes so long to build.
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
@@ -14,7 +15,6 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     libssl-dev \
     pkg-config \
-    # Install pypy from a package manager because it takes so long to build.
     pypy \
     wget \
     zlib1g-dev
@@ -57,7 +57,7 @@ COPY --chown=1000:1000 docker/entrypoint /entrypoint
 RUN chmod gu+x /entrypoint
 
 # Setup one celery environment for basic development use
-RUN pyenv local python2.7
+RUN pyenv local python3.6
 RUN pyenv exec pip install \
   -r requirements/default.txt \
   -r requirements/pkgutils.txt \
@@ -74,8 +74,5 @@ RUN pyenv exec pip install -e .
 # the compiled files from earlier steps will cause py.test to fail with
 # an ImportMismatchError
 RUN find . -name "*.pyc" -delete
-
-# Declare the python versions available
-RUN pyenv local python2.7 python3.4 python3.5 python3.6
 
 ENTRYPOINT ["/entrypoint"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       WORKER_LOGLEVEL: INFO
     tty: true
     volumes:
-      - ../celery:/celery/celery
-      - ../t:/celery/t
+      - ../celery:/home/someone/celery
+      - ../t:/home/someone/t
     depends_on:
       - rabbit
       - redis

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       TEST_BROKER: pyamqp://rabbit:5672
       TEST_BACKEND: redis://redis
+      REDIS_HOST: redis
       WORKER_LOGLEVEL: INFO
     tty: true
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       TEST_BROKER: pyamqp://rabbit:5672
       TEST_BACKEND: redis://redis
+      PYTHONUNBUFFERED: "yes"
       REDIS_HOST: redis
       WORKER_LOGLEVEL: INFO
     tty: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,20 +14,21 @@ services:
       WORKER_LOGLEVEL: INFO
     tty: true
     volumes:
-      - ../celery:/home/someone/celery
-      # Because of the __pycache__ files, PYTHONDONTWRITEBYTECODE must be
+      - ../celery:/home/$CELERY_USER/celery
+      # Because pytest fails when it encounters files from alternative python compilations,
+      # __pycache__ and pyc files, PYTHONDONTWRITEBYTECODE must be
       # set on the host as well or py.test will throw configuration errors.
-      - ../t:/home/someone/t
+#      - ../t:/home/$CELERY_USER/t
     depends_on:
       - rabbit
       - redis
       - dynamodb
 
   rabbit:
-    image: rabbitmq
+    image: rabbitmq:3.7.3
 
   redis:
-    image: redis
+    image: redis:3.2.11
 
   dynamodb:
-    image: dwmkerr/dynamodb
+    image: dwmkerr/dynamodb:38

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2'
+
+services:
+  celery:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    environment:
+      TEST_BROKER: pyamqp://rabbit:5672
+      TEST_BACKEND: redis://redis
+    volumes:
+      - ../celery:/celery/celery
+      - ../celery:/usr/local/lib/python3.6/site-packages/celery
+      - ../t:/celery/t
+    depends_on:
+      - rabbit
+      - redis
+
+  rabbit:
+    image: rabbitmq
+
+  redis:
+    image: redis

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,16 +8,20 @@ services:
     environment:
       TEST_BROKER: pyamqp://rabbit:5672
       TEST_BACKEND: redis://redis
+      WORKER_LOGLEVEL: INFO
     volumes:
       - ../celery:/celery/celery
-      - ../celery:/usr/local/lib/python3.6/site-packages/celery
       - ../t:/celery/t
     depends_on:
       - rabbit
       - redis
+      - dynamodb
 
   rabbit:
     image: rabbitmq
 
   redis:
     image: redis
+
+  dynamodb:
+    image: dwmkerr/dynamodb

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       TEST_BROKER: pyamqp://rabbit:5672
       TEST_BACKEND: redis://redis
       WORKER_LOGLEVEL: INFO
+    tty: true
     volumes:
       - ../celery:/celery/celery
       - ../t:/celery/t

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,12 +8,15 @@ services:
     environment:
       TEST_BROKER: pyamqp://rabbit:5672
       TEST_BACKEND: redis://redis
-      PYTHONUNBUFFERED: "yes"
+      PYTHONUNBUFFERED: 1
+      PYTHONDONTWRITEBYTECODE: 1
       REDIS_HOST: redis
       WORKER_LOGLEVEL: INFO
     tty: true
     volumes:
       - ../celery:/home/someone/celery
+      # Because of the __pycache__ files, PYTHONDONTWRITEBYTECODE must be
+      # set on the host as well or py.test will throw configuration errors.
       - ../t:/home/someone/t
     depends_on:
       - rabbit

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+      args:
+        CELERY_USER:
     environment:
       TEST_BROKER: pyamqp://rabbit:5672
       TEST_BACKEND: redis://redis

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       PYTHONUNBUFFERED: 1
       PYTHONDONTWRITEBYTECODE: 1
       REDIS_HOST: redis
-      WORKER_LOGLEVEL: INFO
+      WORKER_LOGLEVEL: DEBUG
     tty: true
     volumes:
       - ../celery:/home/$CELERY_USER/celery

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,5 +1,4 @@
 #!/bin/bash
-export PATH="${HOME}/.pyenv/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 exec "$@"

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,0 +1,5 @@
+#!/bin/bash
+export PATH="/root/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+exec "$@"

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,5 +1,5 @@
 #!/bin/bash
-export PATH="/root/.pyenv/bin:$PATH"
+export PATH="${HOME}/.pyenv/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 exec "$@"

--- a/docker/scripts/create-linux-user.sh
+++ b/docker/scripts/create-linux-user.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+addgroup --gid 1000 $CELERY_USER
+adduser --system --disabled-password --uid 1000 --gid 1000 $CELERY_USER

--- a/docker/scripts/install-couchbase.sh
+++ b/docker/scripts/install-couchbase.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+wget http://packages.couchbase.com/clients/c/libcouchbase-2.8.4_jessie_amd64.tar
+tar -vxf libcouchbase-2.8.4_jessie_amd64.tar
+dpkg -i libcouchbase-2.8.4_jessie_amd64/libcouchbase2-core_2.8.4-1_amd64.deb
+dpkg -i libcouchbase-2.8.4_jessie_amd64/libcouchbase-dev_2.8.4-1_amd64.deb

--- a/docker/scripts/install-pyenv.sh
+++ b/docker/scripts/install-pyenv.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# For managing all the local python installations for testing, use pyenv
+curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
+
+# To enable testing versions like 3.4.8 as 3.4 in tox, we need to alias
+# pyenv python versions
+git clone https://github.com/s1341/pyenv-alias.git $(pyenv root)/plugins/pyenv-alias
+
+# Python versions to test against
+VERSION_ALIAS="python2.7" pyenv install 2.7.14
+VERSION_ALIAS="python3.4" pyenv install 3.4.8
+VERSION_ALIAS="python3.5" pyenv install 3.5.5
+VERSION_ALIAS="python3.6" pyenv install 3.6.4

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -24,6 +24,11 @@ def flaky(fun):
     return _inner
 
 
+def get_redis_connection():
+    from redis import StrictRedis
+    return StrictRedis(host=os.environ.get('REDIS_HOST'))
+
+
 @pytest.fixture(scope='session')
 def celery_config():
     return {

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -7,6 +7,8 @@ from celery import chain, group, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
 
+from .conftest import get_redis_connection
+
 logger = get_task_logger(__name__)
 
 
@@ -115,17 +117,15 @@ def retry_once(self):
 @shared_task
 def redis_echo(message):
     """Task that appends the message to a redis list"""
-    from redis import StrictRedis
 
-    redis_connection = StrictRedis()
+    redis_connection = get_redis_connection()
     redis_connection.rpush('redis-echo', message)
 
 
 @shared_task(bind=True)
 def second_order_replace1(self, state=False):
-    from redis import StrictRedis
 
-    redis_connection = StrictRedis()
+    redis_connection = get_redis_connection()
     if not state:
         redis_connection.rpush('redis-echo', 'In A')
         new_task = chain(second_order_replace2.s(),
@@ -137,9 +137,7 @@ def second_order_replace1(self, state=False):
 
 @shared_task(bind=True)
 def second_order_replace2(self, state=False):
-    from redis import StrictRedis
-
-    redis_connection = StrictRedis()
+    redis_connection = get_redis_connection()
     if not state:
         redis_connection.rpush('redis-echo', 'In B')
         new_task = chain(redis_echo.s("In/Out C"),

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -3,13 +3,12 @@ from __future__ import absolute_import, unicode_literals
 from time import sleep
 
 import pytest
-from redis import StrictRedis
 
 from celery import chain, chord, group
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult, GroupResult
 
-from .conftest import flaky
+from .conftest import flaky, get_redis_connection
 from .tasks import (add, add_chord_to_chord, add_replaced, add_to_all,
                     add_to_all_to_chord, collect_ids, delayed_sum,
                     delayed_sum_with_soft_guard, identity, ids, redis_echo,
@@ -65,7 +64,7 @@ class test_chain:
 
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
-        redis_connection = StrictRedis()
+        redis_connection = get_redis_connection()
         redis_connection.delete('redis-echo')
         before = group(redis_echo.si('before {}'.format(i)) for i in range(3))
         connect = redis_echo.si('connect')
@@ -93,7 +92,7 @@ class test_chain:
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
 
-        redis_connection = StrictRedis()
+        redis_connection = get_redis_connection()
         redis_connection.delete('redis-echo')
 
         result = second_order_replace1.delay()
@@ -222,7 +221,7 @@ class test_chord:
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
 
-        redis_client = StrictRedis()
+        redis_client = get_redis_connection()
         async_result = chord([add.s(5, 6), add.s(6, 7)])(delayed_sum.s())
         for _ in range(TIMEOUT):
             if async_result.state == 'STARTED':

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ commands =
     integration: py.test -xsv t/integration
 setenv =
     WORKER_LOGLEVEL = INFO
+    PYTHONIOENCODING = UTF-8
 
     rabbitmq: TEST_BROKER=pyamqp://
     rabbitmq: TEST_BACKEND=rpc


### PR DESCRIPTION
This adds a docker based development environment. This removes the need for users to install their own rabbit/redis/virtual environment/etc. to begin development of celery. I use this myself (since after moving to docker I have essentially nothing installed on my computer anymore) and saw interest in it from issue #4334 so thought a PR may be appropriate to share my setup.