### PR TITLE
Fix #2849 - Initial work of celery 5.0.0 alpha1 series by dropping python below 3.6 from marix & remove import from __future__

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 dist: xenial
 cache: pip
 python:
-  - '2.7'
-  - '3.5'
   - '3.6'
   - '3.7'
 os:
@@ -54,12 +52,6 @@ matrix:
   - python: '2.7'
     env: TOXENV=flakeplus
     stage: lint
-  - python: pypy2.7-7.1.1
-    env: TOXENV=pypy
-    before_install: sudo apt-get update && sudo apt-get install libgnutls-dev
-  - python: pypy3.5-7.0
-    env: TOXENV=pypy3
-    before_install: sudo apt-get update && sudo apt-get install libgnutls-dev
   - python: pypy3.6-7.1.1
     env: TOXENV=pypy3
     before_install: sudo apt-get update && sudo apt-get install libgnutls-dev

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp| |ocbackerbadge| |ocsponsorbadge|
 
-:Version: 5.0.0a1 (cliffs)
+:Version: 4.4.0rc3 (cliffs)
 :Web: http://celeryproject.org/
 :Download: https://pypi.org/project/celery/
 :Source: https://github.com/celery/celery/

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp| |ocbackerbadge| |ocsponsorbadge|
 
-:Version: 4.4.0rc3 (cliffs)
+:Version: 5.0.0a1 (cliffs)
 :Web: http://celeryproject.org/
 :Download: https://pypi.org/project/celery/
 :Source: https://github.com/celery/celery/
@@ -55,15 +55,13 @@ in such a way that the client enqueues an URL to be requested by a worker.
 What do I need?
 ===============
 
-Celery version 4.3 runs on,
+Celery version 5.0.0 alpha-1 runs on,
 
-- Python (2.7, 3.4, 3.5, 3.6, 3.7)
-- PyPy2.7 (6.0)
-- PyPy3.5 (6.0)
+- Python (3.6, 3.7)
+- PyPy3.6 (7.1.1)
 
 
-This is the last version to support Python 2.7,
-and from the next version (Celery 5.x) Python 3.5 or newer is required.
+This is the next version to of celery which will support Python 3.6 or newer.
 
 If you're running an older version of Python, you need to be running
 an older version of Celery:
@@ -71,6 +69,7 @@ an older version of Celery:
 - Python 2.6: Celery series 3.1 or earlier.
 - Python 2.5: Celery series 3.0 or earlier.
 - Python 2.4 was Celery series 2.2 or earlier.
+- Python 2.7: Celery 4.x series.
 
 Celery is a project with minimal funding,
 so we don't support Microsoft Windows.
@@ -88,7 +87,7 @@ Get Started
 ===========
 
 If this is the first time you're trying to use Celery, or you're
-new to Celery 4.2 coming from previous versions then you should read our
+new to Celery 5.0.0 alpha-1 coming from previous versions then you should read our
 getting started tutorials:
 
 - `First steps with Celery`_

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,21 +12,14 @@ environment:
     # a later point release.
     # See: https://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
+
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
-      WINDOWS_SDK_VERSION: "v7.0"
-
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
 

--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -176,7 +176,4 @@ old_module, new_module = local.recreate_module(  # pragma: no cover
     version_info=version_info,
     maybe_patch_concurrency=maybe_patch_concurrency,
     _find_option_with_arg=_find_option_with_arg,
-    absolute_import=absolute_import,
-    unicode_literals=unicode_literals,
-    print_function=print_function,
 )

--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -6,8 +6,6 @@
 #                 All rights reserved.
 # :license:   BSD (3 Clause), see LICENSE for more details.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import re
 import sys

--- a/celery/__main__.py
+++ b/celery/__main__.py
@@ -1,5 +1,4 @@
 """Entry-point for the :program:`celery` umbrella command."""
-from __future__ import absolute_import, print_function, unicode_literals
 
 import sys
 

--- a/celery/_state.py
+++ b/celery/_state.py
@@ -6,7 +6,6 @@ like the ``current_app``, and ``current_task``.
 
 This module shouldn't be used directly.
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import sys

--- a/celery/app/__init__.py
+++ b/celery/app/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Celery Application."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 from celery import _state
 from celery._state import (app_or_default, disable_trace, enable_trace,
                            pop_current_task, push_current_task)

--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Sending/Receiving Messages (Kombu integration)."""
-from __future__ import absolute_import, unicode_literals
-
 import numbers
 from collections import namedtuple
 from datetime import timedelta

--- a/celery/app/annotations.py
+++ b/celery/app/annotations.py
@@ -7,8 +7,6 @@ in the configuration.
 This prepares and performs the annotations in the
 :setting:`task_annotations` setting.
 """
-from __future__ import absolute_import, unicode_literals
-
 from celery.five import string_t
 from celery.utils.functional import firstmethod, mlazy
 from celery.utils.imports import instantiate

--- a/celery/app/backends.py
+++ b/celery/app/backends.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Backend selection."""
-from __future__ import absolute_import, unicode_literals
-
 import sys
 import types
 

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Actual App instance implementation."""
-from __future__ import absolute_import, unicode_literals
-
 import os
 import threading
 import warnings

--- a/celery/app/builtins.py
+++ b/celery/app/builtins.py
@@ -3,8 +3,6 @@
 
 The built-in tasks are always available in all app instances.
 """
-from __future__ import absolute_import, unicode_literals
-
 from celery._state import connect_on_app_finalize
 from celery.utils.log import get_logger
 

--- a/celery/app/control.py
+++ b/celery/app/control.py
@@ -4,8 +4,6 @@
 Client for worker remote control commands.
 Server implementation is in :mod:`celery.worker.control`.
 """
-from __future__ import absolute_import, unicode_literals
-
 import warnings
 
 from billiard.common import TERM_SIGNAME

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Configuration introspection and defaults."""
-from __future__ import absolute_import, unicode_literals
-
 import sys
 from collections import deque, namedtuple
 from datetime import timedelta

--- a/celery/app/events.py
+++ b/celery/app/events.py
@@ -1,6 +1,4 @@
 """Implementation for the app.events shortcuts."""
-from __future__ import absolute_import, unicode_literals
-
 from contextlib import contextmanager
 
 from kombu.utils.objects import cached_property

--- a/celery/app/log.py
+++ b/celery/app/log.py
@@ -7,8 +7,6 @@ Sets up logging for the worker and other programs,
 redirects standard outs, colors log output, patches logging
 related compatibility fixes, and so on.
 """
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import os
 import sys

--- a/celery/app/registry.py
+++ b/celery/app/registry.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Registry of available tasks."""
-from __future__ import absolute_import, unicode_literals
-
 import inspect
 from importlib import import_module
 

--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -3,8 +3,6 @@
 
 Contains utilities for working with task routers, (:setting:`task_routes`).
 """
-from __future__ import absolute_import, unicode_literals
-
 import re
 import string
 from collections import OrderedDict

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Task implementation: request context and the task base class."""
-from __future__ import absolute_import, unicode_literals
-
 import signal
 import sys
 

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -4,8 +4,6 @@
 This module defines how the task execution is traced:
 errors are recorded, handlers are applied and so on.
 """
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import os
 import sys

