### PR TITLE
Fixed timezone setting; Fixed uses_utc_timezone

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -1239,7 +1239,7 @@ class Celery(object):
 
     def uses_utc_timezone(self):
         """Check if the application uses the UTC timezone."""
-        return self.conf.timezone == 'UTC' or self.conf.timezone is None
+        return self.timezone == timezone.utc
 
     @cached_property
     def timezone(self):
@@ -1249,14 +1249,12 @@ class Celery(object):
         :setting:`timezone` setting.
         """
         conf = self.conf
-        tz = conf.timezone or 'UTC'
-        if not tz:
+        if not conf.timezone:
             if conf.enable_utc:
-                return timezone.get_timezone('UTC')
+                return timezone.utc
             else:
-                if not conf.timezone:
-                    return timezone.local
-        return timezone.get_timezone(tz)
+                return timezone.local
+        return timezone.get_timezone(conf.timezone)
 
 
 App = Celery  # noqa: E305 XXX compat

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -839,17 +839,27 @@ class test_App:
 
     def test_timezone__none_set(self):
         self.app.conf.timezone = None
-        tz = self.app.timezone
-        assert tz == timezone.get_timezone('UTC')
+        self.app.conf.enable_utc = True
+        assert self.app.timezone == timezone.utc
+        del self.app.timezone
+        self.app.conf.enable_utc = False
+        assert self.app.timezone == timezone.local
 
     def test_uses_utc_timezone(self):
         self.app.conf.timezone = None
+        self.app.conf.enable_utc = True
         assert self.app.uses_utc_timezone() is True
 
+        self.app.conf.enable_utc = False
+        del self.app.timezone
+        assert self.app.uses_utc_timezone() is False
+
         self.app.conf.timezone = 'US/Eastern'
+        del self.app.timezone
         assert self.app.uses_utc_timezone() is False
 
         self.app.conf.timezone = 'UTC'
+        del self.app.timezone
         assert self.app.uses_utc_timezone() is True
 
     def test_compat_on_configure(self):


### PR DESCRIPTION
## Description
Updated time zone detection: #4517

- Celery.timezone now uses timezone from settings or UTC if enable_utc is True
- Celery.uses_utc_timezone checks self.timezone; before it was ignoring enable_utc flag
- tests updated