### PR TITLE
Update docs for sqs

### DIFF
--- a/docs/getting-started/brokers/sqs.rst
+++ b/docs/getting-started/brokers/sqs.rst
@@ -82,7 +82,7 @@ This option is set via the :setting:`broker_transport_options` setting::
 
     broker_transport_options = {'visibility_timeout': 3600}  # 1 hour.
 
-The default visibility timeout is 30 minutes.
+The default visibility timeout is 30 seconds.
 
 Polling Interval
 ----------------


### PR DESCRIPTION
`The default visibility timeout for a message is 30 seconds` ->
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
