### PR TITLE
Fix task serializer ignored when task_always_eager=True

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -531,6 +531,18 @@ class Task(object):
             else:
                 check_arguments(*(args or ()), **(kwargs or {}))
 
+        if self.__v2_compat__:
+            shadow = shadow or self.shadow_name(self(), args, kwargs, options)
+        else:
+            shadow = shadow or self.shadow_name(args, kwargs, options)
+
+        preopts = self._get_exec_options()
+        options = dict(preopts, **options) if options else preopts
+
+        options.setdefault('ignore_result', self.ignore_result)
+        if self.priority:
+            options.setdefault('priority', self.priority)
+
         app = self._get_app()
         if app.conf.task_always_eager:
             with app.producer_or_acquire(producer) as eager_producer:
@@ -550,25 +562,13 @@ class Task(object):
             with denied_join_result():
                 return self.apply(args, kwargs, task_id=task_id or uuid(),
                                   link=link, link_error=link_error, **options)
-
-        if self.__v2_compat__:
-            shadow = shadow or self.shadow_name(self(), args, kwargs, options)
         else:
-            shadow = shadow or self.shadow_name(args, kwargs, options)
-
-        preopts = self._get_exec_options()
-        options = dict(preopts, **options) if options else preopts
-
-        options.setdefault('ignore_result', self.ignore_result)
-        if self.priority:
-            options.setdefault('priority', self.priority)
-
-        return app.send_task(
-            self.name, args, kwargs, task_id=task_id, producer=producer,
-            link=link, link_error=link_error, result_cls=self.AsyncResult,
-            shadow=shadow, task_type=self,
-            **options
-        )
+            return app.send_task(
+                self.name, args, kwargs, task_id=task_id, producer=producer,
+                link=link, link_error=link_error, result_cls=self.AsyncResult,
+                shadow=shadow, task_type=self,
+                **options
+            )
 
     def shadow_name(self, args, kwargs, options):
         """Override for custom task name in worker logs/monitoring.

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -984,6 +984,14 @@ class test_apply_async(TasksCase):
             pass
         task2.apply_async((1, 2, 3, 4, {1}))
 
+    def test_always_eager_with_task_serializer_option(self):
+        self.app.conf.task_always_eager = True
+
+        @self.app.task(serializer='pickle')
+        def task(*args, **kwargs):
+            pass
+        task.apply_async((1, 2, 3, 4, {1}))
+
     def test_task_with_ignored_result(self):
         with patch.object(self.app, 'send_task') as send_task:
             self.task_with_ignored_result.apply_async()


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

fixes https://github.com/celery/celery/issues/5548

With Celery 4.3, when CELERY_ALWAYS_EAGER is true, serialization roundtrip gets applied with `apply_async` method (https://github.com/celery/celery/issues/4008).

However, following task (from http://docs.celeryproject.org/en/latest/userguide/tasks.html#basics) for example fails to use the specified serializer without this fix.
```Py
@app.task(serializer='json')
def create_user(username, password):
    User.objects.create(username=username, password=password)
```

`apply_async` method needs to resolve the `serializer` exec option from `self`. Otherwise the `serializer` option of the Task object gets ignored.

For ease of patch release, I branched this fix off from Celery 4.3 release tag.