### PR TITLE
Add caveat for acks_on_failure_or_timeout

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -255,6 +255,9 @@ class Task(object):
     #: When enabled messages for this task will be acknowledged even if it
     #: fails or times out.
     #:
+    #: Configuring this setting only applies to tasks that are
+    #: acknowledged **after** they have been executed.
+    #:
     #: The application default can be overridden with the
     #: :setting:`task_acks_on_failure_or_timeout` setting.
     acks_on_failure_or_timeout = True


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This pull request is intended to fix the docs mentioned in https://github.com/celery/celery/issues/5377. After looking at the source code, the docs do not imply that the setting only applies when `task_acks_late` is configured. Added some subtle messaging to aid future readers.
