### PR TITLE
Increased test coverage for celery.worker.Request

### DIFF
--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -197,7 +197,11 @@ class test_trace_task(RequestCase):
 
 class test_Request(RequestCase):
 
-    def get_request(self, sig, Request=Request, exclude_headers=None, **kwargs):
+    def get_request(self,
+                    sig,
+                    Request=Request,
+                    exclude_headers=None,
+                    **kwargs):
         msg = self.task_message_from_sig(self.app, sig)
         headers = None
         if exclude_headers:
@@ -221,8 +225,9 @@ class test_Request(RequestCase):
             self.add.s(2, 2).set(shadow='fooxyz')).name == 'fooxyz'
 
     def test_no_shadow_header(self):
-        assert self.get_request(self.add.s(2, 2),
-                                exclude_headers=['shadow']).name == 't.unit.worker.test_request.add'
+        request = self.get_request(self.add.s(2, 2),
+                                   exclude_headers=['shadow'])
+        assert request.name == 't.unit.worker.test_request.add'
 
     def test_invalid_eta_raises_InvalidTaskError(self):
         with pytest.raises(InvalidTaskError):

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -197,21 +197,32 @@ class test_trace_task(RequestCase):
 
 class test_Request(RequestCase):
 
-    def get_request(self, sig, Request=Request, **kwargs):
+    def get_request(self, sig, Request=Request, exclude_headers=None, **kwargs):
+        msg = self.task_message_from_sig(self.app, sig)
+        headers = None
+        if exclude_headers:
+            headers = msg.headers
+            for header in exclude_headers:
+                headers.pop(header)
         return Request(
-            self.task_message_from_sig(self.app, sig),
+            msg,
             on_ack=Mock(name='on_ack'),
             on_reject=Mock(name='on_reject'),
             eventer=Mock(name='eventer'),
             app=self.app,
             connection_errors=(socket.error,),
             task=sig.type,
+            headers=headers,
             **kwargs
         )
 
     def test_shadow(self):
         assert self.get_request(
             self.add.s(2, 2).set(shadow='fooxyz')).name == 'fooxyz'
+
+    def test_no_shadow_header(self):
+        assert self.get_request(self.add.s(2, 2),
+                                exclude_headers=['shadow']).name == 't.unit.worker.test_request.add'
 
     def test_invalid_eta_raises_InvalidTaskError(self):
         with pytest.raises(InvalidTaskError):


### PR DESCRIPTION
Added a test that verifies that even when the shadow header is missing, the task name remains the same.
This increases our branch coverage by one.