### PR TITLE
Revert "Broker connection uses the heartbeat setting from app config unless set otherwise"

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -842,7 +842,7 @@ class Celery(object):
             port or conf.broker_port,
             transport=transport or conf.broker_transport,
             ssl=self.either('broker_use_ssl', ssl),
-            heartbeat=heartbeat or self.conf.broker_heartbeat,
+            heartbeat=heartbeat,
             login_method=login_method or conf.broker_login_method,
             failover_strategy=(
                 failover_strategy or conf.broker_failover_strategy

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -799,20 +799,6 @@ class test_App:
         assert self.app.connection('amqp:////value') \
                        .failover_strategy == my_failover_strategy
 
-    def test_amqp_heartbeat_settings(self):
-        # Test default broker_heartbeat value
-        assert self.app.connection('amqp:////value') \
-                   .heartbeat == 0
-
-        # Test passing heartbeat through app configuration
-        self.app.conf.broker_heartbeat = 60
-        assert self.app.connection('amqp:////value') \
-                   .heartbeat == 60
-
-        # Test passing heartbeat as connection argument
-        assert self.app.connection('amqp:////value', heartbeat=30) \
-                   .heartbeat == 30
-
     def test_after_fork(self):
         self.app._pool = Mock()
         self.app.on_after_fork = Mock(name='on_after_fork')


### PR DESCRIPTION
Reverts celery/celery#4148