### PR TITLE
ADD: local thread context pubsub client for RedisConsumer

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -145,7 +145,7 @@ class ResultConsumer(BaseResultConsumer):
 
     @property
     def _pubsub(self):
-        return getattr(self._thread, "_pubsub", None)
+        return getattr(self._thread, "pubsub", None)
 
 class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
     """Redis task result store."""

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -139,9 +139,9 @@ class ResultConsumer(BaseResultConsumer):
     @property
     def _pubsub(self):
         if getattr(self._thread, "_pubsub", None) is None:
-            self._thread._pubsub = self.backend._create_client(
-                **self.backend.connparams
-            ).pubsub(ignore_subscribe_messages=True)
+            self._thread._pubsub = self.backend.create_client().pubsub(
+                ignore_subscribe_messages=True
+            )
 
         return self._thread._pubsub
 
@@ -417,6 +417,9 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
 
     @cached_property
     def client(self):
+        return self._create_client(**self.connparams)
+
+    def create_client(self):
         return self._create_client(**self.connparams)
 
     def __reduce__(self, args=(), kwargs={}):

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -147,10 +147,6 @@ class ResultConsumer(BaseResultConsumer):
 
         return self._thread.pubsub
 
-    @_pubsub.setter
-    def _pubsub(self, value):
-        self._thread._pubsub = value
-
 
 class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
     """Redis task result store."""

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -104,6 +104,12 @@ class ResultConsumer(BaseResultConsumer):
         self._maybe_cancel_ready_task(meta)
 
     def start(self, initial_task_id, **kwargs):
+        if self._pubsub is None:
+            self._thread.client = self.backend.create_client()
+            self._thread.pubsub = self._thread.client.pubsub(
+                ignore_subscribe_messages=True
+            )
+
         self._consume_from(initial_task_id)
 
     def on_wait_for_pending(self, result, **kwargs):
@@ -139,14 +145,7 @@ class ResultConsumer(BaseResultConsumer):
 
     @property
     def _pubsub(self):
-        if getattr(self._thread, "_pubsub", None) is None:
-            self._thread.client = self.backend.create_client()
-            self._thread.pubsub = self._thread.client.pubsub(
-                ignore_subscribe_messages=True
-            )
-
-        return self._thread.pubsub
-
+        return getattr(self._thread, "_pubsub", None)
 
 class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
     """Redis task result store."""
@@ -415,7 +414,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
 
     @cached_property
     def client(self):
-        return self._create_client(**self.connparams)
+        return self.create_client()
 
     def create_client(self):
         return self._create_client(**self.connparams)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
This PR introduces a local thread context for the ResultConsumer class for the Redis backend that works around the lack of thread safety in redis' Pubsub client.

Fixes #4363 
