### PR TITLE
Fix docker-compose start error

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,0 @@
-CELERY_USER=developer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update && apt-get install -y \
 # unrelated elements, grouping them together makes the Dockerfile read better.
 ENV PROVISIONING /provisioning
 
-# This is provisioned from .env
 ARG CELERY_USER=developer
 
 # Check for mandatory build arguments

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
       args:
-        CELERY_USER:
+        CELERY_USER: developer
     environment:
       TEST_BROKER: pyamqp://rabbit:5672
       TEST_BACKEND: redis://redis
@@ -16,7 +16,7 @@ services:
       WORKER_LOGLEVEL: DEBUG
     tty: true
     volumes:
-      - ../celery:/home/$CELERY_USER/celery
+      - ../celery:/home/developer/celery
       # Because pytest fails when it encounters files from alternative python compilations,
       # __pycache__ and pyc files, PYTHONDONTWRITEBYTECODE must be
       # set on the host as well or py.test will throw configuration errors.


### PR DESCRIPTION
## Description

Running docker-compose on a clean checkout currently fails with a validation error that `services.celery.build.args` contains null.

![Screenshot of docker-compose error due to missing build argument](https://user-images.githubusercontent.com/1086421/39424183-468739dc-4c6d-11e8-9a3c-03ad62758a14.png)

Referencing the `CELERY_USER` environment variable defined in `.env` does not fix this since environment variables are only applied at container run-time, not build-time. To avoid potential confusion due to this, it's easiest to just hard-code the `CELERY_USER` variable in the docker-compose file.
