### PR TITLE
Change backend _ensure_not_eager error to warning

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 import time
+import warnings
 from collections import namedtuple
 from datetime import timedelta
 from functools import partial
@@ -351,8 +352,10 @@ class Backend(object):
 
     def _ensure_not_eager(self):
         if self.app.conf.task_always_eager:
-            raise RuntimeError(
-                "Cannot retrieve result with task_always_eager enabled")
+            warnings.warn(
+                "Shouldn't retrieve result with task_always_eager enabled.",
+                RuntimeWarning
+            )
 
     def get_task_meta(self, task_id, cache=True):
         self._ensure_not_eager()


### PR DESCRIPTION
## Description

As a starter, this is the same pull request as PR #4239. However, that PR has failing tests and hasn't been touched for over a year.

As described over there, `_ensure_not_eager` has been introduced due to issue #2275. I'm currently upgrading my projects from v3 to v4 and can't run some tests anymore. I do know that running celery in eager mode in tests is discouraged, but sometimes you have to rush stuff and using eager settings in tests is a quick workaround. Especially if you only care about running the code in the tasks and you're not interested in the result.

This PR changes the error to a warning, so users of the library will be warned if they try to get the result of tasks that are run with eager mode, instead of not being able to use it at all.