### PR TITLE
task_inherit_parent_priority setting: allow child tasks to inherit priority from parent task

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -729,6 +729,10 @@ class Celery(object):
                 if not parent_id:
                     parent_id = parent.request.id
 
+                if conf.task_inherit_parent_priority:
+                    options.setdefault('priority',
+                            parent.request.delivery_info.get('priority'))
+
         message = amqp.create_task_message(
             task_id, name, args, kwargs, countdown, eta, group_id,
             expires, retries, chord,

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -731,7 +731,7 @@ class Celery(object):
 
                 if conf.task_inherit_parent_priority:
                     options.setdefault('priority',
-                            parent.request.delivery_info.get('priority'))
+                                       parent.request.delivery_info.get('priority'))
 
         message = amqp.create_task_message(
             task_id, name, args, kwargs, countdown, eta, group_id,

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -248,6 +248,7 @@ NAMESPACES = Namespace(
         annotations=Option(type='any'),
         compression=Option(type='string', old={'celery_message_compression'}),
         create_missing_queues=Option(True, type='bool'),
+        inherit_parent_priority=Option(False, type='bool'),
         default_delivery_mode=Option(2, type='string'),
         default_queue=Option('celery'),
         default_exchange=Option(None, type='string'),  # taken from queue

--- a/celery/utils/serialization.py
+++ b/celery/utils/serialization.py
@@ -44,6 +44,7 @@ STRTOBOOL_DEFAULT_TABLE = {'false': False, 'no': False, '0': False,
                            'true': True, 'yes': True, '1': True,
                            'on': True, 'off': False}
 
+
 def subclass_exception(name, parent, module):  # noqa
     """Create new exception class."""
     return type(bytes_if_py2(name), (parent,), {'__module__': module})

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1933,6 +1933,27 @@ Default: :const:`None`.
 
 See :ref:`routing-options-rabbitmq-priorities`.
 
+.. setting:: task_inherit_parent_priority
+
+``task_inherit_parent_priority``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:brokers: RabbitMQ
+
+Default: :const:`False`.
+
+If enabled, child tasks will inherit priority of the parent task.
+
+.. code-block:: python
+
+    # The last task in chain will also have priority set to 5.
+    chain = celery.chain(add.s(2) | add.s(2).set(priority=5) | add.s(3))
+
+Priority inheritance also works when calling child tasks from a parent task
+with `delay` or `apply_async`.
+
+See :ref:`routing-options-rabbitmq-priorities`.
+
+
 .. setting:: worker_direct
 
 ``worker_direct``

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -180,7 +180,7 @@ class test_trace(TraceCase):
         maybe_signature.return_value = sig
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         sig.apply_async.assert_called_with(
-            (4,), parent_id='id-1', root_id='root',
+            (4,), parent_id='id-1', root_id='root', priority=None
         )
 
     @patch('celery.canvas.maybe_signature')
@@ -192,7 +192,21 @@ class test_trace(TraceCase):
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         sig.apply_async.assert_called_with(
             (4, ), parent_id='id-1', root_id='root',
-            chain=[sig2],
+            chain=[sig2], priority=None
+        )
+
+    @patch('celery.canvas.maybe_signature')
+    def test_chain_inherit_parent_priority(self, maybe_signature):
+        self.app.conf.task_inherit_parent_priority = True
+        sig = Mock(name='sig')
+        sig2 = Mock(name='sig2')
+        request = {'chain': [sig2, sig], 'root_id': 'root',
+                'delivery_info': {'priority': 42}}
+        maybe_signature.return_value = sig
+        retval, _ = self.trace(self.add, (2, 2), {}, request=request)
+        sig.apply_async.assert_called_with(
+            (4, ), parent_id='id-1', root_id='root',
+            chain=[sig2], priority=42
         )
 
     @patch('celery.canvas.maybe_signature')
@@ -218,10 +232,10 @@ class test_trace(TraceCase):
         maybe_signature.side_effect = passt
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         group_.assert_called_with(
-            (4,), parent_id='id-1', root_id='root',
+            (4,), parent_id='id-1', root_id='root', priority=None
         )
         sig3.apply_async.assert_called_with(
-            (4,), parent_id='id-1', root_id='root',
+            (4,), parent_id='id-1', root_id='root', priority=None
         )
 
     @patch('celery.canvas.maybe_signature')
@@ -238,10 +252,10 @@ class test_trace(TraceCase):
         maybe_signature.side_effect = passt
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         sig1.apply_async.assert_called_with(
-            (4,), parent_id='id-1', root_id='root',
+            (4,), parent_id='id-1', root_id='root', priority=None
         )
         sig2.apply_async.assert_called_with(
-            (4,), parent_id='id-1', root_id='root',
+            (4,), parent_id='id-1', root_id='root', priority=None
         )
 
     def test_trace_SystemExit(self):

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -201,7 +201,7 @@ class test_trace(TraceCase):
         sig = Mock(name='sig')
         sig2 = Mock(name='sig2')
         request = {'chain': [sig2, sig], 'root_id': 'root',
-                'delivery_info': {'priority': 42}}
+                   'delivery_info': {'priority': 42}}
         maybe_signature.return_value = sig
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         sig.apply_async.assert_called_with(


### PR DESCRIPTION
## Description

An addition to the other priority-related PR #5309. Allow subtasks to inherit priority set for parent task. When the setting is enabled, the following behavior will apply:

    c = celery.chain(
        add.s(2), # priority=None
        add.s(3).set(priority=5), # priority=5
        add.s(4), # priority=5
        add.s(5).set(priority=3), # priority=3
        add.s(6), # priority=3
    )

As well as this:

    @app.task(bind=True)
    def child_task(self):
        pass

    @app.task(bind=True)
    def parent_task(self):
        child_task.delay()

    # child_task will also have priority=5
    parent_task.apply_async(args=[], priority=5)