### PR TITLE
Fixed bug 5411

### DIFF
--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -208,7 +208,7 @@ def remaining(start, ends_in, now=None, relative=False):
     """
     now = now or datetime.utcnow()
     if str(start.tzinfo) == str(now.tzinfo) and now.utcoffset() != start.utcoffset():
-        #DST started/ended
+        # DST started/ended
         start = start.replace(tzinfo=now.tzinfo)
     end_date = start + ends_in
     if relative:

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -207,8 +207,8 @@ def remaining(start, ends_in, now=None, relative=False):
         ~datetime.timedelta: Remaining time.
     """
     now = now or datetime.utcnow()
-    if now.utcoffset() != start.utcoffset():
-        # Timezone has changed, or DST started/ended
+    if str(start.tzinfo) == str(now.tzinfo) and now.utcoffset() != start.utcoffset():
+        #DST started/ended
         start = start.replace(tzinfo=now.tzinfo)
     end_date = start + ends_in
     if relative:

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -109,7 +109,7 @@ def test_maybe_timedelta(arg, expected):
 
 
 def test_remaining():
-    #Relative 
+    # Relative
     remaining(datetime.utcnow(), timedelta(hours=1), relative=True)
 
     """
@@ -118,17 +118,17 @@ def test_remaining():
     eastern_tz = pytz.timezone("US/Eastern")
     tokyo_tz = pytz.timezone("Asia/Tokyo")
 
-    #Case 1: `start` in UTC and `now` in other timezone
+    # Case 1: `start` in UTC and `now` in other timezone
     start = datetime.now(pytz.utc)
     now = datetime.now(eastern_tz)
     delta = timedelta(hours=1)
     assert str(start.tzinfo) == str(pytz.utc)
     assert str(now.tzinfo) == str(eastern_tz)
-    rem_secs = remaining(start, delta , now).total_seconds()
-    #assert remaining time is approximately equal to delta
+    rem_secs = remaining(start, delta, now).total_seconds()
+    # assert remaining time is approximately equal to delta
     assert isclose(rem_secs, delta.total_seconds(), abs_tol=1)
 
-    #Case 2: `start` and `now` in different timezones (other than UTC)
+    # Case 2: `start` and `now` in different timezones (other than UTC)
     start = datetime.now(eastern_tz)
     now = datetime.now(tokyo_tz)
     delta = timedelta(hours=1)
@@ -143,17 +143,18 @@ def test_remaining():
     check whether the `next_run` is actually the time specified in the start (i.e. there is not an hour diff due to DST).
     In 2019, DST starts on March 10
     """
-    start = eastern_tz.localize(datetime(month=3, day=9, year=2019, hour=10, minute=0))         #EST
-    now = eastern_tz.localize(datetime(day=11, month=3, year=2019, hour=1, minute=0))           #EDT
+    start = eastern_tz.localize(datetime(month=3, day=9, year=2019, hour=10, minute=0))         # EST
+    now = eastern_tz.localize(datetime(day=11, month=3, year=2019, hour=1, minute=0))           # EDT
     delta = ffwd(hour=10, year=2019, microsecond=0, minute=0, second=0, day=11, weeks=0, month=3)
-    #`next_actual_time` is the next time to run (derived from delta)
-    next_actual_time = eastern_tz.localize(datetime(day=11, month=3, year=2019, hour=10, minute=0))         #EDT
+    # `next_actual_time` is the next time to run (derived from delta)
+    next_actual_time = eastern_tz.localize(datetime(day=11, month=3, year=2019, hour=10, minute=0))         # EDT
     assert start.tzname() == "EST"
     assert now.tzname() == "EDT"
     assert next_actual_time.tzname() == "EDT"
     rem_time = remaining(start, delta, now)
     next_run = now + rem_time
     assert next_run == next_actual_time
+
 
 class test_timezone:
 

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 from datetime import datetime, timedelta, tzinfo
-from math import isclose
 
 import pytest
 import pytz
@@ -126,7 +125,7 @@ def test_remaining():
     assert str(now.tzinfo) == str(eastern_tz)
     rem_secs = remaining(start, delta, now).total_seconds()
     # assert remaining time is approximately equal to delta
