### PR TITLE
Removed dangerous default mutable arguments from function definitions…

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -995,7 +995,8 @@ class Celery(object):
         return key
 
     def _sig_to_periodic_task_entry(self, schedule, sig,
-                                    args=(), kwargs={}, name=None, **opts):
+                                    args=(), kwargs=None, name=None, **opts):
+        kwargs = {} if not kwargs else kwargs
         sig = (sig.clone(args, kwargs)
                if isinstance(sig, abstract.CallableSignature)
                else self.signature(sig.name, args, kwargs))

--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -78,7 +78,8 @@ class Router(object):
         self.routes = [] if routes is None else routes
         self.create_missing = create_missing
 
-    def route(self, options, name, args=(), kwargs={}, task_type=None):
+    def route(self, options, name, args=(), kwargs=None, task_type=None):
+        kwargs = {} if not kwargs else kwargs
         options = self.expand_destination(options)  # expands 'queue'
         if self.routes:
             route = self.lookup_route(name, args, kwargs, options, task_type)

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -502,8 +502,9 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
     return trace_task
 
 
-def trace_task(task, uuid, args, kwargs, request={}, **opts):
+def trace_task(task, uuid, args, kwargs, request=None, **opts):
     """Trace task execution."""
+    request = {} if not request else request
     try:
         if task.__trace__ is None:
             task.__trace__ = build_tracer(task.name, task, **opts)
@@ -538,8 +539,9 @@ trace_task_ret = _trace_task_ret  # noqa: E305
 
 
 def _fast_trace_task(task, uuid, request, body, content_type,
-                     content_encoding, loads=loads_message, _loc=_localized,
+                     content_encoding, loads=loads_message, _loc=None,
                      hostname=None, **_):
+    _loc = _localized if not _loc else _loc
     embed = None
     tasks, accept, hostname = _loc
     if content_type:

--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -222,8 +222,13 @@ _old_settings_info = _settings_info_t(
 )
 
 
-def detect_settings(conf, preconf={}, ignore_keys=set(), prefix=None,
-                    all_keys=SETTING_KEYS, old_keys=_OLD_SETTING_KEYS):
+def detect_settings(conf, preconf=None, ignore_keys=None, prefix=None,
+                    all_keys=None, old_keys=None):
+    preconf = {} if not preconf else preconf
+    ignore_keys = set() if not ignore_keys else ignore_keys
+    all_keys = SETTING_KEYS if not all_keys else all_keys
+    old_keys = _OLD_SETTING_KEYS if not old_keys else old_keys
+
     source = conf
     if conf is None:
         source, conf = preconf, {}

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -470,7 +470,8 @@ class Backend(object):
         if request:
             return [r.as_tuple() for r in getattr(request, 'children', [])]
 
-    def __reduce__(self, args=(), kwargs={}):
+    def __reduce__(self, args=(), kwargs=None):
+        kwargs = {} if not kwargs else kwargs
         return (unpickle_backend, (self.__class__, args, kwargs))
 
 

--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -98,7 +98,8 @@ class CacheBackend(KeyValueStoreBackend):
     implements_incr = True
 
     def __init__(self, app, expires=None, backend=None,
-                 options={}, url=None, **kwargs):
+                 options=None, url=None, **kwargs):
+        options = {} if not options else options
         super(CacheBackend, self).__init__(app, **kwargs)
         self.url = url
 
@@ -145,7 +146,8 @@ class CacheBackend(KeyValueStoreBackend):
     def client(self):
         return self.Client(self.servers, **self.options)
 
-    def __reduce__(self, args=(), kwargs={}):
+    def __reduce__(self, args=(), kwargs=None):
+        kwargs = {} if not kwargs else kwargs
         servers = ';'.join(self.servers)
         backend = '{0}://{1}/'.format(self.backend, servers)
         kwargs.update(

--- a/celery/backends/cassandra.py
+++ b/celery/backends/cassandra.py
@@ -228,7 +228,8 @@ class CassandraBackend(BaseBackend):
             'children': self.decode(children),
         })
 
