### PR TITLE
Gracefully handles consumer decode error

### DIFF
--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -16,6 +16,7 @@ from time import sleep
 from billiard.common import restart_state
 from billiard.exceptions import RestartFreqExceeded
 from kombu.asynchronous.semaphore import DummyLock
+from kombu.exceptions import DecodeError
 from kombu.utils.compat import _detect_environment
 from kombu.utils.encoding import bytes_t, safe_repr
 from kombu.utils.limits import TokenBucket
@@ -568,6 +569,8 @@ class Consumer(object):
                     )
                 except InvalidTaskError as exc:
                     return on_invalid_task(payload, message, exc)
+                except DecodeError as exc:
+                    return self.on_decode_error(message, exc)
 
         return on_task_received
 

--- a/t/unit/worker/test_loops.py
+++ b/t/unit/worker/test_loops.py
@@ -6,6 +6,7 @@ import socket
 import pytest
 from case import Mock
 from kombu.asynchronous import ERR, READ, WRITE, Hub
+from kombu.exceptions import DecodeError
 
 from celery.bootsteps import CLOSE, RUN
 from celery.exceptions import (InvalidTaskError, WorkerLostError,
@@ -91,6 +92,10 @@ class X(object):
             name='on_invalid_task',
         )
         _consumer.on_invalid_task = self.on_invalid_task
+        self.on_decode_error = self.obj.on_decode_error = Mock(
+            name='on_decode_error',
+        )
+        _consumer.on_decode_error = self.on_decode_error
         _consumer.strategies = self.obj.strategies
 
     def timeout_then_error(self, mock):
@@ -205,6 +210,12 @@ class test_asynloop:
         exc = strategy.side_effect = InvalidTaskError()
         on_task(msg)
         x.on_invalid_task.assert_called_with(None, msg, exc)
+
+    def test_on_task_DecodeError(self):
+        x, on_task, msg, strategy = self.task_context(self.add.s(2, 2))
+        exc = strategy.side_effect = DecodeError()
+        on_task(msg)
+        x.on_decode_error.assert_called_with(msg, exc)
 
     def test_should_terminate(self):
         x = X(self.app)


### PR DESCRIPTION
## Description

Gracefully handles a decode error on the consumer when deserializing a task using the v2 protocol.

If using the v2 protocol, and the consumer encounters an error when deserializing a message's body here https://github.com/celery/celery/blob/master/celery/worker/strategy.py#L136, kombu raises a DecodeError and the worker terminates.

This code block captures and handles the error (in the same way that DecodeErrors are handled in v1), allowing the worker to continue running if it encounters a message it can't serialize.

As it stands now, if the message is unable to be deserialized and the connection drops, it is actually placed back on the queue, at least in our configuration using RabbitMQ and ACKS_LATE.  This is extremely dangerous since one bad message can effectively take down an entire cluster of workers as they continue to fail to deserialize the message and shut down as RabbitMQ places the poisoned message back on the queue for another worker to retrieve.