### PR TITLE
Fix: Add a patch to support Python 2.7

### DIFF
--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -288,7 +288,13 @@ class Command(object):
         try:
             argv = self.setup_app_from_commandline(argv)
         except ModuleNotFoundError as e:
-            self.on_error(UNABLE_TO_LOAD_APP_MODULE_NOT_FOUND.format(e.name))
+            # In Python 2.7 and below, there is no name instance for exceptions
+            # Remove when Python 2.7 is not supported
+            if sys.version_info < (3, 0):
+                package_name = e.message.replace("No module named ", "")
+            else:
+                package_name = e.name
+            self.on_error(UNABLE_TO_LOAD_APP_MODULE_NOT_FOUND.format(package_name))
             return EX_FAILURE
         except AttributeError as e:
             msg = e.args[0].capitalize()

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -17,7 +17,7 @@ from celery import VERSION_BANNER, Celery, maybe_patch_concurrency, signals
 from celery.exceptions import CDeprecationWarning, CPendingDeprecationWarning
 from celery.five import (getfullargspec, items, long_t,
                          python_2_unicode_compatible, string, string_t,
-                         text_t)
+                         text_t, PY2)
 from celery.platforms import EX_FAILURE, EX_OK, EX_USAGE, isatty
 from celery.utils import imports, term, text
 from celery.utils.functional import dictfilter
@@ -289,8 +289,8 @@ class Command(object):
             argv = self.setup_app_from_commandline(argv)
         except ModuleNotFoundError as e:
             # In Python 2.7 and below, there is no name instance for exceptions
-            # Remove when Python 2.7 is not supported
-            if sys.version_info < (3, 0):
+            # TODO: Remove this once we drop support for Python 2.7
+            if PY2:
                 package_name = e.message.replace("No module named ", "")
             else:
                 package_name = e.name


### PR DESCRIPTION
## Description

In Python 2.7 or below, there is no `name` instance for exceptions.   
Thus, whenever the user import a package that does not exist with Python 2.7 or below, following unexpected exception is raised:

```
Traceback (most recent call last):
  File "celery", line 11, in <module>
    load_entry_point('celery==4.4.0rc2', 'console_scripts', 'celery')()
  File "celery/__main__.py", line 16, in main
    _main()
  File "celery/bin/celery.py", line 322, in main
    cmd.execute_from_commandline(argv)
  File "celery/bin/celery.py", line 496, in execute_from_commandline
    super(CeleryCommand, self).execute_from_commandline(argv)))
  File "celery/bin/base.py", line 293, in execute_from_commandline
    self.on_error(UNABLE_TO_LOAD_APP_MODULE_NOT_FOUND.format(e.name))
AttributeError: 'exceptions.ImportError' object has no attribute 'name'
```
This pull request adds a small patch so that Python 2.7 or below user would not be bothered by this error and know what package does not exist.   
This patch could also be easily removed when Python 2.7 is deprecated.