### PR TITLE
Fix: (group() | group()) not equals single group (#5574)

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -392,10 +392,6 @@ class Signature(dict):
         # These could be implemented in each individual class,
         # I'm sure, but for now we have this.
         if isinstance(self, group):
-            if isinstance(other, group):
-                # group() | group() -> single group
-                return group(
-                    itertools.chain(self.tasks, other.tasks), app=self.app)
             # group() | task -> chord
             return chord(self, body=other, app=self._app)
         elif isinstance(other, group):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -324,6 +324,12 @@ class test_chain(CanvasCase):
             assert isinstance(task, Signature)
             assert task.app is self.app
 
+    def test_groups_in_chain_to_chord(self):
+        g1 = group([self.add.s(2, 2), self.add.s(4, 4)])
+        g2 = group([self.add.s(3, 3), self.add.s(5, 5)])
+        c = g1 | g2
+        assert isinstance(c, chord)
+
     def test_group_to_chord(self):
         c = (
             self.add.s(5) |


### PR DESCRIPTION
Fix #5574 
group() | group() not equals single group
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
