### PR TITLE
fix: wrong configuration name CELERY_ACKS_LATE

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -115,7 +115,7 @@ have been moved into a new  ``task_`` prefix.
 ``CELERY_SECURITY_CERTIFICATE``        :setting:`security_certificate`
 ``CELERY_SECURITY_CERT_STORE``         :setting:`security_cert_store`
 ``CELERY_SECURITY_KEY``                :setting:`security_key`
-``CELERY_ACKS_LATE``                   :setting:`task_acks_late`
+``CELERY_TASK_ACKS_LATE``                   :setting:`task_acks_late`
 ``CELERY_TASK_ALWAYS_EAGER``           :setting:`task_always_eager`
 ``CELERY_TASK_ANNOTATIONS``            :setting:`task_annotations`
 ``CELERY_TASK_COMPRESSION``            :setting:`task_compression`


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
I think https://github.com/celery/celery/pull/4291 was either a mistake, or the implementation should be fixed.
for now, using `CELERY_ACKS_LATE` does not work, while `CELERY_TASK_ACKS_LATE` does.
It also seems to me that the configuration in `task.py` adds `TASK` for all configs in `from_config` (https://github.com/celery/celery/blob/6651e145989d6e890c28273d470bf8fb3a2d5c2b/celery/app/task.py#L328)