--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """App utilities: Compat settings, bug-report tool, pickling apps."""
-from __future__ import absolute_import, unicode_literals
-
 import os
 import platform as _platform
 import re

--- a/celery/apps/beat.py
+++ b/celery/apps/beat.py
@@ -7,8 +7,6 @@ It does everything necessary to run that module
 as an actual application, like installing signal handlers
 and so on.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import numbers
 import socket
 import sys

--- a/celery/apps/multi.py
+++ b/celery/apps/multi.py
@@ -1,6 +1,4 @@
 """Start/stop/manage workers."""
-from __future__ import absolute_import, unicode_literals
-
 import errno
 import os
 import shlex

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -7,8 +7,6 @@ It does everything necessary to run that module
 as an actual application, like installing signal handlers,
 platform tweaks, and so on.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
 import os
 import platform as _platform

--- a/celery/backends/__init__.py
+++ b/celery/backends/__init__.py
@@ -1,6 +1,4 @@
 """Result Backends."""
-from __future__ import absolute_import, unicode_literals
-
 from celery.app import backends as _backends
 from celery.utils import deprecated
 

--- a/celery/backends/amqp.py
+++ b/celery/backends/amqp.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """The old AMQP result backend, deprecated and replaced by the RPC backend."""
-from __future__ import absolute_import, unicode_literals
-
 import socket
 from collections import deque
 from operator import itemgetter

--- a/celery/backends/arangodb.py
+++ b/celery/backends/arangodb.py
@@ -3,8 +3,6 @@
 
 # pylint: disable=W1202,W0703
 
-from __future__ import absolute_import, unicode_literals
-
 import json
 import logging
 

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -1,6 +1,4 @@
 """Async I/O backend support utilities."""
-from __future__ import absolute_import, unicode_literals
-
 import socket
 import threading
 from collections import deque

--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -1,6 +1,4 @@
 """The Azure Storage Block Blob backend for Celery."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.utils import cached_property
 from kombu.utils.encoding import bytes_to_str
 

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -6,8 +6,6 @@
 - :class:`KeyValueStoreBackend` is a common base class
     using K/V semantics like _get and _put.
 """
-from __future__ import absolute_import, unicode_literals
-
 import datetime
 import sys
 import time

--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Memcached and in-memory cache result backend."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.utils.encoding import bytes_to_str, ensure_bytes
 from kombu.utils.objects import cached_property
 

--- a/celery/backends/cassandra.py
+++ b/celery/backends/cassandra.py
@@ -1,7 +1,5 @@
 # -* coding: utf-8 -*-
 """Apache Cassandra result store backend using the DataStax driver."""
-from __future__ import absolute_import, unicode_literals
-
 import sys
 
 from celery import states

--- a/celery/backends/consul.py
+++ b/celery/backends/consul.py
@@ -4,8 +4,6 @@
 - :class:`ConsulBackend` implements KeyValueStoreBackend to store results
     in the key-value store of Consul.
 """
-from __future__ import absolute_import, unicode_literals
-
 from kombu.utils.encoding import bytes_to_str
 from kombu.utils.url import parse_url
 

--- a/celery/backends/cosmosdbsql.py
+++ b/celery/backends/cosmosdbsql.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """The CosmosDB/SQL backend for Celery (experimental)."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.utils import cached_property
 from kombu.utils.encoding import bytes_to_str
 from kombu.utils.url import _parse_url

--- a/celery/backends/couchbase.py
+++ b/celery/backends/couchbase.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Couchbase result store backend."""
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 from kombu.utils.encoding import str_t

--- a/celery/backends/couchdb.py
+++ b/celery/backends/couchdb.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """CouchDB result store backend."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.utils.encoding import bytes_to_str
 from kombu.utils.url import _parse_url
 

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """SQLAlchemy result store backend."""
-from __future__ import absolute_import, unicode_literals
-
 import logging
 from contextlib import contextmanager
 

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Database models used by the SQLAlchemy result store backend."""
-from __future__ import absolute_import, unicode_literals
-
 from datetime import datetime
 
 import sqlalchemy as sa

--- a/celery/backends/database/session.py
+++ b/celery/backends/database/session.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """SQLAlchemy session."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.utils.compat import register_after_fork
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base

--- a/celery/backends/dynamodb.py
+++ b/celery/backends/dynamodb.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """AWS DynamoDB result store backend."""
-from __future__ import absolute_import, unicode_literals
-
 from collections import namedtuple
 from time import sleep, time
 

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -1,7 +1,5 @@
 # -* coding: utf-8 -*-
 """Elasticsearch result store backend."""
-from __future__ import absolute_import, unicode_literals
-
 from datetime import datetime
 
 from kombu.utils.encoding import bytes_to_str

--- a/celery/backends/filesystem.py
+++ b/celery/backends/filesystem.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """File-system result store backend."""
-from __future__ import absolute_import, unicode_literals
-
 import locale
 import os
 

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """MongoDB result store backend."""
-from __future__ import absolute_import, unicode_literals
-
 from datetime import datetime, timedelta
 
 from kombu.exceptions import EncodeError

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Redis result store backend."""
-from __future__ import absolute_import, unicode_literals
-
 import time
 from functools import partial
 from ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED

--- a/celery/backends/riak.py
+++ b/celery/backends/riak.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Riak result store backend."""
-from __future__ import absolute_import, unicode_literals
-
 import sys
 import warnings
 

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -3,8 +3,6 @@
 
 RPC-style result backend, using reply-to and one queue per client.
 """
-from __future__ import absolute_import, unicode_literals
-
 import time
 
 import kombu

--- a/celery/backends/s3.py
+++ b/celery/backends/s3.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """s3 result store backend."""
-from __future__ import absolute_import, unicode_literals
-
 from celery.exceptions import ImproperlyConfigured
 
 from .base import KeyValueStoreBackend

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """The periodic task scheduler."""
-from __future__ import absolute_import, unicode_literals
 
 import copy
 import errno

--- a/celery/bin/__init__.py
+++ b/celery/bin/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from .base import Option
 
 __all__ = ('Option',)

--- a/celery/bin/amqp.py
+++ b/celery/bin/amqp.py
@@ -3,8 +3,6 @@
 
 .. program:: celery amqp
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import cmd as _cmd
 import pprint
 import shlex

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Base command-line interface."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 import argparse
 import json
 import os

--- a/celery/bin/beat.py
+++ b/celery/bin/beat.py
@@ -64,8 +64,6 @@
 
     Executable to use for the detached process.
 """
-from __future__ import absolute_import, unicode_literals
-
 from functools import partial
 
 from celery.bin.base import Command, daemon_options

--- a/celery/bin/call.py
+++ b/celery/bin/call.py
@@ -1,6 +1,4 @@
 """The ``celery call`` program used to send tasks from the command-line."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.utils.json import loads
 
 from celery.bin.base import Command

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -253,8 +253,6 @@ in any command that also has a `--detach` option.
 
     Destination routing key (defaults to the queue routing key).
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import numbers
 import sys
 from functools import partial

--- a/celery/bin/celeryd_detach.py
+++ b/celery/bin/celeryd_detach.py
@@ -5,8 +5,6 @@ Using :func:`os.execv` as forking and multiprocessing
 leads to weird issues (it was a long time ago now, but it
 could have something to do with the threading mutex bug)
 """
