### PR TITLE
Flush stderr before exiting with error code 1.

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -791,6 +791,7 @@ def check_privileges(accept_content):
                         uid=uid, euid=euid, gid=gid, egid=egid,
                     ), file=sys.stderr)
                 finally:
+                    sys.stderr.flush()
                     os._exit(1)
         warnings.warn(RuntimeWarning(ROOT_DISCOURAGED.format(
             uid=uid, euid=euid, gid=gid, egid=egid,

--- a/celery/utils/threads.py
+++ b/celery/utils/threads.py
@@ -74,6 +74,7 @@ class bgThread(threading.Thread):
                         self.on_crash('{0!r} crashed: {1!r}', self.name, exc)
                         self._set_stopped()
                     finally:
+                        sys.stderr.flush()
                         os._exit(1)  # exiting by normal means won't work
         finally:
             self._set_stopped()

--- a/celery/utils/timer2.py
+++ b/celery/utils/timer2.py
@@ -91,6 +91,7 @@ class Timer(threading.Thread):
                 pass
         except Exception as exc:
             logger.error('Thread Timer crashed: %r', exc, exc_info=True)
+            sys.stderr.flush()
             os._exit(1)
 
     def stop(self):


### PR DESCRIPTION
Closes #4594.

## Description

As explained in #4594, in some environments (docker, kubernetes, ...), it is possible that Celery terminates with error code 1 without printing anything. This happens when it is run as root with default parameters.

I have searched for all calls to `os._exit(1)` in the code and manually flushed stderr just before them. (Only the one in `celery/platforms.py` is necessary to solve the issue, but I thought that could save sweat to others…)