### PR TITLE
require django 1.11 LTS for celery 4.3

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -30,8 +30,8 @@ def _maybe_close_fd(fh):
 
 
 def _verify_django_version(django):
-    if django.VERSION < (1, 8):
-        raise ImproperlyConfigured('Celery 4.x requires Django 1.8 or later.')
+    if django.VERSION < (1, 11):
+        raise ImproperlyConfigured('Celery 4.x requires Django 1.11 or later.')
 
 
 def fixup(app, env='DJANGO_SETTINGS_MODULE'):

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -68,7 +68,7 @@ class test_DjangoFixup(FixupCase):
                 Fixup.assert_not_called()
             with mock.module_exists('django'):
                 import django
-                django.VERSION = (1, 10, 1)
+                django.VERSION = (1, 11, 1)
                 fixup(self.app)
                 Fixup.assert_called()
 


### PR DESCRIPTION
update minimal django version to django 1.11 for celery 4.3