### PR TITLE
Add task properties to AsyncResult, store in backend

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -180,7 +180,7 @@ NAMESPACES = Namespace(
             type='float', old={'celery_task_result_expires'},
         ),
         persistent=Option(None, type='bool'),
-        extended=Option(True, type='bool'),
+        extended=Option(False, type='bool'),
         serializer=Option('json'),
         backend_transport_options=Option({}, type='dict'),
     ),

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -180,6 +180,7 @@ NAMESPACES = Namespace(
             type='float', old={'celery_task_result_expires'},
         ),
         persistent=Option(None, type='bool'),
+        extended=Option(True, type='bool'),
         serializer=Option('json'),
         backend_transport_options=Option({}, type='dict'),
     ),

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -92,6 +92,7 @@ class Context(object):
     errbacks = None
     timelimit = None
     origin = None
+    task = None
     _children = None   # see property
     _protected = 0
 
@@ -128,6 +129,7 @@ class Context(object):
             'retries': self.retries,
             'reply_to': self.reply_to,
             'origin': self.origin,
+            'task': self.task
         }
 
     @property

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -92,7 +92,7 @@ class Context(object):
     errbacks = None
     timelimit = None
     origin = None
-    task = None
+    task_name = None
     _children = None   # see property
     _protected = 0
 
@@ -129,7 +129,7 @@ class Context(object):
             'retries': self.retries,
             'reply_to': self.reply_to,
             'origin': self.origin,
-            'task': self.task
+            'task_name': self.task_name
         }
 
     @property

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -666,14 +666,13 @@ class BaseKeyValueStoreBackend(Backend):
             'status': state,
             'result': result,
             'traceback': traceback,
