### PR TITLE
Fix redis integration tests

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1315,7 +1315,7 @@ class chord(Signature):
         header.freeze(group_id=group_id, chord=body, root_id=root_id)
         header_result = header(*partial_args, task_id=group_id, **options)
 
-        if header_result:
+        if len(header_result) > 0:
             app.backend.apply_chord(
                 header_result,
                 body,


### PR DESCRIPTION
#5277 introduced failing integration tests for redis on CI. I traced down the line actually causing the issue and reverted it: https://github.com/celery/celery/pull/5277/files#diff-e27381cb5c64031dd28aa6855c78cfddL1315

I don't know if the failing tests were caused by actual changes in the behaviour of the code or if the test code would have to be changed... If anyone knows what's going on here, feel free to take over.