### PR TITLE
Pass task request to backend when calling update_state

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -927,7 +927,7 @@ class Task(object):
         """
         if task_id is None:
             task_id = self.request.id
-        self.backend.store_result(task_id, meta, state, **kwargs)
+        self.backend.store_result(task_id, meta, state, request=self.request, **kwargs)
 
     def on_success(self, retval, task_id, args, kwargs):
         """Success handler.

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -790,6 +790,22 @@ class test_tasks(TasksCase):
         finally:
             yyy.pop_request()
 
+    def test_update_state_passes_request_to_backend(self):
+        backend = Mock()
+
+        @self.app.task(shared=False, backend=backend)
+        def ttt():
+            pass
+
+        ttt.push_request()
+
+        tid = uuid()
+        ttt.update_state(tid, 'SHRIMMING', {'foo': 'bar'})
+
+        backend.store_result.assert_called_once_with(
+            tid, {'foo': 'bar'}, 'SHRIMMING', request=ttt.request
+        )
+
     def test_repr(self):
 
         @self.app.task(shared=False)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Solving the issue described in https://github.com/celery/celery/issues/5470.

In summary, `Task.update_state` calls the `backend.store_result` without passing the `request` as an argument, while it is doing so when the task finishes executing and comes the time to store the final result, which is inconsistent.

My fix simply consists of passing it.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
