### PR TITLE
JSON Serialization fails when exception arguments are not JSON-serializable Fixes #4860

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -260,3 +260,4 @@ Igor Kasianov, 2018/01/20
 Derek Harland, 2018/02/15
 Chris Mitchell, 2018/02/27
 Josue Balandrano Coronel, 2018/05/24
+Tom Booth, 2018/07/06

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -33,6 +33,7 @@ from celery.utils.collections import BufferMap
 from celery.utils.functional import LRUCache, arity_greater
 from celery.utils.log import get_logger
 from celery.utils.serialization import (create_exception_cls,
+                                        ensure_serializable,
                                         get_pickleable_exception,
                                         get_pickled_exception)
 
@@ -236,7 +237,7 @@ class Backend(object):
         if serializer in EXCEPTION_ABLE_CODECS:
             return get_pickleable_exception(exc)
         return {'exc_type': type(exc).__name__,
-                'exc_message': exc.args,
+                'exc_message': ensure_serializable(exc.args, self.encode),
                 'exc_module': type(exc).__module__}
 
     def exception_to_python(self, exc):

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -145,6 +145,17 @@ class test_prepare_exception:
         y = self.b.exception_to_python(x)
         assert isinstance(y, KeyError)
 
+    def test_json_exception_arguments(self):
+        self.b.serializer = 'json'
+        x = self.b.prepare_exception(Exception(object))
+        assert x == {
+            'exc_message': serialization.ensure_serializable(
+                (object,), self.b.encode),
+            'exc_type': Exception.__name__,
+            'exc_module': Exception.__module__}
+        y = self.b.exception_to_python(x)
+        assert isinstance(y, Exception)
+
     def test_impossible(self):
         self.b.serializer = 'pickle'
         x = self.b.prepare_exception(Impossible())


### PR DESCRIPTION
## Description

Fixes #4860 When a using JSON as a serializer and an exception is raised within a task, simple exceptions are handled gracefully. E.g.

```
@app.task
def raise_exc():
   raise Exception('message')
```

However, when the arguments are not serializable, the task is acknowledged and processed but dies when trying to mark the task as failed. Subsequent events are not fired either E.g.

```
import requests

@app.task
def raise_exc():
   raise Exception(requests.ConnectionError)
```

```
Traceback (most recent call last):
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/celery/app/trace.py", line 396, in trace_task
    I, R, state, retval = on_error(task_request, exc, uuid)
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/celery/app/trace.py", line 338, in on_error
    task, request, eager=eager, call_errbacks=call_errbacks,
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/celery/app/trace.py", line 172, in handle_error_state
    call_errbacks=call_errbacks)
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/celery/app/trace.py", line 217, in handle_failure
    call_errbacks=call_errbacks,
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/celery/backends/base.py", line 156, in mark_as_failure
    traceback=traceback, request=request)
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/celery/backends/base.py", line 317, in store_result
    request=request, **kwargs)
  File "/home/thomasbo/Networking-scripts-tools/project/NetTask/net_task/extensions.py", line 52, in _store_result
    self.set(self.get_key_for_task(task_id), self.encode(meta))
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/celery/backends/base.py", line 267, in encode
    _, _, payload = self._encode(data)
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/celery/backends/base.py", line 271, in _encode
    return dumps(data, serializer=self.serializer)
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/kombu/serialization.py", line 221, in dumps
    payload = encoder(data)
  File "/usr/lib/python3.6/contextlib.py", line 99, in __exit__
    self.gen.throw(type, value, traceback)
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/kombu/serialization.py", line 54, in _reraise_errors
    reraise(wrapper, wrapper(exc), sys.exc_info()[2])
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/vine/five.py", line 178, in reraise
    raise value.with_traceback(tb)
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/kombu/serialization.py", line 50, in _reraise_errors
    yield
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/kombu/serialization.py", line 221, in dumps
    payload = encoder(data)
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/kombu/utils/json.py", line 72, in dumps
    **dict(default_kwargs, **kwargs))
  File "/usr/lib/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/home/thomasbo/v-net-task/lib/python3.6/site-packages/kombu/utils/json.py", line 62, in default
    return super(JSONEncoder, self).default(o)
  File "/usr/lib/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
kombu.exceptions.EncodeError: Object of type 'ConnectionError' is not JSON serializable
```

This PR uses the backend's encoding/decoding methods to ensure the result object (in this case, an exception), will correctly serialize before attempting to mark_failure. Regression tested for pickle compatibility.
