### PR TITLE
Require the redis module for test test_timeouts_in_url_coerced

### DIFF
--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -234,6 +234,7 @@ class test_RedisBackend:
         assert x.connparams['socket_timeout'] == 30.0
         assert x.connparams['socket_connect_timeout'] == 100.0
 
+    @skip.unless_module('redis')
     def test_timeouts_in_url_coerced(self):
         x = self.Backend(
             ('redis://:bosco@vandelay.com:123//1?'


### PR DESCRIPTION
The test requires the redis module to be installed. It is referenced in the function [`RedisBackend._params_from_url()`](https://github.com/celery/celery/blob/d20b8a5d469c80f48468e251cbe6451c798d1c29/celery/backends/redis.py#L254).

Fixes AppVeyor build failures.