### PR TITLE
#5409: remove stale pidfile for non privileged user

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -199,7 +199,7 @@ class Pidfile(object):
         try:
             os.kill(pid, 0)
         except os.error as exc:
-            if exc.errno == errno.ESRCH:
+            if exc.errno == errno.ESRCH or exc.errno == errno.EPERM:
                 print('Stale pidfile exists - Removing it.', file=sys.stderr)
                 self.remove()
                 return True

--- a/t/unit/utils/test_platforms.py
+++ b/t/unit/utils/test_platforms.py
@@ -659,6 +659,20 @@ class test_Pidfile:
             assert p.remove_if_stale()
             p.remove.assert_called_with()
 
+    @patch('os.kill')
+    def test_remove_if_stale_unprivileged_user(self):
+        with mock.stdouts():
+            p = Pidfile('/var/pid')
+            p.read_pid = Mock()
+            p.read_pid.return_value = 1817
+            p.remove = Mock()
+            exc = OSError()
+            exc.errno = errno.EPERM
+            kill.side_effect = exc
+            assert p.remove_if_stale()
+            kill.assert_called_with(1817, 0)
+            p.remove.assert_called_with()
+
     def test_remove_if_stale_no_pidfile(self):
         p = Pidfile('/var/pid')
         p.read_pid = Mock()

--- a/t/unit/utils/test_platforms.py
+++ b/t/unit/utils/test_platforms.py
@@ -660,7 +660,7 @@ class test_Pidfile:
             p.remove.assert_called_with()
 
     @patch('os.kill')
-    def test_remove_if_stale_unprivileged_user(self):
+    def test_remove_if_stale_unprivileged_user(self, kill):
         with mock.stdouts():
             p = Pidfile('/var/pid')
             p.read_pid = Mock()


### PR DESCRIPTION
FIx for #5409.  In addition to checking ESRCH, also check for kill returning/throwing EPERM.