### PR TITLE
Force resizing of pool if a connection is in use. Not default to pool…

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -1162,6 +1162,8 @@ class Celery(object):
         if self._pool is None:
             self._ensure_after_fork()
             limit = self.conf.broker_pool_limit
+            # Enable force resizing of pools
+            pools.set_forced_resize(True)
             pools.set_limit(limit)
             self._pool = pools.connections[self.connection_for_write()]
         return self._pool

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -959,6 +959,12 @@ class test_App:
         app = CustomCelery(set_as_current=False)
         assert isinstance(app.tasks, TaskRegistry)
 
+    def test_force_resize_called(self):
+        from kombu import pools
+        pools.set_forced_resize = Mock()
+        with self.Celery():
+            pools.set_forced_resize.assert_called_with(True)
+
 
 class test_defaults:
 


### PR DESCRIPTION
… of 10.


## Description
This goes along with PR #964 of kombu (https://github.com/celery/kombu/pull/964/commits)
Uses force resizing of kombu pools to never default to pool of 10.


Fixes #5215 