### PR TITLE
fix typo in Hands-on with the API section

### DIFF
--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -506,7 +506,7 @@ using the ``basic.publish`` command:
     ok.
 
 Now that the message is sent you can retrieve it again. You can use the
-``basic.get``` command here, that polls for new messages on the queue
+``basic.get`` command here, that polls for new messages on the queue
 in a synchronous manner
 (this is OK for maintenance tasks, but for services you want to use
 ``basic.consume`` instead)


### PR DESCRIPTION

## Description
Fixes a typo in the documentation.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
