### PR TITLE
Fixed typo in chain class definition docstring

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -810,7 +810,7 @@ class chain(_chain):
 
     Returns:
         ~celery.chain: A lazy signature that can be called to apply the first
-            task in the chain.  When that task succeeed the next task in the
+            task in the chain.  When that task succeeds the next task in the
             chain is applied, and so on.
     """
 


### PR DESCRIPTION
This PR fixes a typo in the docstring in the `chain` class definition in `celery/canvas.py`. Before the docstring read `When that task succeeed the next task in the chain is applied, and so on.`, now it reads `When that task succeeds the next task in the chain is applied, and so on.`.