-from __future__ import absolute_import, unicode_literals
-
 import argparse
 import os
 import sys

--- a/celery/bin/control.py
+++ b/celery/bin/control.py
@@ -1,6 +1,4 @@
 """The ``celery control``, ``. inspect`` and ``. status`` programs."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.utils.json import dumps
 from kombu.utils.objects import cached_property
 

--- a/celery/bin/events.py
+++ b/celery/bin/events.py
@@ -65,8 +65,6 @@
 
     Executable to use for the detached process.
 """
-from __future__ import absolute_import, unicode_literals
-
 import sys
 from functools import partial
 

--- a/celery/bin/graph.py
+++ b/celery/bin/graph.py
@@ -3,8 +3,6 @@
 
 .. program:: celery graph
 """
-from __future__ import absolute_import, unicode_literals
-
 from operator import itemgetter
 
 from celery.five import items, python_2_unicode_compatible

--- a/celery/bin/list.py
+++ b/celery/bin/list.py
@@ -1,6 +1,4 @@
 """The ``celery list bindings`` command, used to inspect queue bindings."""
-from __future__ import absolute_import, unicode_literals
-
 from celery.bin.base import Command
 
 

--- a/celery/bin/logtool.py
+++ b/celery/bin/logtool.py
@@ -3,9 +3,6 @@
 
 .. program:: celery logtool
 """
-
-from __future__ import absolute_import, unicode_literals
-
 import re
 from collections import Counter
 from fileinput import FileInput

--- a/celery/bin/migrate.py
+++ b/celery/bin/migrate.py
@@ -1,6 +1,4 @@
 """The ``celery migrate`` command, used to filter and move messages."""
-from __future__ import absolute_import, unicode_literals
-
 from celery.bin.base import Command
 
 MIGRATE_PROGRESS_FMT = """\

--- a/celery/bin/multi.py
+++ b/celery/bin/multi.py
@@ -93,8 +93,6 @@ Examples
     celery worker -n baz@myhost -c 10
     celery worker -n xuzzy@myhost -c 3
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import signal
 import sys

--- a/celery/bin/purge.py
+++ b/celery/bin/purge.py
@@ -1,6 +1,4 @@
 """The ``celery purge`` program, used to delete messages from queues."""
-from __future__ import absolute_import, unicode_literals
-
 from celery.bin.base import Command
 from celery.five import keys
 from celery.utils import text

--- a/celery/bin/result.py
+++ b/celery/bin/result.py
@@ -1,6 +1,4 @@
 """The ``celery result`` program, used to inspect task results."""
-from __future__ import absolute_import, unicode_literals
-
 from celery.bin.base import Command
 
 

--- a/celery/bin/shell.py
+++ b/celery/bin/shell.py
@@ -1,6 +1,4 @@
 """The ``celery shell`` program, used to start a REPL."""
-from __future__ import absolute_import, unicode_literals
-
 import os
 import sys
 from importlib import import_module

--- a/celery/bin/upgrade.py
+++ b/celery/bin/upgrade.py
@@ -1,6 +1,4 @@
 """The ``celery upgrade`` command, used to upgrade from previous versions."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 import codecs
 
 from celery.app import defaults

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -175,8 +175,6 @@ The :program:`celery worker` command (previously known as ``celeryd``)
 
     Executable to use for the detached process.
 """
-from __future__ import absolute_import, unicode_literals
-
 import sys
 
 from celery import concurrency

--- a/celery/bootsteps.py
+++ b/celery/bootsteps.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """A directed acyclic graph of reusable components."""
-from __future__ import absolute_import, unicode_literals
 
 from collections import deque
 from threading import Event

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -5,7 +5,6 @@
 
     You should import these from :mod:`celery` and not this module.
 """
-from __future__ import absolute_import, unicode_literals
 
 import itertools
 import operator

--- a/celery/concurrency/__init__.py
+++ b/celery/concurrency/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Pool implementation abstract factory, and alias definitions."""
-from __future__ import absolute_import, unicode_literals
 
 # Import from kombu directly as it's used
 # early in the import stage, where celery.utils loads

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -13,8 +13,6 @@ This code deals with three major challenges:
 #. Sending jobs to the processes and receiving results back.
 #. Safely shutting down this system.
 """
-from __future__ import absolute_import, unicode_literals
-
 import errno
 import gc
 import os

--- a/celery/concurrency/base.py
+++ b/celery/concurrency/base.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Base Execution Pool."""
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import os
 import sys

--- a/celery/concurrency/eventlet.py
+++ b/celery/concurrency/eventlet.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Eventlet execution pool."""
-from __future__ import absolute_import, unicode_literals
-
 import sys
 
 from kombu.asynchronous import timer as _timer  # noqa

--- a/celery/concurrency/gevent.py
+++ b/celery/concurrency/gevent.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Gevent execution pool."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.asynchronous import timer as _timer
 from kombu.five import monotonic
 

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -3,8 +3,6 @@
 
 Pool implementation using :mod:`multiprocessing`.
 """
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 from billiard import forking_enable

--- a/celery/concurrency/solo.py
+++ b/celery/concurrency/solo.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Single-threaded execution pool."""
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 from celery import signals

--- a/celery/contrib/abortable.py
+++ b/celery/contrib/abortable.py
@@ -83,8 +83,6 @@ have it block until the task is finished.
    database backend.  Therefore, this class will only work with the
    database backends.
 """
-from __future__ import absolute_import, unicode_literals
-
 from celery import Task
 from celery.result import AsyncResult
 

--- a/celery/contrib/migrate.py
+++ b/celery/contrib/migrate.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Message migration tools (Broker <-> Broker)."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 import socket
 from functools import partial
 from itertools import cycle, islice

--- a/celery/contrib/pytest.py
+++ b/celery/contrib/pytest.py
@@ -1,6 +1,4 @@
 """Fixtures and testing utilities for :pypi:`py.test <pytest>`."""
-from __future__ import absolute_import, unicode_literals
-
 import os
 from contextlib import contextmanager
 

--- a/celery/contrib/rdb.py
+++ b/celery/contrib/rdb.py
@@ -41,8 +41,6 @@ Environment Variables
     The debugger will try to find an available port starting from the
     base port.  The selected port will be logged by the worker.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import errno
 import os
 import socket

--- a/celery/contrib/sphinx.py
+++ b/celery/contrib/sphinx.py
@@ -29,8 +29,6 @@ syntax.
 
 Use ``.. autotask::`` to alternatively manually document a task.
 """
-from __future__ import absolute_import, unicode_literals
-
 from celery.app.task import BaseTask
 from sphinx.domains.python import PyModulelevel
 from sphinx.ext.autodoc import FunctionDocumenter

--- a/celery/contrib/testing/app.py
+++ b/celery/contrib/testing/app.py
@@ -1,6 +1,4 @@
 """Create Celery app instances used for testing."""
-from __future__ import absolute_import, unicode_literals
-
 import weakref
 from contextlib import contextmanager
 from copy import deepcopy

