### PR TITLE
Add doc warnings to ensure devs understand backend resource usage

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -152,6 +152,13 @@ class AsyncResult(ResultBase):
            Waiting for tasks within a task may lead to deadlocks.
            Please read :ref:`task-synchronous-subtasks`.
 
+        Warning:
+           Backends use resources to store and transmit results. To ensure 
+           that resources are released, you must eventually call 
+           :meth:`~@AsyncResult.get` or :meth:`~@AsyncResult.forget` on 
+           EVERY :class:`~@AsyncResult` instance returned after calling
+           a task.
+
         Arguments:
             timeout (float): How long to wait, in seconds, before the
                 operation times out.

--- a/celery/result.py
+++ b/celery/result.py
@@ -153,9 +153,9 @@ class AsyncResult(ResultBase):
            Please read :ref:`task-synchronous-subtasks`.
 
         Warning:
-           Backends use resources to store and transmit results. To ensure 
-           that resources are released, you must eventually call 
-           :meth:`~@AsyncResult.get` or :meth:`~@AsyncResult.forget` on 
+           Backends use resources to store and transmit results. To ensure
+           that resources are released, you must eventually call
+           :meth:`~@AsyncResult.get` or :meth:`~@AsyncResult.forget` on
            EVERY :class:`~@AsyncResult` instance returned after calling
            a task.
 

--- a/docs/getting-started/first-steps-with-celery.rst
+++ b/docs/getting-started/first-steps-with-celery.rst
@@ -271,7 +271,14 @@ original traceback:
 .. code-block:: pycon
 
     >>> result.traceback
-    …
+
+.. warning::
+
+    Backends use resources to store and transmit results. To ensure 
+    that resources are released, you must eventually call 
+    :meth:`~@AsyncResult.get` or :meth:`~@AsyncResult.forget` on 
+    EVERY :class:`~@AsyncResult` instance returned after calling
+    a task.
 
 See :mod:`celery.result` for the complete result object reference.
 

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -1045,6 +1045,14 @@ No backend works well for every use case.
 You should read about the strengths and weaknesses of each backend, and choose
 the most appropriate for your needs.
 
+.. warning::
+
+    Backends use resources to store and transmit results. To ensure 
+    that resources are released, you must eventually call 
+    :meth:`~@AsyncResult.get` or :meth:`~@AsyncResult.forget` on 
+    EVERY :class:`~@AsyncResult` instance returned after calling
+    a task.
+
 .. seealso::
 
     :ref:`conf-result-backend`


### PR DESCRIPTION
Per request by @georgepsarakis on Issue #4707, I am suggesting improvements to the documentation about Task Results and backends.

Specifically, I am suggesting that warnings be added to ensure developers understand they must process task return values to avoid resource issues.

From my direct experience, the resource being consumed was redis subscriptions. "Unsubscribe" does not occur unless the caller explicitly cleans it up by calling AsynchResult.get() or AsynchResult.forget(). I am assuming (but have no direct evidence) that this is a problem with other backend providers; therefore, I have not made the documentation specific to Redis.

I chose to add these information as warnings because there are severe consequences if the developer does not take the suggested action. In fact, the problem remains hidden, possibly for weeks or months, until the redis subscription list grows to an unmanageable level.

I chose to add the warning in three places (first-steps, AsyncResult API reference, and Tasks) because the developer will likely not read them all. It could be removed from first-steps because it would be difficult for the developer to fully implement without reading at least one of Tasks or the API reference.


