### PR TITLE
Update docs to reflect correct 'old' value for 'worker_send_task_events'

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -155,7 +155,7 @@ have been moved into a new  ``task_`` prefix.
 ``CELERYD_PREFETCH_MULTIPLIER``        :setting:`worker_prefetch_multiplier`
 ``CELERYD_REDIRECT_STDOUTS``           :setting:`worker_redirect_stdouts`
 ``CELERYD_REDIRECT_STDOUTS_LEVEL``     :setting:`worker_redirect_stdouts_level`
-``CELERYD_SEND_EVENTS``                :setting:`worker_send_task_events`
+``CELERY_SEND_EVENTS``                 :setting:`worker_send_task_events`
 ``CELERYD_STATE_DB``                   :setting:`worker_state_db`
 ``CELERYD_TASK_LOG_FORMAT``            :setting:`worker_task_log_format`
 ``CELERYD_TIMER``                      :setting:`worker_timer`


### PR DESCRIPTION
## Description

The [Celery 4.2.1 docs](http://docs.celeryproject.org/en/v4.2.1/userguide/configuration.html#new-lowercase-settings) show this:

<img width="708" alt="screen shot 2018-09-05 at 3 33 48 pm" src="https://user-images.githubusercontent.com/178680/45124942-29e96980-b121-11e8-9e5d-ffd62ed210ff.png">

which associates `worker_send_task_events ` with the "old" setting of `CELERYD_SEND_EVENTS` _(note the `D`)_ but if you look at the code for v4.2.1 it looks like it's using `CELERY_SEND_EVENTS` _(no `D`)_:

https://github.com/celery/celery/blob/ced86ea58859e9f704cc781c59ea3e137b199638/celery/app/defaults.py#L298-L300

I _think_ this mismatch was introduced in PR https://github.com/celery/celery/pull/3997 where the code was changed but the docs were not updated.