### PR TITLE
Preserve order of return values from groups

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -298,7 +298,7 @@ class AMQP(object):
         )
 
     def as_task_v2(self, task_id, name, args=None, kwargs=None,
-                   countdown=None, eta=None, group_id=None,
+                   countdown=None, eta=None, group_id=None, group_index=None,
                    expires=None, retries=0, chord=None,
                    callbacks=None, errbacks=None, reply_to=None,
                    time_limit=None, soft_time_limit=None,
@@ -356,6 +356,7 @@ class AMQP(object):
                 'eta': eta,
                 'expires': expires,
                 'group': group_id,
+                'group_index': group_index,
                 'retries': retries,
                 'timelimit': [time_limit, soft_time_limit],
                 'root_id': root_id,
@@ -390,7 +391,7 @@ class AMQP(object):
         )
 
     def as_task_v1(self, task_id, name, args=None, kwargs=None,
-                   countdown=None, eta=None, group_id=None,
+                   countdown=None, eta=None, group_id=None, group_index=None,
                    expires=None, retries=0,
                    chord=None, callbacks=None, errbacks=None, reply_to=None,
                    time_limit=None, soft_time_limit=None,
@@ -435,6 +436,7 @@ class AMQP(object):
                 'args': args,
                 'kwargs': kwargs,
                 'group': group_id,
+                'group_index': group_index,
                 'retries': retries,
                 'eta': eta,
                 'expires': expires,

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -694,7 +694,8 @@ class Celery(object):
                   eta=None, task_id=None, producer=None, connection=None,
                   router=None, result_cls=None, expires=None,
                   publisher=None, link=None, link_error=None,
-                  add_to_parent=True, group_id=None, retries=0, chord=None,
+                  add_to_parent=True, group_id=None, group_index=None,
+                  retries=0, chord=None,
                   reply_to=None, time_limit=None, soft_time_limit=None,
                   root_id=None, parent_id=None, route_name=None,
                   shadow=None, chain=None, task_type=None, **options):
