### PR TITLE
Fixes issue 4768.

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -918,7 +918,10 @@ class GroupResult(ResultSet):
                                          ', '.join(r.id for r in self.results))
 
     def as_tuple(self):
-        return (self.id, self.parent), [r.as_tuple() for r in self.results]
+        return (
+            (self.id, self.parent and self.parent.as_tuple()),
+            [r.as_tuple() for r in self.results]
+        )
 
     @property
     def children(self):

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -158,3 +158,23 @@ def second_order_replace2(self, state=False):
         raise self.replace(new_task)
     else:
         redis_connection.rpush('redis-echo', 'Out B')
+
+
+@shared_task(bind=True)
+def build_chain_inside_task(self):
+    """Task to build a chain.
+
+    This task builds a chain and returns the chain's AsyncResult
+    to verify that Asyncresults are correctly converted into
+    serializable objects"""
+    test_chain = (
+        add.s(1, 1) |
+        add.s(2) |
+        group(
+            add.s(3),
+            add.s(4)
+        ) |
+        add.s(5)
+    )
+    result = test_chain()
+    return result

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -1005,9 +1005,9 @@ class test_tuples:
              for i in range(2)],
             parent
         )
-        (result_id, parent_id), group_results = result.as_tuple()
+        (result_id, parent_tuple), group_results = result.as_tuple()
         assert result_id == result.id
-        assert parent_id == parent.id
+        assert parent_tuple == parent.as_tuple()
         assert isinstance(group_results, list)
         expected_grp_res = [(('async-result-{}'.format(i), None), None)
                             for i in range(2)]

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -1008,6 +1008,7 @@ class test_tuples:
         (result_id, parent_tuple), group_results = result.as_tuple()
         assert result_id == result.id
         assert parent_tuple == parent.as_tuple()
+        assert parent_tuple[0][0] == parent.id
         assert isinstance(group_results, list)
         expected_grp_res = [(('async-result-{}'.format(i), None), None)
                             for i in range(2)]


### PR DESCRIPTION
PR #4106 added a GroupResult's parent when converting the object to a tuple for easier access.
The parent was being returned as is. The parent needed to be returned as a tuple.
This way the entire result will be serializable.
Fixes issue #4768 by constructing the first value in a `GroupResult`'s `as_tuple` return value the same way that `AsyncResult` does it.