### PR TITLE
Enable configcheck lint step to be run in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,6 +65,7 @@ RUN pyenv exec pip install \
   -r requirements/test-integration.txt
 
 COPY --chown=1000:1000 MANIFEST.in Makefile setup.py setup.cfg tox.ini $HOME/
+COPY --chown=1000:1000 docs $HOME/docs
 COPY --chown=1000:1000 t $HOME/t
 COPY --chown=1000:1000 celery $HOME/celery
 


### PR DESCRIPTION
## Description

Currently the configcheck lint step can't be run in the Celery Docker container (see screenshot of error message below) which makes it harder to easily verify all the lint steps locally.

![Screenshot of configcheck failure](https://user-images.githubusercontent.com/1086421/39381708-e69c62c4-4a17-11e8-93f8-570eda0edcb1.PNG)

This pull request makes it possible to run the configcheck lint step with one Docker command:

```sh
docker-compose run -e TOXENV=configcheck --rm celery tox
```