### PR TITLE
Added the task_received signal

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -8,6 +8,15 @@ This document contains change notes for bugfix releases in
 the 4.x series, please see :ref:`whatsnew-4.3` for
 an overview of what's new in Celery 4.3.
 
+4.3.0
+=====
+:release-date: TBD
+:release-by: Omer Katz
+
+- Added the :signal:`task_received` signal.
+
+  Contributed by **Omer Katz**
+
 4.3.0 RC2
 =========
 :release-date: 2019-03-03 9:30 P.M UTC+2:00

--- a/celery/signals.py
+++ b/celery/signals.py
@@ -39,6 +39,10 @@ after_task_publish = Signal(
     name='after_task_publish',
     providing_args={'body', 'exchange', 'routing_key'},
 )
+task_received = Signal(
+    name='task_received',
+    providing_args={'request'}
+)
 task_prerun = Signal(
     name='task_prerun',
     providing_args={'task_id', 'task', 'args', 'kwargs'},

--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -12,6 +12,7 @@ from celery.utils.imports import symbol_by_name
 from celery.utils.log import get_logger
 from celery.utils.saferepr import saferepr
 from celery.utils.time import timezone
+from celery import signals
 
 from .request import create_request_cls
 from .state import task_reserved
@@ -156,6 +157,8 @@ def default(task, app, consumer,
             info('Received task: %s', req)
         if (req.expires or req.id in revoked_tasks) and req.revoked():
             return
+
+        signals.task_received.send(sender=consumer, request=req)
 
         if task_sends_events:
             send_event(


### PR DESCRIPTION
## Description

For those who want to execute something when a task is received I added the task_received signal.
It's useful for custom metrics reporting and probably other actions as well.