### PR TITLE
Fix crontab documentation

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -361,7 +361,7 @@ class crontab(BaseSchedule):
         - A (list of) integers from 1-31 that represents the days of the
           month that execution should occur.
         - A string representing a Crontab pattern.  This may get pretty
-          advanced, such as ``day_of_month='2-30/3'`` (for every even
+          advanced, such as ``day_of_month='2-30/2'`` (for every even
           numbered day) or ``day_of_month='1-7,15-21'`` (for the first and
           third weeks of the month).
 

--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -273,7 +273,7 @@ Some examples:
 | ``crontab(0, 0, day_of_month='11',``    | Execute on the eleventh of May every year. |
 |          ``month_of_year='5')``         |                                            |
 +-----------------------------------------+--------------------------------------------+
-| ``crontab(0, 0,``                       | Execute every day on the first month     |
+| ``crontab(0, 0,``                       | Execute every day on the first month       |
 |         ``month_of_year='*/3')``        | of every quarter.                          |
 +-----------------------------------------+--------------------------------------------+
 

--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -265,7 +265,7 @@ Some examples:
 |                                         |                                            |
 +-----------------------------------------+--------------------------------------------+
 | ``crontab(0, 0,``                       | Execute on every even numbered day.        |
-|         ``day_of_month='2-30/3')``      |                                            |
+|         ``day_of_month='2-30/2')``      |                                            |
 +-----------------------------------------+--------------------------------------------+
 | ``crontab(0, 0,``                       | Execute on the first and third weeks of    |
 |         ``day_of_month='1-7,15-21')``   | the month.                                 |


### PR DESCRIPTION
* Crontab examples table does not render on documentation. Pipe border character has been aligned to fix this.
* Update the crontab patterns to match explanation text.