--- a/celery/contrib/testing/manager.py
+++ b/celery/contrib/testing/manager.py
@@ -1,6 +1,4 @@
 """Integration testing utilities."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 import socket
 import sys
 from collections import defaultdict

--- a/celery/contrib/testing/mocks.py
+++ b/celery/contrib/testing/mocks.py
@@ -1,6 +1,4 @@
 """Useful mocks for unit testing."""
-from __future__ import absolute_import, unicode_literals
-
 import numbers
 from datetime import datetime, timedelta
 

--- a/celery/contrib/testing/tasks.py
+++ b/celery/contrib/testing/tasks.py
@@ -1,6 +1,4 @@
 """Helper tasks for integration tests."""
-from __future__ import absolute_import, unicode_literals
-
 from celery import shared_task
 
 

--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -1,6 +1,4 @@
 """Embedded workers for integration tests."""
-from __future__ import absolute_import, unicode_literals
-
 import os
 import threading
 from contextlib import contextmanager

--- a/celery/events/dumper.py
+++ b/celery/events/dumper.py
@@ -4,8 +4,6 @@
 This is a simple program that dumps events to the console
 as they happen.  Think of it like a `tcpdump` for Celery events.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import sys
 from datetime import datetime
 

--- a/celery/events/event.py
+++ b/celery/events/event.py
@@ -1,6 +1,4 @@
 """Creating events, and event exchange definition."""
-from __future__ import absolute_import, unicode_literals
-
 import time
 from copy import copy
 

--- a/celery/events/receiver.py
+++ b/celery/events/receiver.py
@@ -1,6 +1,4 @@
 """Event receiver implementation."""
-from __future__ import absolute_import, unicode_literals
-
 import time
 from operator import itemgetter
 

--- a/celery/events/snapshot.py
+++ b/celery/events/snapshot.py
@@ -7,8 +7,6 @@ state of a cluster at regular intervals.  There's a full
 implementation of this writing the snapshots to a database
 in :mod:`djcelery.snapshots` in the `django-celery` distribution.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 from kombu.utils.limits import TokenBucket
 
 from celery import platforms

--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -13,8 +13,6 @@ Snapshots (:mod:`celery.events.snapshot`) can be used to
 take "pictures" of this state at regular intervals
 to for example, store that in a database.
 """
-from __future__ import absolute_import, unicode_literals
-
 import bisect
 import sys
 import threading

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -47,7 +47,6 @@ Error Hierarchy
         - :exc:`~celery.exceptions.WorkerTerminate`
         - :exc:`~celery.exceptions.WorkerShutdown`
 """
-from __future__ import absolute_import, unicode_literals
 
 import numbers
 

--- a/celery/five.py
+++ b/celery/five.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Python 2/3 compatibility utilities."""
-from __future__ import absolute_import, unicode_literals
 
 import sys
 

--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -1,6 +1,4 @@
 """Django-specific customization."""
-from __future__ import absolute_import, unicode_literals
-
 import os
 import sys
 import warnings

--- a/celery/loaders/__init__.py
+++ b/celery/loaders/__init__.py
@@ -4,8 +4,6 @@
 Loaders define how configuration is read, what happens
 when workers start, when tasks are executed and so on.
 """
-from __future__ import absolute_import, unicode_literals
-
 from celery.utils.imports import import_from_cwd, symbol_by_name
 
 __all__ = ('get_loader_cls',)

--- a/celery/loaders/app.py
+++ b/celery/loaders/app.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """The default loader used with custom app instances."""
-from __future__ import absolute_import, unicode_literals
-
 from .base import BaseLoader
 
 __all__ = ('AppLoader',)

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Loader base class."""
-from __future__ import absolute_import, unicode_literals
-
 import importlib
 import os
 import re

--- a/celery/loaders/default.py
+++ b/celery/loaders/default.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """The default loader used when no custom app has been initialized."""
-from __future__ import absolute_import, unicode_literals
-
 import os
 import warnings
 

--- a/celery/local.py
+++ b/celery/local.py
@@ -6,7 +6,6 @@ soon as possible, and that shall not load any third party modules.
 
 Parts of this module is Copyright by Werkzeug Team.
 """
-from __future__ import absolute_import, unicode_literals
 
 import operator
 import sys

--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -4,7 +4,6 @@
 Utilities dealing with platform specifics: signals, daemonization,
 users, groups, and so on.
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import atexit
 import errno

--- a/celery/result.py
+++ b/celery/result.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Task results/state and results for groups of tasks."""
-from __future__ import absolute_import, unicode_literals
 
 import time
 import datetime

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Schedules define the intervals at which periodic tasks run."""
-from __future__ import absolute_import, unicode_literals
 
 import numbers
 import re

--- a/celery/security/__init__.py
+++ b/celery/security/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Message Signing Serializer."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.serialization import \
     disable_insecure_serializers as _disable_insecure_serializers
 from kombu.serialization import registry

--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """X.509 certificates."""
-from __future__ import absolute_import, unicode_literals
-
 import datetime
 import glob
 import os

--- a/celery/security/key.py
+++ b/celery/security/key.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Private keys for the security serializer."""
-from __future__ import absolute_import, unicode_literals
-
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding

--- a/celery/security/serialization.py
+++ b/celery/security/serialization.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Secure serializer."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.serialization import dumps, loads, registry
 from kombu.utils.encoding import bytes_to_str, ensure_bytes, str_to_bytes
 

--- a/celery/security/utils.py
+++ b/celery/security/utils.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Utilities used by the message signing serializer."""
-from __future__ import absolute_import, unicode_literals
-
 import sys
 from contextlib import contextmanager
 

--- a/celery/signals.py
+++ b/celery/signals.py
@@ -11,7 +11,6 @@ functions are called whenever a signal is called.
 
     :ref:`signals` for more information.
 """
-from __future__ import absolute_import, unicode_literals
 
 from .utils.dispatch import Signal
 

--- a/celery/states.py
+++ b/celery/states.py
@@ -52,7 +52,6 @@ Misc
 ----
 
 """
-from __future__ import absolute_import, unicode_literals
 
 __all__ = (
     'PENDING', 'RECEIVED', 'STARTED', 'SUCCESS', 'FAILURE',

--- a/celery/task/__init__.py
+++ b/celery/task/__init__.py
@@ -6,8 +6,6 @@ import from the main 'celery' module instead.
 If you're looking for the decorator implementation then that's in
 ``celery.app.base.Celery.task``.
 """
-from __future__ import absolute_import, unicode_literals
-
 from celery._state import current_app
 from celery._state import current_task as current
 from celery.local import LazyModule, Proxy, recreate_module

--- a/celery/task/base.py
+++ b/celery/task/base.py
@@ -6,8 +6,6 @@ The task implementation has been moved to :mod:`celery.app.task`.
 This contains the backward compatible Task class used in the old API,
 and shouldn't be used in new applications.
 """
-from __future__ import absolute_import, unicode_literals
-
 from kombu import Exchange
 
 from celery import current_app

--- a/celery/utils/__init__.py
+++ b/celery/utils/__init__.py
@@ -4,8 +4,6 @@
 Don't import from here directly anymore, as these are only
 here for backwards compatibility.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 from kombu.utils.objects import cached_property  # noqa: F401
 from kombu.utils.uuid import uuid  # noqa: F401
 

--- a/celery/utils/abstract.py
+++ b/celery/utils/abstract.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Abstract classes."""
-from __future__ import absolute_import, unicode_literals
-
 from abc import ABCMeta, abstractmethod, abstractproperty
 
 from celery.five import with_metaclass

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Custom maps, sets, sequences, and other data structures."""
-from __future__ import absolute_import, unicode_literals
-
 import sys
 from collections import OrderedDict as _OrderedDict
 from collections import deque

--- a/celery/utils/debug.py
+++ b/celery/utils/debug.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Utilities for debugging memory usage, blocking calls, etc."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import sys
 import traceback

--- a/celery/utils/deprecated.py
+++ b/celery/utils/deprecated.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Deprecation utilities."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 import warnings
 
 from vine.utils import wraps

--- a/celery/utils/dispatch/__init__.py
+++ b/celery/utils/dispatch/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Observer pattern."""
-from __future__ import absolute_import, unicode_literals
-
 from .signal import Signal
 
 __all__ = ('Signal',)

