### PR TITLE
Fix filename in contributing documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -549,7 +549,7 @@ you can do so like this:
 
 .. code-block:: console
 
-    $ py.test t/unit/worker/test_worker_job.py
+    $ py.test t/unit/worker/test_worker.py
 
 .. _contributing-pull-requests:
 


### PR DESCRIPTION
test filename of the example doesn't exist