### PR TITLE
Remove Github and Patreon from Github Funding

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,7 +1,7 @@
 # These are supported funding model platforms
 
-github: auvipy
-patreon: auvipy
+github:
+patreon:
 open_collective: celery
 ko_fi: # Replace with a single Ko-fi username
 tidelift: pypi/celery


### PR DESCRIPTION
Remove the GitHub link because @auvipy isn't on GitHub Sponsors (yet) and it leads to an error banner that users see: "Some users provided are not enrolled in GitHub Sponsors. Apply to the beta."

Remove the Patreon link because it has no way of sponsoring (at the moment?)

[GitHub Docs](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository)
