### PR TITLE
cythonized functions support (#4342)

### DIFF
--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -262,9 +262,10 @@ def head_from_fun(fun, bound=False, debug=False):
     # as just calling a function.
     is_function = inspect.isfunction(fun)
     is_callable = hasattr(fun, '__call__')
+    is_cython = fun.__class__.__name__ == 'cython_function_or_method'
     is_method = inspect.ismethod(fun)
 
-    if not is_function and is_callable and not is_method:
+    if not is_function and is_callable and not is_method and not is_cython:
         name, fun = fun.__class__.__name__, fun.__call__
     else:
         name = fun.__name__


### PR DESCRIPTION
* __call__ should not be extraceted from cythonized functions

Cythonized functions have `__module__` attribute. So, we need to exclude them from replacing with `__call__`. Without this exclusion we get `AttributeError: 'method-wrapper' object has no attribute '__module__'` exception.