### PR TITLE
Changed documentation on eventlet

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -203,7 +203,7 @@ class Celery(object):
     log_cls = 'celery.app.log:Logging'
     control_cls = 'celery.app.control:Control'
     task_cls = 'celery.app.task:Task'
-    registry_cls = TaskRegistry
+    registry_cls = 'celery.app.registry:TaskRegistry'
 
     _fixups = None
     _pool = None

--- a/docs/userguide/concurrency/eventlet.rst
+++ b/docs/userguide/concurrency/eventlet.rst
@@ -21,10 +21,16 @@ change how you run your code, not how you write it.
     * The event dispatch is implicit: meaning you can easily use Eventlet
       from the Python interpreter, or as a small part of a larger application.
 
-Celery supports Eventlet as an alternative execution pool implementation.
-It's in some cases superior to prefork, but you need to ensure
-your tasks don't perform CPU-bound operations, as this will halt all
-other operations in the worker until the CPU-bound operation finishes.
+
+Celery supports Eventlet as an alternative execution pool implementation and
+in some cases superior to prefork. However, you need to ensure one task doesn't
+block the event loop too long. Generally, CPU-bound operations don't go well
+with Evenetlet. Also note that some libraries, usually with C extensions,
+cannot be monkeypatched and therefore cannot benefit from using Eventlet.
+Please refer to their documentation if you are not sure. For example, pylibmc
+does not allow cooperation with Eventlet but psycopg2 does when both of them
+are libraries with C extensions.
+
 
 The prefork pool can take use of multiple processes, but how many is
 often limited to a few processes per CPU. With Eventlet you can efficiently

--- a/docs/userguide/concurrency/eventlet.rst
+++ b/docs/userguide/concurrency/eventlet.rst
@@ -23,8 +23,8 @@ change how you run your code, not how you write it.
 
 Celery supports Eventlet as an alternative execution pool implementation.
 It's in some cases superior to prefork, but you need to ensure
-your tasks don't perform blocking calls, as this will halt all
-other operations in the worker until the blocking call returns.
+your tasks don't perform CPU-bound operations, as this will halt all
+other operations in the worker until the CPU-bound operation finishes.
 
 The prefork pool can take use of multiple processes, but how many is
 often limited to a few processes per CPU. With Eventlet you can efficiently


### PR DESCRIPTION
"You need to ensure your tasks don't perform blocking calls"
This advice seems wrong. As far as I know, green threads are meant to be used for "blocking I/O-bound" operations. For example `requests.get`, which also is used in celery/examples/eventlet/tasks.py, blocks until it gets the response. I think what really matters for eventlet is whether an operation is CPU-bound or I/O-bound, not whether it's blocking or not.