### PR TITLE
Fix test by using utcfromtimestamp instead of fromtimestamp

### DIFF
--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -322,7 +322,7 @@ class test_Scheduler:
         scheduler = mScheduler(app=self.app)
 
         now_ts = 1514797200.2
-        now = datetime.fromtimestamp(now_ts)
+        now = datetime.utcfromtimestamp(now_ts)
         schedule_half = schedule(timedelta(seconds=0.5), nowfun=lambda: now)
         scheduler.add(name='half_second_schedule', schedule=schedule_half)
 


### PR DESCRIPTION
This test previously used `fromtimestamp` which uses the local platform's timezone if not specified. Causes the test to fail if not in UTC timezone. `utcfromtimestamp` is also used in other tests.
