### PR TITLE
Clean up redundent PY3 constants

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -14,7 +14,7 @@ from kombu.utils.functional import maybe_list
 from kombu.utils.objects import cached_property
 
 from celery import signals
-from celery.five import items, string_t
+from celery.five import PY3, items, string_t
 from celery.local import try_import
 from celery.utils.nodenames import anon_nodename
 from celery.utils.saferepr import saferepr
@@ -24,8 +24,6 @@ from celery.utils.time import maybe_make_aware
 from . import routes as _routes
 
 __all__ = ('AMQP', 'Queues', 'task_message')
-
-PY3 = sys.version_info[0] == 3
 
 #: earliest date supported by time.mktime.
 INT_MIN = -2147483648

--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import numbers
-import sys
 from collections import Mapping, namedtuple
 from datetime import timedelta
 from weakref import WeakValueDictionary

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -307,7 +307,6 @@ class Celery(object):
 
     def on_init(self):
         """Optional callback called at init."""
-        pass
 
     def __autoset(self, key, value):
         if value:

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -338,7 +338,6 @@ class Task(object):
             This class method can be defined to do additional actions when
             the task class is bound to an app.
         """
-        pass
 
     @classmethod
     def _get_app(cls):
@@ -553,7 +552,6 @@ class Task(object):
             kwargs (Dict): Task keyword arguments.
             options (Dict): Task execution options.
         """
-        pass
 
     def signature_from_request(self, request=None, args=None, kwargs=None,
                                queue=None, **extra_options):
@@ -904,7 +902,6 @@ class Task(object):
         Returns:
             None: The return value of this handler is ignored.
         """
-        pass
 
     def on_retry(self, exc, task_id, args, kwargs, einfo):
         """Retry handler.
@@ -921,7 +918,6 @@ class Task(object):
         Returns:
             None: The return value of this handler is ignored.
         """
-        pass
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         """Error handler.
@@ -938,7 +934,6 @@ class Task(object):
         Returns:
             None: The return value of this handler is ignored.
         """
-        pass
 
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
         """Handler called after the task returns.
@@ -954,7 +949,6 @@ class Task(object):
         Returns:
             None: The return value of this handler is ignored.
         """
-        pass
 
     def add_trail(self, result):
         if self.trail:

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -402,11 +402,9 @@ class Backend(object):
         Note:
             This is run by :class:`celery.task.DeleteExpiredTaskMetaTask`.
         """
-        pass
 
     def process_cleanup(self):
         """Cleanup actions to do at the end of a task worker process."""
-        pass
 
     def on_task_call(self, producer, task_id):
         return {}

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -25,7 +25,7 @@ from celery import current_app, group, maybe_signature, states
 from celery._state import get_current_task
 from celery.exceptions import (ChordError, ImproperlyConfigured,
                                TaskRevokedError, TimeoutError)
-from celery.five import items
+from celery.five import PY3, items
 from celery.result import (GroupResult, ResultBase, allow_join_result,
                            result_from_tuple)
 from celery.utils.collections import BufferMap
