### PR TITLE
Implement version switches to remove deprecation warnings for collections.abc

### DIFF
--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -7,8 +7,12 @@ from __future__ import absolute_import, unicode_literals
 
 import re
 import string
-from collections import Mapping, OrderedDict
-
+from collections import OrderedDict
+try:
+    from collections.abc import Mapping
+except ImportError:
+    # TODO: Remove this when we drop Python 2.7 support
+    from collections import Mapping
 from kombu import Queue
 
 from celery.exceptions import QueueNotFound

--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -5,7 +5,12 @@ from __future__ import absolute_import, unicode_literals
 import os
 import platform as _platform
 import re
-from collections import Mapping, namedtuple
+from collections import namedtuple
+try:
+    from collections.abc import Mapping
+except ImportError:
+    # TODO: Remove this when we drop Python 2.7 support
+    from collections import Mapping
 from copy import deepcopy
 from types import ModuleType
 

--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -18,7 +18,12 @@ from __future__ import absolute_import, unicode_literals
 import bisect
 import sys
 import threading
-from collections import Callable, defaultdict
+from collections import defaultdict
+try:
+    from collections.abc import Callable
+except ImportError:
+    # TODO: Remove this when we drop Python 2.7 support
+    from collections import Callable
 from datetime import datetime
 from decimal import Decimal
 from itertools import islice

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -5,7 +5,12 @@ from __future__ import absolute_import, unicode_literals
 import numbers
 import re
 from bisect import bisect, bisect_left
-from collections import Iterable, namedtuple
+from collections import namedtuple
+try:
+    from collections.abc import Iterable
+except ImportError:
+    # TODO: Remove this when we drop Python 2.7 support
+    from collections import Iterable
 from datetime import datetime, timedelta
 
 from kombu.utils.objects import cached_property

--- a/celery/utils/abstract.py
+++ b/celery/utils/abstract.py
@@ -3,7 +3,11 @@
 from __future__ import absolute_import, unicode_literals
 
 from abc import ABCMeta, abstractmethod, abstractproperty
-from collections import Callable
+try:
+    from collections.abc import Callable
+except ImportError:
+    # TODO: Remove this when we drop Python 2.7 support
+    from collections import Callable
 
 from celery.five import with_metaclass
 

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -3,9 +3,15 @@
 from __future__ import absolute_import, unicode_literals
 
 import sys
-from collections import Callable, Mapping, MutableMapping, MutableSet
 from collections import OrderedDict as _OrderedDict
-from collections import Sequence, deque
+from collections import deque
+try:
+    from collections.abc import Callable, Mapping, MutableMapping, MutableSet
+    from collections.abc import Sequence
+except ImportError:
+    # TODO: Remove this when we drop Python 2.7 support
+    from collections import Callable, Mapping, MutableMapping, MutableSet
+    from collections import Sequence
 from heapq import heapify, heappop, heappush
 from itertools import chain, count
 

--- a/celery/utils/text.py
+++ b/celery/utils/text.py
@@ -3,7 +3,11 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
-from collections import Callable
+try:
+    from collections.abc import Callable
+except ImportError:
+    # TODO: Remove this when we drop Python 2.7 support
+    from collections import Callable
 from functools import partial
 from pprint import pformat
 from textwrap import fill

--- a/t/unit/app/test_utils.py
+++ b/t/unit/app/test_utils.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import, unicode_literals
 
-from collections import Mapping, MutableMapping
+try:
+    from collections.abc import Mapping, MutableMapping
+except ImportError:
+    # TODO: Remove this when we drop Python 2.7 support
+    from collections import Mapping, MutableMapping
 
 from case import Mock
 


### PR DESCRIPTION
## Description

As [suggested by @MRigal](https://github.com/celery/celery/issues/5180#issuecomment-451515057) this PR gets rid of a number of deprecation warnings with the collections.abc module by implementing import switches.
