### PR TITLE
Improve documentation regarding custom Task class

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -175,6 +175,8 @@ class Celery(object):
         config_source (Union[str, class]): Take configuration from a class,
             or object.  Attributes may include any settings described in
             the documentation.
+        task_cls (Union[str, Type[celery.app.task.Task]]): base task class to
+            use. See :ref:`this section <custom-task-cls-app-wide>` for usage.
     """
 
     #: This is deprecated, use :meth:`reduce_keys` instead

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -1456,8 +1456,10 @@ For example, a base Task class that caches a database connection:
                 self._db = Database.connect()
             return self._db
 
+Per task usage
+~~~~~~~~~~~~~~
 
-that can be added to tasks like this:
+The above can be added to each task like this:
 
 .. code-block:: python
 
@@ -1469,6 +1471,26 @@ that can be added to tasks like this:
 
 The ``db`` attribute of the ``process_rows`` task will then
 always stay the same in each process.
+
+.. _custom-task-cls-app-wide:
+
+App-wide usage
+~~~~~~~~~~~~~~
+
+You can also use your custom class in your whole Celery app by passing it as
+the ``task_cls`` argument when instantiating the app. This argument should be
+either a string giving the python path to your Task class or the class itself:
+
+.. code-block:: python
+
+    from celery import Celery
+
+    app = Celery('tasks', task_cls='your.module.path:DatabaseTask')
+
+This will make all your tasks declared using the decorator syntax within your
+app to use your ``DatabaseTask`` class and will all have a ``db`` attribute.
+
+The default value is the class provided by Celery: ``'celery.app.task:Task'``.
 
 Handlers
 --------


### PR DESCRIPTION
## Description

I recently discovered that we could extend the base class used in a Celery task, but the documentation didn't detail how to customise the base Task class in the entire celery app.

Looking at the code, it seems possible, this adds a section about it in the documentation and link to it from the API reference.