### PR TITLE
docs: fixed MyBootstap().__init__()

### DIFF
--- a/docs/userguide/extending.rst
+++ b/docs/userguide/extending.rst
@@ -759,7 +759,8 @@ All bootsteps will now receive this argument as a keyword argument to
 
     class MyBootstep(bootsteps.Step):
 
-        def __init__(self, worker, enable_my_option=False, **options):
+        def __init__(self, parent, enable_my_option=False, **options):
+            super().__init__(parent, **options)
             if enable_my_option:
                 party()
 


### PR DESCRIPTION
`MyBootstap().__init__()` should run its parent init function. Also fixed `MyBootstap().__init__()` signature to correspond its parent naming.