### PR TITLE
Allow Extraction of Chord Results On Error

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -660,7 +660,7 @@ class BaseKeyValueStoreBackend(Backend):
             'children': self.current_task_children(request),
             'task_id': bytes_to_str(task_id),
         }
-        if request and request.group:
+        if request and getattr(request, 'group', None):
             meta['group_id'] = request.group
         self.set(self.get_key_for_task(task_id), self.encode(meta))
         return result

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -660,6 +660,8 @@ class BaseKeyValueStoreBackend(Backend):
             'children': self.current_task_children(request),
             'task_id': bytes_to_str(task_id),
         }
+        if request and request.group:
+            meta['group_id'] = request.group
         self.set(self.get_key_for_task(task_id), self.encode(meta))
         return result
 

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -359,13 +359,16 @@ class RedisBackend(base.BaseKeyValueStoreBackend, async.AsyncBackendMixin):
             if readycount == total:
                 decode, unpack = self.decode, self._unpack_chord_result
                 with client.pipeline() as pipe:
-                    resl, _, _ = pipe \
+                    resl, = pipe \
                         .lrange(jkey, 0, total) \
-                        .delete(jkey) \
-                        .delete(tkey) \
                         .execute()
                 try:
                     callback.delay([unpack(tup, decode) for tup in resl])
+                    with client.pipeline() as pipe:
+                        _, _ = pipe \
+                            .delete(jkey) \
+                            .delete(tkey) \
+                            .execute()
                 except Exception as exc:  # pylint: disable=broad-except
                     logger.exception(
                         'Chord callback for %r raised: %r', request.group, exc)

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -498,7 +498,7 @@ class Request(object):
     def group(self):
         # used by backend.on_chord_part_return when failures reported
         # by parent process
-        return self.request_dict['group']
+        return self.request_dict.get('group')
 
 
 def create_request_cls(base, task, pool, hostname, eventer,

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -178,3 +178,13 @@ def build_chain_inside_task(self):
     )
     result = test_chain()
     return result
+
+
+@shared_task
+def fail(*args):
+    raise Exception('Task expected to fail')
+
+
+@shared_task
+def chord_error(args):
+    return args

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -186,5 +186,5 @@ def fail(*args):
 
 
 @shared_task
-def chord_error(args):
+def chord_error(*args):
     return args

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -180,9 +180,13 @@ def build_chain_inside_task(self):
     return result
 
 
+class ExpectedException(Exception):
+    pass
+
+
 @shared_task
 def fail(*args):
-    raise Exception('Task expected to fail')
+    raise ExpectedException('Task expected to fail')
 
 
 @shared_task

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -537,7 +537,8 @@ class test_chord:
         res.children[0].children[0].get(propagate=False)
 
         # Use the error callback's result to find the failed task.
-        error_callback_result = AsyncResult(res.children[0].children[0].result)
+        error_callback_result = AsyncResult(
+            res.children[0].children[0].result[0])
         failed_task_id = error_callback_result.result.args[0].split()[3]
 
         # Use new group_id result metadata to get group ID.

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -528,6 +528,9 @@ class test_chord:
         from .tasks import ExpectedException
         import time
 
+        if not manager.app.conf.result_backend.startswith('redis'):
+            raise pytest.skip('Requires redis result backend.')
+
         # Run the chord and wait for the error callback to finish.
         c1 = chord(
             header=[add.s(1, 2), add.s(3, 4), fail.s()],

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -550,6 +550,14 @@ class test_chord:
         except ExpectedException:
             pass
 
+        # Extract the results of the successful tasks from the chord.
+        #
+        # We could do this inside the error handler, and probably would in a
+        #  real system, but for the purposes of the test it's obnoxious to get
+        #  data out of the error handler.
+        #
+        # So for clarity of our test, we instead do it here.
+
         # Use the error callback's result to find the failed task.
         error_callback_result = AsyncResult(
             res.children[0].children[0].result[0])

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -10,10 +10,10 @@ from celery.result import AsyncResult, GroupResult, ResultSet
 
 from .conftest import flaky, get_active_redis_channels, get_redis_connection
 from .tasks import (add, add_chord_to_chord, add_replaced, add_to_all,
-                    add_to_all_to_chord, build_chain_inside_task, collect_ids,
-                    delayed_sum, delayed_sum_with_soft_guard, identity, ids,
-                    print_unicode, redis_echo, second_order_replace1, tsum,
-                    fail, chord_error)
+                    add_to_all_to_chord, build_chain_inside_task, chord_error,
+                    collect_ids, delayed_sum, delayed_sum_with_soft_guard,
+                    fail, identity, ids, print_unicode, redis_echo,
+                    second_order_replace1, tsum)
 
 TIMEOUT = 120
 


### PR DESCRIPTION
## Description

Make it possible to access the results of chord header tasks in the chord body's `on_error` handler. This is desirable in circumstances where some of the work from a parallel process can still be used even if other tasks involved in the process failed.

The major change are:

* to make it so the redis backend does not delete the aggregated results before determining if an error occurred
* to preserve the group ID from the header task's request in its result, so the error handler can find the group ID and use it to access the aggregated results

The integration test validates that the information available to the chord error handler is sufficient for accessing the chord header results even if the process is not precisely convenient, and without changing the external API or expected function signatures.