### PR TITLE
fix warnings when building docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -638,6 +638,13 @@ listed in :file:`requirements/docs.txt` and :file:`requirements/default.txt`:
     $ pip install -U -r requirements/docs.txt
     $ pip install -U -r requirements/default.txt
 
+Additionally, to build with no warnings, you will need to install
+the following packages:
+
+.. code-block:: console
+
+   $ apt-get install texlive texlive-latex-extra dvipng
+
 After these dependencies are installed you should be able to
 build the docs by running:
 

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -151,7 +151,7 @@ class Celery(object):
 
     Keyword Arguments:
         broker (str): URL of the default broker used.
-        backend (Union[str, type]): The result store backend class,
+        backend (Union[str, Type[celery.backends.base.Backend]]): The result store backend class,
             or the name of the backend class to use.
 
             Default is the value of the :setting:`result_backend` setting.
@@ -161,15 +161,15 @@ class Celery(object):
         set_as_current (bool):  Make this the global current app.
         include (List[str]): List of modules every worker should import.
 
-        amqp (Union[str, type]): AMQP object or class name.
-        events (Union[str, type]): Events object or class name.
-        log (Union[str, type]): Log object or class name.
-        control (Union[str, type]): Control object or class name.
-        tasks (Union[str, type]): A task registry, or the name of
+        amqp (Union[str, Type[AMQP]]): AMQP object or class name.
+        events (Union[str, Type[celery.app.events.Events]]): Events object or class name.
+        log (Union[str, Type[Logging]]): Log object or class name.
+        control (Union[str, Type[celery.app.control.Control]]): Control object or class name.
+        tasks (Union[str, Type[TaskRegistry]]): A task registry, or the name of
             a registry class.
         fixups (List[str]): List of fix-up plug-ins (e.g., see
             :mod:`celery.fixups.django`).
-        config_source (Union[str, type]): Take configuration from a class,
+        config_source (Union[str, class]): Take configuration from a class,
             or object.  Attributes may include any settings described in
             the documentation.
     """

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -110,7 +110,7 @@ class Signature(dict):
         :ref:`guide-canvas` for the complete guide.
 
     Arguments:
-        task (Task, str): Either a task class/instance, or the name of a task.
+        task (Union[Type[celery.app.task.Task], str]): Either a task class/instance, or the name of a task.
         args (Tuple): Positional arguments to apply.
         kwargs (Dict): Keyword arguments to apply.
         options (Dict): Additional options to :meth:`Task.apply_async`.

--- a/docs/internals/reference/index.rst
+++ b/docs/internals/reference/index.rst
@@ -22,7 +22,8 @@
     celery.concurrency.base
     celery.backends
     celery.backends.base
-    celery.backends.async
+    celery.backends.asynchronous
+    celery.backends.azureblockblob
     celery.backends.rpc
     celery.backends.database
     celery.backends.amqp

--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -289,7 +289,9 @@ Running the flower command will start a web-server that you can visit:
     $ celery -A proj flower
 
 The default port is http://localhost:5555, but you can change this using the
-:option:`--port <flower --port>` argument:
+`--port`_ argument:
+
+.. _--port: https://flower.readthedocs.io/en/latest/config.html#port
 
 .. code-block:: console
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,3 +2,5 @@ git+https://github.com/celery/sphinx_celery.git
 Sphinx==1.7.1
 typing
 -r extras/sqlalchemy.txt
+-r test.txt
+-r deps/mock.txt


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This PR fixes #5153 ;  A variety of warnings are thrown when attempting to build the documentation.
The nature of the warnings is detailed in that issue. Almost all warnings are fixed in this pull, except for a few which originate in other repos (namely kombu and sphinx_celery) -- I've already submitted a PR to sphinx_celery and am working on one for kombu. 

As I mention in the issue, I know this is some really nit-picky stuff, and I'm sorry if it's annoying. I do think that fixing the warnings improves the usefulness of the documentation, and also makes contributing further improvements to the docs much less intimidating -- I started investigating this after attempting to make an unrelated addition to the docs and encountering a nice chunk of red text on build.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
