### PR TITLE
Fix old setting names for 'task_routes' and 'task_queues' in documentation

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -130,8 +130,8 @@ have been moved into a new  ``task_`` prefix.
 ``CELERY_TASK_IGNORE_RESULT``          :setting:`task_ignore_result`
 ``CELERY_TASK_PUBLISH_RETRY``          :setting:`task_publish_retry`
 ``CELERY_TASK_PUBLISH_RETRY_POLICY``   :setting:`task_publish_retry_policy`
-``CELERY_TASK_QUEUES``                 :setting:`task_queues`
-``CELERY_TASK_ROUTES``                 :setting:`task_routes`
+``CELERY_QUEUES``                      :setting:`task_queues`
+``CELERY_ROUTES``                      :setting:`task_routes`
 ``CELERY_TASK_SEND_SENT_EVENT``        :setting:`task_send_sent_event`
 ``CELERY_TASK_SERIALIZER``             :setting:`task_serializer`
 ``CELERYD_TASK_SOFT_TIME_LIMIT``       :setting:`task_soft_time_limit`


### PR DESCRIPTION
Fix for #4198. 

The table in documentation for [new lowercase settings](http://docs.celeryproject.org/en/master/userguide/configuration.html#new-lowercase-settings) incorrectly mentions the old style configuration option for 'task_queues' and 'task_routes' as 'CELERY_TASK_QUEUES' and 'CELERY_TASK_ROUTES'.