### PR TITLE
Feature/5405/worker init solo signal

### DIFF
--- a/celery/concurrency/solo.py
+++ b/celery/concurrency/solo.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
+from celery import signals
+
 from .base import BasePool, apply_target
 
 __all__ = ('TaskPool',)
@@ -18,6 +20,7 @@ class TaskPool(BasePool):
         super(TaskPool, self).__init__(*args, **kwargs)
         self.on_apply = apply_target
         self.limit = 1
+        signals.worker_process_init.send(sender=self)
 
     def _get_info(self):
         return {

--- a/celery/concurrency/solo.py
+++ b/celery/concurrency/solo.py
@@ -20,7 +20,7 @@ class TaskPool(BasePool):
         super(TaskPool, self).__init__(*args, **kwargs)
         self.on_apply = apply_target
         self.limit = 1
-        signals.worker_process_init.send(sender=self)
+        signals.worker_process_init.send(sender=None)
 
     def _get_info(self):
         return {

--- a/t/unit/concurrency/test_solo.py
+++ b/t/unit/concurrency/test_solo.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import operator
-from unittest.mock import Mock
+from case import Mock
 
 from celery import signals
 from celery.concurrency import solo

--- a/t/unit/concurrency/test_solo.py
+++ b/t/unit/concurrency/test_solo.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
 import operator
+from unittest.mock import Mock, patch
 
+from celery import signals
 from celery.concurrency import solo
 from celery.utils.functional import noop
 
@@ -21,3 +23,11 @@ class test_solo_TaskPool:
         x = solo.TaskPool()
         x.on_start()
         assert x.info
+
+    def test_on_worker_process_init_called(self):
+        """Upon the initialization of a new solo worker a worker_process_init 
+        signal should be emitted"""
+        on_worker_process_init = Mock()
+        signals.worker_process_init.connect(on_worker_process_init)
+        x = solo.TaskPool()
+        assert on_worker_process_init.call_count == 1

--- a/t/unit/concurrency/test_solo.py
+++ b/t/unit/concurrency/test_solo.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import operator
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from celery import signals
 from celery.concurrency import solo
@@ -25,7 +25,7 @@ class test_solo_TaskPool:
         assert x.info
 
     def test_on_worker_process_init_called(self):
-        """Upon the initialization of a new solo worker a worker_process_init 
+        """Upon the initialization of a new solo worker pool a worker_process_init
         signal should be emitted"""
         on_worker_process_init = Mock()
         signals.worker_process_init.connect(on_worker_process_init)

--- a/t/unit/concurrency/test_solo.py
+++ b/t/unit/concurrency/test_solo.py
@@ -29,5 +29,5 @@ class test_solo_TaskPool:
         signal should be emitted"""
         on_worker_process_init = Mock()
         signals.worker_process_init.connect(on_worker_process_init)
-        x = solo.TaskPool()
+        solo.TaskPool()
         assert on_worker_process_init.call_count == 1


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description:

Implemented a signal emission during the initialization of solo worker as described in issue [5405](https://github.com/celery/celery/issues/5405). Implemented a unit test to ensure the signal is called during pool initialization .  

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
