### PR TITLE
Fix strtobool conversion tests on Python 2

### DIFF
--- a/t/unit/utils/test_serialization.py
+++ b/t/unit/utils/test_serialization.py
@@ -111,7 +111,7 @@ class test_strtobool:
         with pytest.raises(TypeError,
                            # todo replace below when dropping python 2.7
                            # match="Cannot coerce 'foo' to type bool"):
-                           match=r"Cannot coerce .*'foo' to type bool"):
+                           match=r"Cannot coerce u?'foo' to type bool"):
             strtobool('foo')
 
     def test_no_op(self):

--- a/t/unit/utils/test_serialization.py
+++ b/t/unit/utils/test_serialization.py
@@ -109,7 +109,9 @@ class test_strtobool:
 
     def test_unknown_value(self):
         with pytest.raises(TypeError,
-                           match="Cannot coerce 'foo' to type bool"):
+                           # todo replace below when dropping python 2.7
+                           # match="Cannot coerce 'foo' to type bool"):
+                           match=r"Cannot coerce .*'foo' to type bool"):
             strtobool('foo')
 
     def test_no_op(self):


### PR DESCRIPTION
In #5276 tests for the `strtobool` function were introduced. One test checks the error message on strings that can't be converted unambiguously to a boolean value, in the test case it's `"foo"`.

The asserted error message is:
*Cannot coerce 'foo' to type bool*

however, in python 2 the error message is 

*Cannot coerce u'foo' to type bool*

This PR should fix the tests for the Python 2.7 configurations

I changed the assertion to not raise if there is a `u` in front of the actual string. Because as far as I understood python 2 support is deprecated, I also added a comment as a reminder to replace the line by it's original one when this happens.