### PR TITLE
Added configuration options to seperate multiple apps on single vhost

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -264,3 +264,4 @@ Federico Bond, 2018/06/20
 Tom Booth, 2018/07/06
 Axel haustant, 2018/08/14
 Bruno Alla, 2018/09/27
+Artem Vasilyev, 2018/11/24

--- a/celery/app/control.py
+++ b/celery/app/control.py
@@ -160,7 +160,7 @@ class Control(object):
     def __init__(self, app=None):
         self.app = app
         self.mailbox = self.Mailbox(
-            'celery',
+            app.conf.control_exchange,
             type='fanout',
             accept=['json'],
             producer_pool=lazy(lambda: self.app.amqp.producer_pool),

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -139,6 +139,7 @@ NAMESPACES = Namespace(
     control=Namespace(
         queue_ttl=Option(300.0, type='float'),
         queue_expires=Option(10.0, type='float'),
+        exchange=Option('celery', type='string'),
     ),
     couchbase=Namespace(
         __old__=old_ns('celery_couchbase'),
@@ -164,6 +165,7 @@ NAMESPACES = Namespace(
         queue_ttl=Option(5.0, type='float'),
         queue_prefix=Option('celeryev'),
         serializer=Option('json'),
+        exchange=Option('celeryev', type='string'),
     ),
     redis=Namespace(
         __old__=old_ns('celery_redis'),
@@ -311,7 +313,6 @@ NAMESPACES = Namespace(
         timer_precision=Option(1.0, type='float'),
     ),
 )
-
 
 def _flatten_keys(ns, key, opt):
     return [(ns + key, opt)]

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -314,6 +314,7 @@ NAMESPACES = Namespace(
     ),
 )
 
+
 def _flatten_keys(ns, key, opt):
     return [(ns + key, opt)]
 

--- a/celery/events/dispatcher.py
+++ b/celery/events/dispatcher.py
@@ -84,7 +84,8 @@ class EventDispatcher(object):
             self.connection = channel.connection.client
         self.enabled = enabled
         conninfo = self.connection or self.app.connection_for_write()
-        self.exchange = get_exchange(conninfo)
+        self.exchange = get_exchange(conninfo,
+                                     name=self.app.conf.event_exchange)
         if conninfo.transport.driver_type in self.DISABLED_TRANSPORTS:
             self.enabled = False
         if self.enabled:

--- a/celery/events/event.py
+++ b/celery/events/event.py
@@ -10,10 +10,11 @@ __all__ = (
     'Event', 'event_exchange', 'get_exchange', 'group_from',
 )
 
+EVENT_EXCHANGE_NAME = 'celeryev'
 #: Exchange used to send events on.
 #: Note: Use :func:`get_exchange` instead, as the type of
 #: exchange will vary depending on the broker connection.
-event_exchange = Exchange('celeryev', type='topic')
+event_exchange = Exchange(EVENT_EXCHANGE_NAME, type='topic')
 
 
 def Event(type, _fields=None, __dict__=dict, __now__=time.time, **fields):
@@ -44,11 +45,12 @@ def group_from(type):
     return type.split('-', 1)[0]
 
 
-def get_exchange(conn):
+def get_exchange(conn, name=EVENT_EXCHANGE_NAME):
     """Get exchange used for sending events.
 
     Arguments:
         conn (kombu.Connection): Connection used for sending/receving events.
+        name (str): Name of the exchange. Default is ``celeryev``.
 
     Note:
         The event type changes if Redis is used as the transport
@@ -58,4 +60,6 @@ def get_exchange(conn):
     if conn.transport.driver_type == 'redis':
         # quick hack for Issue #436
         ex.type = 'fanout'
+    if name != ex.name:
+        ex.name = name
     return ex

--- a/celery/events/receiver.py
+++ b/celery/events/receiver.py
@@ -44,7 +44,8 @@ class EventReceiver(ConsumerMixin):
         self.node_id = node_id or uuid()
         self.queue_prefix = queue_prefix or self.app.conf.event_queue_prefix
         self.exchange = get_exchange(
-            self.connection or self.app.connection_for_write())
+            self.connection or self.app.connection_for_write(),
+            name=self.app.conf.event_exchange)
         if queue_ttl is None:
             queue_ttl = self.app.conf.event_queue_ttl
         if queue_expires is None:

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2375,6 +2375,15 @@ Default: ``"celeryev"``.
 
 The prefix to use for event receiver queue names.
 
+.. setting:: event_exchange
+
+``event_exchange``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``"celeryev"``.
+
+Name of the event exchange.
+
 .. setting:: event_serializer
 
 ``event_serializer``
@@ -2426,6 +2435,15 @@ Time in seconds, before an unused remote control command queue is deleted
 from the broker.
 
 This setting also applies to remote control reply queues.
+
+.. setting:: control_exchange
+
+``control_exchange``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``"celery"``.
+
+Name of the control command exchange.
 
 .. _conf-logging:
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2384,6 +2384,10 @@ Default: ``"celeryev"``.
 
 Name of the event exchange.
 
+.. warning::
+
+    This option is in beta stage, please use it with caution.
+
 .. setting:: event_serializer
 
 ``event_serializer``
@@ -2444,6 +2448,10 @@ This setting also applies to remote control reply queues.
 Default: ``"celery"``.
 
 Name of the control command exchange.
+
+.. warning::
+
+    This option is in beta stage, please use it with caution.
 
 .. _conf-logging:
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2386,7 +2386,7 @@ Name of the event exchange.
 
 .. warning::
 
-    This option is in beta stage, please use it with caution.
+    This option is in experimental stage, please use it with caution.
 
 .. setting:: event_serializer
 
@@ -2451,7 +2451,7 @@ Name of the control command exchange.
 
 .. warning::
 
-    This option is in beta stage, please use it with caution.
+    This option is in experimental stage, please use it with caution.
 
 .. _conf-logging:
 

--- a/t/unit/app/test_control.py
+++ b/t/unit/app/test_control.py
@@ -498,3 +498,12 @@ class test_Control:
         new_pool = Mock(name='new pool')
         amqp.producer_pool = new_pool
         assert new_pool is self.app.control.mailbox.producer_pool
+
+    def test_control_exchange__default(self):
+        c = control.Control(self.app)
+        assert c.mailbox.namespace == 'celery'
+
+    def test_control_exchange__setting(self):
+        self.app.conf.control_exchange = 'test_exchange'
+        c = control.Control(self.app)
+        assert c.mailbox.namespace == 'test_exchange'

--- a/t/unit/events/test_events.py
+++ b/t/unit/events/test_events.py
@@ -229,6 +229,15 @@ class test_EventReceiver:
         r = self.app.events.Receiver(Mock(), queue_prefix='fooq')
         assert r.queue.name.startswith('fooq.')
 
+    def test_event_exchange__default(self):
+        r = self.app.events.Receiver(Mock())
+        assert r.exchange.name == 'celeryev'
+
+    def test_event_exchange__setting(self):
+        self.app.conf.event_exchange = 'exchange_ev'
+        r = self.app.events.Receiver(Mock())
+        assert r.exchange.name == 'exchange_ev'
+
     def test_catch_all_event(self):
         message = {'type': 'world-war'}
         got_event = [False]


### PR DESCRIPTION
Resolves feature request #5189

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This pull request adds options to seperate celery apps when runnung on single RabbitMQ vhost. Before, the would use the same exchanges `celery.pidbox` and `celeryev`. After this feature every celery app may be separeted from others and use their own exchanges.

App 1 example:
```
from celery import Celery

app_name = 'app1'

app = Celery('%s_tasks' % app_name, broker='pyamqp://guest:guest@172.17.0.2:5672//')

app.conf.update(
    control_exchange=app_name,
    event_exchange=app_name + '.ev',
    task_default_queue=app_name,
    task_default_exchange=app_name,
    task_default_routing_key=app_name,
)

@app.task
def add(x, y):
    return x + y
```
App 2 example:
```
from celery import Celery

app_name = 'app2'

app = Celery('%s_tasks' % app_name, broker='pyamqp://guest:guest@172.17.0.2:5672//')

app.conf.update(
    control_exchange=app_name,
    event_exchange=app_name + '.ev',
    task_default_queue=app_name,
    task_default_exchange=app_name,
    task_default_routing_key=app_name,
)

@app.task
def add(x, y):
    return x + y
```

Logs of the app 1:
```
(test-celery) artem@dell-7290:~/devel/art-vasilyev/test-celery$ celery -A app1 worker --loglevel=info

 -------------- celery@dell-7290 v4.2.0 (windowlicker)
---- **** -----
--- * ***  * -- Linux-4.15.0-38-generic-x86_64-with-Ubuntu-18.04-bionic 2018-11-23 22:24:57
-- * - **** ---
- ** ---------- [config]
- ** ---------- .> app:         app1_tasks:0x7f062c90f210
- ** ---------- .> transport:   amqp://guest:**@172.17.0.2:5672//
- ** ---------- .> results:     disabled://
- *** --- * --- .> concurrency: 8 (prefork)
-- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
--- ***** -----
 -------------- [queues]
                .> app1             exchange=app1(direct) key=app1


[tasks]
  . app1.add

[2018-11-23 22:24:57,729: INFO/MainProcess] Connected to amqp://guest:**@172.17.0.2:5672//
[2018-11-23 22:24:57,739: INFO/MainProcess] mingle: searching for neighbors
[2018-11-23 22:24:58,763: INFO/MainProcess] mingle: all alone
[2018-11-23 22:24:58,801: INFO/MainProcess] celery@dell-7290 ready.
^C
worker: Hitting Ctrl+C again will terminate all running tasks!
```

Logs of the app 2:
```
(test-celery) artem@dell-7290:~/devel/art-vasilyev/test-celery$ celery -A app2 worker --loglevel=info

 -------------- celery@dell-7290 v4.2.0 (windowlicker)
---- **** -----
--- * ***  * -- Linux-4.15.0-38-generic-x86_64-with-Ubuntu-18.04-bionic 2018-11-23 22:25:05
-- * - **** ---
- ** ---------- [config]
- ** ---------- .> app:         app2_tasks:0x7f7c7fb95210
- ** ---------- .> transport:   amqp://guest:**@172.17.0.2:5672//
- ** ---------- .> results:     disabled://
- *** --- * --- .> concurrency: 8 (prefork)
-- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
--- ***** -----
 -------------- [queues]
                .> app2             exchange=app2(direct) key=app2


[tasks]
  . app2.add

[2018-11-23 22:25:05,865: INFO/MainProcess] Connected to amqp://guest:**@172.17.0.2:5672//
[2018-11-23 22:25:05,875: INFO/MainProcess] mingle: searching for neighbors
[2018-11-23 22:25:06,898: INFO/MainProcess] mingle: all alone
[2018-11-23 22:25:06,936: INFO/MainProcess] celery@dell-7290 ready.
^C
worker: Hitting Ctrl+C again will terminate all running tasks!

worker: Warm shutdown (MainProcess)
```
Exchanges:
![exchanges](https://user-images.githubusercontent.com/17820623/48964719-ce5fa700-efbe-11e8-8214-c583059e6652.png)
