### PR TITLE
Redis Result Consumer: unsubscribe on message success

### DIFF
--- a/celery/contrib/testing/manager.py
+++ b/celery/contrib/testing/manager.py
@@ -9,10 +9,10 @@ from itertools import count
 
 from kombu.utils.functional import retry_over_time
 
+from celery import states
 from celery.exceptions import TimeoutError
 from celery.five import items
 from celery.result import ResultSet
-from celery import states
 from celery.utils.text import truncate
 from celery.utils.time import humanize_seconds as _humanize_seconds
 


### PR DESCRIPTION
- [x] Reset connection pool and PubSub internal state after consumer fork.
- [x] Unsubscribe from channel when task state changes to ready state.

Addresses issues discussed in #3812 and #3808 .