### PR TITLE
Add support for delayed expansion of generators to groups and chords.

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -386,6 +386,9 @@ class Backend(object):
     def on_chord_part_return(self, request, state, result, **kwargs):
         pass
 
+    def set_chord_size(self, group_id, size):
+        pass
+
     def fallback_chord_unlock(self, group_id, body, result=None,
                               countdown=1, **kwargs):
         kwargs['result'] = [r.as_tuple() for r in result]
@@ -394,11 +397,12 @@ class Backend(object):
         )
 
     def apply_chord(self, header, partial_args, group_id, body,
-                    options={}, **kwargs):
+                    options={}, result=None, **kwargs):
+        result = list(result)
         fixed_options = {k: v for k, v in items(options) if k != 'task_id'}
-        result = header(*partial_args, task_id=group_id, **fixed_options or {})
-        self.fallback_chord_unlock(group_id, body, **kwargs)
-        return result
+        res = header(*partial_args, task_id=group_id, **fixed_options or {})
+        self.fallback_chord_unlock(group_id, body, result=result, **kwargs)
+        return res
 
     def current_task_children(self, request=None):
         request = request or getattr(current_task(), 'request', None)

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -239,6 +239,9 @@ class RedisBackend(base.BaseKeyValueStoreBackend, async.AsyncBackendMixin):
             raise ChordError('Dependency {0} raised {1!r}'.format(tid, retval))
         return retval
 
+    def set_chord_size(self, group_id, chord_size):
+        self.set(self.get_key_for_group(group_id, '.s'), chord_size)
+
     def apply_chord(self, header, partial_args, group_id, body,
                     result=None, options={}, **kwargs):
         # avoids saving the group in the redis db.
@@ -254,17 +257,24 @@ class RedisBackend(base.BaseKeyValueStoreBackend, async.AsyncBackendMixin):
         client = self.client
         jkey = self.get_key_for_group(gid, '.j')
         tkey = self.get_key_for_group(gid, '.t')
+        skey = self.get_key_for_group(gid, '.s')
         result = self.encode_result(result, state)
         with client.pipeline() as pipe:
-            _, readycount, totaldiff, _, _ = pipe                           \
+            _, readycount, totaldiff, total, _, _, _ = pipe                 \
                 .rpush(jkey, self.encode([1, tid, state, result]))          \
                 .llen(jkey)                                                 \
                 .get(tkey)                                                  \
+                .get(skey)                                                  \
                 .expire(jkey, 86400)                                        \
                 .expire(tkey, 86400)                                        \
+                .expire(skey, 86400)                                        \
                 .execute()
 
-        totaldiff = int(totaldiff or 0)
+        if total is None:
+            # chord is not completely submitted yet
+            return
+
+        total = int(total) + int(totaldiff or 0)
 
         try:
             callback = maybe_signature(request.chord, app=app)
@@ -272,10 +282,11 @@ class RedisBackend(base.BaseKeyValueStoreBackend, async.AsyncBackendMixin):
             if readycount == total:
                 decode, unpack = self.decode, self._unpack_chord_result
                 with client.pipeline() as pipe:
-                    resl, _, _ = pipe               \
+                    resl, _, _, _ = pipe            \
                         .lrange(jkey, 0, total)     \
                         .delete(jkey)               \
                         .delete(tkey)               \
+                        .delete(skey)               \
                         .execute()
                 try:
                     callback.delay([unpack(tup, decode) for tup in resl])

--- a/celery/tests/app/test_builtins.py
+++ b/celery/tests/app/test_builtins.py
@@ -115,6 +115,7 @@ class test_group(BuiltinsCase):
     def test_task(self, current_worker_task):
         g, result = self.mock_group(self.add.s(2), self.add.s(4))
         self.task(g.tasks, result, result.id, (2,)).results
