### PR TITLE
Improve documentation of how to stop producers from waiting forever

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2425,6 +2425,13 @@ transports):
 
     broker_transport_options = {'visibility_timeout': 18000}  # 5 hours
 
+Example setting the producer connection maximum number of retries (so producers
+won't retry forever if the broker isn't available at the first task execution):
+
+.. code-block:: python
+
+    broker_transport_options = {'max_retries': 5}
+
 .. _conf-worker:
 
 Worker


### PR DESCRIPTION

## Description
In the [broker timeout settings](https://github.com/celery/celery/blob/master/docs/userguide/configuration.rst#broker_connection_timeout), the docs say to see the broker transport options to provide a timeout for producers trying to send a task.

This adds one way to set that timeout by specifying a max number of retries.

Ref: https://github.com/celery/kombu/issues/842

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
