### PR TITLE
Add link to node-celery-ts client in Introduction

### DIFF
--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -25,7 +25,7 @@ A Celery system can consist of multiple workers and brokers, giving way
 to high availability and horizontal scaling.
 
 Celery is written in Python, but the protocol can be implemented in any
-language. In addition to Python there's node-celery_ for Node.js,
+language. In addition to Python there's node-celery_ and node-celery-ts_ for Node.js,
 and a `PHP client`_.
 
 Language interoperability can also be achieved
@@ -33,6 +33,7 @@ exposing an HTTP endpoint and having a task that requests it (webhooks).
 
 .. _`PHP client`: https://github.com/gjedeer/celery-php
 .. _node-celery: https://github.com/mher/node-celery
+.. _node-celery-ts: https://github.com/IBM/node-celery-ts
 
 What do I need?
 ===============

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -24,7 +24,7 @@ A Celery system can consist of multiple workers and brokers, giving way
 to high availability and horizontal scaling.
 
 Celery is written in Python, but the protocol can be implemented in any
-language. In addition to Python there's node-celery_ for Node.js,
+language. In addition to Python there's node-celery_ and node-celery-ts_ for Node.js,
 and a `PHP client`_.
 
 Language interoperability can also be achieved by using webhooks
@@ -32,6 +32,7 @@ in such a way that the client enqueues an URL to be requested by a worker.
 
 .. _node-celery: https://github.com/mher/node-celery
 .. _`PHP client`: https://github.com/gjedeer/celery-php
+.. _node-celery-ts: https://github.com/IBM/node-celery-ts
 
 What do I need?
 ===============


### PR DESCRIPTION
## Description

We had an issue opened against a typescript node client we've created for celery (https://github.com/IBM/node-celery-ts/issues/48) to include that client in the list of Clients in the documentation. This implements that change.

If there's another place that this should have gone, let us know. If this isn't needed or wanted, feel free to close the PR.

There were no errors in the documentation build output for these changes.