--- a/celery/utils/dispatch/signal.py
+++ b/celery/utils/dispatch/signal.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Implementation of the Observer pattern."""
-from __future__ import absolute_import, unicode_literals
-
 import sys
 import threading
 import warnings

--- a/celery/utils/dispatch/weakref_backports.py
+++ b/celery/utils/dispatch/weakref_backports.py
@@ -10,8 +10,6 @@ The following changes were made to the original sources during backporting:
 * Added ``self`` to ``super`` calls.
 * Removed ``from None`` when raising exceptions.
 """
-from __future__ import absolute_import, unicode_literals
-
 from weakref import ref
 
 

--- a/celery/utils/encoding.py
+++ b/celery/utils/encoding.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """**DEPRECATED**: This module has moved to :mod:`kombu.utils.encoding`."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.utils.encoding import (bytes_t, bytes_to_str,  # noqa
                                   default_encode, default_encoding,
                                   ensure_bytes, from_utf8, safe_repr,

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Functional-style utilties."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 import inspect
 import sys
 from functools import partial

--- a/celery/utils/graph.py
+++ b/celery/utils/graph.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Dependency graph implementation."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 from collections import Counter
 from textwrap import dedent
 

--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Utilities related to importing modules and symbols by name."""
-from __future__ import absolute_import, unicode_literals
-
 import importlib
 import os
 import sys

--- a/celery/utils/iso8601.py
+++ b/celery/utils/iso8601.py
@@ -32,8 +32,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from __future__ import absolute_import, unicode_literals
-
 import re
 from datetime import datetime
 

--- a/celery/utils/log.py
+++ b/celery/utils/log.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Logging utilities."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
 import numbers
 import os

--- a/celery/utils/nodenames.py
+++ b/celery/utils/nodenames.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Worker name utilities."""
-from __future__ import absolute_import, unicode_literals
-
 import os
 import socket
 from functools import partial

--- a/celery/utils/objects.py
+++ b/celery/utils/objects.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Object related utilities, including introspection, etc."""
-from __future__ import absolute_import, unicode_literals
-
 from functools import reduce
 
 __all__ = ('Bunch', 'FallbackContext', 'getitem_property', 'mro_lookup')

--- a/celery/utils/saferepr.py
+++ b/celery/utils/saferepr.py
@@ -10,8 +10,6 @@ Differences from regular :func:`repr`:
 
 Very slow with no limits, super quick with limits.
 """
-from __future__ import absolute_import, unicode_literals
-
 import traceback
 from collections import deque, namedtuple
 from decimal import Decimal

--- a/celery/utils/serialization.py
+++ b/celery/utils/serialization.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Utilities for safely pickling exceptions."""
-from __future__ import absolute_import, unicode_literals
-
 import datetime
 import numbers
 import sys

--- a/celery/utils/static/__init__.py
+++ b/celery/utils/static/__init__.py
@@ -1,6 +1,4 @@
 """Static files."""
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 

--- a/celery/utils/sysinfo.py
+++ b/celery/utils/sysinfo.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """System information utilities."""
-from __future__ import absolute_import, unicode_literals
-
 import os
 from math import ceil
 

--- a/celery/utils/term.py
+++ b/celery/utils/term.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Terminals and colors."""
-from __future__ import absolute_import, unicode_literals
-
 import base64
 import codecs
 import os

--- a/celery/utils/text.py
+++ b/celery/utils/text.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Text formatting utilities."""
-from __future__ import absolute_import, unicode_literals
-
 import re
 from functools import partial
 from pprint import pformat

--- a/celery/utils/threads.py
+++ b/celery/utils/threads.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Threading primitives and utilities."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import socket
 import sys

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Utilities related to dates, times, intervals, and timezones."""
-from __future__ import absolute_import, print_function, unicode_literals
-
 import numbers
 import os
 import random

--- a/celery/utils/timer2.py
+++ b/celery/utils/timer2.py
@@ -5,8 +5,6 @@
     This is used for the thread-based worker only,
     not for amqp/redis/sqs/qpid where :mod:`kombu.asynchronous.timer` is used.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import sys
 import threading

--- a/celery/worker/__init__.py
+++ b/celery/worker/__init__.py
@@ -1,6 +1,4 @@
 """Worker implementation."""
-from __future__ import absolute_import, unicode_literals
-
 from .worker import WorkController
 
 __all__ = ('WorkController',)

--- a/celery/worker/autoscale.py
+++ b/celery/worker/autoscale.py
@@ -8,8 +8,6 @@ current autoscale settings.
 The autoscale thread is only enabled if
 the :option:`celery worker --autoscale` option is used.
 """
-from __future__ import absolute_import, unicode_literals
-
 import os
 import threading
 from time import sleep

--- a/celery/worker/components.py
+++ b/celery/worker/components.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Worker-level Bootsteps."""
-from __future__ import absolute_import, unicode_literals
-
 import atexit
 import warnings
 

--- a/celery/worker/consumer/__init__.py
+++ b/celery/worker/consumer/__init__.py
@@ -1,6 +1,4 @@
 """Worker consumer."""
-from __future__ import absolute_import, unicode_literals
-
 from .agent import Agent
 from .connection import Connection
 from .consumer import Consumer

--- a/celery/worker/consumer/agent.py
+++ b/celery/worker/consumer/agent.py
@@ -1,6 +1,4 @@
 """Celery + :pypi:`cell` integration."""
-from __future__ import absolute_import, unicode_literals
-
 from celery import bootsteps
 
 from .connection import Connection

--- a/celery/worker/consumer/connection.py
+++ b/celery/worker/consumer/connection.py
@@ -1,6 +1,4 @@
 """Consumer Broker Connection Bootstep."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.common import ignore_errors
 
 from celery import bootsteps

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -5,8 +5,6 @@ This module contains the components responsible for consuming messages
 from the broker, processing the messages and keeping the broker connections
 up and running.
 """
-from __future__ import absolute_import, unicode_literals
-
 import errno
 import logging
 import os

--- a/celery/worker/consumer/control.py
+++ b/celery/worker/consumer/control.py
@@ -4,8 +4,6 @@
 
 The actual commands are implemented in :mod:`celery.worker.control`.
 """
-from __future__ import absolute_import, unicode_literals
-
 from celery import bootsteps
 from celery.utils.log import get_logger
 from celery.worker import pidbox

