### PR TITLE
Unpack exception message if it's a list

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -279,7 +279,7 @@ class Backend(object):
                                                    celery.exceptions.__name__)
                 exc_msg = exc['exc_message']
                 try:
-                    if isinstance(exc_msg, tuple):
+                    if isinstance(exc_msg, (tuple, list)):
                         exc = cls(*exc_msg)
                     else:
                         exc = cls(exc_msg)


### PR DESCRIPTION
## Description

As noticed in #5568, serializing a tuple as JSON and deserializing it, results in a list, not a tuple.
Make sure we unpack these exception messages correctly.