### PR TITLE
Fixes travis Python 2.7 build

### DIFF
--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -93,10 +93,11 @@ class test_LoaderBase:
         def trigger_exception(**kwargs):
             raise ImportError('Dummy ImportError')
         from celery.signals import import_modules
-        import_modules.connect(trigger_exception)
+        x = import_modules.connect(trigger_exception)
         self.app.conf.imports = ('os', 'sys')
         with pytest.raises(ImportError):
             self.loader.import_default_modules()
+        import_modules.disconnect(x)
 
     def test_import_from_cwd_custom_imp(self):
         imp = Mock(name='imp')


### PR DESCRIPTION
…to produce exceptions in other tests for pytest in python versions 2.7

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This pull request will fix Python 2.7 tests that are failing on master.


NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
