### PR TITLE
Fix link to contributors page in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -430,7 +430,7 @@ documentation.
 |oc-contributors|
 
 .. |oc-contributors| image:: https://opencollective.com/celery/contributors.svg?width=890&button=false
-    :target: graphs/contributors
+    :target: https://github.com/celery/celery/graphs/contributors
 
 Backers
 -------


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

The link on contributors image is pointing to a 404 page. Fixing it.