### PR TITLE
Fix issue with `RuntimeError: OrderedDict mutated during iteration`

### DIFF
--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -398,7 +398,7 @@ class Task(object):
     def parent(self):
         # issue github.com/mher/flower/issues/648
         try:
-            return self.parent_id and self.cluster_state.tasks[self.parent_id]
+            return self.parent_id and self.cluster_state.tasks.data[self.parent_id]
         except KeyError:
             return None
 
@@ -406,7 +406,7 @@ class Task(object):
     def root(self):
         # issue github.com/mher/flower/issues/648
         try:
-            return self.root_id and self.cluster_state.tasks[self.root_id]
+            return self.root_id and self.cluster_state.tasks.data[self.root_id]
         except KeyError:
             return None
 

--- a/t/unit/events/test_state.py
+++ b/t/unit/events/test_state.py
@@ -676,3 +676,26 @@ class test_State:
         s = State(callback=callback)
         s.event({'type': 'worker-online'})
         assert scratch.get('recv')
+
+    def test_deepcopy(self):
+        import copy
+        s = State()
+        s.event({
+            'type': 'task-success',
+            'root_id': 'x',
+            'uuid': 'x',
+            'hostname': 'y',
+            'clock': 3,
+            'timestamp': time(),
+            'local_received': time(),
+        })
+        s.event({
+            'type': 'task-success',
+            'root_id': 'y',
+            'uuid': 'y',
+            'hostname': 'y',
+            'clock': 4,
+            'timestamp': time(),
+            'local_received': time(),
+        })
+        copy.deepcopy(s)


### PR DESCRIPTION
## Description
In Python > 3.5 OrderedDict is not allowed to be changed during iteration.

Event state contains tasks, workers and other information. Tasks are `kombu LRUCache` implementation which internally stores data as OrderedDict.
When we are trying to [deepcopy](https://docs.python.org/3/library/copy.html) state or [shelve](https://docs.python.org/3/library/shelve.html) it (tasks should be more than 2 otherwise mutation is not happened), then we got exception `RuntimeError: OrderedDict mutated during iteration`

To easy reproduce you can try to `deepcopy` state after it contains 2 tasks with appropriate `root_id`s inside.

Added test which will fail on Python > 3.5 without these changes.