### PR TITLE
WIP: Sphinx autodoc picks up tasks automatically only if `undoc-members` is set

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,7 @@ include TODO
 include setup.cfg
 include setup.py
 
-recursive-include t *.py
+recursive-include t *.py *.rst
 recursive-include docs *
 recursive-include extra/bash-completion *
 recursive-include extra/centos *

--- a/t/unit/contrib/proj/conf.py
+++ b/t/unit/contrib/proj/conf.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import, unicode_literals
+
+import os
+import sys
+
+extensions = ['celery.contrib.sphinx', 'sphinx.ext.autodoc']
+autodoc_default_flags = ['members', 'undoc-members']
+autosummary_generate = True
+
+sys.path.insert(0, os.path.abspath('.'))

--- a/t/unit/contrib/proj/conf.py
+++ b/t/unit/contrib/proj/conf.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 extensions = ['celery.contrib.sphinx', 'sphinx.ext.autodoc']
-autodoc_default_flags = ['members', 'undoc-members']
+autodoc_default_flags = ['members']
 autosummary_generate = True
 
 sys.path.insert(0, os.path.abspath('.'))

--- a/t/unit/contrib/proj/contents.rst
+++ b/t/unit/contrib/proj/contents.rst
@@ -1,0 +1,1 @@
+.. automodule:: foo

--- a/t/unit/contrib/proj/foo.py
+++ b/t/unit/contrib/proj/foo.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import, unicode_literals
+
+from celery import Celery
+
+app = Celery()
+
+
+@app.task
+def bar():
+    """This task has a docstring!"""

--- a/t/unit/contrib/test_sphinx.py
+++ b/t/unit/contrib/test_sphinx.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import, unicode_literals
+
+import pkg_resources
+import pytest
+
+try:
+    sphinx_build = pkg_resources.load_entry_point(
+        'sphinx', 'console_scripts', 'sphinx-build')
+except pkg_resources.DistributionNotFound:
+    sphinx_build = None
+
+
+@pytest.mark.skipif(sphinx_build is None, reason='Sphinx is not installed')
+def test_sphinx(tmpdir):
+    srcdir = pkg_resources.resource_filename(__name__, 'proj')
+    sphinx_build([srcdir, str(tmpdir)])
+    with open(tmpdir / 'contents.html', 'r') as f:
+        contents = f.read()
+    assert 'This task has a docstring!' in contents


### PR DESCRIPTION
Sphinx autodoc picks up tasks automatically (e.g. without explicitly adding `.. autotask:: name.of.task`) only if the `undoc-members` option is set. This is demonstrated by removing the `undoc-members` flag from the default autodoc flags in the unit test from #4583.

The reason is that the task class and task instance have exactly the same docstring, which trips [this conditional in sphinx](https://github.com/sphinx-doc/sphinx/blob/v1.7.1/sphinx/ext/autodoc/__init__.py#L606-L613), which is intended to suppress repetition of the docstring of a class when documenting an instance of that class.