--- a/celery/worker/consumer/events.py
+++ b/celery/worker/consumer/events.py
@@ -2,8 +2,6 @@
 
 ``Events`` -> :class:`celery.events.EventDispatcher`.
 """
-from __future__ import absolute_import, unicode_literals
-
 from kombu.common import ignore_errors
 
 from celery import bootsteps

--- a/celery/worker/consumer/gossip.py
+++ b/celery/worker/consumer/gossip.py
@@ -1,6 +1,4 @@
 """Worker <-> Worker communication Bootstep."""
-from __future__ import absolute_import, unicode_literals
-
 from collections import defaultdict
 from functools import partial
 from heapq import heappush

--- a/celery/worker/consumer/heart.py
+++ b/celery/worker/consumer/heart.py
@@ -1,6 +1,4 @@
 """Worker Event Heartbeat Bootstep."""
-from __future__ import absolute_import, unicode_literals
-
 from celery import bootsteps
 from celery.worker import heartbeat
 

--- a/celery/worker/consumer/mingle.py
+++ b/celery/worker/consumer/mingle.py
@@ -1,6 +1,4 @@
 """Worker <-> Worker Sync at startup (Bootstep)."""
-from __future__ import absolute_import, unicode_literals
-
 from celery import bootsteps
 from celery.five import items
 from celery.utils.log import get_logger

--- a/celery/worker/consumer/tasks.py
+++ b/celery/worker/consumer/tasks.py
@@ -1,6 +1,4 @@
 """Worker Task Consumer Bootstep."""
-from __future__ import absolute_import, unicode_literals
-
 from kombu.common import QoS, ignore_errors
 
 from celery import bootsteps

--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Worker remote control command implementations."""
-from __future__ import absolute_import, unicode_literals
-
 import io
 import tempfile
 from collections import namedtuple

--- a/celery/worker/heartbeat.py
+++ b/celery/worker/heartbeat.py
@@ -4,8 +4,6 @@
 This is the internal thread responsible for sending heartbeat events
 at regular intervals (may not be an actual thread).
 """
-from __future__ import absolute_import, unicode_literals
-
 from celery.signals import heartbeat_sent
 from celery.utils.sysinfo import load_average
 

--- a/celery/worker/loops.py
+++ b/celery/worker/loops.py
@@ -1,6 +1,4 @@
 """The consumers highly-optimized inner loop."""
-from __future__ import absolute_import, unicode_literals
-
 import errno
 import socket
 

--- a/celery/worker/pidbox.py
+++ b/celery/worker/pidbox.py
@@ -1,6 +1,4 @@
 """Worker Pidbox (remote control)."""
-from __future__ import absolute_import, unicode_literals
-
 import socket
 import threading
 

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -4,8 +4,6 @@
 This module defines the :class:`Request` class, that specifies
 how tasks are executed.
 """
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import sys
 from datetime import datetime

--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -4,8 +4,6 @@
 This includes the currently active and reserved tasks,
 statistics, and revoked tasks.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import platform
 import shelve

--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Task execution strategy (optimization)."""
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 from kombu.asynchronous.timer import to_timestamp

--- a/celery/worker/worker.py
+++ b/celery/worker/worker.py
@@ -12,7 +12,6 @@ global side-effects (i.e., except for the global state stored in
 The worker consists of several components, all managed by bootsteps
 (mod:`celery.bootsteps`).
 """
-from __future__ import absolute_import, unicode_literals
 
 import os
 import sys

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ ignore = D102,D104,D203,D105,D213
 [bdist_rpm]
 requires = pytz >= 2016.7
            billiard >= 3.6.0,<4.0
-           kombu >= 4.6.3,<5.0.0
+           kombu >= 4.6.3,<6.0.0
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -94,14 +94,11 @@ classes = """
     Topic :: System :: Distributed Computing
     Topic :: Software Development :: Object Brokering
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: Implementation :: CPython
-    Programming Language :: Python :: Implementation :: PyPy
+    Programming Language :: Python :: Implementation :: PyPy3
     Operating System :: OS Independent
 """
 
