### PR TITLE
Fix termination of asynloop

### DIFF
--- a/celery/worker/loops.py
+++ b/celery/worker/loops.py
@@ -5,7 +5,7 @@ import errno
 import socket
 
 from celery import bootsteps
-from celery.exceptions import WorkerLostError, WorkerShutdown, WorkerTerminate
+from celery.exceptions import WorkerLostError
 from celery.utils.log import get_logger
 
 from . import state
@@ -71,15 +71,7 @@ def asynloop(obj, connection, consumer, blueprint, hub, qos,
 
     try:
         while blueprint.state == RUN and obj.connection:
-            # shutdown if signal handlers told us to.
-            should_stop, should_terminate = (
-                state.should_stop, state.should_terminate,
-            )
-            # False == EX_OK, so must use is not False
-            if should_stop is not None and should_stop is not False:
-                raise WorkerShutdown(should_stop)
-            elif should_terminate is not None and should_stop is not False:
-                raise WorkerTerminate(should_terminate)
+            state.maybe_shutdown()
 
             # We only update QoS when there's no more messages to read.
             # This groups together qos calls, and makes sure that remote

--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -74,10 +74,10 @@ def reset_state():
 
 def maybe_shutdown():
     """Shutdown if flags have been set."""
-    if should_stop is not None and should_stop is not False:
-        raise WorkerShutdown(should_stop)
-    elif should_terminate is not None and should_terminate is not False:
+    if should_terminate is not None and should_terminate is not False:
         raise WorkerTerminate(should_terminate)
+    elif should_stop is not None and should_stop is not False:
+        raise WorkerShutdown(should_stop)
 
 
 def task_reserved(request,

--- a/t/unit/worker/test_loops.py
+++ b/t/unit/worker/test_loops.py
@@ -12,7 +12,7 @@ from celery.bootsteps import CLOSE, RUN
 from celery.exceptions import (InvalidTaskError, WorkerLostError,
                                WorkerShutdown, WorkerTerminate)
 from celery.five import Empty, python_2_unicode_compatible
-from celery.platforms import EX_FAILURE
+from celery.platforms import EX_FAILURE, EX_OK
 from celery.worker import state
 from celery.worker.consumer import Consumer
 from celery.worker.loops import _quick_drain, asynloop, synloop
@@ -217,14 +217,16 @@ class test_asynloop:
         on_task(msg)
         x.on_decode_error.assert_called_with(msg, exc)
 
-    def test_should_terminate(self):
+    @pytest.mark.parametrize('should_stop', (None, False, True, EX_OK))
+    def test_should_terminate(self, should_stop):
         x = X(self.app)
-        # XXX why aren't the errors propagated?!?
+        state.should_stop = should_stop
         state.should_terminate = True
         try:
             with pytest.raises(WorkerTerminate):
                 asynloop(*x.args)
         finally:
+            state.should_stop = None
             state.should_terminate = None
 
     def test_should_terminate_hub_close_raises(self):

--- a/t/unit/worker/test_state.py
+++ b/t/unit/worker/test_state.py
@@ -8,6 +8,7 @@ import pytest
 from case import Mock, patch
 from celery import uuid
 from celery.exceptions import WorkerShutdown, WorkerTerminate
+from celery.platforms import EX_OK
 from celery.utils.collections import LimitedSet
 from celery.worker import state
 
@@ -80,7 +81,9 @@ class test_maybe_shutdown:
         else:
             raise RuntimeError('should have exited')
 
-    def test_should_terminate(self):
+    @pytest.mark.parametrize('should_stop', (None, False, True, EX_OK))
+    def test_should_terminate(self, should_stop):
+        state.should_stop = should_stop
         state.should_terminate = True
         with pytest.raises(WorkerTerminate):
             state.maybe_shutdown()


### PR DESCRIPTION
Currently, `asynloop` hangs on termination in case when `should_terminate` is not `None` and `should_stop` is `False`.

It seems reasonable to use `state.maybe_shutdown` in order to fix the issue and, on the other hand, to simplify the code.

Also, I believe that termination should have a higher priority than shutting down, so order of checking for termination and for shutting down should be changed.

P.S. A CI failure for Windows is expected and it's not related to these changes.