### PR TITLE
Put back undoc-members option in sphinx test

### DIFF
--- a/t/unit/contrib/proj/conf.py
+++ b/t/unit/contrib/proj/conf.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 extensions = ['celery.contrib.sphinx', 'sphinx.ext.autodoc']
-autodoc_default_flags = ['members']
+autodoc_default_flags = ['members', 'undoc-members']
 autosummary_generate = True
 
 sys.path.insert(0, os.path.abspath('.'))


### PR DESCRIPTION
The test will fail without this due to the bug explained in #4584. The flag was removed accidentally because a WIP commit was accidentally merged.