### PR TITLE
Fix 5469

### DIFF
--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -232,11 +232,10 @@ def _argsfromspec(spec, replace_defaults=True):
     varargs = spec.varargs
     varkw = spec.varkw
     if spec.kwonlydefaults:
-        split = len(spec.kwonlydefaults)
-        kwonlyargs = spec.kwonlyargs[:-split]
+        kwonlyargs = spec.kwonlydefaults.keys()
         if replace_defaults:
             kwonlyargs_optional = [
-                (kw, i) for i, kw in enumerate(spec.kwonlyargs[-split:])]
+                (kw, i) for i, kw in enumerate(kwonlyargs)]
         else:
             kwonlyargs_optional = list(spec.kwonlydefaults.items())
     else:


### PR DESCRIPTION
I5469 fix: change default kwargs behaviour

For previous solution if you have function for example:

def my_func(*, name='default', age, city='Kyiv'):
    ...
    
kwargsonly were `age` and `city`, because of split and fetching last 2 kwargs.

In this fix we use kwargs that have default value (fetch from spec.kwonlydefaults.keys()).
So it fixed bug defined in issue https://github.com/celery/celery/issues/5469

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
