### PR TITLE
Update `CELERY_TASK_TRACK_STARTED` setting in the docs

### DIFF
--- a/docs/history/whatsnew-4.0.rst
+++ b/docs/history/whatsnew-4.0.rst
@@ -472,7 +472,7 @@ a few special ones:
 ``CELERY_TASK_SERIALIZER``             :setting:`task_serializer`
 ``CELERYD_TASK_SOFT_TIME_LIMIT``       :setting:`task_soft_time_limit`
 ``CELERYD_TASK_TIME_LIMIT``            :setting:`task_time_limit`
-``CELERY_TRACK_STARTED``               :setting:`task_track_started`
+``CELERY_TASK_TRACK_STARTED``          :setting:`task_track_started`
 ``CELERY_DISABLE_RATE_LIMITS``         :setting:`worker_disable_rate_limits`
 ``CELERY_ENABLE_REMOTE_CONTROL``       :setting:`worker_enable_remote_control`
 ``CELERYD_SEND_EVENTS``                :setting:`worker_send_task_events`

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -136,7 +136,7 @@ have been moved into a new  ``task_`` prefix.
 ``CELERY_TASK_SERIALIZER``             :setting:`task_serializer`
 ``CELERYD_TASK_SOFT_TIME_LIMIT``       :setting:`task_soft_time_limit`
 ``CELERYD_TASK_TIME_LIMIT``            :setting:`task_time_limit`
-``CELERY_TRACK_STARTED``               :setting:`task_track_started`
+``CELERY_TASK_TRACK_STARTED``          :setting:`task_track_started`
 ``CELERYD_AGENT``                      :setting:`worker_agent`
 ``CELERYD_AUTOSCALER``                 :setting:`worker_autoscaler`
 ``CELERYD_CONCURRENCY``                :setting:`worker_concurrency`


### PR DESCRIPTION
## Description

This PR updates the docs to correctly reflect the change in Django setting from `CELERY_TRACK_STARTED`, which no longer works, to `CELERY_TASK_TRACK_STARTED`.
