### PR TITLE
Fix migrate task to work with both v1 and v2 of the message protocol

### DIFF
--- a/celery/contrib/migrate.py
+++ b/celery/contrib/migrate.py
@@ -380,7 +380,7 @@ def move_by_idmap(map, **kwargs):
         ...   queues=['hipri'])
     """
     def task_id_in_map(body, message):
-        return map.get(body['id'])
+        return map.get(message.properties['correlation_id'])
 
     # adding the limit means that we don't have to consume any more
     # when we've found everything.

--- a/t/unit/contrib/test_migrate.py
+++ b/t/unit/contrib/test_migrate.py
@@ -35,7 +35,9 @@ def Message(body, exchange='exchange', routing_key='rkey',
             },
             'content_type': content_type,
             'content_encoding': content_encoding,
-            'properties': {}
+            'properties': {'correlation_id': isinstance(body, dict) \
+                and body['id'] or None
+            }
         },
     )
 
@@ -222,7 +224,8 @@ def test_move_by_idmap():
         move_by_idmap({'123f': Queue('foo')})
         move.assert_called()
         cb = move.call_args[0][0]
-        assert cb({'id': '123f'}, Mock())
+        body = {'id': '123f'}
+        assert cb(body, Message(body))
 
 
 def test_move_task_by_id():
@@ -230,7 +233,8 @@ def test_move_task_by_id():
         move_task_by_id('123f', Queue('foo'))
         move.assert_called()
         cb = move.call_args[0][0]
-        assert cb({'id': '123f'}, Mock()) == Queue('foo')
+        body = {'id': '123f'}
+        assert cb(body, Message(body)) == Queue('foo')
 
 
 class test_migrate_task:

--- a/t/unit/contrib/test_migrate.py
+++ b/t/unit/contrib/test_migrate.py
@@ -35,7 +35,8 @@ def Message(body, exchange='exchange', routing_key='rkey',
             },
             'content_type': content_type,
             'content_encoding': content_encoding,
-            'properties': {'correlation_id': isinstance(body, dict) \
+            'properties': {
+                'correlation_id': isinstance(body, dict)
                 and body['id'] or None
             }
         },


### PR DESCRIPTION
`contrib.migrate` is only compatible with version 1 of the message protocol (see http://docs.celeryproject.org/en/latest/internals/protocol.html). The only issue is that task id has been removed from body in v2, but luckily the task id is present in both v1 and v2 in the message object under a different name - correlation_id. This PR fetches task id from the message object.

