### PR TITLE
Use self.run() when overriding __call__

### DIFF
--- a/docs/userguide/application.rst
+++ b/docs/userguide/application.rst
@@ -506,14 +506,18 @@ class: :class:`celery.Task`.
 
         def __call__(self, *args, **kwargs):
             print('TASK STARTING: {0.name}[{0.request.id}]'.format(self))
-            return super(DebugTask, self).__call__(*args, **kwargs)
+            return self.run(*args, **kwargs)
 
 
 .. tip::
 
-    If you override the tasks ``__call__`` method, then it's very important
-    that you also call super so that the base call method can set up the
-    default request used when a task is called directly.
+    If you override the task's ``__call__`` method, then it's very important
+    that you also call ``self.run`` to execute the body of the task.  Do not
+    call ``super().__call__``.  The ``__call__`` method of the neutral base 
+    class :class:`celery.Task` is only present for reference.  For optimization,
+    this has been unrolled into ``celery.app.trace.build_tracer.trace_task``
+    which calls ``run`` directly on the custom task class if no ``__call__``
+    method is defined.
 
 The neutral base class is special because it's not bound to any specific app
 yet. Once a task is bound to an app it'll read configuration to set default


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Updated documentation to be in line with the optimization of unrolling __call__ into trace_task.  When overriding __call__in a custom task class, call self.run not super.__call__ to execute the body of the task.

Fixes #5643 