-    assert isclose(rem_secs, delta.total_seconds(), abs_tol=1)
+    assert rem_secs == pytest.approx(delta.total_seconds(), abs=1)
 
     # Case 2: `start` and `now` in different timezones (other than UTC)
     start = datetime.now(eastern_tz)
@@ -135,7 +134,7 @@ def test_remaining():
     assert str(start.tzinfo) == str(eastern_tz)
     assert str(now.tzinfo) == str(tokyo_tz)
     rem_secs = remaining(start, delta, now).total_seconds()
-    assert isclose(rem_secs, delta.total_seconds(), abs_tol=1)
+    assert rem_secs == pytest.approx(delta.total_seconds(), abs=1)
 
     """
     Case 3: DST check

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from datetime import datetime, timedelta, tzinfo
+from math import isclose
 
 import pytest
 import pytz
@@ -107,9 +108,52 @@ def test_maybe_timedelta(arg, expected):
     assert maybe_timedelta(arg) == expected
 
 
-def test_remaining_relative():
+def test_remaining():
+    #Relative 
     remaining(datetime.utcnow(), timedelta(hours=1), relative=True)
 
+    """
+    The upcoming cases check whether the next run is calculated correctly
+    """
+    eastern_tz = pytz.timezone("US/Eastern")
+    tokyo_tz = pytz.timezone("Asia/Tokyo")
+
+    #Case 1: `start` in UTC and `now` in other timezone
+    start = datetime.now(pytz.utc)
+    now = datetime.now(eastern_tz)
+    delta = timedelta(hours=1)
+    assert str(start.tzinfo) == str(pytz.utc)
+    assert str(now.tzinfo) == str(eastern_tz)
+    rem_secs = remaining(start, delta , now).total_seconds()
+    #assert remaining time is approximately equal to delta
+    assert isclose(rem_secs, delta.total_seconds(), abs_tol=1)
+
+    #Case 2: `start` and `now` in different timezones (other than UTC)
+    start = datetime.now(eastern_tz)
+    now = datetime.now(tokyo_tz)
+    delta = timedelta(hours=1)
+    assert str(start.tzinfo) == str(eastern_tz)
+    assert str(now.tzinfo) == str(tokyo_tz)
+    rem_secs = remaining(start, delta, now).total_seconds()
+    assert isclose(rem_secs, delta.total_seconds(), abs_tol=1)
+
+    """
+    Case 3: DST check
+    Suppose start (which is last_run_time) is in EST while next_run is in EDT, then
+    check whether the `next_run` is actually the time specified in the start (i.e. there is not an hour diff due to DST).
+    In 2019, DST starts on March 10
+    """
+    start = eastern_tz.localize(datetime(month=3, day=9, year=2019, hour=10, minute=0))         #EST
+    now = eastern_tz.localize(datetime(day=11, month=3, year=2019, hour=1, minute=0))           #EDT
+    delta = ffwd(hour=10, year=2019, microsecond=0, minute=0, second=0, day=11, weeks=0, month=3)
+    #`next_actual_time` is the next time to run (derived from delta)
+    next_actual_time = eastern_tz.localize(datetime(day=11, month=3, year=2019, hour=10, minute=0))         #EDT
+    assert start.tzname() == "EST"
+    assert now.tzname() == "EDT"
+    assert next_actual_time.tzname() == "EDT"
+    rem_time = remaining(start, delta, now)
+    next_run = now + rem_time
+    assert next_run == next_actual_time
 
 class test_timezone:
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## This pull request attempts to fix the bug 5411
Fixes #5411 
The function `remaining` defined in `celery/utils/time.py` was not 
calculating the remaining time for a schedule correctly when the timezones of the `start` and the `now` variables (which are arguments to the function) are different.

The issue was because of the lines 
https://github.com/celery/celery/blob/f2cab7715cceafcae1343fdcdc65704e0a2c751f/celery/utils/time.py#L210-L212

The `start` variable's timezone must be replaced by the `now` variable's timezone ONLY when there the `start` and `now` variable have different `utcoffsets` due to DST. But the above `if` statement is run even if `start` and `now` variables are in different timezones.

Also, the unit-tests are added for the `remaining` function to check whether the next run times are calculated correctly if the `start` and `now` variables are in different timezones or they differ in utcoffset (because of DST).