### PR TITLE
Update time.py to solve the microsecond issues

### DIFF
--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -212,7 +212,7 @@ def remaining(start, ends_in, now=None, relative=False):
         start = start.replace(tzinfo=now.tzinfo)
     end_date = start + ends_in
     if relative:
-        end_date = delta_resolution(end_date, ends_in)
+        end_date = delta_resolution(end_date, ends_in).replace(microsecond=0)
     ret = end_date - now
     if C_REMDEBUG:  # pragma: no cover
         print('rem: NOW:%r START:%r ENDS_IN:%r END_DATE:%s REM:%s' % (


### PR DESCRIPTION
When `relative` is set to True, the day, hour, minutes second will be round to the nearest one, however, the original program do not update the microsecond (reset it). As a result, the run-time offset on the microsecond will then be accumulated. 
For example, given the interval is 15s and relative is set to True
1.    2018-11-27T15:01:30.123236+08:00
2.    2018-11-27T15:01:45.372687+08:00
3.    2018-11-27T15:02:00.712601+08:00
4.    2018-11-27T15:02:15.987720+08:00
5.    2018-11-27T15:02:31.023670+08:00
#5198