### PR TITLE
Add logic around when to requeue the requested message when using the RPC backend.

### DIFF
--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -267,7 +267,8 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
             # null-cache, see :setting:`result_cache_max`) there's also no
             # need to requeue it since the next query will just return what is
             # in the cache.
-            if result['status'] not in states.READY_STATES and task_id not in self._cache:
+            if (result['status'] not in states.READY_STATES and
+                    task_id not in self._cache):
                 latest.requeue()
 
             return result


### PR DESCRIPTION
## Description

This fixes the memory leak described in #4830. The leak happens because `RPCBackend.get_task_meta()` always requeues the received message (if it matches the task ID you're looking for). The message is always requeued, but the result is also sometimes cached onto the `AsyncResult` object, this means that calling `AsyncResult.get()` to "clean up" the object (as [required in the documentation](http://docs.celeryproject.org/en/latest/userguide/tasks.html#result-backends)) doesn't actually reach out to the backend to remove the message since it is cached already.

This avoids requeueing the message in two cases:
* If the task is "done" (i.e. one of the `READY_STATES` has been reached).
* If the current status of the task is already being cached (when using `result_cache_max`).

Note that calling `AsyncResult.get()` ends up following a different code-path that doesn't call into `get_task_meta()`, but manually polling for the `AsyncResult.state` shows this bug. See the sample code in the issue.

I tested this with all combinations of `result_cache_max` and `task_track_started` (which interacts with this code in a subtle way when the null-cache is used) and I got correct results in each of them.

Fixes #4830