### PR TITLE
Accept standard redis ssl_cert_req names

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -272,3 +272,4 @@ Florian Chardin, 2018/10/23
 Shady Rafehi, 2019/02/20
 Fabio Todaro, 2019/06/13
 Shashank Parekh, 2019/07/11
+Arel Cordero, 2019/08/29

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -212,7 +212,10 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             ssl_cert_reqs_missing = 'MISSING'
             ssl_string_to_constant = {'CERT_REQUIRED': CERT_REQUIRED,
                                       'CERT_OPTIONAL': CERT_OPTIONAL,
-                                      'CERT_NONE': CERT_NONE}
+                                      'CERT_NONE': CERT_NONE,
+                                      'required': CERT_REQUIRED,
+                                      'optional': CERT_OPTIONAL,
+                                      'none': CERT_NONE}
             ssl_cert_reqs = self.connparams.get('ssl_cert_reqs', ssl_cert_reqs_missing)
             ssl_cert_reqs = ssl_string_to_constant.get(ssl_cert_reqs, ssl_cert_reqs)
             if ssl_cert_reqs not in ssl_string_to_constant.values():

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -994,7 +994,11 @@ is the same as::
 
 Use the ``rediss://`` protocol to connect to redis over TLS::
 
-    result_backend = 'rediss://:password@host:port/db?ssl_cert_reqs=CERT_REQUIRED'
+    result_backend = 'rediss://:password@host:port/db?ssl_cert_reqs=required'
+
+Note that the ``ssl_cert_reqs`` string should be one of ``required``,
+``optional``, or ``none`` (though, for backwards compatibility, the string
+may also be one of ``CERT_REQUIRED``, ``CERT_OPTIONAL``, ``CERT_NONE``).
 
 If a Unix socket connection should be used, the URL needs to be in the format:::
 
@@ -1024,11 +1028,14 @@ When using a TLS connection (protocol is ``rediss://``), you may pass in all val
 .. code-block:: python
 
     result_backend = 'rediss://:password@host:port/db?\
-        ssl_cert_reqs=CERT_REQUIRED\
+        ssl_cert_reqs=required\
         &ssl_ca_certs=%2Fvar%2Fssl%2Fmyca.pem\                  # /var/ssl/myca.pem
         &ssl_certfile=%2Fvar%2Fssl%2Fredis-server-cert.pem\     # /var/ssl/redis-server-cert.pem
         &ssl_keyfile=%2Fvar%2Fssl%2Fprivate%2Fworker-key.pem'   # /var/ssl/private/worker-key.pem
 
+Note that the ``ssl_cert_reqs`` string should be one of ``required``,
+``optional``, or ``none`` (though, for backwards compatibility, the string
+may also be one of ``CERT_REQUIRED``, ``CERT_OPTIONAL``, ``CERT_NONE``).
 
 .. setting:: redis_backend_use_ssl
 

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -300,9 +300,13 @@ class test_RedisBackend:
         assert x.connparams['connection_class'] is SSLConnection
 
     @skip.unless_module('redis')
-    def test_backend_ssl_certreq_str(self):
+    @pytest.mark.parametrize('cert_str', [
+        "required",
+        "CERT_REQUIRED",
+    ])
+    def test_backend_ssl_certreq_str(self, cert_str):
         self.app.conf.redis_backend_use_ssl = {
-            'ssl_cert_reqs': 'CERT_REQUIRED',
+            'ssl_cert_reqs': cert_str,
             'ssl_ca_certs': '/path/to/ca.crt',
             'ssl_certfile': '/path/to/client.crt',
             'ssl_keyfile': '/path/to/client.key',
@@ -328,11 +332,15 @@ class test_RedisBackend:
         assert x.connparams['connection_class'] is SSLConnection
 
     @skip.unless_module('redis')
-    def test_backend_ssl_url(self):
+    @pytest.mark.parametrize('cert_str', [
+        "required",
+        "CERT_REQUIRED",
+    ])
+    def test_backend_ssl_url(self, cert_str):
         self.app.conf.redis_socket_timeout = 30.0
         self.app.conf.redis_socket_connect_timeout = 100.0
         x = self.Backend(
-            'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=CERT_REQUIRED',
+            'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=%s' % cert_str,
             app=self.app,
         )
         assert x.connparams
@@ -348,14 +356,19 @@ class test_RedisBackend:
         assert x.connparams['connection_class'] is SSLConnection
 
     @skip.unless_module('redis')
-    def test_backend_ssl_url_options(self):
+    @pytest.mark.parametrize('cert_str', [
+        "none",
+        "CERT_NONE",
+    ])
+    def test_backend_ssl_url_options(self, cert_str):
         x = self.Backend(
             (
-                'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=CERT_NONE'
+                'rediss://:bosco@vandelay.com:123//1'
+                '?ssl_cert_reqs={cert_str}'
                 '&ssl_ca_certs=%2Fvar%2Fssl%2Fmyca.pem'
                 '&ssl_certfile=%2Fvar%2Fssl%2Fredis-server-cert.pem'
                 '&ssl_keyfile=%2Fvar%2Fssl%2Fprivate%2Fworker-key.pem'
-            ),
+            ).format(cert_str=cert_str),
             app=self.app,
         )
         assert x.connparams
@@ -369,9 +382,13 @@ class test_RedisBackend:
         assert x.connparams['ssl_keyfile'] == '/var/ssl/private/worker-key.pem'
 
     @skip.unless_module('redis')
-    def test_backend_ssl_url_cert_none(self):
+    @pytest.mark.parametrize('cert_str', [
+        "optional",
+        "CERT_OPTIONAL",
+    ])
+    def test_backend_ssl_url_cert_none(self, cert_str):
         x = self.Backend(
-            'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=CERT_OPTIONAL',
+            'rediss://:bosco@vandelay.com:123//1?ssl_cert_reqs=%s' % cert_str,
             app=self.app,
         )
         assert x.connparams


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Fixes: #5702

The official redis python library expects ssl_cert_reqs
to be one of 'none', 'optional', or 'required'.

Celery expects this to be one of 'CERT_NONE', 'CERT_OPTIONAL',
or 'CERT_REQUIRED'.

This can lead to confusion because the same redis URL cannot
be used for both celery, with a redis backend, and redis directly.

This change allows either term to be recognized by celery.
