### PR TITLE
Deadlock on inqueue close (#4185)

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -737,7 +737,6 @@ class AsynPool(_pool.Pool):
                     fileno_to_inq.pop(fd, None)
                     active_writes.discard(fd)
                     all_inqueues.discard(fd)
-                    hub_remove(fd)
             except KeyError:
                 pass
         self.on_inqueue_close = on_inqueue_close
@@ -1247,7 +1246,7 @@ class AsynPool(_pool.Pool):
             if queue:
                 for sock in (queue._reader, queue._writer):
                     if not sock.closed:
-                    	self.hub_remove(sock)
+                        self.hub_remove(sock)
                         try:
                             sock.close()
                         except (IOError, OSError):

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -741,6 +741,7 @@ class AsynPool(_pool.Pool):
             except KeyError:
                 pass
         self.on_inqueue_close = on_inqueue_close
+        self.hub_remove = hub_remove
 
         def schedule_writes(ready_fds, total_write_count=[0]):
             # Schedule write operation to ready file descriptor.
@@ -1246,6 +1247,7 @@ class AsynPool(_pool.Pool):
             if queue:
                 for sock in (queue._reader, queue._writer):
                     if not sock.closed:
+                    	self.hub_remove(sock)
                         try:
                             sock.close()
                         except (IOError, OSError):


### PR DESCRIPTION
Issue: #4185 

Upon attempting to close a socket, AsynPool only removes the queue writer from the hub, not the reader.  This leads to a deadlock on the file descriptor, and eventually the worker stop accepting new tasks.  I moved the call to hub_remove from on_inqueue_close to destroy_queues, since the latter is called directly after the former and allows removing both fds in a single loop.