### PR TITLE
Added a testcase for #5290

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -225,6 +225,12 @@ class test_result_set:
 
 
 class test_group:
+    @flaky
+    def test_ready_with_exception(self):
+        g = group([add.s(1, 2), raise_error.s()])
+        result = g.apply_async()
+        while not result.ready():
+            pass
 
     @flaky
     def test_empty_group_result(self, manager):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

To prove that `result.ready()` works as expected when using the Redis result backend I've added this test case for #5290.