### PR TITLE
Add a few links in documentation for custom scheduler

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2956,7 +2956,7 @@ Default: ``"celery.beat:PersistentScheduler"``.
 
 The default scheduler class. May be set to
 ``"django_celery_beat.schedulers:DatabaseScheduler"`` for instance,
-if used alongside `django-celery-beat` extension.
+if used alongside :pypi:`django-celery-beat` extension.
 
 Can also be set via the :option:`celery beat -S` argument.
 

--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -461,6 +461,6 @@ To install and use this extension:
 
         $ celery -A proj beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
 
-   Note:  You may also add this as an settings option directly.
+   Note:  You may also add this as the :setting:`beat_scheduler` setting directly.
 
 #. Visit the Django-Admin interface to set up some periodic tasks.


### PR DESCRIPTION
## Description

Make the documentation a bit easier to navigate:

- Link to the beat_scheduler setting in django-celery-beat documentation
- Link to django-celery-beat on PyPI in the beat_scheduler option doc