### PR TITLE
Add optional anchor_id parameter to tasks

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -304,7 +304,7 @@ class AMQP(object):
                    time_limit=None, soft_time_limit=None,
                    create_sent_event=False, root_id=None, parent_id=None,
                    shadow=None, chain=None, now=None, timezone=None,
-                   origin=None, argsrepr=None, kwargsrepr=None):
+                   origin=None, argsrepr=None, kwargsrepr=None, anchor_id=None):
         args = args or ()
         kwargs = kwargs or {}
         if not isinstance(args, (list, tuple)):
@@ -359,6 +359,7 @@ class AMQP(object):
                 'retries': retries,
                 'timelimit': [time_limit, soft_time_limit],
                 'root_id': root_id,
+                'anchor_id': anchor_id,
                 'parent_id': parent_id,
                 'argsrepr': argsrepr,
                 'kwargsrepr': kwargsrepr,
@@ -379,6 +380,7 @@ class AMQP(object):
             sent_event={
                 'uuid': task_id,
                 'root_id': root_id,
+                'anchor_id': anchor_id,
                 'parent_id': parent_id,
                 'name': name,
                 'args': argsrepr,

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -81,6 +81,7 @@ class Context(object):
     reply_to = None
     root_id = None
     parent_id = None
+    anchor_id = None
     correlation_id = None
     taskset = None   # compat alias to group
     group = None
@@ -98,6 +99,11 @@ class Context(object):
 
     def __init__(self, *args, **kwargs):
         self.update(*args, **kwargs)
+        if self.headers is not None:
+            if 'root_id' in self.headers and not self.root_id:
+                self.root_id = self.headers['root_id']
+            if 'anchor_id' in self.headers and not self.anchor_id:
+                self.anchor_id = self.headers['anchor_id']
 
     def update(self, *args, **kwargs):
         return self.__dict__.update(*args, **kwargs)
@@ -116,6 +122,7 @@ class Context(object):
         return {
             'task_id': self.id,
             'root_id': self.root_id,
+            'anchor_id': self.anchor_id,
             'parent_id': self.parent_id,
             'group_id': self.group,
             'chord': self.chord,

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -365,6 +365,7 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
             task_request = Context(request or {}, args=args,
                                    called_directly=False, kwargs=kwargs)
             root_id = task_request.root_id or uuid
+            anchor_id = task_request.anchor_id
             task_priority = task_request.delivery_info.get('priority') if \
                 inherit_parent_priority else None
             push_request(task_request)
@@ -422,17 +423,20 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                                     group_.apply_async(
                                         (retval,),
                                         parent_id=uuid, root_id=root_id,
+                                        anchor_id=anchor_id,
                                         priority=task_priority
                                     )
                                 if sigs:
                                     group(sigs, app=app).apply_async(
                                         (retval,),
                                         parent_id=uuid, root_id=root_id,
+                                        anchor_id=anchor_id,
                                         priority=task_priority
                                     )
                             else:
                                 signature(callbacks[0], app=app).apply_async(
                                     (retval,), parent_id=uuid, root_id=root_id,
+                                    anchor_id=anchor_id,
                                     priority=task_priority
                                 )
 
@@ -443,6 +447,7 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                             _chsig.apply_async(
                                 (retval,), chain=chain,
                                 parent_id=uuid, root_id=root_id,
+                                anchor_id=anchor_id,
                                 priority=task_priority
                             )
                         mark_as_done(

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -114,6 +114,7 @@ class Request(object):
         self.id = headers['id']
         type = self.type = self.name = headers['task']
         self.root_id = headers.get('root_id')
+        self.anchor_id = headers.get('anchor_id')
         self.parent_id = headers.get('parent_id')
         if 'shadow' in headers:
             self.name = headers['shadow'] or self.name

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -180,7 +180,8 @@ class test_trace(TraceCase):
         maybe_signature.return_value = sig
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         sig.apply_async.assert_called_with(
-            (4,), parent_id='id-1', root_id='root', priority=None
+            (4,), parent_id='id-1', root_id='root', anchor_id=None,
+            priority=None
         )
 
     @patch('celery.canvas.maybe_signature')
@@ -191,7 +192,7 @@ class test_trace(TraceCase):
         maybe_signature.return_value = sig
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         sig.apply_async.assert_called_with(
-            (4, ), parent_id='id-1', root_id='root',
+            (4, ), parent_id='id-1', root_id='root', anchor_id=None,
             chain=[sig2], priority=None
         )
 
@@ -205,7 +206,7 @@ class test_trace(TraceCase):
         maybe_signature.return_value = sig
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         sig.apply_async.assert_called_with(
-            (4, ), parent_id='id-1', root_id='root',
+            (4, ), parent_id='id-1', root_id='root', anchor_id=None,
             chain=[sig2], priority=42
         )
 
@@ -232,10 +233,12 @@ class test_trace(TraceCase):
         maybe_signature.side_effect = passt
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         group_.assert_called_with(
-            (4,), parent_id='id-1', root_id='root', priority=None
+            (4,), parent_id='id-1', root_id='root', anchor_id=None,
+            priority=None
         )
         sig3.apply_async.assert_called_with(
-            (4,), parent_id='id-1', root_id='root', priority=None
+            (4,), parent_id='id-1', root_id='root', anchor_id=None,
+            priority=None
         )
 
     @patch('celery.canvas.maybe_signature')
@@ -252,10 +255,12 @@ class test_trace(TraceCase):
         maybe_signature.side_effect = passt
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         sig1.apply_async.assert_called_with(
-            (4,), parent_id='id-1', root_id='root', priority=None
+            (4,), parent_id='id-1', root_id='root', anchor_id=None,
+            priority=None
         )
         sig2.apply_async.assert_called_with(
-            (4,), parent_id='id-1', root_id='root', priority=None
+            (4,), parent_id='id-1', root_id='root', anchor_id=None,
+            priority=None
         )
 
     def test_trace_SystemExit(self):


### PR DESCRIPTION
## Description
In my project, I had a need to pass some extra ID to every subsequent child task, in a similar way how `root_id` is currently propagated to tasks. However, `root_id` is the actual ID of the root task, and I needed to be able to additionally pass an user-suppied value.

Here I present the `anchor_id` header, which, if set by user, will be propagated to every subsequent child task, similar with `root_id`. Example:

    foo.apply_async(args=[42], headers={"anchor_id": "bar"})

Every task called by `foo` will have `anchor_id` available in `self.request.anchor_id`. This would allow users to identify and group tasks together using their own information in `anchor_id`. For example, we have a pipeline of processing tasks related to some business resource, and `anchor_id` could contain such resource ID, so that every task could be able to fetch the resource from the database if needed, avoiding the need to pass an extra parameter to many tasks.

Hope this makes it easy to understand the nature of this change.