### PR TITLE
Changed wording in docs for Task.retry() to mention the fact that it requeues

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -592,7 +592,7 @@ class Task(object):
 
     def retry(self, args=None, kwargs=None, exc=None, throw=True,
               eta=None, countdown=None, max_retries=None, **options):
-        """Retry the task.
+        """Requeue the task.
 
         Example:
             >>> from imaginary_twitter_lib import Twitter


### PR DESCRIPTION
I found it hard to find this information on the documentation and it was confirmed to me by users of the freenode IRC channel. I thought it might be helpful to change the wording slightly.