### PR TITLE
Avoid raising StopIterator in generators

### DIFF
--- a/t/unit/worker/test_loops.py
+++ b/t/unit/worker/test_loops.py
@@ -383,8 +383,8 @@ class test_asynloop:
         x = X(self.app)
 
         def Gen():
-            raise StopIteration()
-            yield
+            if 0:
+                yield
         gen = Gen()
         x.hub.add_writer(6, gen)
         x.hub.on_tick.add(x.close_then_error(Mock(name='tick'), 2))


### PR DESCRIPTION
According to [PEP-479](https://www.python.org/dev/peps/pep-0479/) StopIteration should not be used any more to indicate the termination of a generator.
Starting from Python 3.7 this behaviour is always enforced and a RuntimeError is raised instead.
Instead of raising a StopIterator exception, we now never execute our yield statement.
Since it is present Gen is still a generator but it will never yield any value.