### PR TITLE
Support chords with CELERY_TASK_ALWAYS_EAGER (fix #4873)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -262,3 +262,4 @@ Chris Mitchell, 2018/02/27
 Josue Balandrano Coronel, 2018/05/24
 Federico Bond, 2018/06/20
 Tom Booth, 2018/07/06
+Axel haustant, 2018/08/14

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1226,8 +1226,9 @@ class chord(Signature):
         tasks = (self.tasks.clone() if isinstance(self.tasks, group)
                  else group(self.tasks, app=app))
         if app.conf.task_always_eager:
-            return self.apply(args, kwargs,
-                              body=body, task_id=task_id, **options)
+            with allow_join_result():
+                return self.apply(args, kwargs,
+                                  body=body, task_id=task_id, **options)
         # chord([A, B, ...], C)
         return self.run(tasks, body, args, task_id=task_id, **options)
 

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from time import sleep
 
-from celery import chain, group, shared_task
+from celery import chain, chord, group, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
 
@@ -40,6 +40,11 @@ def chain_add(x, y):
     (
         add.s(x, x) | add.s(y)
     ).apply_async()
+
+
+@shared_task
+def chord_add(x, y):
+    chord(add.s(x, x), add.s(y)).apply_async()
 
 
 @shared_task

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -367,6 +367,17 @@ class test_chord:
         assert res.get() == [0, 5 + 6 + 7]
 
     @flaky
+    def test_eager_chord_inside_task(self, manager):
+        from .tasks import chord_add
+
+        prev = chord_add.app.conf.task_always_eager
+        chord_add.app.conf.task_always_eager = True
+
+        chord_add.apply_async(args=(4, 8), throw=True).get()
+
+        chord_add.app.conf.task_always_eager = prev
+
+    @flaky
     def test_group_chain(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')


### PR DESCRIPTION
## Description

This pull request ensure chrods can work `CELERY_TASK_ALWAYS_EAGER` and fixes #4873. This is the same fix as #4576 applied to chords.
