### PR TITLE
Document ignore_result task execution option

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -11,6 +11,18 @@ an overview of what's new in Celery 4.2.
 4.2.0
 =====
 
+- **Task**: Add ``ignore_result`` as task execution option (#4709, #3834)
+
+    Contributed by **Andrii Kostenko** and **George Psarakis**.
+
+- **Redis Result Backend**: Do not create PubSub subscriptions when results are ignored (#4709, #3834)
+
+    Contributed by **Andrii Kostenko** and **George Psarakis**.
+
+- **Redis Result Backend**: Result consumer always unsubscribes when task state is ready (#4666)
+
+    Contributed by **George Psarakis**.
+
 - **Development/Testing**: Add docker-compose and base Dockerfile for development (#4482)
 
     Contributed by **Chris Mitchell**.

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -578,6 +578,25 @@ the workers :option:`-Q <celery worker -Q>` argument:
 
     To find out more about routing, please see :ref:`guide-routing`.
 
+.. _calling-results:
+
+Results options
+===============
+
+You can enable or disable result storage using the ``ignore_result`` option::
+
+    result = add.apply_async(1, 2, ignore_result=True)
+    result.get() # -> None
+
+    # Do not ignore result (default)
+    result = add.apply_async(1, 2, ignore_result=False)
+    result.get() # -> 3
+
+
+.. seealso::
+
+   For more information on tasks, please see :ref:`guide-tasks`.
+
 Advanced Options
 ----------------
 

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -1047,9 +1047,9 @@ the most appropriate for your needs.
 
 .. warning::
 
-    Backends use resources to store and transmit results. To ensure 
-    that resources are released, you must eventually call 
-    :meth:`~@AsyncResult.get` or :meth:`~@AsyncResult.forget` on 
+    Backends use resources to store and transmit results. To ensure
+    that resources are released, you must eventually call
+    :meth:`~@AsyncResult.get` or :meth:`~@AsyncResult.forget` on
     EVERY :class:`~@AsyncResult` instance returned after calling
     a task.
 
@@ -1633,6 +1633,34 @@ wastes time and resources.
 
 Results can even be disabled globally using the :setting:`task_ignore_result`
 setting.
+
+.. versionadded::4.2
+
+Results can be enabled/disabled on a per-execution basis, by passing the ``ignore_result`` boolean parameter,
+when calling ``apply_async`` or ``delay``.
+
+.. code-block:: python
+
+    @app.task
+    def mytask(x, y):
+        return x + y
+
+    # No result will be stored
+    result = mytask.apply_async(1, 2, ignore_result=True)
+    print result.get() # -> None
+
+    # Result will be stored
+    result = mytask.apply_async(1, 2, ignore_result=False)
+    print result.get() # -> 3
+
+By default tasks will *not ignore results* (``ignore_result=False``) when a result backend is configured.
+
+
+The option precedence order is the following:
+
+1. Global :setting:`task_ignore_result`
+2. :attr:`~@Task.ignore_result` option
+3. Task execution option ``ignore_result``
 
 More optimization tips
 ----------------------


### PR DESCRIPTION
## Description

- [x] Add documentation for enabling/disabling results on a per-execution basis.
- [x] Add Changelog entries regarding `ignore_result` task execution option and Redis result consumer fixes.

Resolves #4721 .