### PR TITLE
Fixed Issue #4638

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -202,6 +202,10 @@ class Pidfile(object):
                 print('Stale pidfile exists - Removing it.', file=sys.stderr)
                 self.remove()
                 return True
+        except SystemError as exc:
+            print('Stale pidfile exists - Removing it.', file=sys.stderr)
+            self.remove()
+            return True
         return False
 
     def write_pid(self):


### PR DESCRIPTION
Fixes #4638 by catching the exception thrown for windows 10 devices with stale pid files.