### PR TITLE
Prepend to sys.path in the Django fixup instead of appending.

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -57,8 +57,10 @@ class DjangoFixup(object):
         self._worker_fixup = None
 
     def install(self):
-        # Need to add project directory to path
-        sys.path.append(os.getcwd())
+        # Need to add project directory to path.
+        # The project directory has precedence over system modules,
+        # so we prepend it to the path.
+        sys.path.prepend(os.getcwd())
 
         self._settings = symbol_by_name('django.conf:settings')
         self.app.loader.now = self.now

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -91,7 +91,7 @@ class test_DjangoFixup(FixupCase):
             f.install()
             self.sigs.worker_init.connect.assert_called_with(f.on_worker_init)
             assert self.app.loader.now == f.now
-            self.p.append.assert_called_with('/opt/vandelay')
+            self.p.prepend.assert_called_with('/opt/vandelay')
 
     def test_now(self):
         with self.fixup_context(self.app) as (f, _, _):


### PR DESCRIPTION
This makes sure that project modules have precedence over system ones.
Closes #5347.

## Description

This follows @Phyks's suggestion of a fix for #5347, by prepending instead of appending to the system path, to ensure that the project modules are not hidden by system-wide ones.
