### PR TITLE
Fix Travis CI job for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: required
 dist: xenial
 cache: pip
 python:
@@ -57,11 +56,9 @@ matrix:
     stage: lint
   - python: pypy2.7-7.1.1
     env: TOXENV=pypy
-    dist: xenial
     before_install: sudo apt-get update && sudo apt-get install libgnutls-dev
   - python: pypy3.5-7.0
     env: TOXENV=pypy3
-    dist: xenial
     before_install: sudo apt-get update && sudo apt-get install libgnutls-dev
 
 before_install:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,6 @@
 sphinx_celery==1.4.6
 Sphinx==1.8.5
 sphinx-testing==0.7.2
-typing
 -r extras/sqlalchemy.txt
 -r test.txt
 -r deps/mock.txt

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ basepython =
     flake8,apicheck,linkcheck,configcheck,pydocstyle,bandit: python3.7
     flakeplus: python2.7
 usedevelop = True
-install_command = python -m pip --disable-pip-version-check install {opts} {packages}
+install_command = {toxinidir}/tox_install_command.sh {opts} {packages}
 
 [testenv:apicheck]
 setenv =

--- a/tox_install_command.sh
+++ b/tox_install_command.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+pip --disable-pip-version-check install "$@"
+
+if [[ "${TRAVIS_PYTHON_VERSION}" == "3.7" ]]; then
+  # We have to uninstall the typing package which comes along with
+  # the couchbase package in order to prevent an error on CI for Python 3.7.
+  pip uninstall typing -y
+fi


### PR DESCRIPTION
Hello,

The [typing](https://github.com/python/typing) package is a built-in for all currently supported Python versions, so it seems to be not required anymore.
Presence of this package leads to an error on CI for Python 3.7.

These changes also:
 - remove redundant options from `.travis.yml`
