### PR TITLE
Use task_serializer for doing roundtrip serialization for eager tasks

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -531,14 +531,17 @@ class Task(object):
         if app.conf.task_always_eager:
             with app.producer_or_acquire(producer) as eager_producer:
                 serializer = options.get(
-                    'serializer', eager_producer.serializer
+                    'serializer',
+                    (eager_producer.serializer if eager_producer.serializer
+                     else app.conf.task_serializer)
                 )
                 body = args, kwargs
                 content_type, content_encoding, data = serialization.dumps(
-                    body, serializer
+                    body, serializer,
                 )
                 args, kwargs = serialization.loads(
-                    data, content_type, content_encoding
+                    data, content_type, content_encoding,
+                    accept=[content_type]
                 )
             with denied_join_result():
                 return self.apply(args, kwargs, task_id=task_id or uuid(),

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -942,6 +942,20 @@ class test_apply_async(TasksCase):
         with pytest.raises(EncodeError):
             task.apply_async((1, 2, 3, 4, {1}))
 
+    def test_eager_serialization_uses_task_serializer_setting(self):
+        @self.app.task
+        def task(*args, **kwargs):
+            pass
+        with pytest.raises(EncodeError):
+            task.apply_async((1, 2, 3, 4, {1}))
+
+        self.app.conf.task_serializer = 'pickle'
+
+        @self.app.task
+        def task2(*args, **kwargs):
+            pass
+        task2.apply_async((1, 2, 3, 4, {1}))
+
     def test_task_with_ignored_result(self):
         with patch.object(self.app, 'send_task') as send_task:
             self.task_with_ignored_result.apply_async()


### PR DESCRIPTION
## Description
Fixes https://github.com/celery/celery/issues/5133
When doing the roundtrip serialization for eager tasks, the task serializer will always be JSON unless the `serializer` argument is present in the call to `Task.apply_async`. If the serializer argument is present but is `'pickle'`, an exception will be raised as pickle-serialized objects cannot be deserialized without specifying to `serialization.loads` what content types should be accepted. The Producer's `serializer` seems to be set to `None`, causing the default to JSON serialization.

This PR will continue using (in order) the `serializer` argument to `Task.apply_async`, if present, or the `Producer`'s serializer if not `None`. If the `Producer`'s serializer is `None`, it will use the Celery app's `task_serializer` configuration entry as the serializer.

