### PR TITLE
Update dynamodb._get_or_create_table

### DIFF
--- a/celery/backends/dynamodb.py
+++ b/celery/backends/dynamodb.py
@@ -199,11 +199,11 @@ class DynamoDBBackend(KeyValueStoreBackend):
             error_code = e.response['Error'].get('Code', 'Unknown')
 
             # If table exists, do not fail, just return the description.
-            if error_code == 'ResourceInUseException':
+            try:
                 return self._client.describe_table(
                     TableName=self.table_name
                 )
-            else:
+            except:
                 raise e
 
     def _wait_for_table_status(self, expected='ACTIVE'):


### PR DESCRIPTION
Attempt to get the existing table, regardless of the experienced error.

For example (my example) a client might not have access to create the table.
This is missed when only catching ResourceInUseException (assumes that we have permission to create the table)