### PR TITLE
Add test for mongodb+srv urls and fix url parsing to handle it correctly

### DIFF
--- a/celery/app/backends.py
+++ b/celery/app/backends.py
@@ -63,7 +63,12 @@ def by_url(backend=None, loader=None):
         url = backend
         scheme, _, _ = url.partition('://')
         if '+' in scheme:
-            backend, url = url.split('+', 1)
+            if scheme.startswith('mongodb+'):
+                # e.g., mongodb+srv://
+                backend = url.split('+', 1)[0]
+            else:
+                # e.g., sqla+mongodb
+                backend, url = url.split('+', 1)
         else:
             backend = scheme
     return by_name(backend, loader), url

--- a/celery/app/backends.py
+++ b/celery/app/backends.py
@@ -57,18 +57,23 @@ def by_name(backend=None, loader=None,
 
 
 def by_url(backend=None, loader=None):
-    """Get backend class by URL."""
+    """Get backend class by URL. Return a class object and the url.
+
+    New in version 4.2.?: url is returned unmodified. Previously any leading
+    schema followed by a plus sign would be stripped off. Now backends that
+    require special formatting must handle that formatting in their own
+    constructors.
+    """
     url = None
     if backend and '://' in backend:
+        # There are two types of uris we'll see:
+        # * <backend>+<backend-defined-ext>:// e.g., mongodb+srv://
+        # * <backend>+<backend-subtype>:// e.g., cache+memory:// (cache is the
+        #   only one tested and documented thus far
         url = backend
         scheme, _, _ = url.partition('://')
         if '+' in scheme:
-            if scheme.startswith('mongodb+'):
-                # e.g., mongodb+srv://
-                backend = url.split('+', 1)[0]
-            else:
-                # e.g., sqla+mongodb
-                backend, url = url.split('+', 1)
+            backend, _, _ = scheme.partition('+')
         else:
             backend = scheme
     return by_name(backend, loader), url

--- a/celery/app/backends.py
+++ b/celery/app/backends.py
@@ -62,6 +62,7 @@ def by_url(backend=None, loader=None):
     Return a class object and the url to provide to the backend when it is
     created.
     """
+    orig_backend = backend
     url = None
     if backend and '://' in backend:
         # There are two types of urls we'll see:
@@ -71,12 +72,12 @@ def by_url(backend=None, loader=None):
         url = backend
         scheme, _, _ = url.partition('://')
         if '+' in scheme:
-            if scheme.startswith('mongodb+'):
-                # e.g., mongodb+srv://
-                backend, _, _ = scheme.partition('+')
-            else:
-                # e.g., sqla+mongodb
-                backend, url = url.split('+', 1)
+            backend, url = url.split('+', 1)
         else:
             backend = scheme
-    return by_name(backend, loader), url
+    cls = by_name(backend, loader)
+
+    if getattr(cls, 'expects_url_munging', True) or url is None:
+        return cls, url
+    else:
+        return cls, orig_backend

--- a/celery/app/backends.py
+++ b/celery/app/backends.py
@@ -57,23 +57,26 @@ def by_name(backend=None, loader=None,
 
 
 def by_url(backend=None, loader=None):
-    """Get backend class by URL. Return a class object and the url.
+    """Get backend class by URL.
 
-    New in version 4.2.?: url is returned unmodified. Previously any leading
-    schema followed by a plus sign would be stripped off. Now backends that
-    require special formatting must handle that formatting in their own
-    constructors.
+    Return a class object and the url to provide to the backend when it is
+    created.
     """
     url = None
     if backend and '://' in backend:
-        # There are two types of uris we'll see:
+        # There are two types of urls we'll see:
         # * <backend>+<backend-defined-ext>:// e.g., mongodb+srv://
-        # * <backend>+<backend-subtype>:// e.g., cache+memory:// (cache is the
-        #   only one tested and documented thus far
+        # * <backend>+<original_scheme>:// e.g., cache+memory://...,
+        #   db+postgresql+psycopg2://..., etc.
         url = backend
         scheme, _, _ = url.partition('://')
         if '+' in scheme:
-            backend, _, _ = scheme.partition('+')
+            if scheme.startswith('mongodb+'):
+                # e.g., mongodb+srv://
+                backend, _, _ = scheme.partition('+')
+            else:
+                # e.g., sqla+mongodb
+                backend, url = url.split('+', 1)
         else:
             backend = scheme
     return by_name(backend, loader), url

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -98,6 +98,11 @@ class Backend(object):
     #: Set to true if the backend is peristent by default.
     persistent = True
 
+    #: Set to true to strip the leading transport from the provisioned URL
+    #: when creating this backend. For example: cache+memory:// will be passed
+    #: through as 'memory://' if this is set to True
+    expects_url_munging = True
+
     retry_policy = {
         'max_retries': 20,
         'interval_start': 0,

--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -106,11 +106,8 @@ class CacheBackend(KeyValueStoreBackend):
                             **options)
 
         self.backend = url or backend or self.app.conf.cache_backend
-        # Changed in 4.2.0: strip the cache+ off the front if it's present
         if self.backend:
             self.backend, _, servers = self.backend.partition('://')
-            if self.backend.startswith('cache+'):
-                self.backend = self.backend[6:]
             self.servers = servers.rstrip('/').split(';')
         self.expires = self.prepare_expires(expires, type=int)
         try:

--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -106,8 +106,11 @@ class CacheBackend(KeyValueStoreBackend):
                             **options)
 
         self.backend = url or backend or self.app.conf.cache_backend
