### PR TITLE
Doc: correct new name for worker setting with namespace using Django

### DIFF
--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -93,9 +93,8 @@ must be specified in uppercase instead of lowercase, and start with
 ``CELERY_``, so for example the :setting:`task_always_eager` setting
 becomes ``CELERY_TASK_ALWAYS_EAGER``, and the :setting:`broker_url`
 setting becomes ``CELERY_BROKER_URL``. This also applies to the
-workers settings, and overrides the usual ``CELERYD_`` prefix.
-For instance, the :setting:`worker_concurrency` setting becomes
-``CELERY_CONCURRENCY``.
+workers settings, for instance, the :setting:`worker_concurrency`
+setting becomes ``CELERY_WORKER_CONCURRENCY``.
 
 You can pass the settings object directly instead, but using a string
 is better since then the worker doesn't have to serialize the object.


### PR DESCRIPTION
Don't mention the old-style setting ``CELERYD_`` which adds to the confusion

Correct an error in an update I recently made to this section of the docs (see #5547).

Also consistent with the test where `CELERY_WORKER_AGENT` controls `app.conf.worker_agent`:

https://github.com/celery/celery/blob/193be0be9dd8b925b3a46fed80887e73707db935/t/unit/app/test_app.py#L325-L335


The old name was `CELERYD_AGENT`, the update in #5547 implies that the name should be `CELERY_AGENT`, which is wrong