@@ -730,7 +731,7 @@ class Celery(object):
                     parent_id = parent.request.id
 
         message = amqp.create_task_message(
-            task_id, name, args, kwargs, countdown, eta, group_id,
+            task_id, name, args, kwargs, countdown, eta, group_id, group_index,
             expires, retries, chord,
             maybe_list(link), maybe_list(link_error),
             reply_to or self.oid, time_limit, soft_time_limit,

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -364,7 +364,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
                 decode, unpack = self.decode, self._unpack_chord_result
                 with client.pipeline() as pipe:
                     resl, = pipe \
-                        .zrangebyscore(jkey, '-inf', '+inf') \
+                        .zrange(jkey, 0, -1) \
                         .execute()
                 try:
                     callback.delay([unpack(tup, decode) for tup in resl])

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -347,8 +347,8 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         result = self.encode_result(result, state)
         with client.pipeline() as pipe:
             _, readycount, totaldiff, _, _ = pipe \
-                .zadd(jkey, group_index,
-                      self.encode([1, tid, state, result])) \
+                .zadd(jkey,
+                      {self.encode([1, tid, state, result]): group_index}) \
                 .zcount(jkey, '-inf', '+inf') \
                 .get(tkey) \
                 .expire(jkey, self.expires) \

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -268,7 +268,7 @@ class Signature(dict):
     partial = clone
 
     def freeze(self, _id=None, group_id=None, chord=None,
-               root_id=None, parent_id=None):
+               root_id=None, parent_id=None, group_index=None):
         """Finalize the signature by adding a concrete task id.
 
         The task won't be called and you shouldn't call the signature
@@ -295,6 +295,8 @@ class Signature(dict):
             opts['group_id'] = group_id
         if chord:
             opts['chord'] = chord
+        if group_index is not None:
+            opts['group_index'] = group_index
         # pylint: disable=too-many-function-args
         #   Borks on this, as it's a property.
         return self.AsyncResult(tid)
@@ -608,19 +610,21 @@ class _chain(Signature):
             return results[0]
 
     def freeze(self, _id=None, group_id=None, chord=None,
-               root_id=None, parent_id=None):
+               root_id=None, parent_id=None, group_index=None):
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         _, results = self._frozen = self.prepare_steps(
             self.args, self.kwargs, self.tasks, root_id, parent_id, None,
             self.app, _id, group_id, chord, clone=False,
+            group_index=group_index,
         )
         return results[0]
 
     def prepare_steps(self, args, kwargs, tasks,
                       root_id=None, parent_id=None, link_error=None, app=None,
                       last_task_id=None, group_id=None, chord_body=None,
-                      clone=True, from_dict=Signature.from_dict):
+                      clone=True, from_dict=Signature.from_dict,
+                      group_index=None):
         app = app or self.app
         # use chain message field for protocol 2 and later.
         # this avoids pickle blowing the stack on the recursion
@@ -687,6 +691,7 @@ class _chain(Signature):
                 res = task.freeze(
                     last_task_id,
                     root_id=root_id, group_id=group_id, chord=chord_body,
+                    group_index=group_index,
                 )
             else:
                 res = task.freeze(root_id=root_id)
@@ -1111,7 +1116,7 @@ class group(Signature):
         return options, group_id, options.get('root_id')
 
     def freeze(self, _id=None, group_id=None, chord=None,
-               root_id=None, parent_id=None):
+               root_id=None, parent_id=None, group_index=None):
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         opts = self.options
@@ -1123,6 +1128,8 @@ class group(Signature):
             opts['group_id'] = group_id
         if chord:
             opts['chord'] = chord
+        if group_index is not None:
+            opts['group_index'] = group_index
         root_id = opts.setdefault('root_id', root_id)
         parent_id = opts.setdefault('parent_id', parent_id)
         new_tasks = []
@@ -1142,6 +1149,7 @@ class group(Signature):
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         stack = deque(self.tasks)
+        i = 0
         while stack:
             task = maybe_signature(stack.popleft(), app=self._app).clone()
             if isinstance(task, group):
@@ -1150,7 +1158,9 @@ class group(Signature):
                 new_tasks.append(task)
                 yield task.freeze(group_id=group_id,
                                   chord=chord, root_id=root_id,
-                                  parent_id=parent_id)
+                                  parent_id=parent_id,
+                                  group_index=i)
+                i += 1
 
     def __repr__(self):
         if self.tasks:
@@ -1229,17 +1239,16 @@ class chord(Signature):
         return self.apply_async((), {'body': body} if body else {}, **options)
 
     def freeze(self, _id=None, group_id=None, chord=None,
-               root_id=None, parent_id=None):
+               root_id=None, parent_id=None, group_index=None):
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         if not isinstance(self.tasks, group):
             self.tasks = group(self.tasks, app=self.app)
         header_result = self.tasks.freeze(
             parent_id=parent_id, root_id=root_id, chord=self.body)
-
         body_result = self.body.freeze(
-            _id, root_id=root_id, chord=chord, group_id=group_id)
-
+            _id, root_id=root_id, chord=chord, group_id=group_id,
+            group_index=group_index)
         # we need to link the body result back to the group result,
         # but the body may actually be a chain,
         # so find the first result without a parent

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1149,7 +1149,7 @@ class group(Signature):
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         stack = deque(self.tasks)
-        i = 0
+        group_index = 0
         while stack:
             task = maybe_signature(stack.popleft(), app=self._app).clone()
             if isinstance(task, group):
@@ -1159,8 +1159,8 @@ class group(Signature):
                 yield task.freeze(group_id=group_id,
                                   chord=chord, root_id=root_id,
                                   parent_id=parent_id,
-                                  group_index=i)
-                i += 1
+                                  group_index=group_index)
+                group_index += 1
 
     def __repr__(self):
         if self.tasks:

--- a/celery/utils/abstract.py
+++ b/celery/utils/abstract.py
@@ -116,7 +116,8 @@ class CallableSignature(CallableTask):  # pragma: no cover
         pass
 
     @abstractmethod
-    def freeze(self, id=None, group_id=None, chord=None, root_id=None):
+    def freeze(self, id=None, group_id=None, chord=None, root_id=None,
+               group_index=None):
         pass
 
     @abstractmethod

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -520,6 +520,11 @@ class Request(object):
         }, **embed or {})
         return Context(request)
 
+    @cached_property
+    def group_index(self):
+        # used by backend.on_chord_part_return to order return values in group
+        return self.request_dict['group_index']
+
 
 def create_request_cls(base, task, pool, hostname, eventer,
                        ref=ref, revoked_tasks=revoked_tasks,

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -523,7 +523,7 @@ class Request(object):
     @cached_property
     def group_index(self):
         # used by backend.on_chord_part_return to order return values in group
-        return self.request_dict['group_index']
+        return self.request_dict.get('group_index')
 
 
 def create_request_cls(base, task, pool, hostname, eventer,

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -1,6 +1,6 @@
 setuptools>=30.0.0
 wheel>=0.29.0
-flake8>=2.5.4
+flake8>=3.7.1
 flakeplus>=1.1
 pydocstyle==1.1.1
 tox>=2.3.1

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -352,7 +352,7 @@ class test_chord:
 
         c = group([add_to_all_to_chord.s([1, 2, 3], 4)]) | identity.s()
         res = c()
-        assert res.get() == [0, 5, 6, 7]
+        assert sorted(res.get()) == [0, 5, 6, 7]
 
     @flaky
     def test_add_chord_to_chord(self, manager):

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -88,21 +88,20 @@ class Redis(mock.MockCallbacks):
     def pipeline(self):
         return self.Pipeline(self)
 
-    def _get_list(self, key):
-        try:
-            return self.keyspace[key]
-        except KeyError:
-            l = self.keyspace[key] = []
-            return l
+    def _get_sorted_set(self, key):
+        return self.keyspace.setdefault(key, [])
 
-    def rpush(self, key, value):
-        self._get_list(key).append(value)
+    def zadd(self, key, score, value):
+        self._get_sorted_set(key).append((float(score), value))
 
-    def lrange(self, key, start, stop):
-        return self._get_list(key)[start:stop]
+    def zrangebyscore(self, key, start, stop):
+        start = float(start)
+        stop = float(stop)
+        return [value for score, value in sorted(self.keyspace.get(key, []))
+                if start <= score <= stop]
 
-    def llen(self, key):
-        return len(self.keyspace.get(key) or [])
+    def zcount(self, key, start, stop):
+        return len(self.zrangebyscore(key, start, stop))
 
 
 class Sentinel(mock.MockCallbacks):
@@ -433,7 +432,7 @@ class test_RedisBackend:
 
     def test_on_chord_part_return_no_gid_or_tid(self):
         request = Mock(name='request')
-        request.id = request.group = None
+        request.id = request.group = request.group_index = None
         assert self.b.on_chord_part_return(request, 'SUCCESS', 10) is None
 
     def test_ConnectionPool(self):
@@ -473,7 +472,7 @@ class test_RedisBackend:
         self.b.expires = None
         self.b.set('foo', 'bar')
 
-    def create_task(self):
+    def create_task(self, i):
         tid = uuid()
         task = Mock(name='task-{0}'.format(tid))
         task.name = 'foobarbaz'
@@ -482,17 +481,19 @@ class test_RedisBackend:
         task.request.id = tid
         task.request.chord['chord_size'] = 10
         task.request.group = 'group_id'
+        task.request.group_index = i
         return task
 
     @patch('celery.result.GroupResult.restore')
     def test_on_chord_part_return(self, restore):
-        tasks = [self.create_task() for i in range(10)]
+        tasks = [self.create_task(i) for i in range(10)]
+        random.shuffle(tasks)
 
         for i in range(10):
             self.b.on_chord_part_return(tasks[i].request, states.SUCCESS, i)
-            assert self.b.client.rpush.call_count
-            self.b.client.rpush.reset_mock()
-        assert self.b.client.lrange.call_count
+            assert self.b.client.zadd.call_count
+            self.b.client.zadd.reset_mock()
+        assert self.b.client.zrangebyscore.call_count
         jkey = self.b.get_key_for_group('group_id', '.j')
         tkey = self.b.get_key_for_group('group_id', '.t')
         self.b.client.delete.assert_has_calls([call(jkey), call(tkey)])
@@ -520,7 +521,7 @@ class test_RedisBackend:
         with self.chord_context(1) as (_, request, callback):
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, ChordError())
-            self.b.client.pipeline.return_value.rpush().llen().get().expire(
+            self.b.client.pipeline.return_value.zadd().zcount().get().expire(
             ).expire().execute.return_value = (1, 1, 0, 4, 5)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
@@ -532,7 +533,7 @@ class test_RedisBackend:
         with self.chord_context(1) as (_, request, callback):
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, RuntimeError())
-            self.b.client.pipeline.return_value.rpush().llen().get().expire(
+            self.b.client.pipeline.return_value.zadd().zcount().get().expire(
             ).expire().execute.return_value = (1, 1, 0, 4, 5)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
@@ -543,10 +544,11 @@ class test_RedisBackend:
     @contextmanager
     def chord_context(self, size=1):
         with patch('celery.backends.redis.maybe_signature') as ms:
-            tasks = [self.create_task() for i in range(size)]
+            tasks = [self.create_task(i) for i in range(size)]
             request = Mock(name='request')
             request.id = 'id1'
             request.group = 'gid1'
+            request.group_index = None
             callback = ms.return_value = Signature('add')
             callback.id = 'id1'
             callback['chord_size'] = size

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -95,10 +95,7 @@ class Redis(mock.MockCallbacks):
         self._get_sorted_set(key).append((float(score), value))
 
     def zrangebyscore(self, key, start, stop):
-        start = float(start)
-        stop = float(stop)
-        return [value for score, value in sorted(self.keyspace.get(key, []))
-                if start <= score <= stop]
+        return list(sorted(self.keyspace.get(key, [])))[start:stop]
 
     def zcount(self, key, start, stop):
         return len(self.zrangebyscore(key, start, stop))


### PR DESCRIPTION
## Description

Preserve the order of return values from groups under the redis backend. Fixes #3781.

## Example

Here is `test.py`:

```python
#!/usr/bin/env python
import random
import time

from celery import Celery, group

app = Celery('hello', broker='redis://', backend='redis://')


@app.task(shared=False)
def f(x):
    time.sleep(random.uniform(0, 1))
    return x


@app.task(shared=False)
def test():
    return (group(f.s(i) for i in range(10)) | f.s()).delay()


if __name__ == '__main__':
    app.start()
```

Start the worker like this:

```
$ ./test.py worker
```

And test it like this:

```
$ ./test.py shell
>>> test().get()
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
```

In previous versions of Celery, the return values would generally be out of order.