### PR TITLE
Issue #5436

### DIFF
--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -100,7 +100,7 @@ class DatabaseBackend(BaseBackend):
 
     @retry
     def _store_result(self, task_id, result, state,
-                      traceback=None, max_retries=3, **kwargs):
+                      args, worker, retries, queue, traceback=None, max_retries=3, **kwargs):
         """Store return value and state of an executed task."""
         session = self.ResultSession()
         with session_cleanup(session):
@@ -113,6 +113,13 @@ class DatabaseBackend(BaseBackend):
             task.result = result
             task.status = state
             task.traceback = traceback
+            if self.app.conf.find_value_for_key('extended', 'result'):
+                task.name = task
+                task.args = args
+                task.kwargs = kwargs
+                task.worker = worker
+                task.retries = retries
+                task.queue = queue
             session.commit()
             return result
 

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -41,19 +41,23 @@ class Task(ResultModelBase):
         self.task_id = task_id
 
     def to_dict(self):
-        return {
+        results = {
             'task_id': self.task_id,
             'status': self.status,
             'result': self.result,
             'traceback': self.traceback,
             'date_done': self.date_done,
-            'name': self.task,
-            'args': self.args,
-            'kwargs': self.kwargs,
-            'worker': self.worker,
-            'retries': self.retries,
-            'queue': self.queue,
         }
+        if self.app.conf.find_value_for_key('extended', 'result'):
+            results.update(
+                {'name': self.task},
+                {'args': self.args},
+                {'kwargs': self.kwargs},
+                {'worker': self.worker},
+                {'retries': self.retries},
+                {'queue': self.queue},
+            )
+        return results
 
     def __repr__(self):
         return '<Task {0.task_id} state: {0.status}>'.format(self)

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -30,6 +30,12 @@ class Task(ResultModelBase):
     date_done = sa.Column(sa.DateTime, default=datetime.utcnow,
                           onupdate=datetime.utcnow, nullable=True)
     traceback = sa.Column(sa.Text, nullable=True)
+    name = sa.Column(sa.String(155))
+    args = sa.Column(sa.String(155))
+    kwargs = sa.Column(sa.String(155))
+    worker = sa.Column(sa.String(155))
+    retries = sa.Column(sa.Integer)
+    queue = sa.Column(sa.String(155))
 
     def __init__(self, task_id):
         self.task_id = task_id
@@ -41,6 +47,12 @@ class Task(ResultModelBase):
             'result': self.result,
             'traceback': self.traceback,
             'date_done': self.date_done,
+            'name': self.task,
+            'args': self.args,
+            'kwargs': self.kwargs,
+            'worker': self.worker,
+            'retries': self.retries,
+            'queue': self.queue,
         }
 
     def __repr__(self):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
The following fix is related to Issue #5436 in which the default result DB (SQLAlchemy) was not storing additional meta data in the result DB when the key result_extended was set to "True". The only DB that worked was the REDIS backend in which the original request for extended meta data was requested. This PR does not address a fix for the Mongo or other DB backends but just addresses the SQLAlchemy backend.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
[Fixes #5436](https://github.com/celery/celery/issues/5436) 