### PR TITLE
Add a version switch when importing Mapping

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import numbers
-from collections import Mapping, namedtuple
+from collections import namedtuple
 from datetime import timedelta
 from weakref import WeakValueDictionary
 
@@ -21,6 +21,12 @@ from celery.utils.text import indent as textindent
 from celery.utils.time import maybe_make_aware
 
 from . import routes as _routes
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    # TODO: Remove this when we drop Python 2.7 support
+    from collections import Mapping
 
 __all__ = ('AMQP', 'Queues', 'task_message')
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This fixes a deprecation warning with the collections.abc module.

It's the same solution as in PR #5283 applied to app/amqp.py.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