@@ -38,7 +38,6 @@ from celery.utils.serialization import (create_exception_cls,
 __all__ = ('BaseBackend', 'KeyValueStoreBackend', 'DisabledBackend')
 
 EXCEPTION_ABLE_CODECS = frozenset({'pickle'})
-PY3 = sys.version_info >= (3, 0)
 
 logger = get_logger(__name__)
 

--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -2,7 +2,6 @@
 """Memcached and in-memory cache result backend."""
 from __future__ import absolute_import, unicode_literals
 
-
 from kombu.utils.encoding import bytes_to_str, ensure_bytes
 from kombu.utils.objects import cached_property
 

--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -2,7 +2,6 @@
 """Memcached and in-memory cache result backend."""
 from __future__ import absolute_import, unicode_literals
 
-import sys
 
 from kombu.utils.encoding import bytes_to_str, ensure_bytes
 from kombu.utils.objects import cached_property

--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -8,6 +8,7 @@ from kombu.utils.encoding import bytes_to_str, ensure_bytes
 from kombu.utils.objects import cached_property
 
 from celery.exceptions import ImproperlyConfigured
+from celery.five import PY3
 from celery.utils.functional import LRUCache
 
 from .base import KeyValueStoreBackend
@@ -15,8 +16,6 @@ from .base import KeyValueStoreBackend
 __all__ = ('CacheBackend',)
 
 _imp = [None]
-
-PY3 = sys.version_info[0] == 3
 
 REQUIRES_BACKEND = """\
 The Memcached backend requires either pylibmc or python-memcached.\

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -563,7 +563,6 @@ class Command(object):
         Example:
               >>> has_pool_option = (['-P'], ['--pool'])
         """
-        pass
 
     def node_format(self, s, nodename, **extra):
         return node_format(s, nodename, **extra)

--- a/celery/bootsteps.py
+++ b/celery/bootsteps.py
@@ -344,7 +344,6 @@ class Step(object):
 
     def create(self, parent):
         """Create the step."""
-        pass
 
     def __repr__(self):
         return bytes_if_py2('<step: {0.alias}>'.format(self))

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, unicode_literals
 
 import itertools
 import operator
-import sys
 from collections import MutableSequence, deque
 from copy import deepcopy
 from functools import partial as _partial

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -22,7 +22,7 @@ from kombu.utils.uuid import uuid
 from vine import barrier
 
 from celery._state import current_app
-from celery.five import python_2_unicode_compatible
+from celery.five import PY3, python_2_unicode_compatible
 from celery.local import try_import
 from celery.result import GroupResult, allow_join_result
 from celery.utils import abstract
@@ -37,8 +37,6 @@ __all__ = (
     'Signature', 'chain', 'xmap', 'xstarmap', 'chunks',
     'group', 'chord', 'signature', 'maybe_signature',
 )
-
-PY3 = sys.version_info[0] == 3
 
 # json in Python 2.7 borks if dict contains byte keys.
 JSON_NEEDS_UNICODE_KEYS = PY3 and not try_import('simplejson')

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -1037,7 +1037,6 @@ class AsynPool(_pool.Pool):
 
     def on_shrink(self, n):
         """Shrink the pool by ``n`` processes."""
-        pass
 
     def create_process_queues(self):
         """Create new in, out, etc. queues, returned as a tuple."""

--- a/celery/contrib/sphinx.py
+++ b/celery/contrib/sphinx.py
@@ -31,10 +31,11 @@ Use ``.. autotask::`` to alternatively manually document a task.
 """
 from __future__ import absolute_import, unicode_literals
 
-from celery.app.task import BaseTask
-from celery.local import PromiseProxy
 from sphinx.domains.python import PyModulelevel
 from sphinx.ext.autodoc import FunctionDocumenter
+
+from celery.app.task import BaseTask
+from celery.local import PromiseProxy
 
 try:  # pragma: no cover
     from inspect import formatargspec, getfullargspec

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -71,23 +71,18 @@ class BaseLoader(object):
 
     def on_task_init(self, task_id, task):
         """Called before a task is executed."""
-        pass
 
     def on_process_cleanup(self):
         """Called after a task is executed."""
-        pass
 
     def on_worker_init(self):
         """Called when the worker (:program:`celery worker`) starts."""
-        pass
 
     def on_worker_shutdown(self):
         """Called when the worker (:program:`celery worker`) shuts down."""
-        pass
 
     def on_worker_process_init(self):
         """Called when a child process starts."""
-        pass
 
     def import_task_module(self, module):
         self.task_modules.add(module)

--- a/celery/local.py
+++ b/celery/local.py
@@ -14,13 +14,11 @@ from functools import reduce
 from importlib import import_module
 from types import ModuleType
 
-from .five import bytes_if_py2, items, string, string_t
+from .five import PY3, bytes_if_py2, items, string, string_t
 
 __all__ = ('Proxy', 'PromiseProxy', 'try_import', 'maybe_evaluate')
 
 __module__ = __name__  # used by Proxy class body
-
-PY3 = sys.version_info[0] == 3
 
 
 def _default_cls_attr(name, type_, cls_value):

--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -721,7 +721,6 @@ if os.environ.get('NOSETPS'):  # pragma: no cover
 
     def set_mp_process_title(*a, **k):
         """Disabled feature."""
-        pass
 else:
 
     def set_mp_process_title(progname, info=None, hostname=None):  # noqa

--- a/celery/utils/__init__.py
+++ b/celery/utils/__init__.py
@@ -12,9 +12,6 @@ from .nodenames import worker_direct, nodename, nodesplit
 __all__ = ('worker_direct', 'gen_task_name', 'nodename', 'nodesplit',
            'cached_property', 'uuid')
 
-PY3 = sys.version_info[0] == 3
-
-
 # ------------------------------------------------------------------------ #
 # > XXX Compat
 from .log import LOG_LEVELS     # noqa

--- a/celery/utils/__init__.py
+++ b/celery/utils/__init__.py
@@ -5,7 +5,6 @@ Don't import from here directly anymore, as these are only
 here for backwards compatibility.
 """
 from __future__ import absolute_import, print_function, unicode_literals
-import sys
 from .functional import memoize  # noqa
 from .nodenames import worker_direct, nodename, nodesplit
 

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -9,7 +9,7 @@ from collections import Sequence, deque
 from heapq import heapify, heappop, heappush
 from itertools import chain, count
 
-from celery.five import (Empty, items, keys, monotonic,
+from celery.five import (PY3, Empty, items, keys, monotonic,
                          python_2_unicode_compatible, values)
 
 from .functional import first, uniq
@@ -34,8 +34,6 @@ __all__ = (
     'LimitedSet', 'Messagebuffer', 'OrderedDict',
     'force_mapping', 'lpmerge',
 )
-
-PY3 = sys.version_info[0] >= 3
 
 REPR_LIMITED_SET = """\
 <{name}({size}): maxlen={0.maxlen}, expires={0.expires}, minlen={0.minlen}>\

--- a/celery/utils/dispatch/signal.py
+++ b/celery/utils/dispatch/signal.py
@@ -10,7 +10,7 @@ import weakref
 from kombu.utils.functional import retry_over_time
 
 from celery.exceptions import CDeprecationWarning
-from celery.five import python_2_unicode_compatible, range, text_t
+from celery.five import PY3, python_2_unicode_compatible, range, text_t
 from celery.local import PromiseProxy, Proxy
 from celery.utils.functional import fun_accepts_kwargs
 from celery.utils.log import get_logger
@@ -23,7 +23,6 @@ except ImportError:
 
 __all__ = ('Signal',)
 
-PY3 = sys.version_info[0] >= 3
 logger = get_logger(__name__)
 
 

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -20,8 +20,6 @@ __all__ = (
     'maybe', 'fun_accepts_kwargs',
 )
 
-IS_PY3 = sys.version_info[0] == 3
-
 FUNHEAD_TEMPLATE = """
 def {fun_name}({fun_args}):
     return {fun_value}

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -58,7 +58,6 @@ def noop(*args, **kwargs):
 
     Takes any arguments/keyword arguments and does nothing.
     """
-    pass
 
 
 def pass1(arg, *args, **kwargs):

--- a/celery/utils/log.py
+++ b/celery/utils/log.py
@@ -10,7 +10,7 @@ import threading
 import traceback
 from contextlib import contextmanager
 
-from kombu.five import values
+from kombu.five import PY3, values
 from kombu.log import LOG_LEVELS
 from kombu.log import get_logger as _get_logger
 from kombu.utils.encoding import safe_str
@@ -28,7 +28,6 @@ __all__ = (
 
 _process_aware = False
 _in_sighandler = False
-PY3 = sys.version_info[0] == 3
 
 MP_LOG = os.environ.get('MP_LOG', False)
 

--- a/celery/utils/saferepr.py
+++ b/celery/utils/saferepr.py
@@ -20,22 +20,11 @@ from itertools import chain
 from numbers import Number
 from pprint import _recursion
 
-from celery.five import items, text_t
+from celery.five import items, range, text_t
 
 from .text import truncate
 
 __all__ = ('saferepr', 'reprstream')
-
-# pylint: disable=redefined-outer-name
-# We cache globals and attribute lookups, so disable this warning.
-
-IS_PY3 = sys.version_info[0] == 3
-
-if IS_PY3:  # pragma: no cover
-    range_t = (range, )
-else:
-    class range_t(object):  # noqa
-        pass
 
 #: Node representing literal text.
 #:   - .value: is the literal text value
@@ -247,7 +236,7 @@ def reprstream(stack, seen=None, maxlevels=3, level=0, isinstance=isinstance):
                 yield text_t(val), it
             elif isinstance(val, chars_t):
                 yield _quoted(val), it
-            elif isinstance(val, range_t):  # pragma: no cover
+            elif isinstance(val, range):  # pragma: no cover
                 yield _repr(val), it
             else:
                 if isinstance(val, set_t):

--- a/celery/utils/saferepr.py
+++ b/celery/utils/saferepr.py
@@ -12,7 +12,6 @@ Very slow with no limits, super quick with limits.
 """
 from __future__ import absolute_import, unicode_literals
 
-import sys
 import traceback
 from collections import deque, namedtuple
 from decimal import Decimal

--- a/celery/utils/saferepr.py
+++ b/celery/utils/saferepr.py
@@ -19,7 +19,7 @@ from itertools import chain
 from numbers import Number
 from pprint import _recursion
 
-from celery.five import items, range, text_t
+from celery.five import items, range, text_t, PY3
 
 from .text import truncate
 
@@ -131,7 +131,7 @@ def _format_binary_bytes(val, maxlen, ellipsis='...'):
 
 
 def _bytes_prefix(s):
-    return 'b' + s if IS_PY3 else s
+    return 'b' + s if PY3 else s
 
 
 def _repr_binary_bytes(val):

--- a/celery/utils/saferepr.py
+++ b/celery/utils/saferepr.py
@@ -19,7 +19,7 @@ from itertools import chain
 from numbers import Number
 from pprint import _recursion
 
-from celery.five import items, range, text_t, PY3
+from celery.five import PY3, items, range, text_t
 
 from .text import truncate
 

--- a/celery/utils/threads.py
+++ b/celery/utils/threads.py
@@ -9,8 +9,7 @@ import threading
 import traceback
 from contextlib import contextmanager
 
-from celery.five import (PY3, THREAD_TIMEOUT_MAX, items,
-                         python_2_unicode_compatible)
+from celery.five import THREAD_TIMEOUT_MAX, items, python_2_unicode_compatible
 from celery.local import Proxy
 
 try:

--- a/celery/utils/threads.py
+++ b/celery/utils/threads.py
@@ -9,7 +9,8 @@ import threading
 import traceback
 from contextlib import contextmanager
 
-from celery.five import THREAD_TIMEOUT_MAX, items, python_2_unicode_compatible
+from celery.five import (PY3, THREAD_TIMEOUT_MAX, items,
+                         python_2_unicode_compatible)
 from celery.local import Proxy
 
 try:
@@ -33,7 +34,6 @@ __all__ = (
 )
 
 USE_FAST_LOCALS = os.environ.get('USE_FAST_LOCALS')
-PY3 = sys.version_info[0] == 3
 
 
 @contextmanager

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -16,7 +16,7 @@ from pytz import AmbiguousTimeError, FixedOffset
 from pytz import timezone as _timezone
 from pytz import utc
 
-from celery.five import python_2_unicode_compatible, string_t
+from celery.five import PY3, python_2_unicode_compatible, string_t
 
 from .functional import dictfilter
 from .iso8601 import parse_iso8601
@@ -30,9 +30,6 @@ __all__ = (
     'ffwd', 'utcoffset', 'adjust_timestamp',
     'get_exponential_backoff_interval',
 )
-
-PY3 = sys.version_info[0] == 3
-PY33 = sys.version_info >= (3, 3)
 
 C_REMDEBUG = os.environ.get('C_REMDEBUG', False)
 
@@ -129,7 +126,7 @@ class _Zone(object):
             dt = make_aware(dt, orig or self.utc)
         return localize(dt, self.tz_or_local(local))
 
-    if PY33:  # pragma: no cover
+    if PY3:  # pragma: no cover
 
         def to_system(self, dt):
             # tz=None is a special case since Python 3.3, and will

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import numbers
 import os
 import random
-import sys
 import time as _time
 from calendar import monthrange
 from datetime import date, datetime, timedelta, tzinfo

--- a/t/unit/backends/test_cache.py
+++ b/t/unit/backends/test_cache.py
@@ -11,9 +11,7 @@ from kombu.utils.encoding import ensure_bytes, str_to_bytes
 from celery import signature, states, uuid
 from celery.backends.cache import CacheBackend, DummyClient, backends
 from celery.exceptions import ImproperlyConfigured
-from celery.five import bytes_if_py2, items, string, text_t
-
-PY3 = sys.version_info[0] == 3
+from celery.five import PY3, bytes_if_py2, items, string, text_t
 
 
 class SomeClass(object):

--- a/t/unit/utils/test_local.py
+++ b/t/unit/utils/test_local.py
@@ -5,10 +5,8 @@ import sys
 import pytest
 from case import Mock, skip
 
-from celery.five import long_t, python_2_unicode_compatible, string
+from celery.five import PY3, long_t, python_2_unicode_compatible, string
 from celery.local import PromiseProxy, Proxy, maybe_evaluate, try_import
-
-PY3 = sys.version_info[0] == 3
 
 
 class test_try_import:

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps=
     flake8,flakeplus,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt
     isort-check: -r{toxinidir}/requirements/test-ci-default.txt
     isort-check: isort>=4.3.4
+    isort-check: Sphinx==1.6.5
     bandit: bandit
 sitepackages = False
 recreate = False


### PR DESCRIPTION
## Description

This PR cleans up redundant PY3 constants. The PY3 constant we should use is located at `vine.five`.
They are just clogging up our code and possibly using a little bit of extra startup time and memory.