### PR TITLE
Use Redis coercion mechanism for converting query parameters

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -252,7 +252,9 @@ class RedisBackend(base.BaseKeyValueStoreBackend, async.AsyncBackendMixin):
 
         for key, value in query.items():
             if key in redis.connection.URL_QUERY_ARGUMENT_PARSERS:
-                query[key] = redis.connection.URL_QUERY_ARGUMENT_PARSERS[key](value)
+                query[key] = redis.connection.URL_QUERY_ARGUMENT_PARSERS[key](
+                    value
+                )
 
         # Query parameters override other parameters
         connparams.update(query)

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -29,6 +29,7 @@ except ImportError:
 
 try:
     import redis
+    import redis.connection
     from kombu.transport.redis import get_redis_error_classes
 except ImportError:  # pragma: no cover
     redis = None  # noqa
@@ -248,6 +249,10 @@ class RedisBackend(base.BaseKeyValueStoreBackend, async.AsyncBackendMixin):
         db = connparams.get('db') or 0
         db = db.strip('/') if isinstance(db, string_t) else db
         connparams['db'] = int(db)
+
+        for key, value in query.items():
+            if key in redis.connection.URL_QUERY_ARGUMENT_PARSERS:
+                query[key] = redis.connection.URL_QUERY_ARGUMENT_PARSERS[key](value)
 
         # Query parameters override other parameters
         connparams.update(query)

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -234,6 +234,20 @@ class test_RedisBackend:
         assert x.connparams['socket_timeout'] == 30.0
         assert x.connparams['socket_connect_timeout'] == 100.0
 
+    def test_timeouts_in_url_coerced(self):
+        x = self.Backend(
+            ('redis://:bosco@vandelay.com:123//1?'
+             'socket_timeout=30&socket_connect_timeout=100'),
+            app=self.app,
+        )
+        assert x.connparams
+        assert x.connparams['host'] == 'vandelay.com'
+        assert x.connparams['db'] == 1
+        assert x.connparams['port'] == 123
+        assert x.connparams['password'] == 'bosco'
+        assert x.connparams['socket_timeout'] == 30
+        assert x.connparams['socket_connect_timeout'] == 100
+
     def test_socket_url(self):
         self.app.conf.redis_socket_timeout = 30.0
         self.app.conf.redis_socket_connect_timeout = 100.0


### PR DESCRIPTION
Fixes #4735 

Redis does coercion of the query parameters when it parses the URL but celery pre-parses it and sends the values in as keyword arguments. When timeouts are specified in the result backend URL they are passed in as strings instead of floats, causing an error when the timeout is set on the socket.

Ideally, celery should pass the URL to the redis client and let it handle the parsing. This patch doesn't do that, though, it just uses the redis client's coercion map on the query params.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/celery/celery/4736)
<!-- Reviewable:end -->
