### PR TITLE
Enable automatic result expiration with couchbase backend

### DIFF
--- a/celery/backends/couchbase.py
+++ b/celery/backends/couchbase.py
@@ -39,6 +39,8 @@ class CouchbaseBackend(KeyValueStoreBackend):
     username = None
     password = None
     quiet = False
+    supports_autoexpire = True
+
     timeout = 2.5
 
     # Use str as couchbase key not bytes
@@ -103,7 +105,7 @@ class CouchbaseBackend(KeyValueStoreBackend):
             return None
 
     def set(self, key, value):
-        self.connection.set(key, value)
+        self.connection.set(key, value, ttl=self.expires)
 
     def mget(self, keys):
         return [self.get(key) for key in keys]

--- a/celery/backends/couchbase.py
+++ b/celery/backends/couchbase.py
@@ -47,7 +47,8 @@ class CouchbaseBackend(KeyValueStoreBackend):
     key_t = str_t
 
     def __init__(self, url=None, *args, **kwargs):
-        super(CouchbaseBackend, self).__init__(*args, **kwargs)
+        super(CouchbaseBackend, self).__init__(expires_type=int, *args,
+                                               **kwargs)
         self.url = url
 
         if Couchbase is None:

--- a/celery/backends/couchbase.py
+++ b/celery/backends/couchbase.py
@@ -47,8 +47,8 @@ class CouchbaseBackend(KeyValueStoreBackend):
     key_t = str_t
 
     def __init__(self, url=None, *args, **kwargs):
-        super(CouchbaseBackend, self).__init__(expires_type=int, *args,
-                                               **kwargs)
+        kwargs.setdefault('expires_type', int)
+        super(CouchbaseBackend, self).__init__(*args, **kwargs)
         self.url = url
 
         if Couchbase is None:

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -661,7 +661,7 @@ on backend specifications).
 
 .. note::
 
-    For the moment this only works with the AMQP, database, cache,
+    For the moment this only works with the AMQP, database, cache, Couchbase,
     and Redis backends.
 
     When using the database backend, ``celery beat`` must be

--- a/t/unit/backends/test_couchbase.py
+++ b/t/unit/backends/test_couchbase.py
@@ -1,6 +1,6 @@
 """Tests for the CouchbaseBackend."""
 from __future__ import absolute_import, unicode_literals
-
+from datetime import timedelta
 import pytest
 from case import MagicMock, Mock, patch, sentinel, skip
 
@@ -59,9 +59,19 @@ class test_CouchbaseBackend:
         assert x.get('1f3fab') == sentinel.retval
         x._connection.get.assert_called_once_with('1f3fab')
 
-    def test_set(self):
+    def test_set_no_expires(self):
         self.app.conf.couchbase_backend_settings = None
         x = CouchbaseBackend(app=self.app)
+        x.expires = None
+        x._connection = MagicMock()
+        x._connection.set = MagicMock()
+        # should return None
+        assert x.set(sentinel.key, sentinel.value) is None
+
+    def test_set_expires(self):
+        self.app.conf.couchbase_backend_settings = None
+        x = CouchbaseBackend(app=self.app, expires=30)
+        assert x.expires == 30
         x._connection = MagicMock()
         x._connection.set = MagicMock()
         # should return None
@@ -107,3 +117,20 @@ class test_CouchbaseBackend:
             assert x.username == 'johndoe'
             assert x.password == 'mysecret'
             assert x.port == 123
+
+    def test_expires_defaults_to_config(self):
+        self.app.conf.result_expires = 10
+        b = CouchbaseBackend(expires=None, app=self.app)
+        assert b.expires == 10
+
+    def test_expires_is_int(self):
+        b = CouchbaseBackend(expires=48, app=self.app)
+        assert b.expires == 48
+
+    def test_expires_is_None(self):
+        b = CouchbaseBackend(expires=None, app=self.app)
+        assert b.expires == self.app.conf.result_expires.total_seconds()
+
+    def test_expires_is_timedelta(self):
+        b = CouchbaseBackend(expires=timedelta(minutes=1), app=self.app)
+        assert b.expires == 60

--- a/t/unit/backends/test_couchbase.py
+++ b/t/unit/backends/test_couchbase.py
@@ -1,9 +1,10 @@
 """Tests for the CouchbaseBackend."""
 from __future__ import absolute_import, unicode_literals
+
 from datetime import timedelta
+
 import pytest
 from case import MagicMock, Mock, patch, sentinel, skip
-
 from celery.app import backends
 from celery.backends import couchbase as module
 from celery.backends.couchbase import CouchbaseBackend

--- a/t/unit/backends/test_couchbase.py
+++ b/t/unit/backends/test_couchbase.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 
 import pytest
 from case import MagicMock, Mock, patch, sentinel, skip
+
 from celery.app import backends
 from celery.backends import couchbase as module
 from celery.backends.couchbase import CouchbaseBackend


### PR DESCRIPTION
## Description
Couchbase has the ability to support automatic result expiration by specifying a ttl keyword argument when saving results.

This PR implements using the couchbase ttl argument and uses the backend expires property for its value.

By default, the ttl value is None, so if backend.expires is None, it won't have any impact.

[Couchbase Documentation including ttl value args](http://docs.couchbase.com/sdk-api/couchbase-python-client-1.2.3/api/couchbase.html#)

Please note that this is a similar change to 4752. Please let me know if you'd like me to combine them
