### PR TITLE
Support PEP 420 namespace packages

### DIFF
--- a/t/unit/utils/test_imports.py
+++ b/t/unit/utils/test_imports.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
+import sys
+
 import pytest
-from case import Mock
+from case import Mock, patch, skip
 
 from celery.five import bytes_if_py2
 from celery.utils.imports import (NotAPackage, find_module, gen_task_name,
@@ -9,12 +11,61 @@ from celery.utils.imports import (NotAPackage, find_module, gen_task_name,
 
 
 def test_find_module():
+    def imp_side_effect(module):
+        if module == 'foo':
+            return None
+        else:
+            raise ImportError(module)
+
     assert find_module('celery')
     imp = Mock()
-    imp.return_value = None
-    with pytest.raises(NotAPackage):
+    imp.side_effect = imp_side_effect
+    with pytest.raises(NotAPackage) as exc_info:
         find_module('foo.bar.baz', imp=imp)
+    assert exc_info.value.args[0] == 'foo'
     assert find_module('celery.worker.request')
+
+
+def test_find_module_legacy_namespace_package(tmp_path, monkeypatch):
+    monkeypatch.chdir(str(tmp_path))
+    (tmp_path / 'pkg' / 'foo').mkdir(parents=True)
+    (tmp_path / 'pkg' / '__init__.py').write_text(
+        'from pkgutil import extend_path\n'
+        '__path__ = extend_path(__path__, __name__)\n')
+    (tmp_path / 'pkg' / 'foo' / '__init__.py').write_text('')
+    (tmp_path / 'pkg' / 'foo' / 'bar.py').write_text('')
+    with patch.dict(sys.modules):
+        for modname in list(sys.modules):
+            if modname == 'pkg' or modname.startswith('pkg.'):
+                del sys.modules[modname]
+        with pytest.raises(ImportError):
+            find_module('pkg.missing')
+        with pytest.raises(ImportError):
+            find_module('pkg.foo.missing')
+        assert find_module('pkg.foo.bar')
+        with pytest.raises(NotAPackage) as exc_info:
+            find_module('pkg.foo.bar.missing')
+        assert exc_info.value.args[0] == 'pkg.foo.bar'
+
+
+@skip.unless_python3()
+def test_find_module_pep420_namespace_package(tmp_path, monkeypatch):
+    monkeypatch.chdir(str(tmp_path))
+    (tmp_path / 'pkg' / 'foo').mkdir(parents=True)
+    (tmp_path / 'pkg' / 'foo' / '__init__.py').write_text('')
+    (tmp_path / 'pkg' / 'foo' / 'bar.py').write_text('')
+    with patch.dict(sys.modules):
+        for modname in list(sys.modules):
+            if modname == 'pkg' or modname.startswith('pkg.'):
+                del sys.modules[modname]
+        with pytest.raises(ImportError):
+            find_module('pkg.missing')
+        with pytest.raises(ImportError):
+            find_module('pkg.foo.missing')
+        assert find_module('pkg.foo.bar')
+        with pytest.raises(NotAPackage) as exc_info:
+            find_module('pkg.foo.bar.missing')
+        assert exc_info.value.args[0] == 'pkg.foo.bar'
 
 
 def test_qualname():


### PR DESCRIPTION
`imp.find_module` doesn't support PEP 420 implicit namespace packages,
and in any case `imp` is deprecated in favour of `importlib`.

We can almost just use `importlib.import_module` directly, except that
loaders rely on the custom `NotAPackage` exception, so emulate that.