### PR TITLE
result_backend setting supports rediss:// protocol URLs

### DIFF
--- a/celery/app/backends.py
+++ b/celery/app/backends.py
@@ -21,6 +21,7 @@ BACKEND_ALIASES = {
     'rpc': 'celery.backends.rpc.RPCBackend',
     'cache': 'celery.backends.cache:CacheBackend',
     'redis': 'celery.backends.redis:RedisBackend',
+    'rediss': 'celery.backends.redis:RedisBackend',
     'sentinel': 'celery.backends.redis:SentinelBackend',
     'mongodb': 'celery.backends.mongodb:MongoBackend',
     'db': 'celery.backends.database:DatabaseBackend',

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, unicode_literals
 
 from functools import partial
 from ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
-from urllib import unquote
 
 from kombu.utils.functional import retry_over_time
 from kombu.utils.objects import cached_property
@@ -21,6 +20,12 @@ from celery.utils.log import get_logger
 from celery.utils.time import humanize_seconds
 
 from . import async, base
+
+try:
+    from urllib.parse import unquote
+except ImportError:
+    # Python 2
+    from urlparse import unquote
 
 try:
     import redis

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -3,6 +3,8 @@
 from __future__ import absolute_import, unicode_literals
 
 from functools import partial
+from ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
+from urllib import unquote
 
 from kombu.utils.functional import retry_over_time
 from kombu.utils.objects import cached_property
@@ -42,6 +44,23 @@ the Redis result store backend.
 E_REDIS_SENTINEL_MISSING = """
 You need to install the redis library with support of \
 sentinel in order to use the Redis result store backend.
+"""
+
+W_REDIS_SSL_CERT_OPTIONAL = """
+Setting ssl_cert_reqs=CERT_OPTIONAL when connecting to redis means that \
+celery might not valdate the identity of the redis broker when connecting. \
+This leaves you vulnerable to man in the middle attacks.
+"""
+
+W_REDIS_SSL_CERT_NONE = """
+Setting ssl_cert_reqs=CERT_NONE when connecting to redis means that celery \
+will not valdate the identity of the redis broker when connecting. This \
+leaves you vulnerable to man in the middle attacks.
+"""
+
+E_REDIS_SSL_CERT_REQS_MISSING = """
+A rediss:// URL must have parameter ssl_cert_reqs be CERT_REQUIRED, \
+CERT_OPTIONAL, or CERT_NONE
 """
 
 E_LOST = 'Connection to Redis lost: Retry (%s/%s) %s.'
@@ -196,6 +215,26 @@ class RedisBackend(base.BaseKeyValueStoreBackend, async.AsyncBackendMixin):
             connparams.pop('socket_connect_timeout')
         else:
             connparams['db'] = path
+
+        if scheme == 'rediss':
+            connparams['connection_class'] = redis.SSLConnection
+            # The following parameters, if present in the URL, are encoded. We
+            # must add the decoded values to connparams.
+            for ssl_setting in ['ssl_ca_certs', 'ssl_certfile', 'ssl_keyfile']:
+                ssl_val = query.pop(ssl_setting, None)
+                if ssl_val:
+                    connparams[ssl_setting] = unquote(ssl_val)
+            ssl_cert_reqs = query.pop('ssl_cert_reqs', 'MISSING')
+            if ssl_cert_reqs == 'CERT_REQUIRED':
+                connparams['ssl_cert_reqs'] = CERT_REQUIRED
+            elif ssl_cert_reqs == 'CERT_OPTIONAL':
+                logger.warn(W_REDIS_SSL_CERT_OPTIONAL)
+                connparams['ssl_cert_reqs'] = CERT_OPTIONAL
+            elif ssl_cert_reqs == 'CERT_NONE':
+                logger.warn(W_REDIS_SSL_CERT_NONE)
+                connparams['ssl_cert_reqs'] = CERT_NONE
+            else:
+                raise ValueError(E_REDIS_SSL_CERT_REQS_MISSING)
 
         # db may be string and start with / like in kombu.
         db = connparams.get('db') or 0

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -875,9 +875,12 @@ Configuring the backend URL
     requirements.
 
 This backend requires the :setting:`result_backend`
-setting to be set to a Redis URL::
+setting to be set to a Redis or `Redis over TLS`_ URL::
 
     result_backend = 'redis://:password@host:port/db'
+
+.. _`Redis over TLS`:
+    https://www.iana.org/assignments/uri-schemes/prov/rediss
 
 For example::
 
@@ -886,6 +889,10 @@ For example::
 is the same as::
 
     result_backend = 'redis://'
+
+Use the ``rediss://`` protocol to connect to redis over TLS::
+
+    result_backend = 'rediss://:password@host:port/db?ssl_cert_reqs=CERT_REQUIRED'
 
 The fields of the URL are defined as follows:
 
@@ -905,6 +912,17 @@ The fields of the URL are defined as follows:
 
     Database number to use. Default is 0.
     The db can include an optional leading slash.
+
+When using a TLS connection (protocol is ``rediss://``), you may pass in all values in :setting:`broker_use_ssl` as query parameters. Paths to certificates must be URL encoded, and ``ssl_cert_reqs`` is required. Example:
+
+.. code-block:: python
+
+    result_backend = 'rediss://:password@host:port/db?\
+        ssl_cert_reqs=CERT_REQUIRED\
+        &ssl_ca_certs=%2Fvar%2Fssl%2Fmyca.pem\                  # /var/ssl/myca.pem
+        &ssl_certfile=%2Fvar%2Fssl%2Fredis-server-cert.pem\     # /var/ssl/redis-server-cert.pem
+        &ssl_keyfile=%2Fvar%2Fssl%2Fprivate%2Fworker-key.pem'   # /var/ssl/private/worker-key.pem
+
 
 .. setting:: redis_backend_use_ssl
 

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -311,6 +311,38 @@ class test_RedisBackend:
         assert x.connparams['ssl_certfile'] == '/var/ssl/redis-server-cert.pem'
         assert x.connparams['ssl_keyfile'] == '/var/ssl/private/worker-key.pem'
 
+    @skip.unless_module('redis')
+    def test_backend_ssl_url_cert_none(self):
+        x = self.Backend(
+            'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=CERT_OPTIONAL',
+            app=self.app,
+        )
+        assert x.connparams
+        assert x.connparams['host'] == 'vandelay.com'
+        assert x.connparams['db'] == 1
+        assert x.connparams['port'] == 123
+        assert x.connparams['ssl_cert_reqs'] == ssl.CERT_OPTIONAL
+
+        from redis.connection import SSLConnection
+        assert x.connparams['connection_class'] is SSLConnection
+
+
+    @skip.unless_module('redis')
+    def test_backend_ssl_url_invalid(self):
+        with pytest.raises(ValueError):
+            x = self.Backend(
+                'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=CERT_KITTY_CATS',
+                app=self.app,
+            )
+
+    @skip.unless_module('redis')
+    def test_backend_ssl_url_invalid(self):
+        with pytest.raises(ValueError):
+            x = self.Backend(
+                'rediss://:bosco@vandelay.com:123//1',
+                app=self.app,
+            )
+
     def test_compat_propertie(self):
         x = self.Backend(
             'redis://:bosco@vandelay.com:123//1', app=self.app,

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -270,6 +270,47 @@ class test_RedisBackend:
         from redis.connection import SSLConnection
         assert x.connparams['connection_class'] is SSLConnection
 
+    @skip.unless_module('redis')
+    def test_backend_ssl_url(self):
+        self.app.conf.redis_socket_timeout = 30.0
+        self.app.conf.redis_socket_connect_timeout = 100.0
+        x = self.Backend(
+            'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=CERT_REQUIRED',
+            app=self.app,
+        )
+        assert x.connparams
+        assert x.connparams['host'] == 'vandelay.com'
+        assert x.connparams['db'] == 1
+        assert x.connparams['port'] == 123
+        assert x.connparams['password'] == 'bosco'
+        assert x.connparams['socket_timeout'] == 30.0
+        assert x.connparams['socket_connect_timeout'] == 100.0
+        assert x.connparams['ssl_cert_reqs'] == ssl.CERT_REQUIRED
+
+        from redis.connection import SSLConnection
+        assert x.connparams['connection_class'] is SSLConnection
+
+    @skip.unless_module('redis')
+    def test_backend_ssl_url_options(self):
+        x = self.Backend(
+            (
+                'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=CERT_NONE'
+                '&ssl_ca_certs=%2Fvar%2Fssl%2Fmyca.pem'
+                '&ssl_certfile=%2Fvar%2Fssl%2Fredis-server-cert.pem'
+                '&ssl_keyfile=%2Fvar%2Fssl%2Fprivate%2Fworker-key.pem'
+            ),
+            app=self.app,
+        )
+        assert x.connparams
+        assert x.connparams['host'] == 'vandelay.com'
+        assert x.connparams['db'] == 1
+        assert x.connparams['port'] == 123
+        assert x.connparams['password'] == 'bosco'
+        assert x.connparams['ssl_cert_reqs'] == ssl.CERT_NONE
+        assert x.connparams['ssl_ca_certs'] == '/var/ssl/myca.pem'
+        assert x.connparams['ssl_certfile'] == '/var/ssl/redis-server-cert.pem'
+        assert x.connparams['ssl_keyfile'] == '/var/ssl/private/worker-key.pem'
+
     def test_compat_propertie(self):
         x = self.Backend(
             'redis://:bosco@vandelay.com:123//1', app=self.app,

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -329,7 +329,7 @@ class test_RedisBackend:
     @skip.unless_module('redis')
     @pytest.mark.parametrize("uri", [
         'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=CERT_KITTY_CATS',
-        'rediss: //:bosco@vandelay.com:123//1'
+        'rediss://:bosco@vandelay.com:123//1'
     ])
     def test_backend_ssl_url_invalid(self, uri):
         with pytest.raises(ValueError):

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -326,20 +326,15 @@ class test_RedisBackend:
         from redis.connection import SSLConnection
         assert x.connparams['connection_class'] is SSLConnection
 
-
     @skip.unless_module('redis')
-    def test_backend_ssl_url_invalid(self):
+    @pytest.mark.parametrize("uri", [
+        'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=CERT_KITTY_CATS',
+        'rediss: //:bosco@vandelay.com:123//1'
+    ])
+    def test_backend_ssl_url_invalid(self, uri):
         with pytest.raises(ValueError):
-            x = self.Backend(
-                'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=CERT_KITTY_CATS',
-                app=self.app,
-            )
-
-    @skip.unless_module('redis')
-    def test_backend_ssl_url_invalid(self):
-        with pytest.raises(ValueError):
-            x = self.Backend(
-                'rediss://:bosco@vandelay.com:123//1',
+            self.Backend(
+                uri,
                 app=self.app,
             )
 


### PR DESCRIPTION
Implements support to configure a Redis + TLS connection to the result backend purely by using `result_backend`, rather than the setting [`redis_backend_use_ssl`](http://docs.celeryproject.org/en/master/userguide/configuration.html#redis-backend-use-ssl).  

The fields within `redis_backend_use_ssl` are now configurable via URL parameters. This has two significant advantages:

1. A settings file does not need to import the `ssl` package in order to declare `redis_backend_use_ssl.cert_reqs`. This allows more configuration to be pulled from the environment rather than committed as code.
2. Projects that depend on celery do not need to expose an analogous setting to `redis_backend_use_ssl`; users can connect to Redis + TLS in dependent projects without any changes by maintainers.

Fixes #4695 