### PR TITLE
Fix canvases which used to raise an exception whenever subsequent groups are chained one after another

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -669,10 +669,20 @@ class _chain(Signature):
                 # signature instead of a group.
                 tasks.pop()
                 results.pop()
-                task = chord(
-                    task, body=prev_task,
-                    task_id=prev_res.task_id, root_id=root_id, app=app,
-                )
+                try:
+                    task = chord(
+                        task, body=prev_task,
+                        task_id=prev_res.task_id, root_id=root_id, app=app,
+                    )
+                except AttributeError:
+                    # A GroupResult does not have a task_id since it is consistent
+                    # of multiple tasks.
+                    # We therefore, have to construct the chord without it.
+                    # Issues #5467, #3585.
+                    task = chord(
+                        task, body=prev_task,
+                        root_id=root_id, app=app,
+                    )
 
             if is_last_task:
                 # chain(task_id=id) means task id is set for the last task

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -675,7 +675,7 @@ class _chain(Signature):
                         task_id=prev_res.task_id, root_id=root_id, app=app,
                     )
                 except AttributeError:
-                    # A GroupResult does not have a task_id since it is consistent
+                    # A GroupResult does not have a task_id since it consists
                     # of multiple tasks.
                     # We therefore, have to construct the chord without it.
                     # Issues #5467, #3585.

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -232,6 +232,21 @@ class test_chain:
         assert len(result) == 2
         assert isinstance(result[0][1], list)
 
+    @flaky
+    def test_chain_of_task_a_group_and_a_chord(self, manager):
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.args[0])
+
+        c = add.si(1, 0)
+        c = c | group(add.s(1), add.s(1))
+        c = c | group(tsum.s(), tsum.s())
+        c = c | tsum.s()
+
+        res = c()
+        assert res.get(timeout=TIMEOUT) == 8
+
 
 class test_result_set:
 


### PR DESCRIPTION
Fix canvases which used to raise an exception whenever subsequent groups are chained one after another and are automatically converted into a chord.

Fixes #5467, fixes #3585.
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->