### PR TITLE
Update docs for unixsocket support for Redis result backend

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -996,6 +996,10 @@ Use the ``rediss://`` protocol to connect to redis over TLS::
 
     result_backend = 'rediss://:password@host:port/db?ssl_cert_reqs=CERT_REQUIRED'
 
+If a Unix socket connection should be used, the URL needs to be in the format:::
+
+    result_backend = 'socket:///path/to/redis.sock'
+
 The fields of the URL are defined as follows:
 
 #. ``password``


### PR DESCRIPTION
Celery supports redis backend via unix socket. Look at unit test:
https://github.com/celery/celery/blob/950c62613d55d6494691bc8f5e54b9fa95e4d33b/t/unit/backends/test_redis.py#L257

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This commit update docs for supporting unix socket for Redis as a result backend. This is supported feature(https://github.com/celery/celery/blob/950c62613d55d6494691bc8f5e54b9fa95e4d33b/t/unit/backends/test_redis.py#L257), but it is not documented. 

Also, do I need to rebuild docs according to "Contribution" guideline?
