### PR TITLE
Correct docs for default_routing_key and default_exchange

### DIFF
--- a/docs/history/whatsnew-4.0.rst
+++ b/docs/history/whatsnew-4.0.rst
@@ -1462,7 +1462,8 @@ Tasks
 
     Fix contributed by **Colin McIntosh**.
 
-- The default routing key and exchange name is now taken from the
+- The default routing key (:setting:`task_default_routing_key`) and exchange
+  name (:setting:`task_default_exchange`) is now taken from the
   :setting:`task_default_queue` setting.
 
     This means that to change the name of the default queue, you now

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1846,7 +1846,7 @@ that queue.
 ``task_default_exchange``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Default: ``"celery"``.
+Default: Uses the value set for :setting:`task_default_queue`.
 
 Name of the default exchange to use when no custom exchange is
 specified for a key in the :setting:`task_queues` setting.
@@ -1866,7 +1866,7 @@ for a key in the :setting:`task_queues` setting.
 ``task_default_routing_key``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Default: ``"celery"``.
+Default: Uses the value set for :setting:`task_default_queue`.
 
 The default routing key used when no custom routing key
 is specified for a key in the :setting:`task_queues` setting.


### PR DESCRIPTION
In Celery 4.0.0, the `default_routing_key` and `default_exchange` settings were altered to inherit from `task_default_queue` by default:
https://github.com/celery/celery/commit/495d3612c1fa06c5e656a42f43c76f79e9933cf9

This updates the configuration section for them accordingly.