### PR TITLE
 Make AsynPool._proc_alive_timeout configurable

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -318,6 +318,7 @@ NAMESPACES = Namespace(
         pool=Option(DEFAULT_POOL),
         pool_putlocks=Option(True, type='bool'),
         pool_restarts=Option(False, type='bool'),
+        proc_alive_timeout=Option(4.0, type='float'),
         prefetch_multiplier=Option(4, type='int'),
         redirect_stdouts=Option(
             True, type='bool', old={'celery_redirect_stdouts'},

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -383,7 +383,7 @@ class AsynPool(_pool.Pool):
         return worker
 
     def __init__(self, processes=None, synack=False,
-                 sched_strategy=None, proc_alive_timeout=PROC_ALIVE_TIMEOUT,
+                 sched_strategy=None, proc_alive_timeout=None,
                  *args, **kwargs):
         self.sched_strategy = SCHED_STRATEGIES.get(sched_strategy,
                                                    sched_strategy)
@@ -405,7 +405,10 @@ class AsynPool(_pool.Pool):
         # sent a WORKER_UP message.  If a process fails to send
         # this message within _proc_alive_timeout we terminate it
         # and hope the next process will recover.
-        self._proc_alive_timeout = proc_alive_timeout
+        self._proc_alive_timeout = (
+            PROC_ALIVE_TIMEOUT if proc_alive_timeout is None
+            else proc_alive_timeout
+        )
         self._waiting_to_start = set()
 
         # denormalized set of all inqueues.

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -383,7 +383,8 @@ class AsynPool(_pool.Pool):
         return worker
 
     def __init__(self, processes=None, synack=False,
-                 sched_strategy=None, *args, **kwargs):
+                 sched_strategy=None, proc_alive_timeout=PROC_ALIVE_TIMEOUT,
+                 *args, **kwargs):
         self.sched_strategy = SCHED_STRATEGIES.get(sched_strategy,
                                                    sched_strategy)
         processes = self.cpu_count() if processes is None else processes
@@ -402,9 +403,9 @@ class AsynPool(_pool.Pool):
 
         # We keep track of processes that haven't yet
         # sent a WORKER_UP message.  If a process fails to send
-        # this message within proc_up_timeout we terminate it
+        # this message within _proc_alive_timeout we terminate it
         # and hope the next process will recover.
-        self._proc_alive_timeout = PROC_ALIVE_TIMEOUT
+        self._proc_alive_timeout = proc_alive_timeout
         self._waiting_to_start = set()
 
         # denormalized set of all inqueues.

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -104,7 +104,10 @@ class TaskPool(BasePool):
         forking_enable(self.forking_enable)
         Pool = (self.BlockingPool if self.options.get('threads', True)
                 else self.Pool)
-        proc_alive_timeout = self.app.conf.worker_proc_alive_timeout
+        proc_alive_timeout = (
+            self.app.conf.worker_proc_alive_timeout if self.app
+            else None
+        )
         P = self._pool = Pool(processes=self.limit,
                               initializer=process_initializer,
                               on_process_exit=process_destructor,

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -104,11 +104,13 @@ class TaskPool(BasePool):
         forking_enable(self.forking_enable)
         Pool = (self.BlockingPool if self.options.get('threads', True)
                 else self.Pool)
+        proc_alive_timeout = self.app.conf.worker_proc_alive_timeout
         P = self._pool = Pool(processes=self.limit,
                               initializer=process_initializer,
                               on_process_exit=process_destructor,
                               enable_timeouts=True,
                               synack=False,
+                              proc_alive_timeout=proc_alive_timeout,
                               **self.options)
 
         # Create proxy methods

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2578,6 +2578,15 @@ Default: Enabled by default.
 
 Specify if remote control of the workers is enabled.
 
+.. setting:: worker_proc_alive_timeout
+
+``worker_proc_alive_timeout``
+~~~~~~~~~~~~~~~~~~~~
+
+Default: 4.0.
+
+The timeout in seconds (int/float) when waiting for a new worker process to start up.
+
 .. _conf-events:
 
 Events

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -398,7 +398,7 @@ class test_TaskPool:
         pool = TaskPool(7)
         pool.start()
         assert pool.num_processes == 7
-    
+
     @patch('billiard.forking_enable')
     def test_on_start_proc_alive_timeout_default(self, __forking_enable):
         app = Mock(conf=AttributeDict(DEFAULTS))

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -125,6 +125,7 @@ class MockPool(object):
         self.maintain_pool = Mock()
         self._state = mp.RUN
         self._processes = kwargs.get('processes')
+        self._proc_alive_timeout = kwargs.get('proc_alive_timeout')
         self._pool = [Bunch(pid=i, inqW_fd=1, outqR_fd=2)
                       for i in range(self._processes)]
         self._current_proc = cycle(range(self._processes))
@@ -397,3 +398,18 @@ class test_TaskPool:
         pool = TaskPool(7)
         pool.start()
         assert pool.num_processes == 7
+    
+    @patch('billiard.forking_enable')
+    def test_on_start_proc_alive_timeout_default(self, __forking_enable):
+        app = Mock(conf=AttributeDict(DEFAULTS))
+        pool = TaskPool(4, app=app)
+        pool.on_start()
+        assert pool._pool._proc_alive_timeout == 4.0
+
+    @patch('billiard.forking_enable')
+    def test_on_start_proc_alive_timeout_custom(self, __forking_enable):
+        app = Mock(conf=AttributeDict(DEFAULTS))
+        app.conf.worker_proc_alive_timeout = 8.0
+        pool = TaskPool(4, app=app)
+        pool.on_start()
+        assert pool._pool._proc_alive_timeout == 8.0


### PR DESCRIPTION
The timeout which determines how long to wait for a new worker process to startup is hard-coded to `4.0` seconds via the [PROC_ALIVE_TIMEOUT](https://github.com/celery/celery/blob/e6ea4331215c6ac1dbee38868f212c4d48872b36/celery/concurrency/asynpool.py#L85:1) constant. This change allows the value to be configured via a new configuration option `worker_proc_alive_timeout`.

This is necessary for worker processes with expensive setups that can exceed `4.0` seconds.