### PR TITLE
Default priority for all tasks (task_default_priority setting)

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -254,6 +254,7 @@ NAMESPACES = Namespace(
         default_exchange_type=Option('direct'),
         default_routing_key=Option(None, type='string'),  # taken from queue
         default_rate_limit=Option(type='string'),
+        default_priority=Option(None, type='string'),
         eager_propagates=Option(
             False, type='bool', old={'celery_eager_propagates_exceptions'},
         ),

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -282,6 +282,9 @@ class Task(object):
     #: Default task expiry time.
     expires = None
 
+    #: Default task priority.
+    priority = None
+
     #: Max length of result representation used in logs and events.
     resultrepr_maxsize = 1024
 
@@ -302,6 +305,7 @@ class Task(object):
     from_config = (
         ('serializer', 'task_serializer'),
         ('rate_limit', 'task_default_rate_limit'),
+        ('priority', 'task_default_priority'),
         ('track_started', 'task_track_started'),
         ('acks_late', 'task_acks_late'),
         ('acks_on_failure_or_timeout', 'task_acks_on_failure_or_timeout'),
@@ -549,6 +553,8 @@ class Task(object):
         options = dict(preopts, **options) if options else preopts
 
         options.setdefault('ignore_result', self.ignore_result)
+        if self.priority:
+            options.setdefault('priority', self.priority)
 
         return app.send_task(
             self.name, args, kwargs, task_id=task_id, producer=producer,

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1923,6 +1923,16 @@ Default: :const:`None`.
 
 See :ref:`routing-options-rabbitmq-priorities`.
 
+.. setting:: task_default_priority
+
+``task_default_priority``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:brokers: RabbitMQ
+
+Default: :const:`None`.
+
+See :ref:`routing-options-rabbitmq-priorities`.
+
 .. setting:: worker_direct
 
 ``worker_direct``

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1927,7 +1927,7 @@ See :ref:`routing-options-rabbitmq-priorities`.
 
 ``task_default_priority``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-:brokers: RabbitMQ
+:brokers: RabbitMQ, Redis
 
 Default: :const:`None`.
 

--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -244,6 +244,13 @@ A default value for all queues can be set using the
 
     app.conf.task_queue_max_priority = 10
 
+A default priority for all tasks can also be specified using the
+:setting:`task_default_priority` setting:
+
+.. code-block:: python
+
+    app.conf.task_default_priority = 5
+
 .. _amqp-primer:
 
 

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -774,6 +774,68 @@ class test_tasks(TasksCase):
 
         assert yyy2.__name__
 
+    def test_default_priority(self):
+
+        @self.app.task(shared=False)
+        def yyy3():
+            pass
+
+        @self.app.task(shared=False, priority=66)
+        def yyy4():
+            pass
+
+        self.app.conf.task_default_priority = 42
+        old_send_task = self.app.send_task
+
+        self.app.send_task = Mock()
+        yyy3.delay()
+        self.app.send_task.assert_called_once_with(ANY, ANY, ANY,
+                                                   compression=ANY,
+                                                   delivery_mode=ANY,
+                                                   exchange=ANY,
+                                                   expires=ANY,
+                                                   immediate=ANY,
+                                                   link=ANY,
+                                                   link_error=ANY,
+                                                   mandatory=ANY,
+                                                   priority=42,
+                                                   producer=ANY,
+                                                   queue=ANY,
+                                                   result_cls=ANY,
+                                                   routing_key=ANY,
+                                                   serializer=ANY,
+                                                   soft_time_limit=ANY,
+                                                   task_id=ANY,
+                                                   task_type=ANY,
+                                                   time_limit=ANY,
+                                                   shadow=None,
+                                                   ignore_result=False)
+
+        self.app.send_task = Mock()
+        yyy4.delay()
+        self.app.send_task.assert_called_once_with(ANY, ANY, ANY,
+                                                   compression=ANY,
+                                                   delivery_mode=ANY,
+                                                   exchange=ANY,
+                                                   expires=ANY,
+                                                   immediate=ANY,
+                                                   link=ANY,
+                                                   link_error=ANY,
+                                                   mandatory=ANY,
+                                                   priority=66,
+                                                   producer=ANY,
+                                                   queue=ANY,
+                                                   result_cls=ANY,
+                                                   routing_key=ANY,
+                                                   serializer=ANY,
+                                                   soft_time_limit=ANY,
+                                                   task_id=ANY,
+                                                   task_type=ANY,
+                                                   time_limit=ANY,
+                                                   shadow=None,
+                                                   ignore_result=False)
+
+        self.app.send_task = old_send_task
 
 class test_apply_task(TasksCase):
 

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -837,6 +837,7 @@ class test_tasks(TasksCase):
 
         self.app.send_task = old_send_task
 
+
 class test_apply_task(TasksCase):
 
     def test_apply_throw(self):

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -39,6 +39,10 @@ class MockApplyTask(Task):
         self.applied += 1
 
 
+class TaskWithPriority(Task):
+    priority = 10
+
+
 class TasksCase:
 
     def setup(self):
@@ -784,6 +788,10 @@ class test_tasks(TasksCase):
         def yyy4():
             pass
 
+        @self.app.task(shared=False, bind=True, base=TaskWithPriority)
+        def yyy5(self):
+            pass
+
         self.app.conf.task_default_priority = 42
         old_send_task = self.app.send_task
 
@@ -823,6 +831,30 @@ class test_tasks(TasksCase):
                                                    link_error=ANY,
                                                    mandatory=ANY,
                                                    priority=66,
+                                                   producer=ANY,
+                                                   queue=ANY,
+                                                   result_cls=ANY,
+                                                   routing_key=ANY,
+                                                   serializer=ANY,
+                                                   soft_time_limit=ANY,
+                                                   task_id=ANY,
+                                                   task_type=ANY,
+                                                   time_limit=ANY,
+                                                   shadow=None,
+                                                   ignore_result=False)
+
+        self.app.send_task = Mock()
+        yyy5.delay()
+        self.app.send_task.assert_called_once_with(ANY, ANY, ANY,
+                                                   compression=ANY,
+                                                   delivery_mode=ANY,
+                                                   exchange=ANY,
+                                                   expires=ANY,
+                                                   immediate=ANY,
+                                                   link=ANY,
+                                                   link_error=ANY,
+                                                   mandatory=ANY,
+                                                   priority=10,
                                                    producer=ANY,
                                                    queue=ANY,
                                                    result_cls=ANY,


### PR DESCRIPTION
## Description

There is a `task_queue_max_priority` configuration setting to specify default max priority for all queues, but there is no `task_default_priority` setting to allow specifying an implicit default priority for all tasks.

I wanted all my tasks to implicitly have a "middle" default priority of 5 (while having x-max-priority of 10), and to be able to selectively tune some specific tasks to have a different priority. So I've added such functionality in this pull request. It has been tested in production and seems to work as designed.
