### PR TITLE
Add documentation for new compression schemes

### DIFF
--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -499,15 +499,40 @@ Celery can compress messages using the following builtin schemes:
 
 - `brotli`
 
+    brotli is optimized for the web, in particular small text
+    documents. It is most effective for serving static content
+    such as fonts and html pages.
+
 - `bzip2`
+
+    bzip2 creates smaller files than gzip, but compression and
+    decompression speeds are noticeably slower than those of gzip.
 
 - `gzip`
 
+    gzip is suitable for systems that require a small memory footprint,
+    making it ideal for systems with limited memory. It is often
+    used to generate files with the ".tar.gz" extension.
+
 - `lzma`
+
+    lzma provides a good compression ratio and executes with
+    fast compression and decompression speeds at the expense
+    of higher memory usage.
 
 - `zlib`
 
+    zlib is an abstraction of the Deflate algorithm in library
+    form which includes support both for the gzip file format
+    and a lightweight stream format in its API. It is a crucial
+    component of many software systems - Linux kernel and Git VCS just
+    to name a few.
+
 - `zstd`
+
+    zstd targets real-time compression scenarios at zlib-level
+    and better compression ratios. It's backed by a very fast entropy
+    stage, provided by Huff0 and FSE library.
 
 You can also create your own compression schemes and register
 them in the :func:`kombu compression registry <kombu.compression.register>`.

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -503,10 +503,30 @@ Celery can compress messages using the following builtin schemes:
     documents. It is most effective for serving static content
     such as fonts and html pages.
 
+    To use it, install kombu with:
+
+    .. code-block:: console
+
+      $ pip install kombu[brotli]
+
 - `bzip2`
 
     bzip2 creates smaller files than gzip, but compression and
     decompression speeds are noticeably slower than those of gzip.
+
+    To use it, please ensure your Python executable was compiled
+    with bzip2 support.
+
+    If you get the following :class:`ImportError`:
+
+    .. code-block:: pycon
+
+      >>> import bz2
+      Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+      ImportError: No module named 'bz2'
+
+    it means that you should recompile your Python version with bzip2 support.
 
 - `gzip`
 
@@ -514,11 +534,45 @@ Celery can compress messages using the following builtin schemes:
     making it ideal for systems with limited memory. It is often
     used to generate files with the ".tar.gz" extension.
 
+    To use it, please ensure your Python executable was compiled
+    with gzip support.
+
+    If you get the following :class:`ImportError`:
+
+    .. code-block:: pycon
+
+      >>> import gzip
+      Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+      ImportError: No module named 'gzip'
+
+    it means that you should recompile your Python version with gzip support.
+
 - `lzma`
 
     lzma provides a good compression ratio and executes with
     fast compression and decompression speeds at the expense
     of higher memory usage.
+
+    To use it, please ensure your Python executable was compiled
+    with lzma support and that your Python version is 3.3 and above.
+
+    If you get the following :class:`ImportError`:
+
+    .. code-block:: pycon
+
+      >>> import lzma
+      Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+      ImportError: No module named 'lzma'
+
+    it means that you should recompile your Python version with lzma support.
+
+    Alternatively, you can also install a backport using:
+
+    .. code-block:: console
+
+      $ pip install kombu[lzma]
 
 - `zlib`
 
@@ -528,11 +582,31 @@ Celery can compress messages using the following builtin schemes:
     component of many software systems - Linux kernel and Git VCS just
     to name a few.
 
+    To use it, please ensure your Python executable was compiled
+    with zlib support.
+
+    If you get the following :class:`ImportError`:
+
+    .. code-block:: pycon
+
+      >>> import zlib
+      Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+      ImportError: No module named 'zlib'
+
+    it means that you should recompile your Python version with zlib support.
+
 - `zstd`
 
     zstd targets real-time compression scenarios at zlib-level
     and better compression ratios. It's backed by a very fast entropy
     stage, provided by Huff0 and FSE library.
+
+    To use it, install kombu with:
+
+    .. code-block:: console
+
+      $ pip install kombu[zstd]
 
 You can also create your own compression schemes and register
 them in the :func:`kombu compression registry <kombu.compression.register>`.

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -495,7 +495,20 @@ Example setting a custom serializer for a single task invocation:
 Compression
 ===========
 
-Celery can compress the messages using either *gzip*, or *bzip2*.
+Celery can compress messages using the following builtin schemes:
+
+- `brotli`
+
+- `bzip2`
+
+- `gzip`
+
+- `lzma`
+
+- `zlib`
+
+- `zstd`
+
 You can also create your own compression schemes and register
 them in the :func:`kombu compression registry <kombu.compression.register>`.
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Attempting to fill in the missing gaps for Celery user guides regarding newly supported compression schemes. I added spacing between the compression schemes so as to allow more room for scheme sub-sections if necessary. This should resolve https://github.com/celery/celery/issues/5328.