### PR TITLE
Add autoscaler information on stats inspect command

### DIFF
--- a/celery/worker/autoscale.py
+++ b/celery/worker/autoscale.py
@@ -60,7 +60,7 @@ class WorkerComponent(bootsteps.StartStopStep):
     def info(self, w):
         """Returns `Autoscaler` info"""
         return {'autoscaler': w.autoscaler.info()}
-    
+
 
 class Autoscaler(bgThread):
     """Background thread to autoscale pool workers."""

--- a/celery/worker/autoscale.py
+++ b/celery/worker/autoscale.py
@@ -58,7 +58,7 @@ class WorkerComponent(bootsteps.StartStopStep):
         )
 
     def info(self, w):
-        """Returns `Autoscaler` info"""
+        """Return `Autoscaler` info."""
         return {'autoscaler': w.autoscaler.info()}
 
 

--- a/celery/worker/autoscale.py
+++ b/celery/worker/autoscale.py
@@ -57,6 +57,10 @@ class WorkerComponent(bootsteps.StartStopStep):
             w.autoscaler.keepalive, w.autoscaler.maybe_scale,
         )
 
+    def info(self, w):
+        """Returns `Autoscaler` info"""
+        return {'autoscaler': w.autoscaler.info()}
+    
 
 class Autoscaler(bgThread):
     """Background thread to autoscale pool workers."""

--- a/t/unit/worker/test_autoscale.py
+++ b/t/unit/worker/test_autoscale.py
@@ -59,6 +59,18 @@ class test_WorkerComponent:
         w.register_with_event_loop(parent, Mock(name='loop'))
         assert parent.consumer.on_task_message
 
+    def test_info_without_event_loop(self):
+        parent = Mock(name='parent')
+        parent.autoscale = True
+        parent.max_concurrency = '10'
+        parent.min_concurrency = '2'
+        parent.use_eventloop = False
+        w = autoscale.WorkerComponent(parent)
+        w.create(parent)
+        info = w.info(parent)
+        assert 'autoscaler' in info
+        assert parent.autoscaler_cls().info.called
+
 
 class test_Autoscaler:
 


### PR DESCRIPTION
The `autoscaler` boot step class is missing an `info` method to return mix and max settings.
An info method is added returning `worker.autoscaler.info()` data.
Fixes issue raised by #4893 