### PR TITLE
Fix minor documentation irregularities

### DIFF
--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -130,9 +130,9 @@ configuration:
         Queue('default',    routing_key='task.#'),
         Queue('feed_tasks', routing_key='feed.#'),
     )
-    task_default_exchange = 'tasks'
-    task_default_exchange_type = 'topic'
-    task_default_routing_key = 'task.default'
+    app.conf.task_default_exchange = 'tasks'
+    app.conf.task_default_exchange_type = 'topic'
+    app.conf.task_default_routing_key = 'task.default'
 
 :setting:`task_queues` is a list of :class:`~kombu.entity.Queue`
 instances.
@@ -736,7 +736,8 @@ default priority.
     responsiveness of your system without the costs of disabling prefetching
     entirely.
 
-    Note that priorities values are sorted in reverse: 0 being highest priority.
+    Note that priorities values are sorted in reverse when
+    using the redis broker: 0 being highest priority.
 
 
 Broadcast


### PR DESCRIPTION
## Description
* `task_default_*` configuration is now described as being set on the `app.conf` object.

* When using RabbitMQ as the broker, the highest number given as`priority` also has highest priority, i.e. it is not reversed. As stated in the [calling docs](https://github.com/celery/celery/blob/f9638fa24110f0589c4f1372bf86e43d6ae1781f/docs/userguide/calling.rst#advanced-options), only redis is reversed

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->