### PR TITLE
Removing last references to task_method

### DIFF
--- a/celery/utils/dispatch/signal.py
+++ b/celery/utils/dispatch/signal.py
@@ -34,7 +34,7 @@ def _make_id(target):  # pragma: no cover
         # see Issue #2475
         return target
     if hasattr(target, '__func__'):
-        return (id(target.__self__), id(target.__func__))
+        return id(target.__func__)
     return id(target)
 
 
@@ -182,15 +182,6 @@ class Signal(object):  # pragma: no cover
         if weak:
             ref = weakref.ref
             receiver_object = receiver
-            # Check for bound methods
-            try:
-                receiver.__self__
-                receiver.__func__
-            except AttributeError:
-                pass
-            else:
-                ref = WeakMethod
-                receiver_object = receiver.__self__
             if PY3:
                 receiver = ref(receiver)
                 weakref.finalize(receiver_object, self._remove_receiver)

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -494,24 +494,6 @@ class test_App:
         i.annotate()
         i.annotate()
 
-    def test_apply_async_has__self__(self):
-        @self.app.task(__self__='hello', shared=False)
-        def aawsX(x, y):
-            pass
-
-        with pytest.raises(TypeError):
-            aawsX.apply_async(())
-        with pytest.raises(TypeError):
-            aawsX.apply_async((2,))
-
-        with patch('celery.app.amqp.AMQP.create_task_message') as create:
-            with patch('celery.app.amqp.AMQP.send_task_message') as send:
-                create.return_value = Mock(), Mock(), Mock(), Mock()
-                aawsX.apply_async((4, 5))
-                args = create.call_args[0][2]
-                assert args, ('hello', 4 == 5)
-                send.assert_called()
-
     def test_apply_async_adds_children(self):
         from celery._state import _task_stack
 

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -683,16 +683,6 @@ class test_tasks(TasksCase):
         self.mytask.__v2_compat__ = True
         assert 'v2 compatible' in repr(self.mytask)
 
-    def test_apply_with_self(self):
-
-        @self.app.task(__self__=42, shared=False)
-        def tawself(self):
-            return self
-
-        assert tawself.apply().get() == 42
-
-        assert tawself() == 42
-
     def test_context_get(self):
         self.mytask.push_request()
         try:


### PR DESCRIPTION
updated from https://github.com/celery/celery/pull/3838