### PR TITLE
Fixes #5106: Retry WorkerLostError fix for canvas

### DIFF
--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 
 import pytest
 
-from case import Mock, call, patch, skip, MagicMock
+from case import Mock, call, patch, skip
 from celery import states, uuid
 from celery.app.task import Context
 from celery.backends.base import SyncBackendMixin


### PR DESCRIPTION
## Description
If `acks_late` and `reject_on_worker_lost` are enabled we do not mark a task as failed, assuming that the task has been requeued. 
Previously a `WorkerLostError` in a single task would cause a potential parent canvas to fail, even though the task was actually requeued and completed successfully.