@@ -223,7 +220,7 @@ setuptools.setup(
     license='BSD',
     platforms=['any'],
     install_requires=install_requires(),
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*,",
+    python_requires=">=3.6,",
     tests_require=reqs('test.txt'),
     extras_require=extras_require(),
     classifiers=[s.strip() for s in classes.split('\n') if s],

--- a/t/benchmarks/bench_worker.py
+++ b/t/benchmarks/bench_worker.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import sys
 

--- a/t/distro/test_CI_reqs.py
+++ b/t/distro/test_CI_reqs.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 import pprint
 

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 from functools import wraps
 

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 
 from time import sleep
 

--- a/t/integration/test_backend.py
+++ b/t/integration/test_backend.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 from case import skip

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from datetime import datetime, timedelta
 
 import pytest

--- a/t/integration/test_security.py
+++ b/t/integration/test_security.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import datetime
 import os
 import tempfile

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from celery import group

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from datetime import datetime, timedelta
 
 import pytest

--- a/t/unit/app/test_annotations.py
+++ b/t/unit/app/test_annotations.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from celery.app.annotations import MapAnnotation, prepare
 from celery.utils.imports import qualname
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import gc
 import itertools
 import os

--- a/t/unit/app/test_backends.py
+++ b/t/unit/app/test_backends.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import patch

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import errno
 from datetime import datetime, timedelta
 from pickle import dumps, loads

--- a/t/unit/app/test_builtins.py
+++ b/t/unit/app/test_builtins.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import ContextMock, Mock, patch

--- a/t/unit/app/test_celery.py
+++ b/t/unit/app/test_celery.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 import celery

--- a/t/unit/app/test_control.py
+++ b/t/unit/app/test_control.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock

--- a/t/unit/app/test_defaults.py
+++ b/t/unit/app/test_defaults.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import sys
 from importlib import import_module
 

--- a/t/unit/app/test_exceptions.py
+++ b/t/unit/app/test_exceptions.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pickle
 from datetime import datetime
 

--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 import sys
 import warnings

--- a/t/unit/app/test_log.py
+++ b/t/unit/app/test_log.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import sys
 from collections import defaultdict

--- a/t/unit/app/test_registry.py
+++ b/t/unit/app/test_registry.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from celery.app.registry import _unpickle_task, _unpickle_task_v2

--- a/t/unit/app/test_routes.py
+++ b/t/unit/app/test_routes.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 from kombu import Exchange, Queue
 from kombu.utils.functional import maybe_evaluate

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import time
 from contextlib import contextmanager
 from datetime import datetime, timedelta

--- a/t/unit/app/test_utils.py
+++ b/t/unit/app/test_utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from case import Mock
 from celery.app.utils import Settings, bugreport, filter_hidden_settings
 

--- a/t/unit/apps/test_multi.py
+++ b/t/unit/apps/test_multi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import errno
 import signal
 import sys

--- a/t/unit/backends/test_amqp.py
+++ b/t/unit/backends/test_amqp.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pickle
 from contextlib import contextmanager
 from datetime import timedelta

--- a/t/unit/backends/test_arangodb.py
+++ b/t/unit/backends/test_arangodb.py
@@ -1,6 +1,4 @@
 """Tests for the ArangoDb."""
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, patch, sentinel, skip

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, call, patch, skip

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import sys
 import types
 from contextlib import contextmanager

--- a/t/unit/backends/test_cache.py
+++ b/t/unit/backends/test_cache.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import sys
 import types
 from contextlib import contextmanager

--- a/t/unit/backends/test_cassandra.py
+++ b/t/unit/backends/test_cassandra.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from datetime import datetime
 from pickle import dumps, loads
 

--- a/t/unit/backends/test_consul.py
+++ b/t/unit/backends/test_consul.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from case import Mock, skip
 from celery.backends.consul import ConsulBackend
 

--- a/t/unit/backends/test_cosmosdbsql.py
+++ b/t/unit/backends/test_cosmosdbsql.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, call, patch, skip

--- a/t/unit/backends/test_couchbase.py
+++ b/t/unit/backends/test_couchbase.py
@@ -1,6 +1,4 @@
 """Tests for the CouchbaseBackend."""
-from __future__ import absolute_import, unicode_literals
-
 from datetime import timedelta
 
 import pytest

--- a/t/unit/backends/test_couchdb.py
+++ b/t/unit/backends/test_couchdb.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import MagicMock, Mock, sentinel, skip

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from datetime import datetime
 from pickle import dumps, loads
 

--- a/t/unit/backends/test_dynamodb.py
+++ b/t/unit/backends/test_dynamodb.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 
 from decimal import Decimal
 

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, patch, sentinel, skip

--- a/t/unit/backends/test_filesystem.py
+++ b/t/unit/backends/test_filesystem.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 
 import os
 import tempfile

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import datetime
 from pickle import dumps, loads
 

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import random
 import ssl
 from contextlib import contextmanager

--- a/t/unit/backends/test_riak.py
+++ b/t/unit/backends/test_riak.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
 
 import sys
 

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, patch

--- a/t/unit/backends/test_s3.py
+++ b/t/unit/backends/test_s3.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import boto3
 import pytest
 from botocore.exceptions import ClientError

--- a/t/unit/bin/celery.py
+++ b/t/unit/bin/celery.py
@@ -1,3 +1,1 @@
-from __future__ import absolute_import, unicode_literals
-
 # here for a test

--- a/t/unit/bin/proj/__init__.py
+++ b/t/unit/bin/proj/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from celery import Celery
 
 hello = Celery(set_as_current=False)

--- a/t/unit/bin/proj/app.py
+++ b/t/unit/bin/proj/app.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from celery import Celery
 
 app = Celery(set_as_current=False)

--- a/t/unit/bin/test_amqp.py
+++ b/t/unit/bin/test_amqp.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, patch

--- a/t/unit/bin/test_base.py
+++ b/t/unit/bin/test_base.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 import pytest

--- a/t/unit/bin/test_beat.py
+++ b/t/unit/bin/test_beat.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import sys
 

--- a/t/unit/bin/test_call.py
+++ b/t/unit/bin/test_call.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from datetime import datetime
 
 import pytest

--- a/t/unit/bin/test_celery.py
+++ b/t/unit/bin/test_celery.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import sys
 
 import pytest

--- a/t/unit/bin/test_celeryd_detach.py
+++ b/t/unit/bin/test_celeryd_detach.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, mock, patch

--- a/t/unit/bin/test_celeryevdump.py
+++ b/t/unit/bin/test_celeryevdump.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from time import time
 
 from case import Mock, patch

--- a/t/unit/bin/test_control.py
+++ b/t/unit/bin/test_control.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, patch

--- a/t/unit/bin/test_events.py
+++ b/t/unit/bin/test_events.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import importlib
 from functools import wraps
 

--- a/t/unit/bin/test_list.py
+++ b/t/unit/bin/test_list.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 from kombu.five import WhateverIO
 

--- a/t/unit/bin/test_migrate.py
+++ b/t/unit/bin/test_migrate.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, patch

--- a/t/unit/bin/test_multi.py
+++ b/t/unit/bin/test_multi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import signal
 import sys
 

--- a/t/unit/bin/test_purge.py
+++ b/t/unit/bin/test_purge.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from case import Mock
 from celery.bin.purge import purge
 from celery.five import WhateverIO

--- a/t/unit/bin/test_report.py
+++ b/t/unit/bin/test_report.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Tests for ``celery report`` command."""
-from __future__ import absolute_import, unicode_literals
 
 from case import Mock, call, patch
 from celery.bin.celery import report

--- a/t/unit/bin/test_result.py
+++ b/t/unit/bin/test_result.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from case import patch
 from celery.bin.result import result
 from celery.five import WhateverIO

--- a/t/unit/bin/test_upgrade.py
+++ b/t/unit/bin/test_upgrade.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Tests for ``celery upgrade`` command."""
-from __future__ import absolute_import, unicode_literals
 
 import pytest
 

--- a/t/unit/bin/test_worker.py
+++ b/t/unit/bin/test_worker.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import os
 import sys

--- a/t/unit/compat_modules/test_compat.py
+++ b/t/unit/compat_modules/test_compat.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from datetime import timedelta
 
 import pytest

--- a/t/unit/compat_modules/test_compat_utils.py
+++ b/t/unit/compat_modules/test_compat_utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 import celery

--- a/t/unit/compat_modules/test_decorators.py
+++ b/t/unit/compat_modules/test_decorators.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import warnings
 
 import pytest

--- a/t/unit/compat_modules/test_messaging.py
+++ b/t/unit/compat_modules/test_messaging.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from celery import messaging

--- a/t/unit/concurrency/test_concurrency.py
+++ b/t/unit/concurrency/test_concurrency.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 from itertools import count
 

--- a/t/unit/concurrency/test_eventlet.py
+++ b/t/unit/concurrency/test_eventlet.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import sys
 
 import pytest

--- a/t/unit/concurrency/test_gevent.py
+++ b/t/unit/concurrency/test_gevent.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from case import Mock
 from celery.concurrency.gevent import TaskPool, Timer, apply_timeout
 

--- a/t/unit/concurrency/test_pool.py
+++ b/t/unit/concurrency/test_pool.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import itertools
 import time
 

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import errno
 import os
 import socket

--- a/t/unit/concurrency/test_solo.py
+++ b/t/unit/concurrency/test_solo.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import operator
 
 from case import Mock

--- a/t/unit/conftest.py
+++ b/t/unit/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import os
 import sys

--- a/t/unit/contrib/proj/conf.py
+++ b/t/unit/contrib/proj/conf.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 import sys
 

--- a/t/unit/contrib/proj/foo.py
+++ b/t/unit/contrib/proj/foo.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from celery import Celery, shared_task
 from xyzzy import plugh  # noqa
 

--- a/t/unit/contrib/proj/xyzzy.py
+++ b/t/unit/contrib/proj/xyzzy.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from celery import Celery
 
 app = Celery()

--- a/t/unit/contrib/test_abortable.py
+++ b/t/unit/contrib/test_abortable.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from celery.contrib.abortable import AbortableAsyncResult, AbortableTask
 
 

--- a/t/unit/contrib/test_migrate.py
+++ b/t/unit/contrib/test_migrate.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from contextlib import contextmanager
 
 import pytest

--- a/t/unit/contrib/test_rdb.py
+++ b/t/unit/contrib/test_rdb.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import errno
 import socket
 

--- a/t/unit/contrib/test_sphinx.py
+++ b/t/unit/contrib/test_sphinx.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import io
 import os
 

--- a/t/unit/events/test_cursesmon.py
+++ b/t/unit/events/test_cursesmon.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from case import skip
 
 

--- a/t/unit/events/test_events.py
+++ b/t/unit/events/test_events.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import socket
 
 import pytest

--- a/t/unit/events/test_snapshot.py
+++ b/t/unit/events/test_snapshot.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, mock, patch

--- a/t/unit/events/test_state.py
+++ b/t/unit/events/test_state.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pickle
 from decimal import Decimal
 from itertools import count

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from contextlib import contextmanager
 
 import pytest

--- a/t/unit/security/case.py
+++ b/t/unit/security/case.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from case import skip
 
 

--- a/t/unit/security/test_certificate.py
+++ b/t/unit/security/test_certificate.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import datetime
 import os
 

--- a/t/unit/security/test_key.py
+++ b/t/unit/security/test_key.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 from kombu.utils.encoding import ensure_bytes
 

--- a/t/unit/security/test_security.py
+++ b/t/unit/security/test_security.py
@@ -12,7 +12,6 @@ Generated with:
               -signkey key1.key -out cert1.crt
     $ rm key1.key.org cert1.csr
 """
-from __future__ import absolute_import, unicode_literals
 
 import os
 import tempfile

--- a/t/unit/security/test_serialization.py
+++ b/t/unit/security/test_serialization.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import base64
 import os
 

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import json
 
 import pytest

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from contextlib import contextmanager
 
 import pytest

--- a/t/unit/tasks/test_context.py
+++ b/t/unit/tasks/test_context.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-'
-from __future__ import absolute_import, unicode_literals
 
 from celery.app.task import Context
 

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import copy
 import datetime
 import traceback

--- a/t/unit/tasks/test_states.py
+++ b/t/unit/tasks/test_states.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from celery import states

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import socket
 import tempfile
 from datetime import datetime, timedelta

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 from kombu.exceptions import EncodeError
 

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pickle
 from collections import Mapping
 from itertools import count

--- a/t/unit/utils/test_debug.py
+++ b/t/unit/utils/test_debug.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock

--- a/t/unit/utils/test_deprecated.py
+++ b/t/unit/utils/test_deprecated.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import patch

--- a/t/unit/utils/test_dispatcher.py
+++ b/t/unit/utils/test_dispatcher.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import gc
 import sys
 import time

--- a/t/unit/utils/test_encoding.py
+++ b/t/unit/utils/test_encoding.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from celery.utils import encoding
 
 

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 from kombu.utils.functional import lazy
 

--- a/t/unit/utils/test_graph.py
+++ b/t/unit/utils/test_graph.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from case import Mock
 from celery.five import WhateverIO, items
 from celery.utils.graph import DependencyGraph

--- a/t/unit/utils/test_imports.py
+++ b/t/unit/utils/test_imports.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import sys
 
 import pytest

--- a/t/unit/utils/test_local.py
+++ b/t/unit/utils/test_local.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import sys
 
 import pytest

--- a/t/unit/utils/test_nodenames.py
+++ b/t/unit/utils/test_nodenames.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from kombu import Queue
 
 from celery.utils.nodenames import worker_direct

--- a/t/unit/utils/test_objects.py
+++ b/t/unit/utils/test_objects.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from celery.utils.objects import Bunch
 
 

--- a/t/unit/utils/test_pickle.py
+++ b/t/unit/utils/test_pickle.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from celery.utils.serialization import pickle
 
 

--- a/t/unit/utils/test_platforms.py
+++ b/t/unit/utils/test_platforms.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import errno
 import os
 import signal

--- a/t/unit/utils/test_serialization.py
+++ b/t/unit/utils/test_serialization.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import json
 import pickle
 import sys

--- a/t/unit/utils/test_sysinfo.py
+++ b/t/unit/utils/test_sysinfo.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from case import skip
 from celery.utils.sysinfo import df, load_average
 

--- a/t/unit/utils/test_term.py
+++ b/t/unit/utils/test_term.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 
 import pytest
 

--- a/t/unit/utils/test_text.py
+++ b/t/unit/utils/test_text.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from celery.utils.text import (abbr, abbrtask, ensure_newlines, indent,

--- a/t/unit/utils/test_threads.py
+++ b/t/unit/utils/test_threads.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import mock, patch

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from datetime import datetime, timedelta, tzinfo
 
 import pytest

--- a/t/unit/utils/test_timer2.py
+++ b/t/unit/utils/test_timer2.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import sys
 import time
 

--- a/t/unit/utils/test_utils.py
+++ b/t/unit/utils/test_utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from celery.utils import cached_property, chunks

--- a/t/unit/worker/test_autoscale.py
+++ b/t/unit/worker/test_autoscale.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import sys
 
 from case import Mock, mock, patch

--- a/t/unit/worker/test_bootsteps.py
+++ b/t/unit/worker/test_bootsteps.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, patch

--- a/t/unit/worker/test_components.py
+++ b/t/unit/worker/test_components.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from case import Mock, patch, skip

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import errno
 import socket
 from collections import deque

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import socket
 import sys
 from collections import defaultdict

--- a/t/unit/worker/test_heartbeat.py
+++ b/t/unit/worker/test_heartbeat.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from case import Mock
 from celery.worker.heartbeat import Heart
 

--- a/t/unit/worker/test_loops.py
+++ b/t/unit/worker/test_loops.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import errno
 import socket
 

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 
 import numbers
 import os

--- a/t/unit/worker/test_revoke.py
+++ b/t/unit/worker/test_revoke.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from celery.worker import state
 
 

--- a/t/unit/worker/test_state.py
+++ b/t/unit/worker/test_state.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pickle
 from time import time
 

--- a/t/unit/worker/test_strategy.py
+++ b/t/unit/worker/test_strategy.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from collections import defaultdict
 from contextlib import contextmanager
 

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import socket
 import sys

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {2.7,3.5,3.6,3.7,pypy,pypy3}-unit
-    {2.7,3.5,3.6,3.7,pypy,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob}
+    {3.6,3.7,pypy3}-unit
+    {3.6,3.7,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob}
 
     flake8
     apicheck
@@ -17,8 +17,8 @@ deps=
     -r{toxinidir}/requirements/docs.txt
     -r{toxinidir}/requirements/pkgutils.txt
 
-    2.7,3.5,3.6,3.7: -r{toxinidir}/requirements/test-ci-default.txt
-    pypy,pypy3: -r{toxinidir}/requirements/test-ci-base.txt
+    3.6,3.7: -r{toxinidir}/requirements/test-ci-default.txt
+    pypy3: -r{toxinidir}/requirements/test-ci-base.txt
 
     integration: -r{toxinidir}/requirements/test-integration.txt
 
@@ -52,11 +52,8 @@ passenv =
     TRAVIS
     AZUREBLOCKBLOB_URL
 basepython =
-    2.7: python2.7
-    3.5: python3.5
     3.6: python3.6
     3.7: python3.7
-    pypy: pypy
     pypy3: pypy3
     flake8,apicheck,linkcheck,configcheck,pydocstyle,bandit: python3.7
     flakeplus: python2.7


### PR DESCRIPTION
work in progress for alpha one of celery 5.0.0.

this PR will drop python2 compat codes against v5-dev branch. All celery v5 work will be pushed against this branch and will be regularly synced with the master.

https://github.com/celery/celery/issues/2849