### PR TITLE
Fixes issue #5118

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -658,9 +658,9 @@ class BaseKeyValueStoreBackend(Backend):
                       traceback=None, request=None, **kwargs):
 
         if state in self.READY_STATES:
-            date_done = datetime.datetime.utcnow()
+            date_done = datetime.datetime.utcnow().isoformat()
         else:
-            date_done = None
+            date_done = ''
 
         meta = {
             'status': state,

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -660,7 +660,7 @@ class BaseKeyValueStoreBackend(Backend):
         if state in self.READY_STATES:
             date_done = datetime.datetime.utcnow().isoformat()
         else:
-            date_done = ''
+            date_done = None
 
         meta = {
             'status': state,

--- a/celery/result.py
+++ b/celery/result.py
@@ -18,6 +18,7 @@ from .five import (items, monotonic, python_2_unicode_compatible, range,
                    string_t)
 from .utils import deprecated
 from .utils.graph import DependencyGraph, GraphFormatter
+from .utils.iso8601 import parse_iso8601
 
 try:
     import tblib
@@ -498,7 +499,10 @@ class AsyncResult(ResultBase):
 
     @property
     def date_done(self):
-        return self._get_task_meta().get('date_done')
+        date_str = self._get_task_meta().get('date_done')
+        if date_str:
+            return parse_iso8601(date_str)
+        return date_str
 
     @property
     def retries(self):

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -417,6 +417,8 @@ class test_AsyncResult:
         assert x.date_done is not None
         assert x.task_id == "1"
         assert x.state == "SUCCESS"
+        result = self.app.AsyncResult(self.task4['id'])
+        assert result.date_done is None
 
 
 class test_ResultSet:


### PR DESCRIPTION
`date_done` object in metadata is not serializable #5118 . Introduced in #4490.
Fixed by saving iso string when creating metadata dict for `date_done` and parsing it celery utils module when returning the value as attribute.