### PR TITLE
Warn Riak backend users for possible 3.7 incompatibilities

### DIFF
--- a/celery/backends/riak.py
+++ b/celery/backends/riak.py
@@ -3,10 +3,11 @@
 from __future__ import absolute_import, unicode_literals
 
 import sys
+import warnings
 
 from kombu.utils.url import _parse_url
 
-from celery.exceptions import ImproperlyConfigured
+from celery.exceptions import CeleryWarning, ImproperlyConfigured
 
 from .base import KeyValueStoreBackend
 
@@ -23,7 +24,15 @@ E_BUCKET_NAME = """\
 Riak bucket names must be composed of ASCII characters only, not: {0!r}\
 """
 
+W_UNSUPPORTED_PYTHON_VERSION = """\
+Python {}.{} is unsupported by the client library \
+https://pypi.org/project/riak\
+""".format(sys.version_info.major, sys.version_info.minor)
+
+
 if sys.version_info[0] == 3:
+    if sys.version_info.minor >= 7:
+        warnings.warn(CeleryWarning(W_UNSUPPORTED_PYTHON_VERSION))
 
     def to_bytes(s):
         return s.encode() if isinstance(s, str) else s

--- a/t/unit/backends/test_riak.py
+++ b/t/unit/backends/test_riak.py
@@ -1,16 +1,28 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, unicode_literals, print_function
+
+import sys
 
 import pytest
 from case import MagicMock, Mock, patch, sentinel, skip
 
-from celery.backends import riak as module
-from celery.backends.riak import RiakBackend
+try:
+    from celery.backends import riak as module
+    from celery.backends.riak import RiakBackend
+except ImportError:
+    pass
+except TypeError as e:
+    if sys.version_info[0:2] >= (3, 7):
+        print(e)
+    else:
+        raise e
+
 from celery.exceptions import ImproperlyConfigured
 
 RIAK_BUCKET = 'riak_bucket'
 
 
+@skip.if_python_version_after(3, 7)
 @skip.unless_module('riak')
 class test_RiakBackend:
 


### PR DESCRIPTION
## Description

- [x] Display warning that the Riak backend may display issues on Python 3.7 and above.
- [x] Skip tests for versions 3.7+ in order to allow unit test job to report success on Travis CI properly.

References:
- https://pypi.org/project/riak/
- https://github.com/basho/riak-python-client/issues/534
- https://github.com/celery/celery/pull/4859
