### PR TITLE
Doc: add warning to max_redis_connections

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1052,6 +1052,10 @@ Default: No limit.
 Maximum number of connections available in the Redis connection
 pool used for sending and retrieving results.
 
+.. warning::
+    Redis will raise a `ConnectionError` if the number of concurrent
+    connections exceeds the maximum.
+
 .. setting:: redis_socket_connect_timeout
 
 ``redis_socket_connect_timeout``


### PR DESCRIPTION
Partially fixes #5567: warns about `max_redis_connections` raising an error if the number of concurrent connections exceeds the allowed maximum.

Also, I would like to add a celery example on how to create a blocking-pool, as it seems from this [kombu example with redis](https://kombu.readthedocs.io/en/latest/userguide/pools.html#the-connection-pool-group) that it should be possible (although the `kombu.transport.redis` only instantiates a RedisPool, which is non-blocking). However, I am unsure on how to pass the `block=True` option when creating the celery instance. Can you help?

