### PR TITLE
Enable docker mounting of test directory

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,9 +70,7 @@ COPY --chown=1000:1000 celery $HOME/celery
 
 RUN pyenv exec pip install -e .
 
-# the compiled files from earlier steps will cause py.test to fail with
-# an ImportMismatchError
-RUN make clean-pyc
-
-# Setup the entrypoint, this ensures pyenv is initialized when a container is started.
+# Setup the entrypoint, this ensures pyenv is initialized when a container is started
+# and that any compiled files from earlier steps or from moutns are removed to avoid
+# py.test failing with an ImportMismatchError
 ENTRYPOINT ["/entrypoint"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,11 +16,9 @@ services:
       WORKER_LOGLEVEL: DEBUG
     tty: true
     volumes:
+      - ../docs:/home/developer/docs
       - ../celery:/home/developer/celery
-      # Because pytest fails when it encounters files from alternative python compilations,
-      # __pycache__ and pyc files, PYTHONDONTWRITEBYTECODE must be
-      # set on the host as well or py.test will throw configuration errors.
-#      - ../t:/home/$CELERY_USER/t
+      - ../t:/home/developer/t
     depends_on:
       - rabbit
       - redis

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+make --quiet --directory="$HOME" clean-pyc
+
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 exec "$@"


### PR DESCRIPTION
## Description

Currently there is a comment in the docker-compose file that indicates that the test directory can't be mounted due to compiled Python version mismatches. This pull request removes this limitation. This is achieved by cleaning up pyc files in the docker entrypoint script which avoids mismatches between compiled Python files on the docker host and/or from previous build steps by construction: before executing any command in the docker container, any remnant platform specific files are cleaned up and as such any subsequent py.test command will run in a clean environment.
