### PR TITLE
Handle microseconds when scheduling

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -256,7 +256,9 @@ class Scheduler(object):
     def _when(self, entry, next_time_to_run, mktime=time.mktime):
         adjust = self.adjust
 
-        return (mktime(entry.default_now().timetuple()) +
+        as_now = entry.default_now()
+        return (mktime(as_now.timetuple()) +
+                as_now.microsecond/1e6 +
                 (adjust(next_time_to_run) or 0))
 
     def populate_heap(self, event_t=event_t, heapify=heapq.heapify):

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -257,8 +257,9 @@ class Scheduler(object):
         adjust = self.adjust
 
         as_now = entry.default_now()
+                         
         return (mktime(as_now.timetuple()) +
-                as_now.microsecond/1e6 +
+                as_now.microsecond / 1e6 +
                 (adjust(next_time_to_run) or 0))
 
     def populate_heap(self, event_t=event_t, heapify=heapq.heapify):

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -12,6 +12,7 @@ from celery.beat import event_t
 from celery.five import keys, string_t
 from celery.schedules import crontab, schedule
 from celery.utils.objects import Bunch
+import pytz
 
 
 class MockShelve(dict):
@@ -315,6 +316,19 @@ class test_Scheduler:
              for i, j in enumerate(nums)}
         scheduler.update_from_dict(s)
         assert scheduler.tick() == min(nums) - 0.010
+
+    def test_ticks_microseconds(self):
+        scheduler = mScheduler(app=self.app)
+
+        now_ts = 1514797200.2
+        now = datetime.fromtimestamp(now_ts)
+        schedule_half = schedule(timedelta(seconds=0.5), nowfun=lambda: now)
+        scheduler.add(name='half_second_schedule', schedule=schedule_half)
+
+        scheduler.tick()
+        # ensure those 0.2 seconds on now_ts don't get dropped
+        expected_time = now_ts + 0.5 - 0.010
+        assert scheduler._heap[0].time == expected_time
 
     def test_ticks_schedule_change(self):
         # initialise schedule and check heap is not initialized

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -12,7 +12,6 @@ from celery.beat import event_t
 from celery.five import keys, string_t
 from celery.schedules import crontab, schedule
 from celery.utils.objects import Bunch
-import pytz
 
 
 class MockShelve(dict):


### PR DESCRIPTION
## Description

Add microseconds back in when calculating the next due time. `timetuple` drops microseconds.
