### PR TITLE
Added an integration test for #1921

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -608,9 +608,9 @@ class test_chord:
         except NotImplementedError as e:
             raise pytest.skip(e.args[0])
 
-        c1 = chord(group(add.s(1, 2), add.s(3, 4)), add.s(1))
-        c2 = chord(group(add.s(1, 2), add.s(3, 4)), add.s(2))
+        c1 = chord(group(add.s(1, 2), add.s(3, 4)), tsum.s())
+        c2 = chord(group(add.s(1, 2), add.s(3, 4)), tsum.s())
         g = group(c1, c2)
         r = g.delay()
 
-        assert r.get(timeout=TIMEOUT) == [11, 12]
+        assert r.get(timeout=TIMEOUT) == [10, 10]

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -612,6 +612,5 @@ class test_chord:
         c2 = chord(group(add.s(1, 2), add.s(3, 4)), add.s(2))
         g = group(c1, c2)
         g.delay()
-        
+
         assert g.get() == [11, 12]
-         

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -601,3 +601,17 @@ class test_chord:
 
         assert len([cr for cr in chord_results if cr[2] != states.SUCCESS]
                    ) == 1
+
+    def test_parallel_chords(self, manager):
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.args[0])
+
+        c1 = chord(group(add.s(1, 2), add.s(3, 4)), add.s(1))
+        c2 = chord(group(add.s(1, 2), add.s(3, 4)), add.s(2))
+        g = group(c1, c2)
+        g.delay()
+        
+        assert g.get() == [11, 12]
+         

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -611,6 +611,6 @@ class test_chord:
         c1 = chord(group(add.s(1, 2), add.s(3, 4)), add.s(1))
         c2 = chord(group(add.s(1, 2), add.s(3, 4)), add.s(2))
         g = group(c1, c2)
-        g.delay()
+        r = g.delay()
 
-        assert g.get(timeout=TIMEOUT) == [11, 12]
+        assert r.get(timeout=TIMEOUT) == [11, 12]

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -613,4 +613,4 @@ class test_chord:
         g = group(c1, c2)
         g.delay()
 
-        assert g.get() == [11, 12]
+        assert g.get(timeout=TIMEOUT) == [11, 12]


### PR DESCRIPTION
Following #5000, it turns out we need an integration test for #1921 to avoid regressions while fixing #5000.
This PR adds it.