### PR TITLE
Fix hybrid_to_proto2 with missing timelimit

### DIFF
--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -48,7 +48,7 @@ def hybrid_to_proto2(message, body):
         'eta': body.get('eta'),
         'expires': body.get('expires'),
         'retries': body.get('retries'),
-        'timelimit': body.get('timelimit'),
+        'timelimit': body.get('timelimit', (None, None)),
         'argsrepr': body.get('argsrepr'),
         'kwargsrepr': body.get('kwargsrepr'),
         'origin': body.get('origin'),


### PR DESCRIPTION
If `timelimit` is not defined in `body`, it will default to `None` value. Which will cause result in a crash here:
https://github.com/celery/celery/blob/master/celery/worker/request.py#L188 (`'NoneType' object is not iterable`).

Defaulting to `(None, None)` instead should fix it.