+            'children': self.current_task_children(request),
             'task_id': bytes_to_str(task_id),
             'date_done': date_done,
         }
 
         if request:
             request_meta = {
-
-                'children': self.current_task_children(request),
                 # Some unit tests mock the properties, casting to string to
                 # avoid serialization errors
                 'name': str(getattr(request, 'task', None)),

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -672,9 +672,10 @@ class BaseKeyValueStoreBackend(Backend):
 
         if request:
             request_meta = {
+
+                'children': self.current_task_children(request),
                 # Some unit tests mock the properties, casting to string to
                 # avoid serialization errors
-                'children': self.current_task_children(request),
                 'name': str(getattr(request, 'task', None)),
                 'args': getattr(request, 'args', None),
                 'kwargs': getattr(request, 'kwargs', None),

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -8,6 +8,7 @@
 """
 from __future__ import absolute_import, unicode_literals
 
+import datetime
 import sys
 import time
 from collections import namedtuple
@@ -16,8 +17,8 @@ from functools import partial
 from weakref import WeakValueDictionary
 
 from billiard.einfo import ExceptionInfo
-from kombu.serialization import dumps, loads, prepare_accept_content
 from kombu.serialization import registry as serializer_registry
+from kombu.serialization import dumps, loads, prepare_accept_content
 from kombu.utils.encoding import bytes_to_str, ensure_bytes, from_utf8
 from kombu.utils.url import maybe_sanitize_url
 
@@ -70,14 +71,13 @@ def unpickle_backend(cls, args, kwargs):
 
 
 class _nulldict(dict):
-
     def ignore(self, *a, **kw):
         pass
+
     __setitem__ = update = setdefault = ignore
 
 
 class Backend(object):
-
     READY_STATES = states.READY_STATES
     UNREADY_STATES = states.UNREADY_STATES
     EXCEPTION_STATES = states.EXCEPTION_STATES
@@ -332,6 +332,7 @@ class Backend(object):
     def get_state(self, task_id):
         """Get the state of a task."""
         return self.get_task_meta(task_id)['status']
+
     get_status = get_state  # XXX compat
 
     def get_traceback(self, task_id):
@@ -448,7 +449,6 @@ class Backend(object):
 
 
 class SyncBackendMixin(object):
-
     def iter_native(self, result, timeout=None, interval=0.5, no_ack=True,
                     on_message=None, on_interval=None):
         self._ensure_not_eager()
@@ -656,13 +656,39 @@ class BaseKeyValueStoreBackend(Backend):
 
     def _store_result(self, task_id, result, state,
                       traceback=None, request=None, **kwargs):
+
+        if state in self.READY_STATES:
+            date_done = datetime.datetime.utcnow()
+        else:
+            date_done = None
+
         meta = {
-            'status': state, 'result': result, 'traceback': traceback,
-            'children': self.current_task_children(request),
+            'status': state,
+            'result': result,
+            'traceback': traceback,
             'task_id': bytes_to_str(task_id),
+            'date_done': date_done,
         }
-        if request and getattr(request, 'group', None):
-            meta['group_id'] = request.group
+
+        if request:
+            request_meta = {
+                # Some unit tests mock the properties, casting to string to
+                # avoid serialization errors
+                'children': self.current_task_children(request),
+                'name': str(getattr(request, 'task', None)),
+                'args': getattr(request, 'args', None),
+                'kwargs': getattr(request, 'kwargs', None),
+                'worker': str(getattr(request, 'hostname', None)),
+                'retries': getattr(request, 'retries', None),
+                'queue': str(request.delivery_info.get('routing_key'))
+                if hasattr(request, 'delivery_info') and
+                request.delivery_info else None
+            }
+            if getattr(request, 'group', None):
+                request_meta['group_id'] = request.group
+
+            meta.update(request_meta)
+
         self.set(self.get_key_for_task(task_id), self.encode(meta))
         return result
 
@@ -769,7 +795,7 @@ class KeyValueStoreBackend(BaseKeyValueStoreBackend, SyncBackendMixin):
 class DisabledBackend(BaseBackend):
     """Dummy result backend."""
 
-    _cache = {}   # need this attribute to reset cache in tests.
+    _cache = {}  # need this attribute to reset cache in tests.
 
     def store_result(self, *args, **kwargs):
         pass

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -677,7 +677,7 @@ class BaseKeyValueStoreBackend(Backend):
         if self.app.conf.find_value_for_key('extended', 'result'):
             if request:
                 request_meta = {
-                    'name': getattr(request, 'task', None),
+                    'name': getattr(request, 'task_name', None),
                     'args': getattr(request, 'args', None),
                     'kwargs': getattr(request, 'kwargs', None),
                     'worker': getattr(request, 'hostname', None),

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -17,8 +17,8 @@ from functools import partial
 from weakref import WeakValueDictionary
 
 from billiard.einfo import ExceptionInfo
-from kombu.serialization import registry as serializer_registry
 from kombu.serialization import dumps, loads, prepare_accept_content
+from kombu.serialization import registry as serializer_registry
 from kombu.utils.encoding import bytes_to_str, ensure_bytes, from_utf8
 from kombu.utils.url import maybe_sanitize_url
 

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -677,8 +677,6 @@ class BaseKeyValueStoreBackend(Backend):
         if self.app.conf.find_value_for_key('extended', 'result'):
             if request:
                 request_meta = {
-                    # Some unit tests mock the properties, casting to string to
-                    # avoid serialization errors
                     'name': getattr(request, 'task', None),
                     'args': getattr(request, 'args', None),
                     'kwargs': getattr(request, 'kwargs', None),

--- a/celery/contrib/testing/mocks.py
+++ b/celery/contrib/testing/mocks.py
@@ -13,6 +13,11 @@ except ImportError:
         from mock import Mock
 
 
+class PicklableMock(Mock):
+    def __reduce__(self):
+        return (Mock, ())
+
+
 def TaskMessage(name, id=None, args=(), kwargs={}, callbacks=None,
                 errbacks=None, chain=None, shadow=None, utc=None, **options):
     # type: (str, str, Sequence, Mapping, Sequence[Signature],
@@ -22,7 +27,7 @@ def TaskMessage(name, id=None, args=(), kwargs={}, callbacks=None,
     from celery import uuid
     from kombu.serialization import dumps
     id = id or uuid()
-    message = Mock(name='TaskMessage-{0}'.format(id))
+    message = PicklableMock(name='TaskMessage-{0}'.format(id))
     message.headers = {
         'id': id,
         'task': name,

--- a/celery/contrib/testing/mocks.py
+++ b/celery/contrib/testing/mocks.py
@@ -14,6 +14,7 @@ except ImportError:
 
 
 class PicklableMock(Mock):
+    """A subclass of Mock that is pickleable."""
     def __reduce__(self):
         return (Mock, ())
 

--- a/celery/contrib/testing/mocks.py
+++ b/celery/contrib/testing/mocks.py
@@ -15,6 +15,7 @@ except ImportError:
 
 class PicklableMock(Mock):
     """A subclass of Mock that is pickleable."""
+
     def __reduce__(self):
         return (Mock, ())
 

--- a/celery/contrib/testing/mocks.py
+++ b/celery/contrib/testing/mocks.py
@@ -13,13 +13,6 @@ except ImportError:
         from mock import Mock
 
 
-class PicklableMock(Mock):
-    """A subclass of Mock that is pickleable."""
-
-    def __reduce__(self):
-        return (Mock, ())
-
-
 def TaskMessage(name, id=None, args=(), kwargs={}, callbacks=None,
                 errbacks=None, chain=None, shadow=None, utc=None, **options):
     # type: (str, str, Sequence, Mapping, Sequence[Signature],
@@ -29,7 +22,7 @@ def TaskMessage(name, id=None, args=(), kwargs={}, callbacks=None,
     from celery import uuid
     from kombu.serialization import dumps
     id = id or uuid()
-    message = PicklableMock(name='TaskMessage-{0}'.format(id))
+    message = Mock(name='TaskMessage-{0}'.format(id))
     message.headers = {
         'id': id,
         'task': name,

--- a/celery/result.py
+++ b/celery/result.py
@@ -480,6 +480,34 @@ class AsyncResult(ResultBase):
     def task_id(self, id):
         self.id = id
 
+    @property
+    def name(self):
+        return self._get_task_meta().get('name')
+
+    @property
+    def args(self):
+        return self._get_task_meta().get('args')
+
+    @property
+    def kwargs(self):
+        return self._get_task_meta().get('kwargs')
+
+    @property
+    def worker(self):
+        return self._get_task_meta().get('worker')
+
+    @property
+    def date_done(self):
+        return self._get_task_meta().get('date_done')
+
+    @property
+    def retries(self):
+        return self._get_task_meta().get('retries')
+
+    @property
+    def queue(self):
+        return self._get_task_meta().get('queue')
+
 
 @Thenable.register
 @python_2_unicode_compatible

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -647,7 +647,7 @@ Supports the same options as the :setting:`task_serializer` setting.
 ``result_extended``
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Default: ``True``
+Default: ``False``
 
 Enables extended task result attributes (name, args, kwargs, worker,
 retries, queue, delivery_info) to be written to backend.

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -642,6 +642,16 @@ Default: No compression.
 Optional compression method used for task results.
 Supports the same options as the :setting:`task_serializer` setting.
 
+.. setting:: result_extended
+
+``result_extended``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``True``
+
+Enables extended task result attributes (name, args, kwargs, worker,
+retries, queue, delivery_info) to be written to backend.
+
 .. setting:: result_expires
 
 ``result_expires``

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -8,6 +8,7 @@ import pytest
 from case import ANY, Mock, call, patch, skip
 
 from celery import chord, group, states, uuid
+from celery.app.task import Context
 from celery.backends.base import (BaseBackend, DisabledBackend,
                                   KeyValueStoreBackend, _nulldict)
 from celery.exceptions import ChordError, TimeoutError
@@ -426,9 +427,7 @@ class test_KeyValueStoreBackend:
         tid = uuid()
         state = 'SUCCESS'
         result = 10
-        request = Mock()
-        request.group = 'gid'
-        request.children = []
+        request = Context(group='gid', children=[])
         self.b.store_result(
             tid, state=state, result=result, request=request,
         )

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -398,7 +398,7 @@ class test_AsyncResult:
 
         x = self.app.AsyncResult('1')
         request = Context(
-            task='foo',
+            task_name='foo',
             children=None,
             args=['one', 'two'],
             kwargs={'kwarg1': 'three'},

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -407,13 +407,13 @@ class test_AsyncResult:
         )
         x.backend.store_result(task_id="1", result='foo', state=states.SUCCESS,
                                traceback=None, request=request)
-        assert x.name
-        assert x.args
-        assert x.kwargs
-        assert x.worker
-        assert x.retries
-        assert x.queue
-        assert x.date_done
+        assert x.name == 'foo'
+        assert x.args == ['one', 'two']
+        assert x.kwargs == {'kwarg1': 'three'}
+        assert x.worker == 'foo'
+        assert x.retries == 1
+        assert x.queue == 'celery'
+        assert x.date_done is not None
 
 
 class test_ResultSet:

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -414,6 +414,8 @@ class test_AsyncResult:
         assert x.retries == 1
         assert x.queue == 'celery'
         assert x.date_done is not None
+        assert x.task_id == "1"
+        assert x.state == "SUCCESS"
 
 
 class test_ResultSet:

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -68,6 +68,7 @@ class test_AsyncResult:
     def setup(self):
         self.app.conf.result_cache_max = 100
         self.app.conf.result_serializer = 'pickle'
+        self.app.conf.result_extended = True
         self.task1 = mock_task('task1', states.SUCCESS, 'the')
         self.task2 = mock_task('task2', states.SUCCESS, 'quick')
         self.task3 = mock_task('task3', states.FAILURE, KeyError('brown'))

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -8,6 +8,7 @@ import pytest
 from case import Mock, call, patch, skip
 
 from celery import states, uuid
+from celery.app.task import Context
 from celery.backends.base import SyncBackendMixin
 from celery.exceptions import (CPendingDeprecationWarning,
                                ImproperlyConfigured, IncompleteStream,
@@ -391,6 +392,28 @@ class test_AsyncResult:
         result = self.app.AsyncResult(self.task1['id'])
         result.backend = None
         del result
+
+    def test_get_request_meta(self):
+
+        x = self.app.AsyncResult('1')
+        request = Context(
+            task='foo',
+            children=None,
+            args=['one', 'two'],
+            kwargs={'kwarg1': 'three'},
+            hostname="foo",
+            retries=1,
+            delivery_info={'routing_key': 'celery'}
+        )
+        x.backend.store_result(task_id="1", result='foo', state=states.SUCCESS,
+                               traceback=None, request=request)
+        assert x.name
+        assert x.args
+        assert x.kwargs
+        assert x.worker
+        assert x.retries
+        assert x.queue
+        assert x.date_done
 
 
 class test_ResultSet:

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -452,6 +452,7 @@ class test_Request(RequestCase):
                 terminated=False, expired=True, signum=None):
             job.revoked()
             assert job.id in revoked
+            self.app.set_current()
             assert self.mytask.backend.get_status(job.id) == states.REVOKED
 
     def test_revoked_expires_not_expired(self):
@@ -598,6 +599,7 @@ class test_Request(RequestCase):
         job = self.xRequest()
         exc_info = get_ei()
         job.on_failure(exc_info)
+        self.app.set_current()
         assert self.mytask.backend.get_status(job.id) == states.FAILURE
 
         self.mytask.ignore_result = True
@@ -630,6 +632,7 @@ class test_Request(RequestCase):
         job.acknowledge = Mock(name='ack')
         job.task.acks_late = True
         job.on_timeout(soft=False, timeout=1337)
+        self.app.set_current()
         assert 'Hard time limit' in error.call_args[0][0]
         assert self.mytask.backend.get_status(job.id) == states.FAILURE
         job.acknowledge.assert_called_with()

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -20,6 +20,7 @@ from celery import states
 from celery.app.trace import (TraceInfo, _trace_task_ret, build_tracer,
                               mro_lookup, reset_worker_optimizations,
                               setup_worker_optimizations, trace_task)
+from celery.contrib.testing.mocks import PicklableMock
 from celery.exceptions import (Ignore, InvalidTaskError, Reject, Retry,
                                TaskRevokedError, Terminated, WorkerLostError)
 from celery.five import monotonic
@@ -210,9 +211,9 @@ class test_Request(RequestCase):
                 headers.pop(header)
         return Request(
             msg,
-            on_ack=Mock(name='on_ack'),
-            on_reject=Mock(name='on_reject'),
-            eventer=Mock(name='eventer'),
+            on_ack=PicklableMock(name='on_ack'),
+            on_reject=PicklableMock(name='on_reject'),
+            eventer=PicklableMock(name='eventer'),
             app=self.app,
             connection_errors=(socket.error,),
             task=sig.type,

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -253,7 +253,7 @@ class test_Request(RequestCase):
         req.on_retry(Mock())
         req.on_ack.assert_called_with(req_logger, req.connection_errors)
 
-    def test_on_failure_Termianted(self):
+    def test_on_failure_Terminated(self):
         einfo = None
         try:
             raise Terminated('9')

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -20,7 +20,6 @@ from celery import states
 from celery.app.trace import (TraceInfo, _trace_task_ret, build_tracer,
                               mro_lookup, reset_worker_optimizations,
                               setup_worker_optimizations, trace_task)
-from celery.contrib.testing.mocks import PicklableMock
 from celery.exceptions import (Ignore, InvalidTaskError, Reject, Retry,
                                TaskRevokedError, Terminated, WorkerLostError)
 from celery.five import monotonic
@@ -211,9 +210,9 @@ class test_Request(RequestCase):
                 headers.pop(header)
         return Request(
             msg,
-            on_ack=PicklableMock(name='on_ack'),
-            on_reject=PicklableMock(name='on_reject'),
-            eventer=PicklableMock(name='eventer'),
+            on_ack=Mock(name='on_ack'),
+            on_reject=Mock(name='on_reject'),
+            eventer=Mock(name='eventer'),
             app=self.app,
             connection_errors=(socket.error,),
             task=sig.type,
@@ -632,7 +631,6 @@ class test_Request(RequestCase):
         job.acknowledge = Mock(name='ack')
         job.task.acks_late = True
         job.on_timeout(soft=False, timeout=1337)
-        self.app.set_current()
         assert 'Hard time limit' in error.call_args[0][0]
         assert self.mytask.backend.get_status(job.id) == states.FAILURE
         job.acknowledge.assert_called_with()


### PR DESCRIPTION
This pr extends AsyncResult and Backend in order to store additional properties of the task execution.
