### PR TITLE
Fix memory leak of AsyncResult 

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -379,11 +379,6 @@ class AsyncResult(ResultBase):
     def __reduce_args__(self):
         return self.id, self.backend, None, None, self.parent
 
-    def __del__(self):
-        """Cancel pending operations when the instance is destroyed."""
-        if self.backend is not None:
-            self.backend.remove_pending_result(self)
-
     @cached_property
     def graph(self):
         return self.build_graph()


### PR DESCRIPTION
#4131 fixed a memory leak issue by remove weakref to a bound method. But when I upgraded my prod celery to 4.2.0, I come to this memory leak issue again. The test script in the issue also report memory leak in 4.2.0 :   https://github.com/celery/celery/pull/4131#issuecomment-346949954

The root case is `AsyncResult` defined  `__del__` method, but the `self.on_ready` created a ref cycle as well. `__del__` will prevent gc to collect ref cycle objects.

A simple script to test:

```
import resource
import gc

from celery import Celery

app = Celery()
app.conf.update(BROKER_URL='redis://localhost:6379/1')

@app.task
def dummy():
    return '1'


def print_mem():
    print 'Memory usage: %s (kb)' % resource.getrusage(resource.RUSAGE_SELF).ru_maxrss

def run():
    for i in range(10000):
        dummy.delay()
        if i % 1000 == 0:
            print_mem()

run()
print gc.garbag
```

Before remove `__del__`:

```
Memory usage: 31736 (kb)
Memory usage: 32916 (kb)
Memory usage: 34628 (kb)
Memory usage: 36432 (kb)
Memory usage: 38292 (kb)
Memory usage: 39812 (kb)
Memory usage: 41668 (kb)
Memory usage: 42608 (kb)
Memory usage: 43576 (kb)
Memory usage: 44592 (kb)

[<AsyncResult: 9ad49b99-73e3-41de-a972-3ab196874f91>, <AsyncResult: 7638fc5a-6c14-4fe5-bbe7-1d19ab992582>, <AsyncResult: 95a158b6-9c1b-408e-9364-679b01e3d36f>, <AsyncResult: 6bd7cac9-4a65-47ae-97ee-8a0bb0b24cee>.......]
```
After remove `__del__`:

```
Memory usage: 31828 (kb)
Memory usage: 31960 (kb)
Memory usage: 31960 (kb)
Memory usage: 31960 (kb)
Memory usage: 31960 (kb)
Memory usage: 31960 (kb)
Memory usage: 31960 (kb)
Memory usage: 31960 (kb)
Memory usage: 32188 (kb)
Memory usage: 32188 (kb)

[]
```
