### PR TITLE
Small change in celery.app.base.Celery. (Redundant code improved)

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -203,7 +203,7 @@ class Celery(object):
     log_cls = 'celery.app.log:Logging'
     control_cls = 'celery.app.control:Control'
     task_cls = 'celery.app.task:Task'
-    registry_cls = TaskRegistry
+    registry_cls = 'celery.app.registry:TaskRegistry'
 
     _fixups = None
     _pool = None


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Because you set `Celery.registry_cls` to an actual `TaskRegistry` class object (not a string object), `symbol_by_name` in the `__init__` method becomes just redundant (line 240).
I thought it's better to keep `Celery.registry_class` to string type.