### PR TITLE
Do not subscribe to Redis channels when results are ignored

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -525,6 +525,9 @@ class Task(object):
 
         preopts = self._get_exec_options()
         options = dict(preopts, **options) if options else preopts
+
+        options.setdefault('ignore_result', self.ignore_result)
+
         return app.send_task(
             self.name, args, kwargs, task_id=task_id, producer=producer,
             link=link, link_error=link_error, result_cls=self.AsyncResult,

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -243,6 +243,10 @@ class RedisBackend(base.BaseKeyValueStoreBackend, async.AsyncBackendMixin):
             pipe.publish(key, value)
             pipe.execute()
 
+    def forget(self, task_id):
+        super(RedisBackend, self).forget(task_id)
+        self.result_consumer.cancel_for(task_id)
+
     def delete(self, key):
         self.client.delete(key)
 

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -12,7 +12,7 @@ from celery import states
 from celery._state import task_join_will_block
 from celery.canvas import maybe_signature
 from celery.exceptions import ChordError, ImproperlyConfigured
-from celery.five import string_t
+from celery.five import string_t, text_t
 from celery.utils import deprecated
 from celery.utils.functional import dictfilter
 from celery.utils.log import get_logger
@@ -59,9 +59,12 @@ class ResultConsumer(async.BaseResultConsumer):
         self.subscribed_to = set()
 
     def on_after_fork(self):
-        self.backend.client.connection_pool.reset()
-        if self._pubsub is not None:
-            self._pubsub.close()
+        try:
+            self.backend.client.connection_pool.reset()
+            if self._pubsub is not None:
+                self._pubsub.close()
+        except KeyError as e:
+            logger.warn(text_t(e))
         super(ResultConsumer, self).on_after_fork()
 
     def _maybe_cancel_ready_task(self, meta):

--- a/celery/result.py
+++ b/celery/result.py
@@ -101,6 +101,19 @@ class AsyncResult(ResultBase):
         self.parent = parent
         self.on_ready = promise(self._on_fulfilled)
         self._cache = None
+        self._ignored = False
+
+    @property
+    def ignored(self):
+        """"If True, task result retrieval is disabled."""
+        if hasattr(self, '_ignored'):
+            return self._ignored
+        return False
+
+    @ignored.setter
+    def ignored(self, value):
+        """Enable/disable task result retrieval."""
+        self._ignored = value
 
     def then(self, callback, on_error=None, weak=False):
         self.backend.add_pending_result(self, weak=weak)
@@ -176,6 +189,9 @@ class AsyncResult(ResultBase):
             Exception: If the remote call raised an exception then that
                 exception will be re-raised in the caller process.
         """
+        if self.ignored:
+            return
+
         if disable_sync_subtasks:
             assert_will_not_block()
         _on_interval = promise()

--- a/celery/result.py
+++ b/celery/result.py
@@ -372,6 +372,11 @@ class AsyncResult(ResultBase):
     def __reduce_args__(self):
         return self.id, self.backend, None, None, self.parent
 
+    def __del__(self):
+        """Cancel pending operations when the instance is destroyed."""
+        if self.backend is not None:
+            self.backend.remove_pending_result(self)
+
     @cached_property
     def graph(self):
         return self.build_graph()

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -29,6 +29,10 @@ def get_redis_connection():
     return StrictRedis(host=os.environ.get('REDIS_HOST'))
 
 
+def get_active_redis_channels():
+    return get_redis_connection().execute_command('PUBSUB CHANNELS')
+
+
 @pytest.fixture(scope='session')
 def celery_config():
     return {

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -23,6 +23,12 @@ def add(x, y):
     return x + y
 
 
+@shared_task(ignore_result=True)
+def add_ignore_result(x, y):
+    """Add two numbers."""
+    return x + y
+
+
 @shared_task
 def chain_add(x, y):
     (

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
+import pytest
+
 from celery import group
 
-from .conftest import flaky
-from .tasks import print_unicode, retry_once, sleeping
+from .conftest import flaky, get_active_redis_channels
+from .tasks import add, add_ignore_result, print_unicode, retry_once, sleeping
 
 
 class test_tasks:
@@ -25,3 +27,31 @@ class test_tasks:
             group(print_unicode.s() for _ in range(5))(),
             timeout=10, propagate=True,
         )
+
+
+class tests_task_redis_result_backend:
+    def setup(self, manager):
+        if not manager.app.conf.result_backend.startswith('redis'):
+            raise pytest.skip('Requires redis result backend.')
+
+    def test_ignoring_result_no_subscriptions(self):
+        assert get_active_redis_channels() == []
+        result = add_ignore_result.delay(1, 2)
+        assert result.ignored is True
+        assert get_active_redis_channels() == []
+
+    def test_asyncresult_forget_cancels_subscription(self):
+        result = add.delay(1, 2)
+        assert get_active_redis_channels() == [
+            "celery-task-meta-{}".format(result.id)
+        ]
+        result.forget()
+        assert get_active_redis_channels() == []
+
+    def test_asyncresult_get_cancels_subscription(self):
+        result = add.delay(1, 2)
+        assert get_active_redis_channels() == [
+            "celery-task-meta-{}".format(result.id)
+        ]
+        assert result.get(timeout=3) == 3
+        assert get_active_redis_channels() == []

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -163,6 +163,14 @@ class test_RedisResultConsumer:
         parent_method.assert_called_once()
         consumer.backend.client.connection_pool.reset.assert_called_once()
 
+        # Continues on KeyError
+        consumer._pubsub = Mock()
+        consumer._pubsub.close = Mock(side_effect=KeyError)
+        parent_method.reset_mock()
+        consumer.backend.client.connection_pool.reset.reset_mock()
+        consumer.on_after_fork()
+        parent_method.assert_called_once()
+
     @patch('celery.backends.redis.ResultConsumer.cancel_for')
     @patch('celery.backends.async.BaseResultConsumer.on_state_change')
     def test_on_state_change(self, parent_method, cancel_for):


### PR DESCRIPTION
## Description

The unnecessary channel subscriptions were occurring in two cases: 
- `backends.base.Backend.on_task_call` was being called unconditionally, which initiated the PubSub subscription.
- `AsyncBackendMixin.add_pending_result` also initiates a subscription.

The code excerpt given in #4707 was executed and produced no channel leak, neither on the worker nor on the consumer. Both `chord` and `AsyncResult` return values are retrieved correctly.

- [x] Avoid consumer Redis channel subscriptions if result is to be ignored.
- [x] Calling `AsyncResult.get()` now returns `None` directly, instead of subscribing to Redis channel.

Fixes #4707.