### PR TITLE
Fix a typo in /userguide/optimizing

### DIFF
--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -225,11 +225,11 @@ have a buffer as small as 64KB but on recent Linux versions the buffer
 size is 1MB (can only be changed system wide).
 
 You can disable this prefetching behavior by enabling the
-:option:`-Ofair <celery worker -O>` worker option:
+:option:`-O fair <celery worker -O>` worker option:
 
 .. code-block:: console
 
-    $ celery -A proj worker -l info -Ofair
+    $ celery -A proj worker -l info -O fair
 
 With this option enabled the worker will only write to processes that are
 available for work, disabling the prefetch behavior::


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fix a typo in /userguide/optimizing
(http://docs.celeryproject.org/en/latest/userguide/optimizing.html)

<img width="728" alt="screen shot 2018-08-14 at 1 43 23 pm" src="https://user-images.githubusercontent.com/11539188/44073751-0a51f1d8-9fc8-11e8-9be9-7e36473e35f8.png">
