### PR TITLE
Updated Dockerfile to resolve error building Python 3.7

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,10 @@ RUN apt-get update && apt-get install -y build-essential \
     zlib1g-dev \
     pkg-config
 
+# Update libssl to 1.0.2 from backports to support Python 3.7
+RUN echo "deb http://deb.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
+RUN apt-get update && apt-get install -y -t jessie-backports libssl-dev
+
 # Setup variables. Even though changing these may cause unnecessary invalidation of
 # unrelated elements, grouping them together makes the Dockerfile read better.
 ENV PROVISIONING /provisioning


### PR DESCRIPTION
Fixes #5402.

This PR modifies the `Dockerfile` used for building the Celery container that can be used to support [development and testing](http://docs.celeryproject.org/en/master/contributing.html#developing-and-testing-with-docker). After the core package install, `libssl` is updated to v1.0.2 using packages from the jessie-backports repo. OpenSSL >= 1.0.2 is required by Python 3.7.