### PR TITLE
Passthrough Celery Task Name into AsyncResult

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -756,7 +756,7 @@ class Celery(object):
                 if not ignored_result:
                     self.backend.on_task_call(P, task_id)
                 amqp.send_task_message(P, name, message, **options)
-        result = (result_cls or self.AsyncResult)(task_id)
+        result = (result_cls or self.AsyncResult)(task_id, task_name=name)
         # We avoid using the constructor since a custom result class
         # can be used, in which case the constructor may still use
         # the old signature.

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -790,8 +790,7 @@ class Task(object):
         Arguments:
             task_id (str): Task id to get result for.
         """
-        return self._get_app().AsyncResult(task_id, backend=self.backend,
-                                           task_name=self.name, **kwargs)
+        return self._get_app().AsyncResult(task_id, backend=self.backend, **kwargs)
 
     def signature(self, args=None, *starargs, **starkwargs):
         """Create signature.

--- a/celery/contrib/abortable.py
+++ b/celery/contrib/abortable.py
@@ -147,9 +147,9 @@ class AbortableTask(Task):
 
     abstract = True
 
-    def AsyncResult(self, task_id):
+    def AsyncResult(self, task_id, **kwargs):
         """Return the accompanying AbortableAsyncResult instance."""
-        return AbortableAsyncResult(task_id, backend=self.backend)
+        return AbortableAsyncResult(task_id, backend=self.backend, **kwargs)
 
     def is_aborted(self, **kwargs):
         """Return true if task is aborted.


### PR DESCRIPTION
## Description

Simple changeset to allow `AsyncResult` to always be populated with a `task_name`. Though a comment in the initializer for `celery.Result` says that `task_name` in there is deprecated, I think it would be useful to keep.