### PR TITLE
Windows Not Supported

### DIFF
--- a/docs/getting-started/first-steps-with-celery.rst
+++ b/docs/getting-started/first-steps-with-celery.rst
@@ -30,6 +30,8 @@ it's a good idea to browse the rest of the documentation.
 For example the :ref:`next-steps` tutorial will
 showcase Celery's capabilities.
 
+NOTE: To save you time, please be aware As of 4.0 `Celery does not support Windows <http://docs.celeryproject.org/en/latest/whatsnew-4.0.html#removed-features>`_.
+
 .. contents::
     :local:
 
@@ -66,7 +68,7 @@ ready to move messages for you: ``Starting rabbitmq-server: SUCCESS``.
 
 Don't worry if you're not running Ubuntu or Debian, you can go to this
 website to find similarly simple installation instructions for other
-platforms, including Microsoft Windows:
+platforms:
 
     http://www.rabbitmq.com/download.html
 


### PR DESCRIPTION
Its very misleading to say you can run RabbitMQ on Windows and then also at the same time not support Celery on Windows. This doc change helps the community head down the correct path in the beginning as opposed to wasting time trying things that won't work (liek I did).

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
