### PR TITLE
Fix BytesWarning in concurrency/asynpool.py

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -13,6 +13,7 @@ import numbers
 import os
 import platform as _platform
 import signal as _signal
+import struct
 import sys
 import warnings
 from collections import namedtuple
@@ -795,3 +796,21 @@ def check_privileges(accept_content):
         warnings.warn(RuntimeWarning(ROOT_DISCOURAGED.format(
             uid=uid, euid=euid, gid=gid, egid=egid,
         )))
+
+
+if sys.version_info < (2, 7, 7):  # pragma: no cover
+    import functools
+
+    def _to_bytes_arg(fun):
+        @functools.wraps(fun)
+        def _inner(s, *args, **kwargs):
+            return fun(s.encode(), *args, **kwargs)
+        return _inner
+
+    pack = _to_bytes_arg(struct.pack)
+    unpack = _to_bytes_arg(struct.unpack)
+    unpack_from = _to_bytes_arg(struct.unpack_from)
+else:
+    pack = struct.pack
+    unpack = struct.unpack
+    unpack_from = struct.unpack_from


### PR DESCRIPTION
When Python is executed with the `-b` CLI option, Celery issues the following warnings:

```
.../celery/concurrency/asynpool.py:1254: BytesWarning: Comparison between bytes and string
  header = pack(b'>I', size)
.../celery/concurrency/asynpool.py:814: BytesWarning: Comparison between bytes and string
  header = pack(b'>I', body_size)
.../celery/concurrency/asynpool.py:76: BytesWarning: Comparison between bytes and string
  return unpack(fmt, iobuf.getvalue())  # <-- BytesIO
```

This occurs due to passing a `bytes` object to the `fmt` argument of `struct` functions. The solution was borrowed from py-amqp: https://github.com/celery/py-amqp/pull/117#issuecomment-267181264

For a discussion on passing `str` instead of `bytes` to `struct` functions, see: https://github.com/python/typeshed/pull/669

Information on the `-b` CLI option: https://docs.python.org/3/using/cmdline.html#miscellaneous-options

> `-b`
>
> Issue a warning when comparing bytes or bytearray with `str` or `bytes` with int. Issue an error when the option is given twice (`-bb`).