### PR TITLE
Attribute Error should be caught in backends base exception 

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -274,7 +274,7 @@ class Backend(object):
                     exc_type = from_utf8(exc['exc_type'])
                     try:
                         cls = getattr(sys.modules[exc_module], exc_type)
-                    except KeyError:
+                    except (KeyError, AttributeError):
                         cls = create_exception_cls(exc_type,
                                                    celery.exceptions.__name__)
                 exc_msg = exc['exc_message']

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -446,6 +446,15 @@ class test_BaseBackend_dict:
     def test_exception_to_python_when_None(self):
         b = BaseBackend(app=self.app)
         assert b.exception_to_python(None) is None
+    
+    def test_exception_to_python_when_attribute_exception(self):
+        b = BaseBackend(app=self.app)
+        test_exception = {'exc_type': 'AttributeDoesNotExist',
+                          'exc_module': 'celery',
+                          'exc_message': ['Raise Custom Message']}
+
+        result_exc = b.exception_to_python(test_exception)
+        assert str(result_exc) == 'Raise Custom Message'
 
     def test_wait_for__on_interval(self):
         self.patching('time.sleep')


### PR DESCRIPTION
Celery looks for exceptions in sys.modules and catches a keyerror if it doesn't exist. However,  it is also possible that it finds the exec_module but finds the wrong one. In this case an Attribute Error gets raised. It would be nice if celery caught that exception and created a custom exception class that correctly propogates the error message instead of raising a new one. 