### PR TITLE
allow couchbase to automatically detect serialization format

### DIFF
--- a/celery/backends/couchbase.py
+++ b/celery/backends/couchbase.py
@@ -19,6 +19,7 @@ try:
     from couchbase import Couchbase
     from couchbase.connection import Connection
     from couchbase.exceptions import NotFoundError
+    from couchbase import FMT_AUTO
 except ImportError:
     Couchbase = Connection = NotFoundError = None   # noqa
 
@@ -106,7 +107,7 @@ class CouchbaseBackend(KeyValueStoreBackend):
             return None
 
     def set(self, key, value):
-        self.connection.set(key, value, ttl=self.expires)
+        self.connection.set(key, value, ttl=self.expires, format=FMT_AUTO)
 
     def mget(self, keys):
         return [self.get(key) for key in keys]


### PR DESCRIPTION
Fixes #4449

Use FMT_AUTO when saving couchbase results, allowing couchbase to store both json and pickled results with the same setting

[In my previous PR](https://github.com/celery/celery/pull/4752), it was suggested to created some tests for this change, however i'm not sure exactly what additional tests we can add unless we have a real (non-mocked) couchbase instance running during integration testing. 

It seems like the [set/get method is already covered by unit tests](https://github.com/celery/celery/blob/master/t/unit/backends/test_couchbase.py#L62).

The only thing i can think of would be to try to set/get a pickled python class with the pickle serializer in unit tests, but it wouldn't actually be saving that real data (and hitting the same error I hit) unless it's a real Couchbase server instance and not mocked.

If there's any suggestions for how to test this in a unit tests, please let me know.