### PR TITLE
Escapes single quotes in kwargsrepr strings

### DIFF
--- a/celery/utils/saferepr.py
+++ b/celery/utils/saferepr.py
@@ -167,7 +167,7 @@ def _format_chars(val, maxlen):
     if isinstance(val, bytes):  # pragma: no cover
         return _format_binary_bytes(val, maxlen)
     else:
-        return "'{0}'".format(truncate(val, maxlen))
+        return "'{0}'".format(truncate(val, maxlen).replace("'", "\\'"))
 
 
 def _repr(obj):


### PR DESCRIPTION
## Description

Trying to [`ast.literal_eval`](https://docs.python.org/3/library/ast.html#ast.literal_eval) the value that [`kwargsrepr`](http://docs.celeryproject.org/en/latest/internals/protocol.html#message-protocol-task-v2) maps to (e.g., when handling [`after_task_publish`](http://docs.celeryproject.org/en/latest/userguide/signals.html#after-task-publish) signal) results in a syntax error if any of the keys and/or values contains single quote(s) since [`_format_chars`](https://github.com/celery/celery/blob/1a4497e94791e6662c328638db7cf0513534a7ac/celery/utils/saferepr.py#L170) wraps quoted tokens in single quotes. This PR replaces any single quotes within the quoted token with `\\'` to ensure they're escaped.

