### PR TITLE
Minor documentation tweaks for broken links

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -699,7 +699,7 @@ class Celery(object):
 
         Arguments:
             name (str): Name of task to call (e.g., `"tasks.add"`).
-            result_cls (~@AsyncResult): Specify custom result class.
+            result_cls (AsyncResult): Specify custom result class.
         """
         parent = have_parent = None
         amqp = self.amqp

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -471,10 +471,10 @@ class Task(object):
                 :func:`kombu.compression.register`.
                 Defaults to the :setting:`task_compression` setting.
 
-            link (~@Signature): A single, or a list of tasks signatures
+            link (Signature): A single, or a list of tasks signatures
                 to apply if the task returns successfully.
 
-            link_error (~@Signature): A single, or a list of task signatures
+            link_error (Signature): A single, or a list of task signatures
                 to apply if an error occurs while executing the task.
 
             producer (kombu.Producer): custom producer to use when publishing

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -144,7 +144,7 @@ class Command(object):
     """Base class for command-line applications.
 
     Arguments:
-        app (~@Celery): The app to use.
+        app (Celery): The app to use.
         get_app (Callable): Fucntion returning the current app
             when no app provided.
     """

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -113,7 +113,7 @@ class schedule(BaseSchedule):
         relative (bool):  If set to True the run time will be rounded to the
             resolution of the interval.
         nowfun (Callable): Function returning the current date and time
-            (~datetime.datetime).
+            (:class:`~datetime.datetime`).
         app (Celery): Celery app instance.
     """
 

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -113,8 +113,8 @@ class schedule(BaseSchedule):
         relative (bool):  If set to True the run time will be rounded to the
             resolution of the interval.
         nowfun (Callable): Function returning the current date and time
-            (class:`~datetime.datetime`).
-        app (~@Celery): Celery app instance.
+            (~datetime.datetime).
+        app (Celery): Celery app instance.
     """
 
     relative = False
@@ -689,7 +689,7 @@ class solar(BaseSchedule):
         lon (int): The longitude of the observer.
         nowfun (Callable): Function returning the current date and time
             as a class:`~datetime.datetime`.
-        app (~@Celery): Celery app instance.
+        app (Celery): Celery app instance.
     """
 
     _all_events = {

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -707,7 +707,7 @@ Sometimes you just want to retry a task whenever a particular exception
 is raised.
 
 Fortunately, you can tell Celery to automatically retry a task using
-`autoretry_for` argument in `~@Celery.task` decorator:
+`autoretry_for` argument in the :meth:`~@Celery.task` decorator:
 
 .. code-block:: python
 
@@ -717,8 +717,8 @@ Fortunately, you can tell Celery to automatically retry a task using
     def refresh_timeline(user):
         return twitter.refresh_timeline(user)
 
-If you want to specify custom arguments for internal `~@Task.retry`
-call, pass `retry_kwargs` argument to `~@Celery.task` decorator:
+If you want to specify custom arguments for an internal :meth:`~@Task.retry`
+call, pass `retry_kwargs` argument to :meth:`~@Celery.task` decorator:
 
 .. code-block:: python
 


### PR DESCRIPTION
Some documentation hyperlinks are not generating correctly.

Here's what I was able to find and update:
* The `app` parameter in [celery.schedules documentation](http://docs.celeryproject.org/en/master/reference/celery.schedules.html#celery-schedules) links to ~@Celery, which in the browser attempts to open an email client.
* A `datetime` reference in [celery.schedules `nowfun` parameter description](http://docs.celeryproject.org/en/master/reference/celery.schedules.html#celery-schedules)
* The [tasks userguide](http://docs.celeryproject.org/en/master/userguide/tasks.html#automatic-retry-for-known-exceptions) was not generating the desired hyperlink to the `Celery.task` method.
* The [Celery.send_task method's `result_cls` parameter type](http://docs.celeryproject.org/en/master/reference/celery.html#celery.Celery.send_task) generated ~@AsyncResult, which also attempted to open an email client.