### PR TITLE
Fixes #5439: When storing result, Request key is task, not task_name

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -92,7 +92,6 @@ class Context(object):
     errbacks = None
     timelimit = None
     origin = None
-    task_name = None
     _children = None   # see property
     _protected = 0
 
@@ -129,7 +128,6 @@ class Context(object):
             'retries': self.retries,
             'reply_to': self.reply_to,
             'origin': self.origin,
-            'task_name': self.task_name
         }
 
     @property

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -699,7 +699,7 @@ class BaseKeyValueStoreBackend(Backend):
         if self.app.conf.find_value_for_key('extended', 'result'):
             if request:
                 request_meta = {
-                    'name': getattr(request, 'task_name', None),
+                    'name': getattr(request, 'task', None),
                     'args': getattr(request, 'args', None),
                     'kwargs': getattr(request, 'kwargs', None),
                     'worker': getattr(request, 'hostname', None),

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -408,7 +408,7 @@ class test_AsyncResult:
 
         x = self.app.AsyncResult('1')
         request = Context(
-            task_name='foo',
+            task='foo',
             children=None,
             args=['one', 'two'],
             kwargs={'kwarg1': 'three'},


### PR DESCRIPTION
## Description

Fixes #5439 -- when storing Request metadata for task result, task_name key was being used, but the key was not initialized properly in the Request object and is always None.  Since 'task' key is already in the Request properties, just use that.

