### PR TITLE
Fix docs about early ack and prefetch multiplier of 1

### DIFF
--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -170,7 +170,7 @@ When using the default of early acknowledgment, having a prefetch multiplier set
 of *one*, means the worker will reserve at most one extra task for every
 worker process: or in other words, if the worker is started with
 :option:`-c 10 <celery worker -c>`, the worker may reserve at most 20
-tasks (10 unacknowledged tasks executing, and 10 unacknowledged reserved
+tasks (10 acknowledged tasks executing, and 10 unacknowledged reserved
 tasks) at any time.
 
 Often users ask if disabling "prefetching of tasks" is possible, but what


### PR DESCRIPTION
With early ack and prefetch multiplier of *one*, the executing tasks **are** acknowledged. That's why the worker will "reserve" twice the number of worker processes of tasks.

Or I'm just confused and am missing something?