### PR TITLE
Fix django celery migrate typo

### DIFF
--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -187,7 +187,7 @@ To use this with your project you need to follow these steps:
 
     .. code-block:: console
 
-        $ python manage.py migrate django_celery_results
+        $ python manage.py migrate celery_results
 
 #. Configure Celery to use the :pypi:`django-celery-results` backend.
 


### PR DESCRIPTION
Running `python manage.py migrate django_celery_results` gives an error
    
      CommandError: App 'django_celery_results' does not have migrations.

`python manage.py migrate celery_results` works
    
 ``` 
Operations to perform:
  Apply all migrations: celery_results
Running migrations:
  Applying celery_results.0001_initial... OK
  Applying celery_results.0002_update_index... OK
```
