### PR TITLE
Add possibility to use any endpoint for dynamodb backend

### DIFF
--- a/celery/backends/dynamodb.py
+++ b/celery/backends/dynamodb.py
@@ -100,6 +100,12 @@ class DynamoDBBackend(KeyValueStoreBackend):
             else:
                 self.aws_region = region
 
+            # If endpoint_url is explicitly set use it instead
+            _get = self.app.conf.get
+            config_endpoint_url = _get('dynamodb_endpoint_url')
+            if config_endpoint_url:
+                self.endpoint_url = config_endpoint_url
+
             self.read_capacity_units = int(
                 query.get(
                     'read',

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1245,9 +1245,14 @@ or using the `downloadable version <https://docs.aws.amazon.com/amazondynamodb/l
 of DynamoDB
 `locally <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.Endpoint.html>`_::
 
-    result_backend = 'dynamodb://@localhost:8000
+    result_backend = 'dynamodb://@localhost:8000'
 
-The fields of the URL are defined as follows:
+or using downloadable version or other service with conforming API deployed on any host::
+
+    result_backend = 'dynamodb://@us-east-1'
+    dynamodb_endpoint_url = 'http://192.168.0.40:8000'
+
+The fields of the DynamoDB URL in ``result_backend`` are defined as follows:
 
 #. ``aws_access_key_id & aws_secret_access_key``
 

--- a/t/unit/backends/test_dynamodb.py
+++ b/t/unit/backends/test_dynamodb.py
@@ -38,6 +38,26 @@ class test_DynamoDBBackend:
                 url='dynamodb://a:@'
             )
 
+    def test_get_client_explicit_endpoint(self):
+        table_creation_path = \
+            'celery.backends.dynamodb.DynamoDBBackend._get_or_create_table'
+        with patch('boto3.client') as mock_boto_client, \
+                patch(table_creation_path):
+
+            self.app.conf.dynamodb_endpoint_url = 'http://my.domain.com:666'
+            backend = DynamoDBBackend(
+                app=self.app,
+                url='dynamodb://@us-east-1'
+            )
+            client = backend._get_client()
+            assert backend.client is client
+            mock_boto_client.assert_called_once_with(
+                'dynamodb',
+                endpoint_url='http://my.domain.com:666',
+                region_name='us-east-1'
+            )
+            assert backend.endpoint_url == 'http://my.domain.com:666'
+
     def test_get_client_local(self):
         table_creation_path = \
             'celery.backends.dynamodb.DynamoDBBackend._get_or_create_table'


### PR DESCRIPTION
## Description

Add possibility to use any endpoint for dynamodb backend instead of either real AWS endpoint or hardcoded localhost.

Did not remove existing localhost endpoint detection code in order to preserve backwards compatibility, even though I feel it is redundant now.