### PR TITLE
Travis CI and Tox: Upgrade from Python 3.6 --> 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,8 @@ matrix:
   - python: '3.7'
     dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=pypy-unit PYPY_VERSION="pypy2.7-6.0.0"
-  - python: '3.7'
-    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-    env: TOXENV=pypy-integration-rabbitmq PYPY_VERSION="pypy2.7-6.0.0"
+  - python: '3.6'
+     env: TOXENV=pypy-integration-rabbitmq PYPY_VERSION="pypy2.7-6.0.0"
   - python: '3.7'
     dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=pypy-integration-redis PYPY_VERSION="pypy2.7-6.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ language: python
 sudo: required
 dist: trusty
 cache: pip
-python:
-  - '2.7'
-  - '3.4'
-  - '3.5'
-  - '3.6'
 os:
     - linux
 stages:
@@ -22,33 +17,50 @@ env:
   - MATRIX_TOXENV=integration-dynamodb
 matrix:
   include:
+  - python: '2.7'
+  - python: '3.4'
+  - python: '3.5'
   - python: '3.6'
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=pypy-unit PYPY_VERSION="pypy2.7-6.0.0"
-  - python: '3.6'
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=pypy-integration-rabbitmq PYPY_VERSION="pypy2.7-6.0.0"
-  - python: '3.6'
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=pypy-integration-redis PYPY_VERSION="pypy2.7-6.0.0"
-  - python: '3.6'
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=pypy-integration-dynamodb PYPY_VERSION="pypy2.7-6.0.0"
-  - python: '3.6'
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=flake8
     stage: lint
-  - python: '3.6'
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=flakeplus
     stage: lint
-  - python: '3.6'
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=apicheck
     stage: lint
-  - python: '3.6'
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=configcheck
     stage: lint
-  - python: '3.6'
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=bandit
     stage: lint
-  - python: '3.6'
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=pydocstyle
     stage: lint
-  - python: '3.6'
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=isort-check
     stage: lint
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,7 @@ matrix:
     dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=pydocstyle
     stage: lint
-  - python: '3.7'
-    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+  - python: '3.6'
     env: TOXENV=isort-check
     stage: lint
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ matrix:
   - python: '3.4'
   - python: '3.5'
   - python: '3.6'
-  - python: '3.7'
-    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+  #- python: '3.7'
+  #  dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
   - python: '3.7'
     dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=pypy-unit PYPY_VERSION="pypy2.7-6.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,10 @@ matrix:
     dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=flakeplus
     stage: lint
-  - python: '3.7'
-    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+  - python: '3.6'
     env: TOXENV=apicheck
     stage: lint
-  - python: '3.7'
-    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+  - python: '3.6'
     env: TOXENV=configcheck
     stage: lint
   - python: '3.7'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,10 +20,6 @@ environment:
       PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python37"
-      PYTHON_VERSION: "3.7.x"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
@@ -31,11 +27,6 @@ environment:
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "64"
-      WINDOWS_SDK_VERSION: "v7.1"
-
-    - PYTHON: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,10 @@ environment:
       PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "32"
 
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "32"
+
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
@@ -27,6 +31,11 @@ environment:
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+      WINDOWS_SDK_VERSION: "v7.1"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,7 @@ deps=
     -r{toxinidir}/requirements/default.txt
     -r{toxinidir}/requirements/test.txt
 
-    2.7: -r{toxinidir}/requirements/test-ci-default.txt
-    3.4,3.5,3.6,3.7: -r{toxinidir}/requirements/test-ci-default.txt
-    pypy: -r{toxinidir}/requirements/test-ci-base.txt
+    2.7,pypy,3.4,3.5,3.6,3.7: -r{toxinidir}/requirements/test-ci-default.txt
 
     integration: -r{toxinidir}/requirements/test-integration.txt
 
@@ -26,7 +24,7 @@ deps=
     flake8,flakeplus,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt
     isort-check: -r{toxinidir}/requirements/test-ci-default.txt
     isort-check: isort>=4.3.4
-    isort-check: Sphinx==1.6.5
+    isort-check: Sphinx>=1.7.6
     bandit: bandit
 sitepackages = False
 recreate = False
@@ -50,15 +48,9 @@ setenv =
 PASSENV =
     TRAVIS
 basepython =
-    2.7: python2.7
-    3.4: python3.4
-    3.5: python3.5
-    3.6: python3.6
-    3.7: python3.7
     pypy: pypy
-    apicheck,configcheck,isort-check: python3.6
-    flake8,linkcheck,pydocstyle,bandit: python3.7
-    flakeplus: python2.7
+    apicheck,configcheck: python3.6
+    flake8,flakeplusisort-check,linkcheck,pydocstyle,bandit: python3.7
 usedevelop = True
 
 [testenv:apicheck]

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,8 @@ basepython =
     3.6: python3.6
     3.7: python3.7
     pypy: pypy
-    flake8,apicheck,linkcheck,configcheck,pydocstyle,isort-check,bandit: python3.7
+    isort-check: python3.6
+    flake8,apicheck,linkcheck,configcheck,pydocstyle,bandit: python3.7
     flakeplus: python2.7
 usedevelop = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -56,8 +56,8 @@ basepython =
     3.6: python3.6
     3.7: python3.7
     pypy: pypy
-    isort-check: python3.6
-    flake8,apicheck,linkcheck,configcheck,pydocstyle,bandit: python3.7
+    apicheck,configcheck,isort-check: python3.6
+    flake8,linkcheck,pydocstyle,bandit: python3.7
     flakeplus: python2.7
 usedevelop = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {2.7,pypy,3.4,3.5,3.6}-unit
-    {2.7,pypy,3.4,3.5,3.6}-integration-{rabbitmq,redis,dynamodb}
+    {2.7,pypy,3.4,3.5,3.6,3.7}-unit
+    {2.7,pypy,3.4,3.5,3.6,3.7}-integration-{rabbitmq,redis,dynamodb}
 
     flake8
     flakeplus
@@ -17,7 +17,7 @@ deps=
     -r{toxinidir}/requirements/test.txt
 
     2.7: -r{toxinidir}/requirements/test-ci-default.txt
-    3.4,3.5,3.6: -r{toxinidir}/requirements/test-ci-default.txt
+    3.4,3.5,3.6,3.7: -r{toxinidir}/requirements/test-ci-default.txt
     pypy: -r{toxinidir}/requirements/test-ci-base.txt
 
     integration: -r{toxinidir}/requirements/test-integration.txt
@@ -54,8 +54,9 @@ basepython =
     3.4: python3.4
     3.5: python3.5
     3.6: python3.6
+    3.7: python3.7
     pypy: pypy
-    flake8,apicheck,linkcheck,configcheck,pydocstyle,isort-check,bandit: python3.6
+    flake8,apicheck,linkcheck,configcheck,pydocstyle,isort-check,bandit: python3.7
     flakeplus: python2.7
 usedevelop = True
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Travis CI and Tox: Upgrade from Python 3.6 --> 3.7.  This a different take on #4859

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
