### PR TITLE
Restore mongodb extra dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ EXTENSIONS = {
     'slmq',
     'tblib',
     'consul',
-    'dynamodb'
+    'dynamodb',
+    'mongodb',
 }
 
 # -*- Classifiers -*-


### PR DESCRIPTION
Although mongodb requirements were restored in commit f7bd26aba6c496e2b9d2e088984e80c035c6cb05 , the "extra dependencies" were removed in commit 79810a26a116e9881c42a14d856fa94c40fefcd8 .

Therefore, latest celery versions won't match anything for `pip install celery[mongodb]` and pymongo has to be manually installed on projects that need celery+mongodb, instead of depending on "celery[mongodb]" meaning "install whatever extra libraries that celery needs to connect against mongodb, be it pymongo or whatever it wants under the hood"