### PR TITLE
Fix install celery from source via setuptools > 20.1.1, < 20.10.0

### DIFF
--- a/requirements/extras/brotli.txt
+++ b/requirements/extras/brotli.txt
@@ -1,2 +1,2 @@
-brotlipy>=0.7.0;python_implementation=="PyPy"
-brotli>=1.0.0;python_implementation=="CPython"
+brotlipy>=0.7.0;platform_python_implementation=="PyPy"
+brotli>=1.0.0;platform_python_implementation=="CPython"


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Use [documented environment markers](https://www.python.org/dev/peps/pep-0508/#environment-markers). Because `python_implementation` marker is ["undocumented setuptools legacy"](https://github.com/pypa/setuptools/blob/83c667e0b2a98193851c07115d1af65011ed0fb6/pkg_resources/_vendor/packaging/markers.py#L94) and is absent in some versions of setuptools, for example in version 20.7.0 which is default in ubuntu 16.04

```
> pip install setuptools==20.7.0
> pip install --upgrade --no-cache-dir --force-reinstall celery==4.3.0 --no-binary :all:
...
    error in celery setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.

...
```