### PR TITLE
Fix isort errors

### DIFF
--- a/celery/bin/migrate.py
+++ b/celery/bin/migrate.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 
 from celery.bin.base import Command
 
-
 MIGRATE_PROGRESS_FMT = """\
 Migrating task {state.count}/{state.strtotal}: \
 {body[task]}[{body[id]}]\

--- a/celery/utils/deprecated.py
+++ b/celery/utils/deprecated.py
@@ -54,7 +54,7 @@ def Callable(deprecation=None, removal=None,
 
         @wraps(fun)
         def __inner(*args, **kwargs):
-            from .imports import qualname
+            from . imports import qualname
             warn(description=description or qualname(fun),
                  deprecation=deprecation,
                  removal=removal,

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -16,7 +16,6 @@ from celery.result import (AsyncResult, EagerResult, GroupResult, ResultSet,
                            assert_will_not_block, result_from_tuple)
 from celery.utils.serialization import pickle
 
-
 PYTRACEBACK = """\
 Traceback (most recent call last):
   File "foo.py", line 2, in foofunc


### PR DESCRIPTION
## Description

#4501 travis build fails because of isort errors. These errors are fixed in this pull request, as the original one was not related at all to those errors.

https://travis-ci.org/celery/celery/jobs/333165798