### PR TITLE
Update documentation links to munin plugins

### DIFF
--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -476,12 +476,12 @@ maintaining a Celery cluster.
 * ``celery_tasks``: Monitors the number of times each task type has
   been executed (requires `celerymon`).
 
-    http://exchange.munin-monitoring.org/plugins/celery_tasks-2/details
+    https://github.com/munin-monitoring/contrib/blob/master/plugins/celery/celery_tasks
 
-* ``celery_task_states``: Monitors the number of tasks in each state
+* ``celery_tasks_states``: Monitors the number of tasks in each state
   (requires `celerymon`).
 
-    http://exchange.munin-monitoring.org/plugins/celery_tasks/details
+    https://github.com/munin-monitoring/contrib/blob/master/plugins/celery/celery_tasks_states
 
 .. _monitoring-events:
 


### PR DESCRIPTION
The munin exchange was moved to a github repository some time ago.
