### PR TITLE
Fix service stop

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -284,7 +284,8 @@ restart_workers () {
 
 
 kill_workers() {
-    _chuid kill $DAEMON_OPTS $CELERYD_NODES --pidfile="$CELERYD_PID_FILE"
+    _chuid kill $CELERYD_NODES $DAEMON_OPTS         \
+                   --pidfile="$CELERYD_PID_FILE"
 }
 
 

--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -284,8 +284,7 @@ restart_workers () {
 
 
 kill_workers() {
-    _chuid kill $CELERYD_NODES $DAEMON_OPTS         \
-                   --pidfile="$CELERYD_PID_FILE"
+    _chuid kill $CELERYD_NODES $DAEMON_OPTS --pidfile="$CELERYD_PID_FILE"
 }
 
 

--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -284,7 +284,7 @@ restart_workers () {
 
 
 kill_workers() {
-    _chuid kill $CELERYD_NODES --pidfile="$CELERYD_PID_FILE"
+    _chuid kill $DAEMON_OPTS $CELERYD_NODES --pidfile="$CELERYD_PID_FILE"
 }
 
 


### PR DESCRIPTION
The kill_workers function in this template init file was missing the $DAEMON_OPTS parameters. In my case this contained the work-dir option required to find the PID file.