### PR TITLE
Add a concurrency model with ThreadPoolExecutor

### DIFF
--- a/celery/concurrency/__init__.py
+++ b/celery/concurrency/__init__.py
@@ -17,6 +17,13 @@ ALIASES = {
     'processes': 'celery.concurrency.prefork:TaskPool',  # XXX compat alias
 }
 
+try:
+    import concurrent.futures
+except:
+    pass
+else:
+    ALIASES['threads'] = 'celery.concurrency.thread:TaskPool'
+
 
 def get_implementation(cls):
     """Return pool implementation by name."""

--- a/celery/concurrency/thread.py
+++ b/celery/concurrency/thread.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Thread execution pool."""
+
+from concurrent.futures import wait, ThreadPoolExecutor
+from .base import BasePool, apply_target
+
+__all__ = ('TaskPool',)
+
+class ApplyResult(object):
+    def __init__(self, future):
+        self.f = future
+        self.get = self.f.result
+
+    def wait(self, timeout=None):
+        wait([self.f], timeout)
+
+class TaskPool(BasePool):
+    """Thread Task Pool."""
+
+    body_can_be_buffer = True
+    signal_safe = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.executor = ThreadPoolExecutor(max_workers=self.limit)
+
+    def on_stop(self):
+        self.executor.shutdown()
+        super().on_stop()
+
+    def on_apply(self, target, args=None, kwargs=None, callback=None,
+                 accept_callback=None, **_):
+        f = self.executor.submit(apply_target, target, args, kwargs, callback, accept_callback)
+        return ApplyResult(f)
+
+    def _get_info(self):
+        return {
+            'max-concurrency': self.limit,
+            'threads': len(self.executor._threads)
+        }


### PR DESCRIPTION
Hello,

I don't know if it would be useful to someone else, but I needed to implement a concurrency model based on thread (and not processes) in celery because I wanted to pass future objects between tasks and some coroutines and it is not pickable.

Of course it is not scale out and it has limitations (because of the GIL), but it can be useful for people who wants the share memory between tasks and another thread (for example the asyncio event loop) without blocking as the 'solo' concurrency model.

I am open to comment. Maybe this model won't be needed anymore in celery 5 as it could be replaced by an asyncio loop, which is not possible in celery 4. 
And I would be happy to help on a massive asyncio refactoring for Celery 5.

Regards