### PR TITLE
Fix call to list.prepend to use list.insert

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -60,7 +60,7 @@ class DjangoFixup(object):
         # Need to add project directory to path.
         # The project directory has precedence over system modules,
         # so we prepend it to the path.
-        sys.path.prepend(os.getcwd())
+        sys.path.insert(0, os.getcwd())
 
         self._settings = symbol_by_name('django.conf:settings')
         self.app.loader.now = self.now

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -91,7 +91,7 @@ class test_DjangoFixup(FixupCase):
             f.install()
             self.sigs.worker_init.connect.assert_called_with(f.on_worker_init)
             assert self.app.loader.now == f.now
-            self.p.prepend.assert_called_with('/opt/vandelay')
+            self.p.insert.assert_called_with(0, '/opt/vandelay')
 
     def test_now(self):
         with self.fixup_context(self.app) as (f, _, _):


### PR DESCRIPTION
This fixes #5355 which used the well known `list.prepend` method which does not actually exist. Oops.