### PR TITLE
Fix mogodb backend authentication and add unittests

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -271,7 +271,10 @@ class MongoBackend(BaseBackend):
         conn = self._get_connection()
         db = conn[self.database_name]
         if self.user and self.password:
-            if not db.authenticate(self.user, self.password):
+            source = self.options.get('authsource', 
+                        self.database_name or 'admin'
+            )
+            if not db.authenticate(self.user, self.password, source=source):
                 raise ImproperlyConfigured(
                     'Invalid MongoDB username or password.')
         return db

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -235,7 +235,7 @@ class test_MongoBackend:
         assert database is mock_database
         assert self.backend.__dict__['database'] is mock_database
         mock_database.authenticate.assert_called_once_with(
-            MONGODB_USER, MONGODB_PASSWORD)
+            MONGODB_USER, MONGODB_PASSWORD, source=self.backend.database_name)
 
     @patch('celery.backends.mongodb.MongoBackend._get_connection')
     def test_get_database_no_existing_no_auth(self, mock_get_connection):


### PR DESCRIPTION
Following through on @jinuljt's PR: https://github.com/celery/celery/pull/4581

Updating unit tests to confirm mongodb backend supports authentication.

This fixes #4454.

Please let me know what else I can do to help complete this PR.