### PR TITLE
add {posargs} to tox.ini to allow to execute only a subset of unit tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps=
 sitepackages = False
 recreate = False
 commands =
-    unit: py.test -xv --cov=celery --cov-report=xml --cov-report term
+    unit: py.test -xv --cov=celery --cov-report=xml --cov-report term {posargs}
     integration: py.test -xsv t/integration
 setenv =
     BOTO_CONFIG = /dev/null


### PR DESCRIPTION
## Description

Trivial change to `tox.ini` allows to specify additional arguments for tox (e.g. `-k` to execute only specific tests or `-s` to see output from tests in standard output.