### PR TITLE
Retry if the heartbeat connection dies

### DIFF
--- a/celery/worker/heartbeat.py
+++ b/celery/worker/heartbeat.py
@@ -46,6 +46,7 @@ class Heart(object):
                                  active=len(active_requests),
                                  processed=all_total_count[0],
                                  loadavg=load_average(),
+                                 retry=True,
                                  **SOFTWARE_INFO)
 
     def start(self):


### PR DESCRIPTION
Otherwise it will keep trying to write to the broken connection and
memory will leak because the event dispatcher will keep appending
the message to _outbound_buffer in EventDispatcher._publish.

```python
    def _publish(self, event, producer, routing_key, retry=False,
                 retry_policy=None, utcoffset=utcoffset):
        exchange = self.exchange
        try:
            producer.publish(
                event,
                routing_key=routing_key,
                exchange=exchange.name,
                retry=retry,
                retry_policy=retry_policy,
                declare=[exchange],
                serializer=self.serializer,
                headers=self.headers,
                delivery_mode=self.delivery_mode,
            )
        except Exception as exc:  # pylint: disable=broad-except
            if not self.buffer_while_offline:
                raise
            self._outbound_buffer.append((event, routing_key, exc))
```

What happens in #5047 is that after the AMQ connection dies, the try-except in the above code will first catch a ConnectionResetError and after that BrokenPipeError's. `buffer_while_offline` is False, so it will just keep appending to the buffer. Raising the exception doesn't help because it just gets reported and ignored further on. Inside `producer.publish` if `retry` is True, it'll check if the connection is still ok and if not re-open it. That's what this patch does.

If needed I can try to add unit tests. Tests seem broken in general in master at the moment, so that would require some further digging.