### PR TITLE
Stop using pymongo collection deprecated methods

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -240,7 +240,7 @@ class MongoBackend(BaseBackend):
 
     def _delete_group(self, group_id):
         """Delete a group by id."""
-        self.group_collection.remove({'_id': group_id})
+        self.group_collection.delete_one({'_id': group_id})
 
     def _forget(self, task_id):
         """Remove result from MongoDB.
@@ -252,14 +252,14 @@ class MongoBackend(BaseBackend):
         # By using safe=True, this will wait until it receives a response from
         # the server.  Likewise, it will raise an OperationsError if the
         # response was unable to be completed.
-        self.collection.remove({'_id': task_id})
+        self.collection.delete_one({'_id': task_id})
 
     def cleanup(self):
         """Delete expired meta-data."""
-        self.collection.remove(
+        self.collection.delete_many(
             {'date_done': {'$lt': self.app.now() - self.expires_delta}},
         )
-        self.group_collection.remove(
+        self.group_collection.delete_many(
             {'date_done': {'$lt': self.app.now() - self.expires_delta}},
         )
 

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -269,10 +269,10 @@ class test_MongoBackend:
 
         mock_get_database.assert_called_once_with()
         mock_database.__getitem__.assert_called_once_with(MONGODB_COLLECTION)
-        mock_collection.save.assert_called_once_with(ANY)
+        mock_collection.replace_one.assert_called_once_with(ANY)
         assert sentinel.result == ret_val
 
-        mock_collection.save.side_effect = InvalidDocument()
+        mock_collection.replace_one.side_effect = InvalidDocument()
         with pytest.raises(EncodeError):
             self.backend._store_result(
                 sentinel.task_id, sentinel.result, sentinel.status)
@@ -295,11 +295,11 @@ class test_MongoBackend:
 
         mock_get_database.assert_called_once_with()
         mock_database.__getitem__.assert_called_once_with(MONGODB_COLLECTION)
-        parameters = mock_collection.save.call_args[0][0]
+        parameters = mock_collection.replace_one.call_args[0][0]
         assert parameters['parent_id'] == sentinel.parent_id
         assert sentinel.result == ret_val
 
-        mock_collection.save.side_effect = InvalidDocument()
+        mock_collection.replace_one.side_effect = InvalidDocument()
         with pytest.raises(EncodeError):
             self.backend._store_result(
                 sentinel.task_id, sentinel.result, sentinel.status)
@@ -358,7 +358,7 @@ class test_MongoBackend:
         mock_database.__getitem__.assert_called_once_with(
             MONGODB_GROUP_COLLECTION,
         )
-        mock_collection.save.assert_called_once_with(ANY)
+        mock_collection.replace_one.assert_called_once_with(ANY)
         assert res == ret_val
 
     @patch('celery.backends.mongodb.MongoBackend._get_database')

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -401,7 +401,7 @@ class test_MongoBackend:
         self.backend._delete_group(sentinel.taskset_id)
 
         mock_get_database.assert_called_once_with()
-        mock_collection.remove.assert_called_once_with(
+        mock_collection.delete_one.assert_called_once_with(
             {'_id': sentinel.taskset_id})
 
     @patch('celery.backends.mongodb.MongoBackend._get_database')
@@ -420,7 +420,7 @@ class test_MongoBackend:
         mock_get_database.assert_called_once_with()
         mock_database.__getitem__.assert_called_once_with(
             MONGODB_COLLECTION)
-        mock_collection.remove.assert_called_once_with(
+        mock_collection.delete_one.assert_called_once_with(
             {'_id': sentinel.task_id})
 
     @patch('celery.backends.mongodb.MongoBackend._get_database')
@@ -440,7 +440,7 @@ class test_MongoBackend:
         self.backend.cleanup()
 
         mock_get_database.assert_called_once_with()
-        mock_collection.remove.assert_called()
+        mock_collection.delete_many.assert_called()
 
     def test_get_database_authfailure(self):
         x = MongoBackend(app=self.app)

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -296,7 +296,7 @@ class test_MongoBackend:
 
         mock_get_database.assert_called_once_with()
         mock_database.__getitem__.assert_called_once_with(MONGODB_COLLECTION)
-        parameters = mock_collection.replace_one.call_args[0][0]
+        parameters = mock_collection.replace_one.call_args[0][1]
         assert parameters['parent_id'] == sentinel.parent_id
         assert sentinel.result == ret_val
 

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -269,7 +269,8 @@ class test_MongoBackend:
 
         mock_get_database.assert_called_once_with()
         mock_database.__getitem__.assert_called_once_with(MONGODB_COLLECTION)
-        mock_collection.replace_one.assert_called_once_with(ANY)
+        mock_collection.replace_one.assert_called_once_with(ANY, ANY,
+                                                            upsert=True)
         assert sentinel.result == ret_val
 
         mock_collection.replace_one.side_effect = InvalidDocument()
@@ -358,7 +359,8 @@ class test_MongoBackend:
         mock_database.__getitem__.assert_called_once_with(
             MONGODB_GROUP_COLLECTION,
         )
-        mock_collection.replace_one.assert_called_once_with(ANY)
+        mock_collection.replace_one.assert_called_once_with(ANY, ANY,
+                                                            upsert=True)
         assert res == ret_val
 
     @patch('celery.backends.mongodb.MongoBackend._get_database')


### PR DESCRIPTION
1. Using `collection.replace_one` instead `collection.save`.
2. Using `collection.create_index` instead `collection.ensure_index`.
3. Using `collection.delete_one` and `collection.delete_many`  instead `collection.remove`.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
