### PR TITLE
Updates documentation with more detailed information about priorities.

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -816,10 +816,10 @@ Example configuration
 
     result_backend = 'rpc://'
     result_persistent = False
-   
-**Please note**: using this backend could trigger the raise of ``celery.backends.rpc.BacklogLimitExceeded`` if the task tombstone is too *old*. 
 
-E.g.  
+**Please note**: using this backend could trigger the raise of ``celery.backends.rpc.BacklogLimitExceeded`` if the task tombstone is too *old*.
+
+E.g.
 
 .. code-block:: python
 
@@ -827,7 +827,7 @@ E.g.
         r = debug_task.delay()
 
     print(r.state)  # this would raise celery.backends.rpc.BacklogLimitExceeded
-    
+
 .. _conf-cache-result-backend:
 
 Cache backend settings
@@ -1692,7 +1692,7 @@ it's a queue name in :setting:`task_queues`, a dict means it's a custom route.
 
 When sending tasks, the routers are consulted in order. The first
 router that doesn't return ``None`` is the route to use. The message options
-is then merged with the found route settings, where the routers settings
+is then merged with the found route settings, where the task's settings
 have priority.
 
 Example if :func:`~celery.execute.apply_async` has these arguments:
@@ -1712,7 +1712,7 @@ the final message options will be:
 
 .. code-block:: python
 
-    immediate=True, exchange='urgent', routing_key='video.compress'
+    immediate=False, exchange='video', routing_key='video.compress'
 
 (and any default message options defined in the
 :class:`~celery.task.base.Task` class)

--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -246,6 +246,39 @@ A default value for all queues can be set using the
 
 .. _amqp-primer:
 
+
+Redis Message Priorities
+------------------------
+:supported transports: Redis
+
+While the Celery Redis transport does honor the priority field, Redis itself has
+no notion of priorities. Please read this note before attempting to implement
+priorities with Redis as you may experience some unexpected behavior.
+
+The priority support is implemented by creating n lists for each queue.
+This means that even though there are 10 (0-9) priority levels, these are
+consolidated into 4 levels by default to save resources. This means that a
+queue named celery will really be split into 4 queues:
+
+.. code-block:: python
+
+    ['celery0', 'celery3`, `celery6`, `celery9`]
+
+
+If you want more priority levels you can set the priority_steps transport option:
+
+.. code-block:: python
+
+    app.conf.broker_transport_options = {
+        'priority_steps': list(range(10)),
+    }
+
+
+That said, note that this will never be as good as priorities implemented at the
+server level, and may be approximate at best. But it may still be good enough
+for your application.
+
+
 AMQP Primer
 ===========
 
@@ -663,6 +696,41 @@ You can also have multiple routers defined in a sequence:
 
 The routers will then be visited in turn, and the first to return
 a value will be chosen.
+
+If you're using Redis or RabbitMQ you can also specify the queue's default priority
+in the route.
+
+.. code-block:: python
+
+    task_routes = {
+        'myapp.tasks.compress_video': {
+            'queue': 'video',
+            'routing_key': 'video.compress',
+            'priority': 10,
+        },
+    }
+
+
+Similarly, calling `apply_async` on a task will override that
+default priority.
+
+.. code-block:: python
+
+    task.apply_async(priority=0)
+
+
+.. admonition:: Priority Order and Cluster Responsiveness
+
+    It is important to note that, due to worker prefetching, if a bunch of tasks
+    submitted at the same time they may be out of priority order at first.
+    Disabling worker prefetching will prevent this issue, but may cause less than
+    ideal performance for small, fast tasks. In most cases, simply reducing
+    `worker_prefetch_multiplier`to 1 is an easier and cleaner way to increase the
+    responsiveness of your system without the costs of disabling prefetching
+    entirely.
+
+    Note that priorities values are sorted in reverse: 0 being highest priority.
+
 
 Broadcast
 ---------


### PR DESCRIPTION
## Description

I seem to have found a misnomer when it comes to task_routes: The documentation claims that given a task dispatched with certain options and a global routes config, that the routes config would always have priority. This is unintuitive and after investigating, I found it to be incorrect, and so I've updated that section to reflect my testing.

I've also added some information about assigning priority to tasks with Redis. I found @ask's answer on StackOverflow really helpful, so I've added it (essentially verbatim) to the docs along with some little hints about optimizing priority clusters.

It also looks like my editor found some weird line endings on the contributing page. 