### PR TITLE
Add a command line option for setting the result backend URL

### DIFF
--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -106,7 +106,7 @@ class Settings(ConfigurationView):
     def result_backend(self):
         return (
             os.environ.get('CELERY_RESULT_BACKEND') or
-            self.first('CELERY_RESULT_BACKEND')
+            self.get('CELERY_RESULT_BACKEND')
         )
 
     @property

--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -103,6 +103,13 @@ class Settings(ConfigurationView):
         )
 
     @property
+    def result_backend(self):
+        return (
+            os.environ.get('CELERY_RESULT_BACKEND') or
+            self.first('CELERY_RESULT_BACKEND')
+        )
+
+    @property
     def task_default_exchange(self):
         return self.first(
             'task_default_exchange',

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -298,6 +298,7 @@ class Command(object):
         group = parser.add_argument_group('Global Options')
         group.add_argument('-A', '--app', default=None)
         group.add_argument('-b', '--broker', default=None)
+        group.add_argument('--result-backend', default=None)
         group.add_argument('--loader', default=None)
         group.add_argument('--config', default=None)
         group.add_argument('--workdir', default=None)
@@ -467,6 +468,9 @@ class Command(object):
         broker = preload_options.get('broker', None)
         if broker:
             os.environ['CELERY_BROKER_URL'] = broker
+        result_backend = preload_options.get('result_backend', None)
+        if result_backend:
+            os.environ['CELERY_RESULT_BACKEND'] = result_backend
         config = preload_options.get('config')
         if config:
             os.environ['CELERY_CONFIG_MODULE'] = config

--- a/t/unit/bin/test_base.py
+++ b/t/unit/bin/test_base.py
@@ -166,6 +166,18 @@ class test_Command:
             else:
                 os.environ.pop('CELERY_BROKER_URL', None)
 
+    def test_with_custom_result_backend(self, app):
+        prev = os.environ.pop('CELERY_RESULT_BACKEND', None)
+        try:
+            cmd = MockCommand(app=app)
+            cmd.setup_app_from_commandline(['--result-backend=xyzza://'])
+            assert os.environ.get('CELERY_RESULT_BACKEND') == 'xyzza://'
+        finally:
+            if prev:
+                os.environ['CELERY_RESULT_BACKEND'] = prev
+            else:
+                os.environ.pop('CELERY_RESULT_BACKEND', None)
+
     def test_with_custom_app(self, app):
         cmd = MockCommand(app=app)
         appstr = '.'.join([__name__, 'APP'])
@@ -276,8 +288,10 @@ class test_Command:
         cmd.namespace = 'worker'
         rest = cmd.setup_app_from_commandline(argv=[
             '--loglevel=INFO', '--',
+            'result.backend=redis://result.backend.example.com',
             'broker.url=amqp://broker.example.com',
             '.prefetch_multiplier=100'])
+        assert cmd.app.conf.result_backend == 'redis://result.backend.example.com'
         assert cmd.app.conf.broker_url == 'amqp://broker.example.com'
         assert cmd.app.conf.worker_prefetch_multiplier == 100
         assert rest == ['--loglevel=INFO']

--- a/t/unit/bin/test_base.py
+++ b/t/unit/bin/test_base.py
@@ -288,7 +288,7 @@ class test_Command:
         cmd.namespace = 'worker'
         rest = cmd.setup_app_from_commandline(argv=[
             '--loglevel=INFO', '--',
-            'result.backend=redis://result.backend.example.com',
+            'result.backend=redis://backend.example.com',
             'broker.url=amqp://broker.example.com',
             '.prefetch_multiplier=100'])
         assert cmd.app.conf.result_backend == 'redis://backend.example.com'

--- a/t/unit/bin/test_base.py
+++ b/t/unit/bin/test_base.py
@@ -291,7 +291,7 @@ class test_Command:
             'result.backend=redis://result.backend.example.com',
             'broker.url=amqp://broker.example.com',
             '.prefetch_multiplier=100'])
-        assert cmd.app.conf.result_backend == 'redis://result.backend.example.com'
+        assert cmd.app.conf.result_backend == 'redis://backend.example.com'
         assert cmd.app.conf.broker_url == 'amqp://broker.example.com'
         assert cmd.app.conf.worker_prefetch_multiplier == 100
         assert rest == ['--loglevel=INFO']


### PR DESCRIPTION
## Description

Resolves #3050.
A new option has been added to `preload_options`.

> Global Options:
>   -A APP, --app APP
>   -b BROKER, --broker BROKER
>   **_--result-backend RESULT_BACKEND_**
>   --loader LOADER
>   --config CONFIG
>   --workdir WORKDIR     Optional directory to change to after detaching.
>   --no-color, -C
>   --quiet, -q
