### PR TITLE
couchbase backend stores with utf-8

### DIFF
--- a/celery/backends/couchbase.py
+++ b/celery/backends/couchbase.py
@@ -19,6 +19,7 @@ try:
     from couchbase import Couchbase
     from couchbase.connection import Connection
     from couchbase.exceptions import NotFoundError
+    from couchbase import FMT_UTF8
 except ImportError:
     Couchbase = Connection = NotFoundError = None   # noqa
 
@@ -103,7 +104,7 @@ class CouchbaseBackend(KeyValueStoreBackend):
             return None
 
     def set(self, key, value):
-        self.connection.set(key, value)
+        self.connection.set(key, value, format=FMT_UTF8)
 
     def mget(self, keys):
         return [self.get(key) for key in keys]


### PR DESCRIPTION
## Description
Fixes #4449 

Use FMT_UTF8 when saving couchbase results, allowing couchbase to store both json and pickled results with the same setting

Please note that this is a similar change to 4751. Please let me know if you'd like me to combine them