### PR TITLE
Update documenation for broker_connection_timeout

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1929,6 +1929,13 @@ The default timeout in seconds before we give up establishing a connection
 to the AMQP server. This setting is disabled when using
 gevent.
 
+.. note::
+
+    The broker connection timeout only applies to a worker attempting to
+    connect to the broker. It does not apply to producer sending a task, see
+    :setting:`broker_transport_options` for how to provide a timeout for that
+    situation.
+
 .. setting:: broker_connection_retry
 
 ``broker_connection_retry``


### PR DESCRIPTION
See https://github.com/celery/celery/issues/4328#issuecomment-367801326 for some background on this. I'm assuming that the current implementation is correct and the documentation should be expanded. If this is not so, let me know and I can close this and try to fix the underlying issue.

## Description

This documents that the `broker_connection_timeout` option only applies to the worker connection to the broker (and not to producers sending tasks).