### PR TITLE
fix race condition problems

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -102,9 +102,9 @@ class ResultConsumer(BaseResultConsumer):
 
     @property
     def pubsub(self):
-        """current thread's pubsub"""
+        """Current thread's pubsub."""
         if (not hasattr(self._pubsubs, 'pubsub') or
-            self._pubsubs.pubsub is None):
+                self._pubsubs.pubsub is None):
             self._pubsubs.pubsub = self.backend.client.pubsub(
                 ignore_subscribe_messages=True,
             )

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -153,19 +153,14 @@ class test_RedisResultConsumer:
         consumer.on_after_fork()
         parent_method.assert_called_once()
         consumer.backend.client.connection_pool.reset.assert_called_once()
-        consumer._pubsub.close.assert_called_once()
         # PubSub instance not initialized - exception would be raised
         # when calling .close()
-        consumer._pubsub = None
         parent_method.reset_mock()
         consumer.backend.client.connection_pool.reset.reset_mock()
         consumer.on_after_fork()
         parent_method.assert_called_once()
         consumer.backend.client.connection_pool.reset.assert_called_once()
 
-        # Continues on KeyError
-        consumer._pubsub = Mock()
-        consumer._pubsub.close = Mock(side_effect=KeyError)
         parent_method.reset_mock()
         consumer.backend.client.connection_pool.reset.reset_mock()
         consumer.on_after_fork()


### PR DESCRIPTION
## Description
### I have found two race condition problems:
1. when using redis as result backend, celery use redis pubsub to know when the result is ready.
but in my project, i often found exceptions like this

```
Traceback (most recent call last):
  File "/opt/titan/titan/titan/api_views.py", line 71, in dispatch
    return super(TitanAPIView, self).dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/views.py", line 466, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/views.py", line 463, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/titan/titan/tdocker/api_views.py", line 1470, in post
    total_queued = RedisList.get_total_queued(channels)
  File "/opt/titan/titan/tdocker/api_views.py", line 1302, in get_total_queued
    queue=short_time_q
  File "/usr/local/lib/python2.7/dist-packages/celery/app/base.py", line 744, in send_task
    self.backend.on_task_call(P, task_id)
  File "/usr/local/lib/python2.7/dist-packages/celery/backends/redis.py", line 265, in on_task_call
    self.result_consumer.consume_from(task_id)
  File "/usr/local/lib/python2.7/dist-packages/celery/backends/redis.py", line 126, in consume_from
    self._consume_from(task_id)
  File "/usr/local/lib/python2.7/dist-packages/celery/backends/redis.py", line 132, in _consume_from
    self._pubsub.subscribe(key)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 2482, in subscribe
    ret_val = self.execute_command('SUBSCRIBE', *iterkeys(new_channels))
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 2404, in execute_command
    self._execute(connection, connection.send_command, *args)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 2408, in _execute
    return command(*args)
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 610, in send_command
    self.send_packed_command(self.pack_command(*args))
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 585, in send_packed_command
    self.connect()
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 493, in connect
    self.on_connect()
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 567, in on_connect
    if nativestr(self.read_response()) != 'OK':
  File "/usr/local/lib/python2.7/dist-packages/redis/_compat.py", line 115, in nativestr
    return x if isinstance(x, str) else x.encode('utf-8', 'replace')
AttributeError: 'list' object has no attribute 'encode'
```

```
Traceback (most recent call last):
  File "/opt/titan/titan/titan/api_views.py", line 144, in dispatch
    return super(TitanView, self).dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/views/generic/base.py", line 88, in dispatch
    return handler(request, *args, **kwargs)
  File "/opt/titan/titan/tdocker/api_views.py", line 1038, in post
    success, err_msg = auto_scale.start()
  File "/opt/titan/titan/tdocker/auto_scale.py", line 120, in start
    success, ret = result.get()
  File "/usr/local/lib/python2.7/dist-packages/celery/result.py", line 224, in get
    on_message=on_message,
  File "/usr/local/lib/python2.7/dist-packages/celery/backends/async.py", line 188, in wait_for_pending
    for _ in self._wait_for_pending(result, **kwargs):
  File "/usr/local/lib/python2.7/dist-packages/celery/backends/async.py", line 255, in _wait_for_pending
    on_interval=on_interval):
  File "/usr/local/lib/python2.7/dist-packages/celery/backends/async.py", line 56, in drain_events_until
    yield self.wait_for(p, wait, timeout=1)
  File "/usr/local/lib/python2.7/dist-packages/celery/backends/async.py", line 65, in wait_for
    wait(timeout=timeout)
  File "/usr/local/lib/python2.7/dist-packages/celery/backends/redis.py", line 119, in drain_events
    m = self._pubsub.get_message(timeout=timeout)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 2515, in get_message
    return self.handle_message(response, ignore_subscribe_messages)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 2524, in handle_message
    message_type = nativestr(response[0])
TypeError: 'long' object has no attribute '__getitem__'
```

I found that this is because there is only one pubsub object at one time. If used in multi-thread,
all of these threads will use this only pubsub object, which means only one connection. One thread
send a command, another thread may get its result, obviously this would result to `Protocol Error`.

2.when app.pool and app.producer_pool called in multi-thread, they would be instantiated multiple 
times, which would cause exceptions, too. In fact, even the cached_property is not thread-safety.

