### PR TITLE
Fix Sphinx support for shared_task decorated functions

### DIFF
--- a/celery/contrib/sphinx.py
+++ b/celery/contrib/sphinx.py
@@ -35,7 +35,7 @@ from sphinx.domains.python import PyModulelevel
 from sphinx.ext.autodoc import FunctionDocumenter
 
 from celery.app.task import BaseTask
-from celery.local import PromiseProxy
+from celery.local import Proxy
 
 try:  # pragma: no cover
     from inspect import formatargspec, getfullargspec
@@ -72,8 +72,7 @@ class TaskDocumenter(FunctionDocumenter):
         # given by *self.modname*. But since functions decorated with the @task
         # decorator are instances living in the celery.local, we have to check
         # the wrapped function instead.
-        modname = self.get_attr(self.object, '__module__', None)
-        if modname and modname == 'celery.local':
+        if isinstance(self.object, Proxy):
             wrapped = getattr(self.object, '__wrapped__', None)
             if wrapped and getattr(wrapped, '__module__') == self.modname:
                 return True
@@ -95,7 +94,7 @@ def autodoc_skip_member_handler(app, what, name, obj, skip, options):
     # suppress repetition of class documentation in an instance of the
     # class. This overrides that behavior.
     if isinstance(obj, BaseTask) and getattr(obj, '__wrapped__'):
-        if skip and isinstance(obj, PromiseProxy):
+        if skip and isinstance(obj, Proxy):
             return False
     return None
 


### PR DESCRIPTION
Currently, functions decorated with `@app.task` are picked up by
Sphinx's `automodule` directive, but those decorated with `@shared_task`
are not. This is related to the use of `PromiseProxy` in `app.task` vs.
`Proxy` in `shared_task` and how each of those handle `__module__`. This
change allows `celery.contrib.sphinx` to detect and render `shared_task`
functions as well.