### PR TITLE
Fixes to SSL config handling

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -271,12 +271,8 @@ class Celery(object):
         self.__autoset('broker_url', broker)
         self.__autoset('result_backend', backend)
         self.__autoset('include', include)
-        self.__autoset('broker_use_ssl',
-                       (kwargs['broker_use_ssl'] if 'broker_use_ssl'
-                        in kwargs else None))
-        self.__autoset('redis_backend_use_ssl',
-                       (kwargs['redis_backend_use_ssl'] if
-                        'redis_backend_use_ssl' in kwargs else None))
+        self.__autoset('broker_use_ssl', kwargs.get('broker_use_ssl'))
+        self.__autoset('redis_backend_use_ssl', kwargs.get('redis_backend_use_ssl'))
         self._conf = Settings(
             PendingConfiguration(
                 self._preconf, self._finalize_pending_conf),

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -271,11 +271,11 @@ class Celery(object):
         self.__autoset('broker_url', broker)
         self.__autoset('result_backend', backend)
         self.__autoset('include', include)
-        self.__autoset('broker_use_ssl', 
-                       (kwargs['broker_use_ssl'] if 'broker_use_ssl' 
+        self.__autoset('broker_use_ssl',
+                       (kwargs['broker_use_ssl'] if 'broker_use_ssl'
                         in kwargs else None))
-        self.__autoset('redis_backend_use_ssl', 
-                       (kwargs['redis_backend_use_ssl'] if  
+        self.__autoset('redis_backend_use_ssl',
+                       (kwargs['redis_backend_use_ssl'] if
                         'redis_backend_use_ssl' in kwargs else None))
         self._conf = Settings(
             PendingConfiguration(

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -271,6 +271,12 @@ class Celery(object):
         self.__autoset('broker_url', broker)
         self.__autoset('result_backend', backend)
         self.__autoset('include', include)
+        self.__autoset('broker_use_ssl', 
+                       (kwargs['broker_use_ssl'] if 'broker_use_ssl' 
+                        in kwargs else None))
+        self.__autoset('redis_backend_use_ssl', 
+                       (kwargs['redis_backend_use_ssl'] if  
+                        'redis_backend_use_ssl' in kwargs else None))
         self._conf = Settings(
             PendingConfiguration(
                 self._preconf, self._finalize_pending_conf),

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -66,10 +66,9 @@ will not valdate the identity of the redis broker when connecting. This \
 leaves you vulnerable to man in the middle attacks.
 """
 
-W_REDIS_SSL_PARAMS_AND_SCHEME_MISMATCH = """
+E_REDIS_SSL_PARAMS_AND_SCHEME_MISMATCH = """
 SSL connection parameters have been provided but the specified URL scheme \
-is redis://. A Redis SSL connection URL should use the scheme rediss://. \
-An SSL connection will be attempted.
+is redis://. A Redis SSL connection URL should use the scheme rediss://.
 """
 
 E_REDIS_SSL_CERT_REQS_MISSING = """
@@ -258,10 +257,10 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
                           'ssl_cert_reqs']
 
         if scheme == 'redis':
-            # Check IF connparams or query string contain ssl params, if so show warning.]
+            # If connparams or query string contain ssl params, raise error
             if (any(key in connparams for key in ssl_param_keys) or
                     any(key in query for key in ssl_param_keys)):
-                logger.warning(W_REDIS_SSL_PARAMS_AND_SCHEME_MISMATCH)
+                raise ValueError(E_REDIS_SSL_PARAMS_AND_SCHEME_MISMATCH)
 
         if scheme == 'rediss':
             connparams['connection_class'] = redis.SSLConnection

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -208,7 +208,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         # redis_backend_use_ssl dict, check ssl_cert_reqs is valid. If set
         # via query string ssl_cert_reqs will be a string so convert it here
         if ('connection_class' in self.connparams and
-                self.connparams['connection_class'] == redis.SSLConnection):
+                self.connparams['connection_class'] is redis.SSLConnection):
             ssl_cert_reqs_missing = 'MISSING'
             ssl_string_to_constant = {'CERT_REQUIRED': CERT_REQUIRED,
                                       'CERT_OPTIONAL': CERT_OPTIONAL,

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -239,12 +239,14 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
                 if ssl_val:
                     connparams[ssl_setting] = unquote(ssl_val)
             ssl_cert_reqs = query.pop('ssl_cert_reqs', 'MISSING')
-            if ssl_cert_reqs == 'CERT_REQUIRED':
+            if ssl_cert_reqs == 'MISSING':
+                ssl_cert_reqs = connparams.get('ssl_cert_reqs', 'MISSING')
+            if ssl_cert_reqs in ['CERT_REQUIRED', CERT_REQUIRED]:
                 connparams['ssl_cert_reqs'] = CERT_REQUIRED
-            elif ssl_cert_reqs == 'CERT_OPTIONAL':
+            elif ssl_cert_reqs in ['CERT_OPTIONAL', CERT_OPTIONAL]:
                 logger.warning(W_REDIS_SSL_CERT_OPTIONAL)
                 connparams['ssl_cert_reqs'] = CERT_OPTIONAL
-            elif ssl_cert_reqs == 'CERT_NONE':
+            elif ssl_cert_reqs in ['CERT_NONE', CERT_NONE]:
                 logger.warning(W_REDIS_SSL_CERT_NONE)
                 connparams['ssl_cert_reqs'] = CERT_NONE
             else:

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -204,12 +204,12 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
 
         if url:
             self.connparams = self._params_from_url(url, self.connparams)
-        
-        # If we've received SSL parameters via query string or the 
-        # redis_backend_use_ssl dict, check ssl_cert_reqs is valid. If set 
+
+        # If we've received SSL parameters via query string or the
+        # redis_backend_use_ssl dict, check ssl_cert_reqs is valid. If set
         # via query string ssl_cert_reqs will be a string so convert it here
-        if ('connection_class' in self.connparams 
-            and self.connparams['connection_class'] == redis.SSLConnection):
+        if ('connection_class' in self.connparams and
+                self.connparams['connection_class'] == redis.SSLConnection):
             ssl_cert_reqs = self.connparams.get('ssl_cert_reqs', 'MISSING')
             if ssl_cert_reqs in [CERT_REQUIRED, 'CERT_REQUIRED']:
                 self.connparams['ssl_cert_reqs'] = CERT_REQUIRED
@@ -254,13 +254,13 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         else:
             connparams['db'] = path
 
-        ssl_param_keys = ['ssl_ca_certs', 'ssl_certfile', 'ssl_keyfile', 
+        ssl_param_keys = ['ssl_ca_certs', 'ssl_certfile', 'ssl_keyfile',
                           'ssl_cert_reqs']
 
         if scheme == 'redis':
             # Check IF connparams or query string contain ssl params, if so show warning.]
             if (any(key in connparams for key in ssl_param_keys) or
-                any(key in query for key in ssl_param_keys)):
+                    any(key in query for key in ssl_param_keys)):
                 logger.warning(W_REDIS_SSL_PARAMS_AND_SCHEME_MISMATCH)
 
         if scheme == 'rediss':

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -392,8 +392,8 @@ class test_App:
                              'ssl_cert_reqs': ssl.CERT_REQUIRED,
                              'ssl_ca_certs': '/path/to/ca.crt',
                              'ssl_certfile': '/path/to/client.crt',
-                             'ssl_keyfile': '/path/to/client.key'}, 
-                         redis_backend_use_ssl = {
+                             'ssl_keyfile': '/path/to/client.key'},
+                         redis_backend_use_ssl={
                              'ssl_cert_reqs': ssl.CERT_REQUIRED,
                              'ssl_ca_certs': '/path/to/ca.crt',
                              'ssl_certfile': '/path/to/client.crt',
@@ -401,21 +401,21 @@ class test_App:
             assert not app.configured
             assert app.conf.broker_url == 'foo://bar'
             assert app.conf.broker_use_ssl['ssl_certfile'] == \
-                                                    '/path/to/client.crt'
+                '/path/to/client.crt'
             assert app.conf.broker_use_ssl['ssl_keyfile'] == \
-                                                    '/path/to/client.key'
+                '/path/to/client.key'
             assert app.conf.broker_use_ssl['ssl_ca_certs'] == \
-                                                    '/path/to/ca.crt'
+                '/path/to/ca.crt'
             assert app.conf.broker_use_ssl['ssl_cert_reqs'] == \
-                                                    ssl.CERT_REQUIRED
+                ssl.CERT_REQUIRED
             assert app.conf.redis_backend_use_ssl['ssl_certfile'] == \
-                                                    '/path/to/client.crt'
+                '/path/to/client.crt'
             assert app.conf.redis_backend_use_ssl['ssl_keyfile'] == \
-                                                    '/path/to/client.key'
+                '/path/to/client.key'
             assert app.conf.redis_backend_use_ssl['ssl_ca_certs'] == \
-                                                    '/path/to/ca.crt'
+                '/path/to/ca.crt'
             assert app.conf.redis_backend_use_ssl['ssl_cert_reqs'] == \
-                                                    ssl.CERT_REQUIRED                                        
+                ssl.CERT_REQUIRED
 
     def test_repr(self):
         assert repr(self.app)

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -24,6 +24,7 @@ from celery.utils.collections import DictAttribute
 from celery.utils.objects import Bunch
 from celery.utils.serialization import pickle
 from celery.utils.time import localize, timezone, to_utc
+import ssl
 
 THIS_IS_A_KEY = 'this is a value'
 
@@ -384,6 +385,37 @@ class test_App:
 
         with self.Celery() as app:
             assert not self.app.conf.task_always_eager
+
+    def test_pending_configuration__ssl_settings(self):
+        with self.Celery(broker='foo://bar',
+                         broker_use_ssl={
+                             'ssl_cert_reqs': ssl.CERT_REQUIRED,
+                             'ssl_ca_certs': '/path/to/ca.crt',
+                             'ssl_certfile': '/path/to/client.crt',
+                             'ssl_keyfile': '/path/to/client.key'}, 
+                         redis_backend_use_ssl = {
+                             'ssl_cert_reqs': ssl.CERT_REQUIRED,
+                             'ssl_ca_certs': '/path/to/ca.crt',
+                             'ssl_certfile': '/path/to/client.crt',
+                             'ssl_keyfile': '/path/to/client.key'}) as app:
+            assert not app.configured
+            assert app.conf.broker_url == 'foo://bar'
+            assert app.conf.broker_use_ssl['ssl_certfile'] == \
+                                                    '/path/to/client.crt'
+            assert app.conf.broker_use_ssl['ssl_keyfile'] == \
+                                                    '/path/to/client.key'
+            assert app.conf.broker_use_ssl['ssl_ca_certs'] == \
+                                                    '/path/to/ca.crt'
+            assert app.conf.broker_use_ssl['ssl_cert_reqs'] == \
+                                                    ssl.CERT_REQUIRED
+            assert app.conf.redis_backend_use_ssl['ssl_certfile'] == \
+                                                    '/path/to/client.crt'
+            assert app.conf.redis_backend_use_ssl['ssl_keyfile'] == \
+                                                    '/path/to/client.key'
+            assert app.conf.redis_backend_use_ssl['ssl_ca_certs'] == \
+                                                    '/path/to/ca.crt'
+            assert app.conf.redis_backend_use_ssl['ssl_cert_reqs'] == \
+                                                    ssl.CERT_REQUIRED                                        
 
     def test_repr(self):
         assert repr(self.app)

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -281,7 +281,7 @@ class test_RedisBackend:
         self.app.conf.redis_socket_timeout = 30.0
         self.app.conf.redis_socket_connect_timeout = 100.0
         x = self.Backend(
-            'redis://:bosco@vandelay.com:123//1', app=self.app,
+            'rediss://:bosco@vandelay.com:123//1', app=self.app,
         )
         assert x.connparams
         assert x.connparams['host'] == 'vandelay.com'

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -299,6 +299,34 @@ class test_RedisBackend:
         assert x.connparams['connection_class'] is SSLConnection
 
     @skip.unless_module('redis')
+    def test_backend_ssl_certreq_str(self):
+        self.app.conf.redis_backend_use_ssl = {
+            'ssl_cert_reqs': 'CERT_REQUIRED',
+            'ssl_ca_certs': '/path/to/ca.crt',
+            'ssl_certfile': '/path/to/client.crt',
+            'ssl_keyfile': '/path/to/client.key',
+        }
+        self.app.conf.redis_socket_timeout = 30.0
+        self.app.conf.redis_socket_connect_timeout = 100.0
+        x = self.Backend(
+            'rediss://:bosco@vandelay.com:123//1', app=self.app,
+        )
+        assert x.connparams
+        assert x.connparams['host'] == 'vandelay.com'
+        assert x.connparams['db'] == 1
+        assert x.connparams['port'] == 123
+        assert x.connparams['password'] == 'bosco'
+        assert x.connparams['socket_timeout'] == 30.0
+        assert x.connparams['socket_connect_timeout'] == 100.0
+        assert x.connparams['ssl_cert_reqs'] == ssl.CERT_REQUIRED
+        assert x.connparams['ssl_ca_certs'] == '/path/to/ca.crt'
+        assert x.connparams['ssl_certfile'] == '/path/to/client.crt'
+        assert x.connparams['ssl_keyfile'] == '/path/to/client.key'
+
+        from redis.connection import SSLConnection
+        assert x.connparams['connection_class'] is SSLConnection
+
+    @skip.unless_module('redis')
     def test_backend_ssl_url(self):
         self.app.conf.redis_socket_timeout = 30.0
         self.app.conf.redis_socket_connect_timeout = 100.0

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -254,6 +254,7 @@ class test_RedisBackend:
         assert x.connparams['socket_timeout'] == 30
         assert x.connparams['socket_connect_timeout'] == 100
 
+    @skip.unless_module('redis')
     def test_socket_url(self):
         self.app.conf.redis_socket_timeout = 30.0
         self.app.conf.redis_socket_connect_timeout = 100.0


### PR DESCRIPTION
Addresses issue with handling of SSL parameters as detailed in #5371.

 - Adds configuration provided via the `broker_use_ssl` and `redis_backend_use_ssl` parameters to the application config.

 - Adds a warning if a `redis://` URL scheme is used but SSL configuration is provided (parameters may not be correctly handled in this case)

 - Refactored checking of the `ssl_cert_reqs` parameter so that this is checked correctly whether the parameter is provided via the query string or in the SSL parameter dict.

 - Tests: Added app config test to check SSL configuration is correctly added to application configuration object. Fixed incorrect URL scheme in SSL backend test.