### PR TITLE
Meaningful error messages for filesystem backend

### DIFF
--- a/celery/backends/filesystem.py
+++ b/celery/backends/filesystem.py
@@ -20,6 +20,10 @@ except NameError:
 
 default_encoding = locale.getpreferredencoding(False)
 
+E_NO_PATH_SET = 'You need to configure a path for the file-system backend'
+E_PATH_NON_CONFORMING_SCHEME = (
+    'A path for the file-system backend should conform to the file URI scheme'
+)
 E_PATH_INVALID = """\
 The configured path for the file-system backend does not
 work correctly, please make sure that it exists and has
@@ -56,14 +60,12 @@ class FilesystemBackend(KeyValueStoreBackend):
 
     def _find_path(self, url):
         if not url:
-            raise ImproperlyConfigured(
-                'You need to configure a path for the File-system backend')
+            raise ImproperlyConfigured(E_NO_PATH_SET)
         if url.startswith('file:///'):
             return url[7:]
         if url.startswith('file://localhost/'):
             return url[16:]
-        raise ImproperlyConfigured(
-            'A path for the File-system backend should conform to the file URI scheme')
+        raise ImproperlyConfigured(E_PATH_NON_CONFORMING_SCHEME)
 
     def _do_directory_test(self, key):
         try:

--- a/celery/backends/filesystem.py
+++ b/celery/backends/filesystem.py
@@ -58,8 +58,12 @@ class FilesystemBackend(KeyValueStoreBackend):
         if not url:
             raise ImproperlyConfigured(
                 'You need to configure a path for the File-system backend')
-        if url is not None and url.startswith('file:///'):
+        if url.startswith('file:///'):
             return url[7:]
+        if url.startswith('file://localhost/'):
+            return url[16:]
+        raise ImproperlyConfigured(
+            'A path for the File-system backend should conform to the file URI scheme')
 
     def _do_directory_test(self, key):
         try:

--- a/t/unit/backends/test_filesystem.py
+++ b/t/unit/backends/test_filesystem.py
@@ -8,6 +8,7 @@ import pytest
 from case import skip
 
 from celery import states, uuid
+from celery.backends import filesystem
 from celery.backends.filesystem import FilesystemBackend
 from celery.exceptions import ImproperlyConfigured
 
@@ -28,9 +29,26 @@ class test_FilesystemBackend:
         tb = FilesystemBackend(app=self.app, url=self.url)
         assert tb.path == self.path
 
-    def test_path_is_incorrect(self):
-        with pytest.raises(ImproperlyConfigured):
-            FilesystemBackend(app=self.app, url=self.url + '-incorrect')
+    @pytest.mark.parametrize("url,expected_error_message", [
+        ('file:///non-existing', filesystem.E_PATH_INVALID),
+        ('url://non-conforming', filesystem.E_PATH_NON_CONFORMING_SCHEME),
+        (None, filesystem.E_NO_PATH_SET)
+    ])
+    def test_raises_meaningful_errors_for_invalid_urls(
+        self,
+        url,
+        expected_error_message
+    ):
+        with pytest.raises(
+            ImproperlyConfigured,
+            match=expected_error_message
+        ):
+            FilesystemBackend(app=self.app, url=url)
+
+    def test_localhost_is_removed_from_url(self):
+        url = 'file://localhost' + self.directory
+        tb = FilesystemBackend(app=self.app, url=url)
+        assert tb.path == self.path
 
     def test_missing_task_is_PENDING(self):
         tb = FilesystemBackend(app=self.app, url=self.url)


### PR DESCRIPTION
I took over #5206 because it was missing tests. There @bt2901 wrote

> Currently, the _find_path silently returns None and then everything fails with "None has no attribute 'encode'", which isn't very clear.

Apart from that, he also allowed urls to be `file://localhost/path/to/directory`. **Does this require a change in the documentation?** I'd say it's fine without.

For both changes I added tests but didn't really change anything of the actual code.