### PR TITLE
Make task.acks_on_failure_or_timeout settable via settings

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -222,6 +222,7 @@ NAMESPACES = Namespace(
     task=Namespace(
         __old__=OLD_NS,
         acks_late=Option(False, type='bool'),
+        acks_on_failure_or_timeout=Option(True, type='bool'),
         always_eager=Option(False, type='bool'),
         annotations=Option(type='any'),
         compression=Option(type='string', old={'celery_message_compression'}),

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -257,7 +257,7 @@ class Task(object):
     #:
     #: The application default can be overridden with the
     #: :setting:`task_acks_on_failure_or_timeout` setting.
-    acks_on_failure_or_timeout = True
+    acks_on_failure_or_timeout = None
 
     #: Even if :attr:`acks_late` is enabled, the worker will
     #: acknowledge tasks when the worker process executing them abruptly

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -116,6 +116,7 @@ have been moved into a new  ``task_`` prefix.
 ``CELERY_SECURITY_CERT_STORE``         :setting:`security_cert_store`
 ``CELERY_SECURITY_KEY``                :setting:`security_key`
 ``CELERY_ACKS_LATE``                   :setting:`task_acks_late`
+``CELERY_ACKS_ON_FAILURE_OR_TIMEOUT``  :setting:`task_acks_on_failure_or_timeout`
 ``CELERY_TASK_ALWAYS_EAGER``           :setting:`task_always_eager`
 ``CELERY_TASK_ANNOTATIONS``            :setting:`task_annotations`
 ``CELERY_TASK_COMPRESSION``            :setting:`task_compression`
@@ -490,6 +491,15 @@ has been executed, not *just before* (the default behavior).
     FAQ: :ref:`faq-acks_late-vs-retry`.
 
 .. setting:: task_reject_on_worker_lost
+
+``task_acks_on_failure_or_timeout``
+~~~~~~~~~~~~~~~~~~
+
+Default: Enabled.
+
+Ack on failure or timeout means that the task will be removed from the queue regardless the status,
+once Celery is done with retrying logic. Disabling this makes it possible to use SQS's dead letter queues natively.
+
 
 ``task_reject_on_worker_lost``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description
Turns out that task attributes are not really set from config unless
the attribute is set to `None` beforehand (or not set at all).

https://github.com/celery/celery/blob/a1fb557b6ecc494514e3480518be57b985d0927d/celery/app/task.py#L328-L330.