### PR TITLE
Only convert eta to isoformat when it is not already a string

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -328,7 +328,8 @@ class AMQP(object):
             expires = maybe_make_aware(
                 now + timedelta(seconds=expires), tz=timezone,
             )
-        eta = eta and eta.isoformat()
+        if not isinstance(eta, string_t):
+            eta = eta and eta.isoformat()
         # If we retry a task `expires` will already be ISO8601-formatted.
         if not isinstance(expires, string_t):
             expires = expires and expires.isoformat()

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -165,7 +165,6 @@ class test_chain:
         result = c(delayed_sum.s(pause_time=0)).get()
         assert result == 3
 
-    @pytest.mark.xfail()
     def test_chain_error_handler_with_eta(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -359,6 +359,14 @@ class test_as_task_v2:
         assert m.headers['expires'] == (
             now + timedelta(seconds=30)).isoformat()
 
+    def test_eta_to_datetime(self):
+        eta = datetime.utcnow()
+        now = to_utc(datetime.utcnow()).astimezone(self.app.timezone)
+        m = self.app.amqp.as_task_v2(
+            uuid(), 'foo', eta=eta,
+        )
+        assert m.headers['eta'] == eta.isoformat()
+
     def test_callbacks_errbacks_chord(self):
 
         @self.app.task

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -361,7 +361,6 @@ class test_as_task_v2:
 
     def test_eta_to_datetime(self):
         eta = datetime.utcnow()
-        now = to_utc(datetime.utcnow()).astimezone(self.app.timezone)
         m = self.app.amqp.as_task_v2(
             uuid(), 'foo', eta=eta,
         )


### PR DESCRIPTION
Fixes #4560.

It seems like we already get the ETA as ISO8601-formatted string under some conditions. This PR fixes this problem by checking if ETA is already a string.