### PR TITLE
Fix error when timelimit header contains a None value

### DIFF
--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -116,8 +116,9 @@ class Request(object):
         self.parent_id = headers.get('parent_id')
         if 'shadow' in headers:
             self.name = headers['shadow'] or self.name
-        if 'timelimit' in headers:
-            self.time_limits = headers['timelimit']
+        timelimit = headers.get('timelimit', None)
+        if timelimit:
+            self.time_limits = timelimit
         self.argsrepr = headers.get('argsrepr', '')
         self.kwargsrepr = headers.get('kwargsrepr', '')
         self.on_ack = on_ack

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -1008,6 +1008,30 @@ class test_create_request_class(RequestCase):
         weakref_ref.assert_called_with(self.pool.apply_async())
         assert job._apply_result is weakref_ref()
 
+    def test_execute_using_pool_with_none_timelimit_header(self):
+        from celery.app.trace import trace_task_ret as trace
+        weakref_ref = Mock(name='weakref.ref')
+        job = self.zRequest(id=uuid(),
+                            revoked_tasks=set(),
+                            ref=weakref_ref,
+                            headers={'timelimit': None})
+        job.execute_using_pool(self.pool)
+        self.pool.apply_async.assert_called_with(
+            trace,
+            args=(job.type, job.id, job.request_dict, job.body,
+                  job.content_type, job.content_encoding),
+            accept_callback=job.on_accepted,
+            timeout_callback=job.on_timeout,
+            callback=job.on_success,
+            error_callback=job.on_failure,
+            soft_timeout=self.task.soft_time_limit,
+            timeout=self.task.time_limit,
+            correlation_id=job.id,
+        )
+        assert job._apply_result
+        weakref_ref.assert_called_with(self.pool.apply_async())
+        assert job._apply_result is weakref_ref()
+
     def test_execute_using_pool__defaults_of_hybrid_to_proto2(self):
         weakref_ref = Mock(name='weakref.ref')
         headers = strategy.hybrid_to_proto2('', {'id': uuid(),


### PR DESCRIPTION
Somewhere in our codebase we are passing the following headers:

```python
headers = {
  # ...
  'timelimit': None
  # ...
}
```
The `celery.worker.Request` class does not expect such a construct.
I fixed this by sanitizing the input inside the Request's class constructor.

Fixes #4906 #4907.