### PR TITLE
Dockerfile - Upgrade from jessie to stretch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 ENV PYTHONIOENCODING UTF-8
 
@@ -18,18 +18,14 @@ RUN apt-get update && apt-get install -y build-essential \
     libbz2-dev \
     llvm \
     libncurses5-dev \
-    libssl-dev \
     libsqlite3-dev \
     wget \
     pypy \
     python-openssl \
     libncursesw5-dev \
     zlib1g-dev \
-    pkg-config
-
-# Update libssl to 1.0.2 from backports to support Python 3.7
-RUN echo "deb http://deb.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
-RUN apt-get update && apt-get install -y -t jessie-backports libssl-dev
+    pkg-config \
+    libssl1.0-dev
 
 # Setup variables. Even though changing these may cause unnecessary invalidation of
 # unrelated elements, grouping them together makes the Dockerfile read better.

--- a/docker/scripts/install-couchbase.sh
+++ b/docker/scripts/install-couchbase.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-wget http://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-4-amd64.deb
-dpkg -i couchbase-release-1.0-4-amd64.deb
-apt-get update
-apt-get install libcouchbase-dev build-essential
+wget http://packages.couchbase.com/clients/c/libcouchbase-2.10.3_stretch_amd64.tar
+tar -vxf libcouchbase-2.10.3_stretch_amd64.tar
+dpkg -i libcouchbase-2.10.3_stretch_amd64/libcouchbase2-core_2.10.3-1_amd64.deb
+dpkg -i libcouchbase-2.10.3_stretch_amd64/libcouchbase-dev_2.10.3-1_amd64.deb


### PR DESCRIPTION
Build of the Celery docker container fails when running docker-compose build celery as described in the Developing and Testing with Docker section of the Contributing documentation.

Build environment:
Host OS: Ubuntu 18.04
Docker version: 18.09.3
Docker-compose version: 1.23.1

During build of the Celery container, the build fails with:

```
$ docker-compose build celery
Building celery
Step 1/28 : FROM debian:jessie
 ---> 7cd9fb1ee74f
Step 2/28 : ENV PYTHONIOENCODING UTF-8
 ---> Using cache
 ---> 45a0f8b47610
Step 3/28 : RUN apt-get update && apt-get install -y build-essential     libcurl4-openssl-dev     libffi-dev     tk-dev     xz-utils     curl     lsb-release     git     libmemcached-dev     make     liblzma-dev     libreadline-dev     libbz2-dev     llvm     libncurses5-dev     libssl-dev     libsqlite3-dev     wget     pypy     python-openssl     libncursesw5-dev     zlib1g-dev     pkg-config
 ---> Using cache
 ---> d42117c47cdf
Step 4/28 : RUN echo "deb http://deb.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
 ---> Using cache
 ---> cbda491522c7
Step 5/28 : RUN apt-get update && apt-get install -y -t jessie-backports libssl-dev
 ---> Running in 6b229728cf51
Get:1 http://security.debian.org jessie/updates InRelease [44.9 kB]
Ign http://deb.debian.org jessie InRelease
Ign http://deb.debian.org jessie-backports InRelease
Hit http://deb.debian.org jessie Release.gpg
Ign http://deb.debian.org jessie-backports Release.gpg
Hit http://deb.debian.org jessie Release
Ign http://deb.debian.org jessie-backports Release
Err http://deb.debian.org jessie-backports/main amd64 Packages
  
Err http://deb.debian.org jessie-backports/main amd64 Packages
  
Err http://deb.debian.org jessie-backports/main amd64 Packages
  
Err http://deb.debian.org jessie-backports/main amd64 Packages
  
Err http://deb.debian.org jessie-backports/main amd64 Packages
  404  Not Found
Get:2 http://deb.debian.org jessie/main amd64 Packages [9098 kB]
Get:3 http://security.debian.org jessie/updates/main amd64 Packages [825 kB]
Fetched 9968 kB in 4s (2052 kB/s)
W: Size of file /var/lib/apt/lists/security.debian.org_debian-security_dists_jessie_updates_main_binary-amd64_Packages.gz is not what the server reported 824671 825152
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-backports/main/binary-amd64/Packages  404  Not Found

E: Some index files failed to download. They have been ignored, or old ones used instead.

```

Kudos to @GCardona

FYI -  @jcohen02 and @georgepsarakis agreed the upgrade should be done. Hopefully this PR helps
