### PR TITLE
Linking the backers and sponsors badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -492,6 +492,8 @@ file in the top distribution directory for the full license text.
 
 .. |ocbackerbadge| image:: https://opencollective.com/celery/backers/badge.svg
     :alt: Backers on Open Collective
+    :target: #backers
 
 .. |ocsponsorbadge| image:: https://opencollective.com/celery/sponsors/badge.svg
     :alt: Sponsors on Open Collective
+    :target: #sponsors


### PR DESCRIPTION
Right now clicking on the backers or sponsors badge opens the badge image.

This should make the badge link to the backers and sponsors on the same GitHub page (anchor tag)