### PR TITLE
Fix redis ResultConsumer.drain_events when called before start

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -2,6 +2,8 @@
 """Redis result store backend."""
 from __future__ import absolute_import, unicode_literals
 
+import time
+
 from functools import partial
 from ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
 
@@ -117,9 +119,12 @@ class ResultConsumer(BaseResultConsumer):
             self._pubsub.close()
 
     def drain_events(self, timeout=None):
-        message = self._pubsub.get_message(timeout=timeout)
-        if message and message['type'] == 'message':
-            self.on_state_change(self._decode_result(message['data']), message)
+        if self._pubsub:
+            message = self._pubsub.get_message(timeout=timeout)
+            if message and message['type'] == 'message':
+                self.on_state_change(self._decode_result(message['data']), message)
+        elif timeout:
+            time.sleep(timeout)
 
     def consume_from(self, task_id):
         if self._pubsub is None:

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -189,6 +189,11 @@ class test_RedisResultConsumer:
         parent_method.assert_called_once_with(meta, message)
         cancel_for.assert_not_called()
 
+    def test_drain_events_before_start(self):
+        consumer = self.get_consumer()
+        # drain_events shouldn't crash when called before start
+        consumer.drain_events(0.001)
+
 
 class test_RedisBackend:
     def get_backend(self):

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -8,6 +8,19 @@ from celery._state import _task_stack
 from celery.backends.rpc import RPCBackend
 
 
+class test_RPCResultConsumer:
+    def get_backend(self):
+        return RPCBackend(app=self.app)
+
+    def get_consumer(self):
+        return self.get_backend().result_consumer
+
+    def test_drain_events_before_start(self):
+        consumer = self.get_consumer()
+        # drain_events shouldn't crash when called before start
+        consumer.drain_events(0.001)
+
+
 class test_RPCBackend:
 
     def setup(self):


### PR DESCRIPTION
This fixes #4105 by correcting the `drain_events` behavior.
It replicates the same behavior from RPC backend ([backends/rpc.py](https://github.com/celery/celery/blob/76d10453ab9267c45b12d7c60b5ee0e4113b4369/celery/backends/rpc.py#L62)), which doesn't assume that `start` was called before the `drain_events` call, and therefore skips trying to fetch a message from backend. Additionally, there's no trivial way to call `start` since it requires a task id.