+        print('TASKS: %r' % (g.tasks,))
         g.tasks[0].clone().apply_async.assert_called_with(
             group_id=result.id, producer=self.app.producer_or_acquire(),
             add_to_parent=False,
@@ -178,5 +179,6 @@ class test_chord(BuiltinsCase):
     def test_apply_eager_with_arguments(self):
         self.app.conf.task_always_eager = True
         x = chord([self.add.s(i) for i in range(10)], body=self.xsum.s())
+        print(list(x.tasks))
         r = x.apply_async([1])
         self.assertEqual(r.get(), 55)

--- a/celery/tests/backends/test_cache.py
+++ b/celery/tests/backends/test_cache.py
@@ -12,6 +12,7 @@ from celery import group, signature, uuid
 from celery.backends.cache import CacheBackend, DummyClient, backends
 from celery.exceptions import ImproperlyConfigured
 from celery.five import items, bytes_if_py2, string, text_t
+from celery.utils.functional import regen
 
 from celery.tests.case import AppCase, Mock, mock, patch, skip
 
@@ -67,7 +68,8 @@ class test_CacheBackend(AppCase):
 
     def test_apply_chord(self):
         tb = CacheBackend(backend='memory://', app=self.app)
-        gid, res = uuid(), [self.app.AsyncResult(uuid()) for _ in range(3)]
+        gid = uuid()
+        res = regen(self.app.AsyncResult(uuid()) for _ in range(3))
         tb.apply_chord(group(app=self.app), (), gid, {}, result=res)
 
     @patch('celery.result.GroupResult.restore')

--- a/celery/tests/backends/test_redis.py
+++ b/celery/tests/backends/test_redis.py
@@ -278,6 +278,12 @@ class test_RedisBackend(AppCase):
         b.add_to_chord(gid, 'sig')
         b.client.incr.assert_called_with(b.get_key_for_group(gid, '.t'), 1)
 
+    def test_set_chord_size(self):
+        b = self.Backend('redis://', app=self.app)
+        gid = uuid()
+        b.set_chord_size(gid, 10)
+        b.client.set.assert_called_with(b.get_key_for_group(gid, '.s'), 10)
+
     def test_expires_is_None(self):
         b = self.Backend(expires=None, app=self.app)
         self.assertEqual(
@@ -304,13 +310,14 @@ class test_RedisBackend(AppCase):
         self.app.tasks['foobarbaz'] = task
         task.request.chord = signature(task)
         task.request.id = tid
-        task.request.chord['chord_size'] = 10
         task.request.group = 'group_id'
         return task
 
     @patch('celery.result.GroupResult.restore')
     def test_on_chord_part_return(self, restore):
         tasks = [self.create_task() for i in range(10)]
+
+        self.b.set_chord_size('group_id', 10)
 
         for i in range(10):
             self.b.on_chord_part_return(tasks[i].request, states.SUCCESS, i)
@@ -319,20 +326,27 @@ class test_RedisBackend(AppCase):
         self.assertTrue(self.b.client.lrange.call_count)
         jkey = self.b.get_key_for_group('group_id', '.j')
         tkey = self.b.get_key_for_group('group_id', '.t')
-        self.b.client.delete.assert_has_calls([call(jkey), call(tkey)])
+        skey = self.b.get_key_for_group('group_id', '.s')
+        self.b.client.delete.assert_has_calls([
+            call(jkey), call(tkey), call(skey),
+        ])
         self.b.client.expire.assert_has_calls([
-            call(jkey, 86400), call(tkey, 86400),
+            call(jkey, 86400), call(tkey, 86400), call(skey, 86400),
         ])
 
     def test_on_chord_part_return__success(self):
-        with self.chord_context(2) as (_, request, callback):
+        with self.chord_context(3) as (_, request, callback):
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
             callback.delay.assert_not_called()
+            self.b.set_chord_size('gid1', 3)
             self.b.on_chord_part_return(request, states.SUCCESS, 20)
-            callback.delay.assert_called_with([10, 20])
+            callback.delay.assert_not_called()
+            self.b.on_chord_part_return(request, states.SUCCESS, 30)
+            callback.delay.assert_called_with([10, 20, 30])
 
     def test_on_chord_part_return__callback_raises(self):
         with self.chord_context(1) as (_, request, callback):
+            self.b.set_chord_size('gid1', 1)
             callback.delay.side_effect = KeyError(10)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
@@ -342,22 +356,27 @@ class test_RedisBackend(AppCase):
 
     def test_on_chord_part_return__ChordError(self):
         with self.chord_context(1) as (_, request, callback):
+            self.b.set_chord_size('gid1', 1)
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, ChordError())
-            self.b.client.pipeline.return_value.rpush().llen().get().expire(
-            ).expire().execute.return_value = (1, 1, 0, 4, 5)
+            self._set_pipeline_ret(1, 1, 0, 1, 4, 5, 6)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
             task.backend.fail_from_current_stack.assert_called_with(
                 callback.id, exc=ANY,
             )
 
+    def _set_pipeline_ret(self, *args):
+            self.b.client.pipeline.return_value.rpush().llen().get().get()\
+                .expire().expire().expire()\
+                .execute.return_value = args
+
     def test_on_chord_part_return__other_error(self):
         with self.chord_context(1) as (_, request, callback):
+            self.b.set_chord_size('gid1', 1)
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, RuntimeError())
-            self.b.client.pipeline.return_value.rpush().llen().get().expire(
-            ).expire().execute.return_value = (1, 1, 0, 4, 5)
+            self._set_pipeline_ret(1, 1, 0, 1, 4, 5, 6)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
             task.backend.fail_from_current_stack.assert_called_with(
@@ -373,7 +392,6 @@ class test_RedisBackend(AppCase):
             request.group = 'gid1'
             callback = ms.return_value = Signature('add')
             callback.id = 'id1'
-            callback['chord_size'] = size
             callback.delay = Mock(name='callback.delay')
             yield tasks, request, callback
 

--- a/celery/utils/abstract.py
+++ b/celery/utils/abstract.py
@@ -102,10 +102,6 @@ class CallableSignature(CallableTask):  # pragma: no cover
         pass
 
     @abstractproperty
-    def chord_size(self):
-        pass
-
-    @abstractproperty
     def immutable(self):
         pass
 


### PR DESCRIPTION
Prior to this change, if a generator was passed to group or chord it was completely expanded prior to any tasks being submitted to the backend.  After this change, tasks will be submitted to the backend as they are retreived from the generator, allowing work to begin much sooner for long-running generators.
This is currently a work in progress: only redis is supported.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
