### PR TITLE
Fix a deprecation warning about logger.warn()

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -263,3 +263,4 @@ Josue Balandrano Coronel, 2018/05/24
 Federico Bond, 2018/06/20
 Tom Booth, 2018/07/06
 Axel haustant, 2018/08/14
+Bruno Alla, 2018/09/27

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -90,7 +90,7 @@ class ResultConsumer(BaseResultConsumer):
             if self._pubsub is not None:
                 self._pubsub.close()
         except KeyError as e:
-            logger.warn(text_t(e))
+            logger.warning(text_t(e))
         super(ResultConsumer, self).on_after_fork()
 
     def _maybe_cancel_ready_task(self, meta):
@@ -238,10 +238,10 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             if ssl_cert_reqs == 'CERT_REQUIRED':
                 connparams['ssl_cert_reqs'] = CERT_REQUIRED
             elif ssl_cert_reqs == 'CERT_OPTIONAL':
-                logger.warn(W_REDIS_SSL_CERT_OPTIONAL)
+                logger.warning(W_REDIS_SSL_CERT_OPTIONAL)
                 connparams['ssl_cert_reqs'] = CERT_OPTIONAL
             elif ssl_cert_reqs == 'CERT_NONE':
-                logger.warn(W_REDIS_SSL_CERT_NONE)
+                logger.warning(W_REDIS_SSL_CERT_NONE)
                 connparams['ssl_cert_reqs'] = CERT_NONE
             else:
                 raise ValueError(E_REDIS_SSL_CERT_REQS_MISSING)


### PR DESCRIPTION
## Description

This fixes a deprecation warning from the standard library's logging module:

> The 'warn' method is deprecated, use 'warning' instead



This appeared in on of my project. However, we were not using it anywhere, so I grepped my site-packages and found a couple of usages in Celery.

I don't think there is any issues open for that, I couldn't find any.