### PR TITLE
Fixed sphinx-build check in Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,11 +7,6 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 
-# User-friendly check for sphinx-build
-ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-	$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don\'t have Sphinx installed, grab it from http://sphinx-doc.org/)
-endif
-
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter


### PR DESCRIPTION
## Description
If sphinx-build is not installed, the Makefile returns the cryptic 'recipe commences before first target.  Stop.' when building the docs. The cause is a tab resulting in a syntax error. This was a bug in the
Makefile generated by Sphinx, which has since been fixed: https://github.com/sphinx-doc/sphinx/issues/2521

I've applied the same fix, which is removing the 'user-friendly' message. The resulting error message is 'sphinx-build: Command not found', which ought to be clear enough.