### PR TITLE
Change column type for Extended Task Meta args/kwargs

### DIFF
--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -8,6 +8,8 @@ from contextlib import contextmanager
 
 from vine.utils import wraps
 
+from kombu.utils.encoding import ensure_bytes
+
 from celery import states
 from celery.backends.base import BaseBackend
 from celery.exceptions import ImproperlyConfigured
@@ -134,8 +136,12 @@ class DatabaseBackend(BaseBackend):
         task.traceback = traceback
         if self.app.conf.find_value_for_key('extended', 'result'):
             task.name = getattr(request, 'task_name', None)
-            task.args = self.encode(getattr(request, 'args', None))
-            task.kwargs = self.encode(getattr(request, 'kwargs', None))
+            task.args = ensure_bytes(
+                self.encode(getattr(request, 'args', None))
+            )
+            task.kwargs = ensure_bytes(
+                self.encode(getattr(request, 'kwargs', None))
+            )
             task.worker = getattr(request, 'hostname', None)
             task.retries = getattr(request, 'retries', None)
             task.queue = (

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -54,8 +54,8 @@ class TaskExtended(Task):
     __table_args__ = {'sqlite_autoincrement': True, 'extend_existing': True}
 
     name = sa.Column(sa.String(155), nullable=True)
-    args = sa.Column(sa.Text, nullable=True)
-    kwargs = sa.Column(sa.Text, nullable=True)
+    args = sa.Column(sa.LargeBinary, nullable=True)
+    kwargs = sa.Column(sa.LargeBinary, nullable=True)
     worker = sa.Column(sa.String(155), nullable=True)
     retries = sa.Column(sa.Integer, nullable=True)
     queue = sa.Column(sa.String(155), nullable=True)

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -271,8 +271,9 @@ class MongoBackend(BaseBackend):
         conn = self._get_connection()
         db = conn[self.database_name]
         if self.user and self.password:
-            source = self.options.get('authsource', 
-                        self.database_name or 'admin'
+            source = self.options.get(
+                'authsource',
+                self.database_name or 'admin'
             )
             if not db.authenticate(self.user, self.password, source=source):
                 raise ImproperlyConfigured(

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -454,7 +454,8 @@ class test_MongoBackend:
         x.password = 'cere4l'
         with pytest.raises(ImproperlyConfigured):
             x._get_database()
-        db.authenticate.assert_called_with('jerry', 'cere4l')
+        db.authenticate.assert_called_with('jerry', 'cere4l',
+                                           source=x.database_name)
 
     def test_prepare_client_options(self):
         with patch('pymongo.version_tuple', new=(3, 0, 3)):


### PR DESCRIPTION
## Description

SQLite3 database driver requires unicode strings.

Column type changed to Binary instead of Text https://docs.sqlalchemy.org/en/13/core/type_basics.html#sqlalchemy.types.LargeBinary

Fixes Travis CI errors reported [here](https://travis-ci.org/celery/celery/jobs/536997981).