### PR TITLE
Allow _start_worker_thread to be reused by other applications.

### DIFF
--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -100,7 +100,6 @@ def _start_worker_thread(app,
         celery.worker.Worker: worker instance.
     """
     setup_app_for_worker(app, loglevel, logfile)
-    assert 'celery.ping' in app.tasks
     # Make sure we can connect to the broker
     with app.connection(hostname=os.environ.get('TEST_BROKER')) as conn:
         conn.default_channel.queue_declare


### PR DESCRIPTION
`_start_worker_thread` is used by Celery in its own tests, but it's useful in other applications as well. This PR removes an assertion that only holds in Celery's tests.