### PR TITLE
Fix restoring of exceptions with required param

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -278,7 +278,10 @@ class Backend(object):
                         cls = create_exception_cls(exc_type,
                                                    celery.exceptions.__name__)
                 exc_msg = exc['exc_message']
-                exc = cls(*exc_msg if isinstance(exc_msg, tuple) else exc_msg)
+                try:
+                    exc = cls(*exc_msg if isinstance(exc_msg, tuple) else exc_msg)
+                except Exception as err:  # noqa
+                    exc = Exception('{}({})'.format(cls, exc_msg))
             if self.serializer in EXCEPTION_ABLE_CODECS:
                 exc = get_pickled_exception(exc)
         return exc

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -8,6 +8,7 @@ import pytest
 from case import ANY, Mock, call, patch, skip
 from kombu.serialization import prepare_accept_content
 
+import celery
 from celery import chord, group, signature, states, uuid
 from celery.app.task import Context, Task
 from celery.backends.base import (BaseBackend, DisabledBackend,
@@ -27,6 +28,12 @@ class wrapobject(object):
 
     def __init__(self, *args, **kwargs):
         self.args = args
+
+
+class paramexception(Exception):
+
+    def __init__(self, param):
+        self.param = param
 
 
 if sys.version_info[0] == 3 or getattr(sys, 'pypy_version_info', None):
@@ -455,6 +462,17 @@ class test_BaseBackend_dict:
 
         result_exc = b.exception_to_python(test_exception)
         assert str(result_exc) == 'Raise Custom Message'
+
+    def test_exception_to_python_when_type_error(self):
+        b = BaseBackend(app=self.app)
+        celery.TestParamException = paramexception
+        test_exception = {'exc_type': 'TestParamException',
+                          'exc_module': 'celery',
+                          'exc_message': []}
+
+        result_exc = b.exception_to_python(test_exception)
+        del celery.TestParamException
+        assert str(result_exc) == "<class 't.unit.backends.test_base.paramexception'>([])"
 
     def test_wait_for__on_interval(self):
         self.patching('time.sleep')


### PR DESCRIPTION
## Description

Some exceptions have required args which are not stored in
Exception.args, making it impossible to restore them.

Fixes #5057

Patch is based on @georgepsarakis suggestion in https://github.com/celery/celery/issues/5057#issuecomment-481797247

I don't like injecting test exception into other module, but I was not able to figure out some better approach, suggestions to improve that are welcome.