### PR TITLE
Enable building docs in the Docker image (includes Sphinx version bump to 1.7.1)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,6 +58,7 @@ RUN pyenv local python2.7 python3.4 python3.5 python3.6
 # Setup one celery environment for basic development use
 RUN pyenv exec pip install \
   -r requirements/default.txt \
+  -r requirements/docs.txt \
   -r requirements/pkgutils.txt \
   -r requirements/test.txt \
   -r requirements/test-ci-base.txt \

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
 git+https://github.com/celery/sphinx_celery.git
-Sphinx==1.6.5
+Sphinx==1.7.1
 typing
 -r extras/sqlalchemy.txt


### PR DESCRIPTION
I noticed the docs requirements weren't installed in the Docker image, so I added them. While testing that, I manually upgraded pip to version 10, and it complained that sphinx_celery requires Sphinx 1.7.1, while 1.6.5 was installed. pip-9.0.1 doesn't complain about this. If pip is ignored, building the docs fails due to the incompatibility. After updating to Sphinx 1.7.1, the docs build succeeds.

The original reason I went through that is because the docs at for example http://docs.celeryproject.org/en/latest/reference/celery.app.task.html#celery.app.task.Task.apply_async have mailto links in the return type value. That didn't reproduce in my build.