### PR TITLE
 FEATURE: add a new setting `result_accept_content`

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -77,6 +77,7 @@ class Option(object):
 
 NAMESPACES = Namespace(
     accept_content=Option(DEFAULT_ACCEPT_CONTENT, type='list', old=OLD_NS),
+    result_accept_content=Option(None, type='list'),
     enable_utc=Option(True, type='bool'),
     imports=Option((), type='tuple', old=OLD_NS),
     include=Option((), type='tuple', old=OLD_NS),

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -123,7 +123,7 @@ class Backend(object):
 
         # precedence: accept, conf.result_accept_content, conf.accept_content
         self.accept = conf.result_accept_content if accept is None else accept
-        self.accept = conf.accept_content if self.accept is None else self.accept
+        self.accept = conf.accept_content if self.accept is None else self.accept  # noqa: E501
         self.accept = prepare_accept_content(self.accept)
 
         self._pending_results = pending_results_t({}, WeakValueDictionary())

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -120,8 +120,12 @@ class Backend(object):
         self._cache = _nulldict() if cmax == -1 else LRUCache(limit=cmax)
 
         self.expires = self.prepare_expires(expires, expires_type)
-        self.accept = prepare_accept_content(
-            conf.accept_content if accept is None else accept)
+
+        # precedence: accept, conf.result_accept_content, conf.accept_content
+        self.accept = conf.result_accept_content if accept is None else accept
+        self.accept = conf.accept_content if self.accept is None else self.accept
+        self.accept = prepare_accept_content(self.accept)
+
         self._pending_results = pending_results_t({}, WeakValueDictionary())
         self._pending_messages = BufferMap(MESSAGE_BUFFER_MAX)
         self.url = url

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -195,6 +195,35 @@ Example::
     # or the actual content-type (MIME)
     accept_content = ['application/json']
 
+.. setting:: result_accept_content
+
+``result_accept_content``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``None`` (can be set, list or tuple).
+
+.. versionadded:: 4.3
+
+A white-list of content-types/serializers to allow for the result backend.
+
+If a message is received that's not in this list then
+the message will be discarded with an error.
+
+By default it is the same serializer as ``accept_content``.
+However, a different serializer for accepted content of the result backend
+can be specified.
+Usually this is needed if signed messaging is used and the result is stored
+unsigned in the result backend.
+See :ref:`guide-security` for more.
+
+Example::
+
+    # using serializer name
+    result_accept_content = ['json']
+
+    # or the actual content-type (MIME)
+    result_accept_content = ['application/json']
+
 Time and date settings
 ----------------------
 

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -21,6 +21,8 @@ from celery.utils.serialization import find_pickleable_exception as fnpe
 from celery.utils.serialization import get_pickleable_exception as gpe
 from celery.utils.serialization import subclass_exception
 
+from kombu.serialization import prepare_accept_content
+
 
 class wrapobject(object):
 
@@ -57,6 +59,39 @@ class test_serialization:
     def test_create_exception_cls(self):
         assert serialization.create_exception_cls('FooError', 'm')
         assert serialization.create_exception_cls('FooError', 'm', KeyError)
+
+
+class test_Backend_interface:
+
+    def setup(self):
+        self.app.conf.accept_content = ['json']
+
+    def test_accept_precedence(self):
+
+        # default is app.conf.accept_content
+        accept_content = self.app.conf.accept_content
+        b1 = BaseBackend(self.app)
+        assert prepare_accept_content(accept_content) == b1.accept
+
+        # accept parameter
+        b2 = BaseBackend(self.app, accept=['yaml'])
+        assert len(b2.accept) == 1
+        assert list(b2.accept)[0] == 'application/x-yaml'
+        assert prepare_accept_content(['yaml']) == b2.accept
+
+        # accept parameter over result_accept_content
+        self.app.conf.result_accept_content = ['json']
+        b3 = BaseBackend(self.app, accept=['yaml'])
+        assert len(b3.accept) == 1
+        assert list(b3.accept)[0] == 'application/x-yaml'
+        assert prepare_accept_content(['yaml']) == b3.accept
+
+        # conf.result_accept_content if specified
+        self.app.conf.result_accept_content = ['yaml']
+        b4 = BaseBackend(self.app)
+        assert len(b4.accept) == 1
+        assert list(b4.accept)[0] == 'application/x-yaml'
+        assert prepare_accept_content(['yaml']) == b4.accept
 
 
 class test_BaseBackend_interface:

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -380,6 +380,7 @@ class test_RedisBackend:
             'result_cache_max': 1,
             'result_expires': None,
             'accept_content': ['json'],
+            'result_accept_content': ['json'],
         })
         self.Backend(app=self.app)
 


### PR DESCRIPTION
## Description

this feature allows to configure different accepted content for the result backend.
A special serializer (`auth`) is used for signed messaging, but the result_serializer remains in json, because we don't want encrypted content in our result backend.
To accept unsigned content from the result backend, there is a new configuration
`result_accept_content` to configure the accepted content from the backend.

this is needed for #5091 , see discussion https://github.com/celery/celery/pull/5091#issuecomment-430184608