+        # Changed in 4.2.0: strip the cache+ off the front if it's present
         if self.backend:
             self.backend, _, servers = self.backend.partition('://')
+            if self.backend.startswith('cache+'):
+                self.backend = self.backend[6:]
             self.servers = servers.rstrip('/').split(';')
         self.expires = self.prepare_expires(expires, type=int)
         try:

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -141,9 +141,8 @@ class MongoBackend(BaseBackend):
                 # This enables the use of replica sets and sharding.
                 # See pymongo.Connection() for more info.
                 host = self.host
-                if isinstance(host, string_t) \
-                   and not host.startswith('mongodb://'):
-                    host = 'mongodb://{0}:{1}'.format(host, self.port)
+                if isinstance(url, string_t) and '://' not in url:
+                    url = 'mongodb://{0}:{1}'.format(url, self.port)
             # don't change self.options
             conf = dict(self.options)
             conf['host'] = host

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -141,8 +141,8 @@ class MongoBackend(BaseBackend):
                 # This enables the use of replica sets and sharding.
                 # See pymongo.Connection() for more info.
                 host = self.host
-                if isinstance(url, string_t) and '://' not in url:
-                    url = 'mongodb://{0}:{1}'.format(url, self.port)
+                if isinstance(host, string_t) and '://' not in host:
+                    host = 'mongodb://{0}:{1}'.format(host, self.port)
             # don't change self.options
             conf = dict(self.options)
             conf['host'] = host

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -54,6 +54,7 @@ class MongoBackend(BaseBackend):
     groupmeta_collection = 'celery_groupmeta'
     max_pool_size = 10
     options = None
+    expects_url_munging = False
 
     supports_autoexpire = False
 

--- a/t/unit/app/test_backends.py
+++ b/t/unit/app/test_backends.py
@@ -6,6 +6,8 @@ from case import patch
 from celery.app import backends
 from celery.backends.amqp import AMQPBackend
 from celery.backends.cache import CacheBackend
+from celery.backends.database import DatabaseBackend
+from celery.backends.mongodb import MongoBackend
 from celery.exceptions import ImproperlyConfigured
 
 
@@ -14,10 +16,14 @@ class test_backends:
     @pytest.mark.parametrize('url,expect_cls', [
         ('amqp://', AMQPBackend),
         ('cache+memory://', CacheBackend),
+        ('mongodb://', MongoBackend),
+        ('mongodb+srv://', MongoBackend),
+        ('db+postgresql+psycopg2://', DatabaseBackend),
     ])
     def test_get_backend_aliases(self, url, expect_cls, app):
         backend, url = backends.by_url(url, app.loader)
-        assert isinstance(backend(app=app, url=url), expect_cls)
+        # Don't instantiate, let the unit tests for the backends test that
+        assert backend is expect_cls
 
     def test_unknown_backend(self, app):
         with pytest.raises(ImportError):

--- a/t/unit/app/test_backends.py
+++ b/t/unit/app/test_backends.py
@@ -6,8 +6,6 @@ from case import patch
 from celery.app import backends
 from celery.backends.amqp import AMQPBackend
 from celery.backends.cache import CacheBackend
