### PR TITLE
Documentation - add example systemd celerybeat.service file

### DIFF
--- a/docs/userguide/daemonizing.rst
+++ b/docs/userguide/daemonizing.rst
@@ -450,6 +450,37 @@ This is an example configuration for a Python project:
     CELERYD_LOG_FILE="/var/log/celery/%n%I.log"
     CELERYD_LOG_LEVEL="INFO"
 
+    # you may wish to add these options for Celery Beat
+    CELERYBEAT_PID_FILE="/var/run/celery/beat.pid"
+    CELERYBEAT_LOG_FILE="/var/log/celery/beat.log"
+
+Service file: celerybeat.service
+----------------------------------------------------------------------
+
+This is an example systemd file for Celery Beat:
+
+:file:`/etc/systemd/system/celerybeat.service`:
+
+.. code-block:: bash
+
+  [Unit]
+  Description=Celery Beat Service
+  After=network.target
+
+  [Service]
+  Type=simple
+  User=celery
+  Group=celery
+  EnvironmentFile=/etc/conf.d/celery
+  WorkingDirectory=/opt/celery
+  ExecStart=/bin/sh -c '${CELERY_BIN} beat  \
+    -A ${CELERY_APP} --pidfile=${CELERYBEAT_PID_FILE} \
+    --logfile=${CELERYBEAT_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL}'
+
+  [Install]
+  WantedBy=multi-user.target
+
+
 Running the worker with superuser privileges (root)
 ======================================================================
 

--- a/extra/systemd/celery.conf
+++ b/extra/systemd/celery.conf
@@ -8,3 +8,9 @@ CELERY_BIN="/usr/bin/celery"
 CELERYD_PID_FILE="/var/run/celery/%n.pid"
 CELERYD_LOG_FILE="/var/log/celery/%n%I.log"
 CELERYD_LOG_LEVEL="INFO"
+
+# The below lines should be uncommented if using the celerybeat.service example 
+# unit file, but are unnecessary otherwise
+
+# CELERYBEAT_PID_FILE="/var/run/celery/beat.pid"
+# CELERYBEAT_LOG_FILE="/var/log/celery/beat.log"

--- a/extra/systemd/celerybeat.service
+++ b/extra/systemd/celerybeat.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Celery Beat Service
+After=network.target
+
+[Service]
+Type=simple
+User=celery
+Group=celery
+EnvironmentFile=-/etc/conf.d/celery
+WorkingDirectory=/opt/celery
+ExecStart=/bin/sh -c '${CELERY_BIN} beat  \
+    -A ${CELERY_APP} --pidfile=${CELERYBEAT_PID_FILE} \
+    --logfile=${CELERYBEAT_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL}'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This commit adds an example systemd celerybeat.service file, and also adds a couple of celerybeat-specific vars to the example EnvironmentFile (Fixes #4304)

Despite the contributing guide specifying there should be no warnings when building docs, I saw several when building with my change, but none are related to this change.

## Scope

There's a deficiency in the documentation for Daemonization - the Periodic Tasks page suggests you can learn more about daemonizing celery beat there, but systemd users find nothing to help them, as noted in #4304. This is just to help folks daemonize celery beat under systemd, and avoid people using things like StackOverflow answers suggesting to start workers with --beat or other settings not recommended for production.