### PR TITLE
Remove "experimental" label from SQS support in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -271,7 +271,7 @@ Transports and Backends
     for using Redis as a message transport or as a result backend.
 
 :``celery[sqs]``:
-    for using Amazon SQS as a message transport (*experimental*).
+    for using Amazon SQS as a message transport.
 
 :``celery[tblib``]:
     for using the ``task_remote_tracebacks`` feature.


### PR DESCRIPTION
The [Brokers documentation](docs/getting-started/brokers/index.rst) states
that the Amazon SQS backend is stable. This PR removes a conflicting "experimental" note from the README.