### PR TITLE
Activate Kombu publish retry in Heartbeat

### DIFF
--- a/celery/worker/heartbeat.py
+++ b/celery/worker/heartbeat.py
@@ -46,6 +46,7 @@ class Heart(object):
                                  active=len(active_requests),
                                  processed=all_total_count[0],
                                  loadavg=load_average(),
+                                 retry=True,
                                  **SOFTWARE_INFO)
 
     def start(self):


### PR DESCRIPTION
The lack of this retry option lead to a curious bug where the hearbeat connection would be lost if the connection was block for a smaller amount of time than the heartbeat interval

https://github.com/celery/celery/issues/4758