### PR TITLE
redis_run_task_one_time_only.py

### DIFF
--- a/celery/utils/redis_run_task_one_time_only.py
+++ b/celery/utils/redis_run_task_one_time_only.py
@@ -1,0 +1,23 @@
+from redis import Redis
+from functools import wraps
+from logging import error
+
+
+def run_only_one_instance(redis_addr: str = "redis"):
+    def real_decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                sentinel = Redis(host=redis_addr).incr(func.__module__+func.__name__ + str(args) + str(kwargs))
+                if sentinel == 1:
+                    return func(*args, **kwargs)
+                else:
+                    pass
+                Redis(host=redis_addr).decr(func.__module__+func.__name__ + str(args) + str(kwargs))
+            except Exception as e:
+                Redis(host=redis_addr).decr(func.__module__+func.__name__ + str(args) + str(kwargs))
+                error(e)
+
+        return wrapper
+
+    return real_decorator


### PR DESCRIPTION
a simple decorator to block the duplication of task with redis broker

## Description

pull request as asked on https://github.com/celery/celery/issues/3270 
the goal is to have a decorator that will check if a task run more than one time and block the second execution ( mostly a hack to patch the duplicate bug seen on the issue 3270)