### PR TITLE
Allow passing "related_name=None" for autodiscovery (#4810)

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -655,7 +655,8 @@ class Celery(object):
                 value returned is used (for lazy evaluation).
             related_name (str): The name of the module to find.  Defaults
                 to "tasks": meaning "look for 'module.tasks' for every
-                module in ``packages``."
+                module in ``packages``.".  If ``None`` will only try to import
+                the package, i.e. "look for 'module'".
             force (bool): By default this call is lazy so that the actual
                 auto-discovery won't happen until an application imports
                 the default modules.  Forcing will cause the auto-discovery

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -253,7 +253,9 @@ def find_related_module(package, related_name):
     # Django 1.7 allows for speciying a class name in INSTALLED_APPS.
     # (Issue #2248).
     try:
-        importlib.import_module(package)
+        module = importlib.import_module(package)
+        if not related_name and module:
+            return module
     except ImportError:
         package, _, _ = package.rpartition('.')
         if not package:


### PR DESCRIPTION
* Passing "None" as the "related_name" in "Celery.autodiscover_tasks"
  will just try to import the plain package.

* Removes usage of the "imp" module from tests.

* Adds extra tests for the "find_related_module" function.