### PR TITLE
Allow GroupResult.join timeout to be configurable in celery.chord_unlock

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -267,3 +267,4 @@ Bruno Alla, 2018/09/27
 Artem Vasilyev, 2018/11/24
 Victor Mireyev, 2018/12/13
 Florian Chardin, 2018/10/23
+Shady Rafehi, 2019/02/20

--- a/celery/app/builtins.py
+++ b/celery/app/builtins.py
@@ -78,7 +78,10 @@ def add_unlock_chord_task(app):
         callback = maybe_signature(callback, app=app)
         try:
             with allow_join_result():
-                ret = j(timeout=app.conf.result_chord_join_timeout, propagate=True)
+                ret = j(
+                    timeout=app.conf.result_chord_join_timeout,
+                    propagate=True,
+                )
         except Exception as exc:  # pylint: disable=broad-except
             try:
                 culprit = next(deps._failed_join_report())

--- a/celery/app/builtins.py
+++ b/celery/app/builtins.py
@@ -78,7 +78,7 @@ def add_unlock_chord_task(app):
         callback = maybe_signature(callback, app=app)
         try:
             with allow_join_result():
-                ret = j(timeout=3.0, propagate=True)
+                ret = j(timeout=app.conf.result_chord_join_timeout, propagate=True)
         except Exception as exc:  # pylint: disable=broad-except
             try:
                 culprit = next(deps._failed_join_report())

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -210,6 +210,7 @@ NAMESPACES = Namespace(
         extended=Option(False, type='bool'),
         serializer=Option('json'),
         backend_transport_options=Option({}, type='dict'),
+        chord_join_timeout=Option(3.0, type='float'),
     ),
     elasticsearch=Namespace(
         __old__=old_ns('celery_elasticsearch'),

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -753,7 +753,7 @@ Disabled by default.
 
 Default: 3.0.
 
-The timeout when joining the group's results within a chord in seconds.
+The timeout in seconds (int/float) when joining a group's results within a chord.
 
 .. _conf-database-result-backend:
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -746,6 +746,15 @@ will disable the cache.
 
 Disabled by default.
 
+.. setting:: result_chord_join_timeout
+
+``result_chord_join_timeout``
+~~~~~~~~~~~~~~~~~~~~
+
+Default: 3.0.
+
+The timeout when joining the group's results within a chord in seconds.
+
 .. _conf-database-result-backend:
 
 Database backend settings

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -188,7 +188,7 @@ class test_unlock_chord_task(ChordCase):
         with self._chord_context(MockJoinResult):
             MockJoinResult.join.assert_called_with(
                 timeout=timeout,
-                spropagate=True,
+                propagate=True,
             )
 
     def test_unlock_join_timeout_default(self):

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -177,32 +177,27 @@ class test_unlock_chord_task(ChordCase):
     def test_is_in_registry(self):
         assert 'celery.chord_unlock' in self.app.tasks
 
+    def _test_unlock_join_timeout(self, timeout):
+        class MockJoinResult(TSR):
+            is_ready = True
+            value = [(None,)]
+            join = Mock(return_value=value)
+            join_native = join
+        
+        self.app.conf.result_chord_join_timeout = timeout
+        with self._chord_context(MockJoinResult):
+            MockJoinResult.join.assert_called_with(
+                timeout=timeout,
+                spropagate=True,
+            )
+
     def test_unlock_join_timeout_default(self):
-        class MockJoinResult(TSR):
-            is_ready = True
-            value = [(None,)]
-            join = Mock(return_value=value)
-            join_native = join
-        
-        with self._chord_context(MockJoinResult):
-            MockJoinResult.join.assert_called_with(
-                timeout=self.app.conf.result_chord_join_timeout,
-                propagate=True,
-            )
-    
+        self._test_unlock_join_timeout(
+            timeout=self.app.conf.result_chord_join_timeout,
+        )
+
     def test_unlock_join_timeout_custom(self):
-        class MockJoinResult(TSR):
-            is_ready = True
-            value = [(None,)]
-            join = Mock(return_value=value)
-            join_native = join
-        
-        self.app.conf.result_chord_join_timeout = 5.0
-        with self._chord_context(MockJoinResult):
-            MockJoinResult.join.assert_called_with(
-                timeout=self.app.conf.result_chord_join_timeout,
-                propagate=True,
-            )
+        self._test_unlock_join_timeout(timeout=5.0)
 
 
 class test_chord(ChordCase):

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -177,6 +177,33 @@ class test_unlock_chord_task(ChordCase):
     def test_is_in_registry(self):
         assert 'celery.chord_unlock' in self.app.tasks
 
+    def test_unlock_join_timeout_default(self):
+        class MockJoinResult(TSR):
+            is_ready = True
+            value = [(None,)]
+            join = Mock(return_value=value)
+            join_native = join
+        
+        with self._chord_context(MockJoinResult):
+            MockJoinResult.join.assert_called_with(
+                timeout=self.app.conf.result_chord_join_timeout,
+                propagate=True,
+            )
+    
+    def test_unlock_join_timeout_custom(self):
+        class MockJoinResult(TSR):
+            is_ready = True
+            value = [(None,)]
+            join = Mock(return_value=value)
+            join_native = join
+        
+        self.app.conf.result_chord_join_timeout = 5.0
+        with self._chord_context(MockJoinResult):
+            MockJoinResult.join.assert_called_with(
+                timeout=self.app.conf.result_chord_join_timeout,
+                propagate=True,
+            )
+
 
 class test_chord(ChordCase):
 

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -183,7 +183,7 @@ class test_unlock_chord_task(ChordCase):
             value = [(None,)]
             join = Mock(return_value=value)
             join_native = join
-        
+
         self.app.conf.result_chord_join_timeout = timeout
         with self._chord_context(MockJoinResult):
             MockJoinResult.join.assert_called_with(


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Resolves #5349

Previously the timeout passed down to `GroupResult.join` in `celery.chord_unlock` was hardcoded to 3.0 seconds. This introduces the new configuration option `result_chord_join_timeout` which allows users to configure the timeout. The default value remains as 3.0.

