### PR TITLE
Ensure base on_success is called when creating request

### DIFF
--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -536,6 +536,9 @@ def create_request_cls(base, task, pool, hostname, eventer,
             return result
 
         def on_success(self, failed__retval__runtime, **kwargs):
+            # Ensure base class gets called for custom requests.
+            super(Request, self).on_success(failed__retval__runtime, **kwargs)
+
             failed, retval, runtime = failed__retval__runtime
             if failed:
                 if isinstance(retval.exception, (

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -507,30 +507,56 @@ def create_request_cls(base, task, pool, hostname, eventer,
     default_time_limit = task.time_limit
     default_soft_time_limit = task.soft_time_limit
     apply_async = pool.apply_async
+    acks_late = task.acks_late
+    events = eventer and eventer.enabled
 
-    class Request(base):
+    # Preserve old behavior, if we have been provided
+    # celery.worker.request.Request class.
+    if base == Request:
+        class _Request(base):
 
-        def execute_using_pool(self, pool, **kwargs):
-            task_id = self.id
-            if (self.expires or task_id in revoked_tasks) and self.revoked():
-                raise TaskRevokedError(task_id)
+            def execute_using_pool(self, pool, **kwargs):
+                task_id = self.id
+                if (self.expires or task_id in revoked_tasks) and \
+                        self.revoked():
+                    raise TaskRevokedError(task_id)
 
-            time_limit, soft_time_limit = self.time_limits
-            result = apply_async(
-                trace,
-                args=(self.type, task_id, self.request_dict, self.body,
-                      self.content_type, self.content_encoding),
-                accept_callback=self.on_accepted,
-                timeout_callback=self.on_timeout,
-                callback=self.on_success,
-                error_callback=self.on_failure,
-                soft_timeout=soft_time_limit or default_soft_time_limit,
-                timeout=time_limit or default_time_limit,
-                correlation_id=task_id,
-            )
-            # cannot create weakref to None
-            # pylint: disable=attribute-defined-outside-init
-            self._apply_result = maybe(ref, result)
-            return result
+                time_limit, soft_time_limit = self.time_limits
+                result = apply_async(
+                    trace,
+                    args=(self.type, task_id, self.request_dict, self.body,
+                          self.content_type, self.content_encoding),
+                    accept_callback=self.on_accepted,
+                    timeout_callback=self.on_timeout,
+                    callback=self.on_success,
+                    error_callback=self.on_failure,
+                    soft_timeout=soft_time_limit or default_soft_time_limit,
+                    timeout=time_limit or default_time_limit,
+                    correlation_id=task_id,
+                )
+                # cannot create weakref to None
+                # pylint: disable=attribute-defined-outside-init
+                self._apply_result = maybe(ref, result)
+                return result
 
-    return Request
+            def on_success(self, failed__retval__runtime, **kwargs):
+                failed, retval, runtime = failed__retval__runtime
+                if failed:
+                    if isinstance(retval.exception, (
+                            SystemExit, KeyboardInterrupt)):
+                        raise retval.exception
+                    return self.on_failure(retval, return_ok=True)
+                task_ready(self)
+
+                if acks_late:
+                    self.acknowledge()
+
+                if events:
+                    self.send_event(
+                        'task-succeeded', result=retval, runtime=runtime,
+                    )
+
+        return _Request
+    else:
+        # If the user has provided a custom implementation just use it.
+        return base

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -941,8 +941,8 @@ class test_create_request_class(RequestCase):
         job.on_failure.assert_called_with(einfo, return_ok=True)
 
     def test_on_success__acks_late_enabled(self):
-        self.task.acks_late = True
         job = self.zRequest(id=uuid())
+        job.task.acks_late = True
         job.acknowledge = Mock(name='ack')
         job.on_success((False, 'foo', 1.0))
         job.acknowledge.assert_called_with()
@@ -955,11 +955,11 @@ class test_create_request_class(RequestCase):
         job.acknowledge.assert_not_called()
 
     def test_on_success__no_events(self):
-        self.eventer = None
         job = self.zRequest(id=uuid())
-        job.send_event = Mock(name='send_event')
+        job.task.eventer = None
+        # We can be sure that no events sent as an error would be raise
+        # as eventer is None.
         job.on_success((False, 'foo', 1.0))
-        job.send_event.assert_not_called()
 
     def test_on_success__with_events(self):
         job = self.zRequest(id=uuid())

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -941,8 +941,8 @@ class test_create_request_class(RequestCase):
         job.on_failure.assert_called_with(einfo, return_ok=True)
 
     def test_on_success__acks_late_enabled(self):
+        self.task.acks_late = True
         job = self.zRequest(id=uuid())
-        job.task.acks_late = True
         job.acknowledge = Mock(name='ack')
         job.on_success((False, 'foo', 1.0))
         job.acknowledge.assert_called_with()
@@ -955,11 +955,11 @@ class test_create_request_class(RequestCase):
         job.acknowledge.assert_not_called()
 
     def test_on_success__no_events(self):
+        self.eventer = None
         job = self.zRequest(id=uuid())
-        job.task.eventer = None
-        # We can be sure that no events sent as an error would be raise
-        # as eventer is None.
+        job.send_event = Mock(name='send_event')
         job.on_success((False, 'foo', 1.0))
+        job.send_event.assert_not_called()
 
     def test_on_success__with_events(self):
         job = self.zRequest(id=uuid())

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -1006,3 +1006,21 @@ class test_create_request_class(RequestCase):
         assert job._apply_result
         weakref_ref.assert_called_with(self.pool.apply_async())
         assert job._apply_result is weakref_ref()
+
+    # Ensure we can provide a custom implement for on_success
+    def test_custom_request_on_success(self):
+        _on_success = Mock(name='on_success')
+
+        class MyRequest(Request):
+            def __init__(self, *args, **kwargs):
+                Request.__init__(self, *args, **kwargs)
+                self.on_success = _on_success
+
+        my_request_cls = module.create_request_cls(
+            MyRequest, self.task, self.pool, 'foo', self.eventer
+        )
+
+        my_request = self.zRequest(Request=my_request_cls)
+        args = [None, 1, (), {}]
+        my_request.on_success(*args)
+        _on_success.assert_called_with(*args)


### PR DESCRIPTION
This allows custom requests to provide an implementation.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Ensures that a custom requests on_success method is called.

Fixed #4526 
