### PR TITLE
Pytest marker warning

### DIFF
--- a/celery/contrib/pytest.py
+++ b/celery/contrib/pytest.py
@@ -15,6 +15,16 @@ NO_WORKER = os.environ.get('NO_WORKER')
 # Well, they're called fixtures....
 
 
+def pytest_configure(config):
+    """Register additional pytest configuration"""
+    # add the pytest.mark.celery() marker registration to the pytest.ini [markers] section
+    # this prevents pytest 4.5 and newer from issueing a warning about an unknown marker
+    # and shows helpful marker documentation when running pytest --markers.
+    config.addinivalue_line(
+        "markers", "celery(**overrides): override celery configuration for a test case"
+    )
+
+
 @contextmanager
 def _create_app(enable_logging=False,
                 use_trap=False,

--- a/celery/contrib/pytest.py
+++ b/celery/contrib/pytest.py
@@ -16,7 +16,7 @@ NO_WORKER = os.environ.get('NO_WORKER')
 
 
 def pytest_configure(config):
-    """Register additional pytest configuration"""
+    """Register additional pytest configuration."""
     # add the pytest.mark.celery() marker registration to the pytest.ini [markers] section
     # this prevents pytest 4.5 and newer from issueing a warning about an unknown marker
     # and shows helpful marker documentation when running pytest --markers.

--- a/t/unit/contrib/test_pytest.py
+++ b/t/unit/contrib/test_pytest.py
@@ -1,0 +1,34 @@
+import pytest
+
+try:
+    from pytest import PytestUnknownMarkWarning  # noqa: F401
+
+    pytest_marker_warnings = True
+except ImportError:
+    pytest_marker_warnings = False
+
+
+pytest_plugins = ["pytester"]
+
+
+@pytest.mark.skipif(
+    not pytest_marker_warnings,
+    reason="Older pytest version without marker warnings",
+)
+def test_pytest_celery_marker_registration(testdir):
+    """Verify that using the 'celery' marker does not result in a warning"""
+    testdir.plugins.append("celery")
+    testdir.makepyfile(
+        """
+        import pytest
+        @pytest.mark.celery(foo="bar")
+        def test_noop():
+            pass
+        """
+    )
+
+    result = testdir.runpytest('-q')
+    with pytest.raises(ValueError):
+        result.stdout.fnmatch_lines_random(
+            "*PytestUnknownMarkWarning: Unknown pytest.mark.celery*"
+        )


### PR DESCRIPTION
## Description

In pytest 4.5 and newer, markers that have not been configured in the pytest.ini `[markers]` section [result in a warning or error](https://docs.pytest.org/en/latest/mark.html#raising-errors-on-unknown-marks). Register the celery marker (with documentation) to silence these.

Fixes #5719

