### PR TITLE
Clarification for Windows Instructions

### DIFF
--- a/docs/getting-started/first-steps-with-celery.rst
+++ b/docs/getting-started/first-steps-with-celery.rst
@@ -66,9 +66,10 @@ ready to move messages for you: ``Starting rabbitmq-server: SUCCESS``.
 
 Don't worry if you're not running Ubuntu or Debian, you can go to this
 website to find similarly simple installation instructions for other
-platforms, including Microsoft Windows:
+platforms, including specific instructions for `Installing on Microsoft Windows <https://www.rabbitmq.com/install-windows.html>`_:
 
     http://www.rabbitmq.com/download.html
+
 
 Redis
 -----


### PR DESCRIPTION
The guide as-is makes it appear as if you can just run setup and follow along with the demo. That is _not_ true on Windows. see #4081 for example. Hopefully this additional link will help the community get through the tutorial without hitting `Task handler raised error: ValueError('not enough values to unpack (expected 3, got 0)',)`

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
