### PR TITLE
Support load result_backend setting in app.config_from_object.

### DIFF
--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -114,8 +114,8 @@ class Settings(ConfigurationView):
     def result_backend(self):
         return (
             os.environ.get('CELERY_RESULT_BACKEND') or
-            self.get('CELERY_RESULT_BACKEND') or
-            self.get('result_backend')
+            self.get('result_backend') or
+            self.get('CELERY_RESULT_BACKEND')
         )
 
     @property

--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -114,7 +114,8 @@ class Settings(ConfigurationView):
     def result_backend(self):
         return (
             os.environ.get('CELERY_RESULT_BACKEND') or
-            self.get('CELERY_RESULT_BACKEND')
+            self.get('CELERY_RESULT_BACKEND') or
+            self.get('result_backend')
         )
 
     @property


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

I define the following parameters in the celeryconfig.py.
celery_broker_url = 'redis://localhost/0'
celery_result_backend = 'redis://localhost/1'

When I read the configuration using the following method:
app. config_from_object('celeryconfig', namespace = 'celery')

Broker_url loads correctly, but result_backend is not set.

So I tried to fix it, If there is any questions, please let me know. thanks.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
