### PR TITLE
Added compatibility with python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
 os:
     - linux
 stages:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,9 @@ environment:
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
 
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "64"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"

--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -17,6 +17,11 @@ from celery.utils.collections import lpmerge
 from celery.utils.functional import maybe_evaluate, mlazy
 from celery.utils.imports import symbol_by_name
 
+try:
+    Pattern = re._pattern_type
+except AttributeError:
+    Pattern = re.Pattern
+
 __all__ = ('MapRoute', 'Router', 'prepare')
 
 
@@ -33,7 +38,7 @@ class MapRoute(object):
         self.map = {}
         self.patterns = OrderedDict()
         for k, v in map:
-            if isinstance(k, re._pattern_type):
+            if isinstance(k, Pattern):
                 self.patterns[k] = v
             elif '*' in k:
                 self.patterns[re.compile(glob_to_re(k))] = v

--- a/t/unit/app/test_routes.py
+++ b/t/unit/app/test_routes.py
@@ -78,12 +78,17 @@ class test_MapRoute(RouteCase):
         assert route('celery.awesome') is None
 
     def test_route_for_task__glob(self):
+        from re import compile
+
         route = routes.MapRoute([
             ('proj.tasks.*', 'routeA'),
             ('demoapp.tasks.bar.*', {'exchange': 'routeB'}),
+            (compile(r'(video|image)\.tasks\..*'), {'queue': 'media'}),
         ])
         assert route('proj.tasks.foo') == {'queue': 'routeA'}
         assert route('demoapp.tasks.bar.moo') == {'exchange': 'routeB'}
+        assert route('video.tasks.foo') == {'queue': 'media'}
+        assert route('image.tasks.foo') == {'queue': 'media'}
         assert route('demoapp.foo.bar.moo') is None
 
     def test_expand_route_not_found(self):


### PR DESCRIPTION
In Python 3.7 removed re._pattern_type, see python/cpython#1646. Now in 3.7 need using re.Pattern instead it.