### PR TITLE
Address resizing of pool while a connection is in use. Allow option t…

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -299,6 +299,8 @@ class Celery(object):
 
         self.on_init()
         _register_app(self)
+        # Enable force resizing of connection and producer pools
+        pools.set_forced_resize(True)
 
     def _get_default_loader(self):
         # the --loader command-line argument sets the environment variable.


### PR DESCRIPTION
…o forcibly resize and quietly ignore the RuntimeError for Resource.resize() which it currently does.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This goes along with PR #961 of kombu (https://github.com/celery/kombu/pull/961/commits)
Setting force resizing of pool to be true to prevent silent ignore of run time errors and defaulting to pool of 10 connections even when broker_pool_limit is set to a lower value or 0 (disabled)

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
