### PR TITLE
Clarify documentation for worker settings with namespace with Django

### DIFF
--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -92,7 +92,10 @@ The uppercase name-space means that all Celery configuration options
 must be specified in uppercase instead of lowercase, and start with
 ``CELERY_``, so for example the :setting:`task_always_eager` setting
 becomes ``CELERY_TASK_ALWAYS_EAGER``, and the :setting:`broker_url`
-setting becomes ``CELERY_BROKER_URL``.
+setting becomes ``CELERY_BROKER_URL``. This also applies to the
+workers settings, and overrides the usual ``CELERYD_`` prefix.
+For instance, the :setting:`worker_concurrency` setting becomes
+``CELERY_CONCURRENCY``.
 
 You can pass the settings object directly instead, but using a string
 is better since then the worker doesn't have to serialize the object.


### PR DESCRIPTION
## Description

The Django documentation explains briefly the namespace argument to the Celery app constructor, but isn't saying what happens to workers settings. I think adding a sentence to this section would prevent some mis-configurations.

~As I couldn't find any that covering this, I've updated 2 existing test cases to add assertions for that.~

Looks like it's already covered in tests:

https://github.com/celery/celery/blob/193be0be9dd8b925b3a46fed80887e73707db935/t/unit/app/test_app.py#L323-L337