-from celery.backends.database import DatabaseBackend
-from celery.backends.mongodb import MongoBackend
 from celery.exceptions import ImproperlyConfigured
 
 
@@ -16,9 +14,6 @@ class test_backends:
     @pytest.mark.parametrize('url,expect_cls', [
         ('amqp://', AMQPBackend),
         ('cache+memory://', CacheBackend),
-        ('mongodb://', MongoBackend),
-        ('mongodb+srv://', MongoBackend),
-        ('db+postgresql+psycopg2://', DatabaseBackend),
     ])
     def test_get_backend_aliases(self, url, expect_cls, app):
         backend, url = backends.by_url(url, app.loader)

--- a/t/unit/backends/test_cache.py
+++ b/t/unit/backends/test_cache.py
@@ -61,8 +61,13 @@ class test_CacheBackend:
             assert self.tb.get_state(self.tid) == states.FAILURE
             assert isinstance(self.tb.get_result(self.tid), KeyError)
 
+    def test_backend_provided_as_unmodified_url(self):
+        tb = CacheBackend(backend='cache+memory://', app=self.app)
+        assert tb.backend == 'memory'
+        assert tb.as_uri() == 'memory:///'
+
     def test_apply_chord(self):
-        tb = CacheBackend(backend='memory://', app=self.app)
+        tb = CacheBackend(backend='cache+memory://', app=self.app)
         result = self.app.GroupResult(
             uuid(),
             [self.app.AsyncResult(uuid()) for _ in range(3)],
@@ -72,7 +77,7 @@ class test_CacheBackend:
 
     @patch('celery.result.GroupResult.restore')
     def test_on_chord_part_return(self, restore):
-        tb = CacheBackend(backend='memory://', app=self.app)
+        tb = CacheBackend(backend='cache+memory://', app=self.app)
 
         deps = Mock()
         deps.__len__ = Mock()
@@ -114,7 +119,7 @@ class test_CacheBackend:
         self.tb.process_cleanup()
 
     def test_expires_as_int(self):
-        tb = CacheBackend(backend='memory://', expires=10, app=self.app)
+        tb = CacheBackend(backend='cache+memory://', expires=10, app=self.app)
         assert tb.expires == 10
 
     def test_unknown_backend_raises_ImproperlyConfigured(self):

--- a/t/unit/backends/test_cache.py
+++ b/t/unit/backends/test_cache.py
@@ -61,13 +61,8 @@ class test_CacheBackend:
             assert self.tb.get_state(self.tid) == states.FAILURE
             assert isinstance(self.tb.get_result(self.tid), KeyError)
 
-    def test_backend_provided_as_unmodified_url(self):
-        tb = CacheBackend(backend='cache+memory://', app=self.app)
-        assert tb.backend == 'memory'
-        assert tb.as_uri() == 'memory:///'
-
     def test_apply_chord(self):
-        tb = CacheBackend(backend='cache+memory://', app=self.app)
+        tb = CacheBackend(backend='memory://', app=self.app)
         result = self.app.GroupResult(
             uuid(),
             [self.app.AsyncResult(uuid()) for _ in range(3)],
@@ -77,7 +72,7 @@ class test_CacheBackend:
 
     @patch('celery.result.GroupResult.restore')
     def test_on_chord_part_return(self, restore):
-        tb = CacheBackend(backend='cache+memory://', app=self.app)
+        tb = CacheBackend(backend='memory://', app=self.app)
 
         deps = Mock()
         deps.__len__ = Mock()
@@ -119,7 +114,7 @@ class test_CacheBackend:
         self.tb.process_cleanup()
 
     def test_expires_as_int(self):
-        tb = CacheBackend(backend='cache+memory://', expires=10, app=self.app)
+        tb = CacheBackend(backend='memory://', expires=10, app=self.app)
         assert tb.expires == 10
 
     def test_unknown_backend_raises_ImproperlyConfigured(self):

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -7,6 +7,7 @@ import pytest
 from case import Mock, patch, skip
 
 from celery import states, uuid
+from celery.app import backends
 from celery.exceptions import ImproperlyConfigured
 
 try:
@@ -27,6 +28,23 @@ class SomeClass(object):
 
     def __init__(self, data):
         self.data = data
+
+
+@skip.unless_module('sqlalchemy')
+class test_backend_by_url:
+    """We can't test these in t/unit/app/test_backends, because of importing in
+    various ci environments, so we repeat it here just for db lookups.
+    """
+
+    @pytest.mark.parametrize('url,expect_cls', [
+        ('db+postgresql+psycopg2://', DatabaseBackend),
+        ('db+mysql+mysqldb://', DatabaseBackend),
+        ('db+postgresql://', DatabaseBackend),
+    ])
+    def test_get_backend_aliases(self, url, expect_cls, app):
+        backend, url = backends.by_url(url, app.loader)
+        # Don't instantiate, let the unit tests for the backends test that
+        assert backend is expect_cls
 
 
 @skip.unless_module('sqlalchemy')

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import, unicode_literals
 import datetime
 from pickle import dumps, loads
 
-from kombu.exceptions import EncodeError
-
 import pytest
 from case import ANY, MagicMock, Mock, mock, patch, sentinel, skip
+from kombu.exceptions import EncodeError
+
 from celery import states, uuid
 from celery.app import backends
 from celery.backends.mongodb import InvalidDocument, MongoBackend

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import, unicode_literals
 import datetime
 from pickle import dumps, loads
 
-import pytest
-from case import ANY, MagicMock, Mock, mock, patch, sentinel, skip
 from kombu.exceptions import EncodeError
 
-from celery.app import backends
+import pytest
+from case import ANY, MagicMock, Mock, mock, patch, sentinel, skip
 from celery import states, uuid
+from celery.app import backends
 from celery.backends.mongodb import InvalidDocument, MongoBackend
 from celery.exceptions import ImproperlyConfigured
 

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -176,7 +176,7 @@ class test_MongoBackend:
             mock_Connection.assert_called_once_with(
                 host=mongodb_uri, **self.backend._prepare_client_options()
             )
-            self.assertEqual(sentinel.connection, connection)
+            assert sentinel.connection == connection
 
     @patch('celery.backends.mongodb.MongoBackend._get_connection')
     def test_get_database_no_existing(self, mock_get_connection):

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -30,6 +30,7 @@ class test_MongoBackend:
         'mongodb://uuuu:pwpw@hostname.dom,'
         'hostname.dom/database?replicaSet=rs'
     )
+    srv_url = 'mongodb+srv://hostname.dom/database'
     sanitized_default_url = 'mongodb://uuuu:**@hostname.dom/database'
     sanitized_replica_set_url = (
         'mongodb://uuuu:**@hostname.dom/,'
@@ -162,6 +163,20 @@ class test_MongoBackend:
                 host=mongodb_uri, **self.backend._prepare_client_options()
             )
             assert sentinel.connection == connection
+
+    def test_get_connection_no_connection_mongodb_srv_url(self):
+        with patch('pymongo.MongoClient') as mock_Connection:
+            mongodb_uri = self.srv_url
+            self.backend._connection = None
+            self.backend.host = mongodb_uri
+
+            mock_Connection.return_value = sentinel.connection
+
+            connection = self.backend._get_connection()
+            mock_Connection.assert_called_once_with(
+                host=mongodb_uri, **self.backend._prepare_client_options()
+            )
+            self.assertEqual(sentinel.connection, connection)
 
     @patch('celery.backends.mongodb.MongoBackend._get_connection')
     def test_get_database_no_existing(self, mock_get_connection):

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -7,6 +7,7 @@ import pytest
 from case import ANY, MagicMock, Mock, mock, patch, sentinel, skip
 from kombu.exceptions import EncodeError
 
+from celery.app import backends
 from celery import states, uuid
 from celery.backends.mongodb import InvalidDocument, MongoBackend
 from celery.exceptions import ImproperlyConfigured
@@ -43,6 +44,12 @@ class test_MongoBackend:
         self.patching('celery.backends.mongodb.Binary')
         self.patching('datetime.datetime')
         self.backend = MongoBackend(app=self.app, url=self.default_url)
+
+    def test_backend_by_url(self):
+        for url in (self.default_url, self.srv_url):
+            backend, url_ = backends.by_url(url, self.app.loader)
+            assert backend is MongoBackend
+            assert url_ == url
 
     def test_init_no_mongodb(self, patching):
         patching('celery.backends.mongodb.pymongo', None)


### PR DESCRIPTION
## Description

This fixes bug #4668 (Fixes #4668) where passing a mongodb+srv url to celery causes a traceback in parsing before creating the MongoClient.