### PR TITLE
Fix Chain Exceptions propagations

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -269,3 +269,4 @@ Artem Vasilyev, 2018/11/24
 Victor Mireyev, 2018/12/13
 Florian Chardin, 2018/10/23
 Shady Rafehi, 2019/02/20
+Fabio Todaro, 2019/06/13

--- a/celery/result.py
+++ b/celery/result.py
@@ -205,7 +205,7 @@ class AsyncResult(ResultBase):
             assert_will_not_block()
         _on_interval = promise()
         if follow_parents and propagate and self.parent:
-            on_interval = promise(self._maybe_reraise_parent_error, weak=True)
+            _on_interval = promise(self._maybe_reraise_parent_error, weak=True)
             self._maybe_reraise_parent_error()
         if on_interval:
             _on_interval.then(on_interval)

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -561,14 +561,14 @@ class test_chord:
         )
         res = c1()
         try:
-            res.get()
+            res.get(propagate=True)
         except ExpectedException:
             pass
         # Got to wait for children to populate.
         while not res.children:
             time.sleep(0.1)
         try:
-            res.children[0].wait(propagate=True)
+            res.children[0].get(propagate=True)
         except ExpectedException:
             pass
 

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -55,6 +55,27 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == [4, 5]
 
+
+    def test_chain_on_error(self, manager):
+        from celery import states
+        from .tasks import ExpectedException
+        import time
+
+        if not manager.app.conf.result_backend.startswith('redis'):
+            raise pytest.skip('Requires redis result backend.')
+
+        # Run the chord and wait for the error callback to finish.
+        c1 = chain(
+            add.s(1, 2), fail.s(), add.s(3, 4),
+        )
+        res = c1()
+
+        with pytest.raises(ExpectedException):
+            res.get(propagate=True)
+
+        with pytest.raises(ExpectedException):
+            res.parent.get(propagate=True)
+
     @flaky
     def test_chain_inside_group_receives_arguments(self, manager):
         c = (
@@ -547,32 +568,6 @@ class test_chord:
         assert root_id == expected_root_id
         assert parent_id is None
 
-    def test_chain_on_error(self, manager):
-        from celery import states
-        from .tasks import ExpectedException
-        import time
-
-        if not manager.app.conf.result_backend.startswith('redis'):
-            raise pytest.skip('Requires redis result backend.')
-
-        # Run the chord and wait for the error callback to finish.
-        c1 = chain(
-            add.s(1, 2), fail.s(), add.s(3, 4),
-        )
-        res = c1()
-        try:
-            res.get(propagate=True)
-        except ExpectedException:
-            pass
-        # Got to wait for children to populate.
-        while not res.children:
-            time.sleep(0.1)
-        try:
-            res.children[0].get(propagate=True)
-        except ExpectedException:
-            pass
-
-
     def test_chord_on_error(self, manager):
         from celery import states
         from .tasks import ExpectedException
@@ -588,17 +583,13 @@ class test_chord:
                 chord_error.s()),
         )
         res = c1()
-        try:
+        with pytest.raises(ExpectedException):
             res.wait(propagate=False)
-        except ExpectedException:
-            pass
         # Got to wait for children to populate.
         while not res.children:
             time.sleep(0.1)
-        try:
+        with pytest.raises(ExpectedException):
             res.children[0].children[0].wait(propagate=False)
-        except ExpectedException:
-            pass
 
         # Extract the results of the successful tasks from the chord.
         #


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fixes #3810, #3743

This commit https://github.com/celery/celery/commit/2055cbd056f4d2822e0e88b22e36cfca363952a6 introduced the `on_interval` arg but there is a typo and the promise passed to `self.backend.wait_for_pending` is messed up.
