### PR TITLE
Fix #5142 bug: Celery uses redis sentinel as backend exception

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -495,15 +495,17 @@ class SentinelBackend(RedisBackend):
         Arguments:
             include_password (bool): Password censored if disabled.
         """
-
         if not self.url:
             return 'sentinel://'
-
         if include_password:
             return self.url
 
-        hosts = [{"host": x["host"],
-                  "password": x["password"],
-                  "port": x["port"]} for x in self.connparams.get("hosts", [])]
-
-        return ';'.join([maybe_sanitize_url(as_url("sentinel", **h)) for h in hosts])
+        urls = []
+        for h in self.connparams.get('hosts', []):
+            urls.append(maybe_sanitize_url(as_url('sentinel',
+                                                  host=h['host'],
+                                                  port=h['port'],
+                                                  password=h['password'])
+                                           )
+                        )
+        return ';'.join(urls)


### PR DESCRIPTION
## Description

Fix  (Fixes ##5142) bug: Celery uses redis sentinel as backend exception

In the celery/backends/redis.py file,
Add the as_uri() method to the SentinelBackend class
