### PR TITLE
requirements: use msgpack instead of msgpack-python

### DIFF
--- a/requirements/extras/msgpack.txt
+++ b/requirements/extras/msgpack.txt
@@ -1,1 +1,1 @@
-msgpack-python>=0.3.0
+msgpack


### PR DESCRIPTION
msgpack-python is deprecated, and msgpack should be used:
https://pypi.org/project/msgpack-python/