### PR TITLE
Correctly building graphs with `GroupResult`.

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -907,6 +907,8 @@ class GroupResult(ResultSet):
                 other.results == self.results and
                 other.parent == self.parent
             )
+        elif isinstance(other, string_t):
+            return other == self.id
         return NotImplemented
 
     def __ne__(self, other):
@@ -914,8 +916,18 @@ class GroupResult(ResultSet):
         return True if res is NotImplemented else not res
 
     def __repr__(self):
-        return '<{0}: {1} [{2}]>'.format(type(self).__name__, self.id,
-                                         ', '.join(r.id for r in self.results))
+        return '<{0}: {1} [{2}]>'.format(
+            type(self).__name__, self.id,
+            ', '.join(r.id for r in self.results)
+        )
+
+    def __str__(self):
+        """`str(self) -> self.id`."""
+        return str(self.id)
+
+    def __hash__(self):
+        """`hash(self) -> hash(self.id)`."""
+        return hash(self.id)
 
     def as_tuple(self):
         return (

--- a/t/unit/utils/test_graph.py
+++ b/t/unit/utils/test_graph.py
@@ -9,11 +9,19 @@ from celery.utils.graph import DependencyGraph
 class test_DependencyGraph:
 
     def graph1(self):
+        res_a = self.app.AsyncResult('A')
+        res_b = self.app.AsyncResult('B')
+        res_c = self.app.GroupResult('C', [res_a])
+        res_d = self.app.GroupResult('D', [res_c, res_b])
+        node_a = (res_a, [])
+        node_b = (res_b, [])
+        node_c = (res_c, [res_a])
+        node_d = (res_d, [res_c, res_b])
         return DependencyGraph([
-            ('A', []),
-            ('B', []),
-            ('C', ['A']),
-            ('D', ['C', 'B']),
+            node_a,
+            node_b,
+            node_c,
+            node_d,
         ])
 
     def test_repr(self):
@@ -29,7 +37,8 @@ class test_DependencyGraph:
         assert order.index('A') < order.index('C')
 
     def test_edges(self):
-        assert sorted(list(self.graph1().edges())) == ['C', 'D']
+        edges = self.graph1().edges()
+        assert sorted(edges, key=str) == ['C', 'D']
 
     def test_connect(self):
         x, y = self.graph1(), self.graph1()


### PR DESCRIPTION
Fixes issue #4739

`__str__` and `__hash__` methods implemented in `GroupResult` in the same way that `AsyncResult` implements them.
Also, `__eq__` was updated to check equality with a result's id as a string.
Meaning, in the same way `AsyncResult('some_uuid') == 'some_uuid'` this will be true for `GropuResult('some_uuid') == 'some_uuid'`.

I believe the current unit tests in [`test_graph.py`](https://github.com/celery/celery/blob/master/t/unit/utils/test_graph.py) are complete.
The test graph being used in these tests uses lists of strings as mock results.
Probably because a uuid in string form should be comparable to any result.
Hence, the test graph is updated to use proper `GropuResult` and `AsyncResult` instances.