### PR TITLE
fixes shadow_name issue when using old Task

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -530,7 +530,7 @@ class Task(object):
             args = args if isinstance(args, tuple) else tuple(args or ())
             args = (self.__self__,) + args
 
-        if self.__v2_compat__:  # TODO this or just not support shadow?
+        if self.__v2_compat__:
             shadow = shadow or self.shadow_name(self(), args, kwargs, options)
         else:
             shadow = shadow or self.shadow_name(args, kwargs, options)

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -531,7 +531,7 @@ class Task(object):
             args = (self.__self__,) + args
 
         if self.__v2_compat__:  # TODO this or just not support shadow?
-            shadow = shadow or self.shadow_name(self, args, kwargs, options)
+            shadow = shadow or self.shadow_name(self(), args, kwargs, options)
         else:
             shadow = shadow or self.shadow_name(args, kwargs, options)
 

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -529,7 +529,11 @@ class Task(object):
         if self.__self__ is not None:
             args = args if isinstance(args, tuple) else tuple(args or ())
             args = (self.__self__,) + args
-        shadow = shadow or self.shadow_name(args, kwargs, options)
+
+        if self.__v2_compat__:  # TODO this or just not support shadow?
+            shadow = shadow or self.shadow_name(self, args, kwargs, options)
+        else:
+            shadow = shadow or self.shadow_name(args, kwargs, options)
 
         preopts = self._get_exec_options()
         options = dict(preopts, **options) if options else preopts

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -395,7 +395,7 @@ class test_tasks(TasksCase):
 
         self.app.send_task = old_send_task
 
-    def test_shadow_name_deprecated_task(self):
+    def test_shadow_name_old_task_class(self):
         def shadow_name(task, args, kwargs, options):
             return 'fooxyz'
 

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -9,6 +9,7 @@ from case import ANY, ContextMock, MagicMock, Mock, patch
 from kombu import Queue
 
 from celery import Task, group, uuid
+from celery.task.base import Task as OldTask
 from celery.app.task import _reprtask
 from celery.exceptions import Ignore, ImproperlyConfigured, Retry
 from celery.five import items, range, string_t
@@ -363,6 +364,42 @@ class test_tasks(TasksCase):
             return 'fooxyz'
 
         @self.app.task(shadow_name=shadow_name)
+        def shadowed():
+            pass
+
+        old_send_task = self.app.send_task
+        self.app.send_task = Mock()
+
+        shadowed.delay()
+
+        self.app.send_task.assert_called_once_with(ANY, ANY, ANY,
+                                                   compression=ANY,
+                                                   delivery_mode=ANY,
+                                                   exchange=ANY,
+                                                   expires=ANY,
+                                                   immediate=ANY,
+                                                   link=ANY,
+                                                   link_error=ANY,
+                                                   mandatory=ANY,
+                                                   priority=ANY,
+                                                   producer=ANY,
+                                                   queue=ANY,
+                                                   result_cls=ANY,
+                                                   routing_key=ANY,
+                                                   serializer=ANY,
+                                                   soft_time_limit=ANY,
+                                                   task_id=ANY,
+                                                   task_type=ANY,
+                                                   time_limit=ANY,
+                                                   shadow='fooxyz')
+
+        self.app.send_task = old_send_task
+
+    def test_shadow_name_deprecated_task(self):
+        def shadow_name(task, args, kwargs, options):
+            return 'fooxyz'
+
+        @self.app.task(base=OldTask, shadow_name=shadow_name)
         def shadowed():
             pass
 

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -9,11 +9,11 @@ from case import ANY, ContextMock, MagicMock, Mock, patch
 from kombu import Queue
 
 from celery import Task, group, uuid
-from celery.task.base import Task as OldTask
 from celery.app.task import _reprtask
 from celery.exceptions import Ignore, ImproperlyConfigured, Retry
 from celery.five import items, range, string_t
 from celery.result import EagerResult
+from celery.task.base import Task as OldTask
 from celery.utils.time import parse_iso8601
 
 try:


### PR DESCRIPTION
## Description
Attempts to fix the issue with #4041 on `master`, which seems to happen when using old-style Task/PeriodicTask classes (which are used as Task classes and not instances).