-    def __reduce__(self, args=(), kwargs={}):
+    def __reduce__(self, args=(), kwargs=None):
+        kwargs = {} if not kwargs else kwargs
         kwargs.update(
             {'servers': self.servers,
              'keyspace': self.keyspace,

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -216,7 +216,8 @@ class DatabaseBackend(BaseBackend):
                 self.taskset_cls.date_done < (now - expires)).delete()
             session.commit()
 
-    def __reduce__(self, args=(), kwargs={}):
+    def __reduce__(self, args=(), kwargs=None):
+        kwargs = {} if not kwargs else kwargs
         kwargs.update(
             {'dburi': self.url,
              'expires': self.expires,

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -263,7 +263,8 @@ class MongoBackend(BaseBackend):
             {'date_done': {'$lt': self.app.now() - self.expires_delta}},
         )
 
-    def __reduce__(self, args=(), kwargs={}):
+    def __reduce__(self, args=(), kwargs=None):
+        kwargs = {} if not kwargs else kwargs
         return super(MongoBackend, self).__reduce__(
             args, dict(kwargs, expires=self.expires, url=self.url))
 

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -440,7 +440,8 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
     def client(self):
         return self._create_client(**self.connparams)
 
-    def __reduce__(self, args=(), kwargs={}):
+    def __reduce__(self, args=(), kwargs=None):
+        kwargs = {} if not kwargs else kwargs
         return super(RedisBackend, self).__reduce__(
             (self.url,), {'expires': self.expires},
         )

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -318,7 +318,8 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
         raise NotImplementedError(
             'delete_group is not supported by this backend.')
 
-    def __reduce__(self, args=(), kwargs={}):
+    def __reduce__(self, args=(), kwargs=None):
+        kwargs = {} if not kwargs else kwargs
         return super(RPCBackend, self).__reduce__(args, dict(
             kwargs,
             connection=self._connection,

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -78,13 +78,14 @@ def _optparse_callback_to_type(option, callback):
     return _on_arg
 
 
-def _add_optparse_argument(parser, opt, typemap={
+def _add_optparse_argument(parser, opt, typemap=None):
+    typemap = {
         'string': text_t,
         'int': int,
         'long': long_t,
         'float': float,
         'complex': complex,
-        'choice': None}):
+        'choice': None} if not typemap else typemap
     if opt.callback:
         opt.type = _optparse_callback_to_type(opt, opt.type)
     # argparse checks for existence of this kwarg

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -222,7 +222,8 @@ class worker(Command):
         self.maybe_detach([command] + argv)
         return self(*args, **options)
 
-    def maybe_detach(self, argv, dopts=['-D', '--detach']):
+    def maybe_detach(self, argv, dopts=None):
+        dopts = ['-D', '--detach'] if not dopts else dopts
         if any(arg in argv for arg in dopts):
             argv = [v for v in argv if v not in dopts]
             # will never return

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -756,7 +756,9 @@ class AsynPool(_pool.Pool):
         self.on_inqueue_close = on_inqueue_close
         self.hub_remove = hub_remove
 
-        def schedule_writes(ready_fds, total_write_count=[0]):
+        def schedule_writes(ready_fds, total_write_count=None):
+            if not total_write_count:
+                total_write_count = [0]
             # Schedule write operation to ready file descriptor.
             # The file descriptor is writable, but that does not
             # mean the process is currently reading from the socket.

--- a/celery/concurrency/base.py
+++ b/celery/concurrency/base.py
@@ -21,10 +21,11 @@ __all__ = ('BasePool', 'apply_target')
 logger = get_logger('celery.pool')
 
 
-def apply_target(target, args=(), kwargs={}, callback=None,
+def apply_target(target, args=(), kwargs=None, callback=None,
                  accept_callback=None, pid=None, getpid=os.getpid,
                  propagate=(), monotonic=monotonic, **_):
     """Apply function within pool context."""
+    kwargs = {} if not kwargs else kwargs
     if accept_callback:
         accept_callback(pid or getpid(), monotonic())
     try:
@@ -138,12 +139,14 @@ class BasePool(object):
     def on_close(self):
         pass
 
-    def apply_async(self, target, args=[], kwargs={}, **options):
+    def apply_async(self, target, args=None, kwargs=None, **options):
         """Equivalent of the :func:`apply` built-in function.
 
         Callbacks should optimally return as soon as possible since
         otherwise the thread which handles the result will get blocked.
         """
+        kwargs = {} if not kwargs else kwargs
+        args = [] if not args else args
         if self._does_debug:
             logger.debug('TaskPool: Apply %s (args:%s kwargs:%s)',
                          target, truncate(safe_repr(args), 1024),

--- a/celery/concurrency/eventlet.py
+++ b/celery/concurrency/eventlet.py
@@ -28,8 +28,9 @@ for mod in (mod for mod in sys.modules if mod.startswith(RACE_MODS)):
             warnings.warn(RuntimeWarning(W_RACE % side))
 
 
-def apply_target(target, args=(), kwargs={}, callback=None,
+def apply_target(target, args=(), kwargs=None, callback=None,
                  accept_callback=None, getpid=None):
+    kwargs = {} if not kwargs else kwargs
     return base.apply_target(target, args, kwargs, callback, accept_callback,
                              pid=getpid())
 

--- a/celery/concurrency/gevent.py
+++ b/celery/concurrency/gevent.py
@@ -18,10 +18,11 @@ __all__ = ('TaskPool',)
 # We cache globals and attribute lookups, so disable this warning.
 
 
-def apply_timeout(target, args=(), kwargs={}, callback=None,
+def apply_timeout(target, args=(), kwargs=None, callback=None,
                   accept_callback=None, pid=None, timeout=None,
                   timeout_callback=None, Timeout=Timeout,
                   apply_target=base.apply_target, **rest):
+    kwargs = {} if not kwargs else kwargs
     try:
         with Timeout(timeout):
             return apply_target(target, args, kwargs, callback,

--- a/celery/contrib/migrate.py
+++ b/celery/contrib/migrate.py
@@ -55,10 +55,9 @@ class State(object):
 def republish(producer, message, exchange=None, routing_key=None,
               remove_props=None):
     """Republish message."""
-    remove_props = ['application_headers',
-                            'content_type',
-                            'content_encoding',
-                            'headers'] if not remove_props else remove_props
+    if not remove_props:
+        remove_props = ['application_headers', 'content_type',
+                        'content_encoding', 'headers']
     body = ensure_bytes(message.body)  # use raw message body.
     info, headers, props = (message.delivery_info,
                             message.headers, message.properties)

--- a/celery/contrib/migrate.py
+++ b/celery/contrib/migrate.py
@@ -53,11 +53,12 @@ class State(object):
 
 
 def republish(producer, message, exchange=None, routing_key=None,
-              remove_props=['application_headers',
+              remove_props=None):
+    """Republish message."""
+    remove_props = ['application_headers',
                             'content_type',
                             'content_encoding',
-                            'headers']):
-    """Republish message."""
+                            'headers'] if not remove_props else remove_props
     body = ensure_bytes(message.body)  # use raw message body.
     info, headers, props = (message.delivery_info,
                             message.headers, message.properties)

--- a/celery/contrib/pytest.py
+++ b/celery/contrib/pytest.py
@@ -18,10 +18,11 @@ NO_WORKER = os.environ.get('NO_WORKER')
 @contextmanager
 def _create_app(enable_logging=False,
                 use_trap=False,
-                parameters={},
+                parameters=None,
                 **config):
     # type: (Any, **Any) -> Celery
     """Utility context used to setup Celery app for pytest fixtures."""
+    parameters = {} if not parameters else parameters
     test_app = TestApp(
         set_as_current=False,
         enable_logging=enable_logging,

--- a/celery/contrib/testing/manager.py
+++ b/celery/contrib/testing/manager.py
@@ -58,6 +58,7 @@ class ManagerMixin(object):
         has not happened yet.
         """
         kwargs = {} if not kwargs else kwargs
+
         def on_error(exc, intervals, retries):
             interval = next(intervals)
             if emit_warning:

--- a/celery/contrib/testing/manager.py
+++ b/celery/contrib/testing/manager.py
@@ -47,7 +47,7 @@ class ManagerMixin(object):
         return [res.id for res in r if res.id not in res.backend._cache]
 
     def wait_for(self, fun, catch,
-                 desc='thing', args=(), kwargs={}, errback=None,
+                 desc='thing', args=(), kwargs=None, errback=None,
                  max_retries=10, interval_start=0.1, interval_step=0.5,
                  interval_max=5.0, emit_warning=False, **options):
         # type: (Callable, Sequence[Any], str, Tuple, Dict, Callable,
@@ -57,6 +57,7 @@ class ManagerMixin(object):
         The `catch` argument specifies the exception that means the event
         has not happened yet.
         """
+        kwargs = {} if not kwargs else kwargs
         def on_error(exc, intervals, retries):
             interval = next(intervals)
             if emit_warning:

--- a/celery/contrib/testing/mocks.py
+++ b/celery/contrib/testing/mocks.py
@@ -13,12 +13,13 @@ except ImportError:
         from mock import Mock
 
 
-def TaskMessage(name, id=None, args=(), kwargs={}, callbacks=None,
+def TaskMessage(name, id=None, args=(), kwargs=None, callbacks=None,
                 errbacks=None, chain=None, shadow=None, utc=None, **options):
     # type: (str, str, Sequence, Mapping, Sequence[Signature],
     #        Sequence[Signature], Sequence[Signature],
     #        str, bool, **Any) -> Any
     """Create task message in protocol 2 format."""
+    kwargs = {} if not kwargs else kwargs
     from celery import uuid
     from kombu.serialization import dumps
     id = id or uuid()
@@ -37,11 +38,12 @@ def TaskMessage(name, id=None, args=(), kwargs={}, callbacks=None,
     return message
 
 
-def TaskMessage1(name, id=None, args=(), kwargs={}, callbacks=None,
+def TaskMessage1(name, id=None, args=(), kwargs=None, callbacks=None,
                  errbacks=None, chain=None, **options):
     # type: (str, str, Sequence, Mapping, Sequence[Signature],
     #        Sequence[Signature], Sequence[Signature]) -> Any
     """Create task message in protocol 1 format."""
+    kwargs = {} if not kwargs else kwargs
     from celery import uuid
     from kombu.serialization import dumps
     id = id or uuid()

--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -347,8 +347,9 @@ class Task(object):
         # update current state with info from this event.
         self.__dict__.update(fields)
 
-    def info(self, fields=None, extra=[]):
+    def info(self, fields=None, extra=None):
         """Information about this task suitable for on-screen display."""
+        extra = [] if not extra else extra
         fields = self._info_fields if fields is None else fields
 
         def _keys():

--- a/celery/utils/objects.py
+++ b/celery/utils/objects.py
@@ -14,7 +14,7 @@ class Bunch(object):
         self.__dict__.update(kwargs)
 
 
-def mro_lookup(cls, attr, stop=set(), monkey_patched=[]):
+def mro_lookup(cls, attr, stop=None, monkey_patched=None):
     """Return the first node by MRO order that defines an attribute.
 
     Arguments:
@@ -29,6 +29,8 @@ def mro_lookup(cls, attr, stop=set(), monkey_patched=[]):
     Returns:
         Any: The attribute value, or :const:`None` if not found.
     """
+    stop = set() if not stop else stop
+    monkey_patched = [] if not monkey_patched else monkey_patched
     for node in cls.mro():
         if node in stop:
             try:

--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -89,10 +89,13 @@ def task_reserved(request,
 
 
 def task_accepted(request,
-                  _all_total_count=all_total_count,
+                  _all_total_count=None,
                   add_active_request=active_requests.add,
                   add_to_total_count=total_count.update):
     """Update global state when a task has been accepted."""
+
+    if not _all_total_count:
+        _all_total_count = all_total_count
     add_active_request(request)
     add_to_total_count({request.name: 1})
     all_total_count[0] += 1

--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -93,7 +93,6 @@ def task_accepted(request,
                   add_active_request=active_requests.add,
                   add_to_total_count=total_count.update):
     """Update global state when a task has been accepted."""
-
     if not _all_total_count:
         _all_total_count = all_total_count
     add_active_request(request)


### PR DESCRIPTION
In several places, Celery & Kombu use dangerous default arguments which may cause subtle, insidious bugs, e.g.:

# bug demo code, not in Celery:

In [1]: def append(number, number_list=[]):
   ...:     number_list.append(number)
   ...:     print(number_list)
   ...:     return number_list
   ...: 

In [2]: append(5)  # expecting: [5], actual: [5]
[5]
Out[2]: [5]

In [3]: append(7)  # expecting: [7], actual: [5, 7]
[5, 7]
Out[3]: [5, 7]

In [4]: append(2)  # expecting: [2], actual: [5, 7, 2]
[5, 7, 2]
Out[4]: [5, 7, 2]

--As you can see, mutable default arguments can cause unwanted caching and spurious persistent values 
that can make debugging difficult.

This PR changes the mutable default argument values with None and then checks and replaces once inside the function call; this is the standard way to avoid the unwanted, buggy behavior.


