### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -115,7 +115,7 @@ an overview of what's new in Celery 4.2.
 
     Contributed by **Alex Hill**.
 
-- **CI**: Run `Openstack Bandit <https://pypi.python.org/pypi/bandit/1.0.1>`_ in Travis CI in order to detect security issues.
+- **CI**: Run `Openstack Bandit <https://pypi.org/project/bandit/1.0.1/>`_ in Travis CI in order to detect security issues.
 
     Contributed by **Omer Katz**.
 

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 :Version: 4.2.0rc2 (latentcall)
 :Web: http://celeryproject.org/
-:Download: https://pypi.python.org/pypi/celery/
+:Download: https://pypi.org/project/celery/
 :Source: https://github.com/celery/celery/
 :Keywords: task, queue, job, async, rabbitmq, amqp, redis,
   python, distributed, actors
@@ -188,8 +188,8 @@ database connections at ``fork``.
 .. _`web2py`: http://web2py.com/
 .. _`Bottle`: https://bottlepy.org/
 .. _`Pyramid`: http://docs.pylonsproject.org/en/latest/docs/pyramid.html
-.. _`pyramid_celery`: https://pypi.python.org/pypi/pyramid_celery/
-.. _`celery-pylons`: https://pypi.python.org/pypi/celery-pylons
+.. _`pyramid_celery`: https://pypi.org/project/pyramid_celery/
+.. _`celery-pylons`: https://pypi.org/project/celery-pylons/
 .. _`web2py-celery`: https://code.google.com/p/web2py-celery/
 .. _`Tornado`: http://www.tornadoweb.org/
 .. _`tornado-celery`: https://github.com/mher/tornado-celery/
@@ -323,7 +323,7 @@ Downloading and installing from source
 
 Download the latest version of Celery from PyPI:
 
-https://pypi.python.org/pypi/celery/
+https://pypi.org/project/celery/
 
 You can install it by doing the following,:
 
@@ -480,15 +480,15 @@ file in the top distribution directory for the full license text.
 
 .. |wheel| image:: https://img.shields.io/pypi/wheel/celery.svg
     :alt: Celery can be installed via wheel
-    :target: https://pypi.python.org/pypi/celery/
+    :target: https://pypi.org/project/celery/
 
 .. |pyversion| image:: https://img.shields.io/pypi/pyversions/celery.svg
     :alt: Supported Python versions.
-    :target: https://pypi.python.org/pypi/celery/
+    :target: https://pypi.org/project/celery/
 
 .. |pyimp| image:: https://img.shields.io/pypi/implementation/celery.svg
     :alt: Support Python implementations.
-    :target: https://pypi.python.org/pypi/celery/
+    :target: https://pypi.org/project/celery/
 
 .. |ocbackerbadge| image:: https://opencollective.com/celery/backers/badge.svg
     :alt: Backers on Open Collective

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -24,7 +24,7 @@ try:
 except ImportError:  # pragma: no cover
     raise ImproperlyConfigured(
         'The database result backend requires SQLAlchemy to be installed.'
-        'See https://pypi.python.org/pypi/SQLAlchemy')
+        'See https://pypi.org/project/SQLAlchemy/')
 
 logger = logging.getLogger(__name__)
 

--- a/docs/includes/installation.txt
+++ b/docs/includes/installation.txt
@@ -120,7 +120,7 @@ Downloading and installing from source
 
 Download the latest version of Celery from PyPI:
 
-https://pypi.python.org/pypi/celery/
+https://pypi.org/project/celery/
 
 You can install it by doing the following,:
 

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,6 +1,6 @@
 :Version: 4.2.0rc2 (latentcall)
 :Web: http://celeryproject.org/
-:Download: https://pypi.python.org/pypi/celery/
+:Download: https://pypi.org/project/celery/
 :Source: https://github.com/celery/celery/
 :Keywords: task, queue, job, async, rabbitmq, amqp, redis,
   python, distributed, actors
@@ -184,8 +184,8 @@ database connections at ``fork``.
 .. _`web2py`: http://web2py.com/
 .. _`Bottle`: https://bottlepy.org/
 .. _`Pyramid`: http://docs.pylonsproject.org/en/latest/docs/pyramid.html
-.. _`pyramid_celery`: https://pypi.python.org/pypi/pyramid_celery/
-.. _`celery-pylons`: https://pypi.python.org/pypi/celery-pylons
+.. _`pyramid_celery`: https://pypi.org/project/pyramid_celery/
+.. _`celery-pylons`: https://pypi.org/project/celery-pylons/
 .. _`web2py-celery`: https://code.google.com/p/web2py-celery/
 .. _`Tornado`: http://www.tornadoweb.org/
 .. _`tornado-celery`: https://github.com/mher/tornado-celery/

--- a/docs/sec/CELERYSA-0001.txt
+++ b/docs/sec/CELERYSA-0001.txt
@@ -62,19 +62,19 @@ Users of the 2.4 series should upgrade to 2.4.4:
 
     * ``pip install -U celery``, or
     * ``easy_install -U celery``, or
-    * https://pypi.python.org/pypi/celery/2.4.4
+    * https://pypi.org/project/celery/2.4.4/
 
 Users of the 2.3 series should upgrade to 2.3.4:
 
     * ``pip install -U celery==2.3.4``, or
     * ``easy_install -U celery==2.3.4``, or
-    * https://pypi.python.org/pypi/celery/2.3.4
+    * https://pypi.org/project/celery/2.3.4/
 
 Users of the 2.2 series should upgrade to 2.2.8:
 
     * ``pip install -U celery==2.2.8``, or
     * ``easy_install -U celery==2.2.8``, or
-    * https://pypi.python.org/pypi/celery/2.2.8
+    * https://pypi.org/project/celery/2.2.8/
 
 The 2.1 series is no longer being maintained, so we urge users
 of that series to upgrade to a more recent version.

--- a/docs/sec/CELERYSA-0002.txt
+++ b/docs/sec/CELERYSA-0002.txt
@@ -69,13 +69,13 @@ Or you can upgrade to a more recent version:
 
     * ``pip install -U celery``, or
     * ``easy_install -U celery``, or
-    * https://pypi.python.org/pypi/celery/3.1.13
+    * https://pypi.org/project/celery/3.1.13/
 
 - Users of the 3.0 series should upgrade to 3.0.25:
 
     * ``pip install -U celery==3.0.25``, or
     * ``easy_install -U celery==3.0.25``, or
-    * https://pypi.python.org/pypi/celery/3.0.25
+    * https://pypi.org/project/celery/3.0.25/
 
 Distribution package maintainers are urged to provide their users
 with updated packages.

--- a/docs/templates/readme.txt
+++ b/docs/templates/readme.txt
@@ -21,12 +21,12 @@
 
 .. |wheel| image:: https://img.shields.io/pypi/wheel/celery.svg
     :alt: Celery can be installed via wheel
-    :target: https://pypi.python.org/pypi/celery/
+    :target: https://pypi.org/project/celery/
 
 .. |pyversion| image:: https://img.shields.io/pypi/pyversions/celery.svg
     :alt: Supported Python versions.
-    :target: https://pypi.python.org/pypi/celery/
+    :target: https://pypi.org/project/celery/
 
 .. |pyimp| image:: https://img.shields.io/pypi/implementation/celery.svg
     :alt: Support Python implementations.
-    :target: https://pypi.python.org/pypi/celery/
+    :target: https://pypi.org/project/celery/


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html