### PR TITLE
Don't log a debug statement every time the celery event loop is polled

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -775,9 +775,6 @@ class AsynPool(_pool.Pool):
         def on_poll_start():
             # Determine which io descriptors are not busy
             inactive = diff(active_writes)
-            logger.debug(
-                "AsyncPool._create_write_handlers ALL: %r ACTIVE: %r",
-                len(all_inqueues), len(active_writes))
 
             # Determine hub_add vs hub_remove strategy conditional
             if is_fair_strategy:


### PR DESCRIPTION
## Description
When I run celery locally using the rc candidate, I get a huge amount of debugging messages like this in my console:

```
worker_1  | [2019-09-10 18:00:57,146: DEBUG/MainProcess] AsyncPool._create_write_handlers ALL: 4 ACTIVE: 0
worker_1  | [2019-09-10 18:00:57,759: DEBUG/MainProcess] AsyncPool._create_write_handlers ALL: 4 ACTIVE: 0
worker_1  | [2019-09-10 18:00:58,768: DEBUG/MainProcess] AsyncPool._create_write_handlers ALL: 4 ACTIVE: 0
worker_1  | [2019-09-10 18:00:59,147: DEBUG/MainProcess] AsyncPool._create_write_handlers ALL: 4 ACTIVE: 0
worker_1  | [2019-09-10 18:00:59,149: DEBUG/MainProcess] AsyncPool._create_write_handlers ALL: 4 ACTIVE: 0
worker_1  | [2019-09-10 18:00:59,776: DEBUG/MainProcess] AsyncPool._create_write_handlers ALL: 4 ACTIVE: 0
```

Checking the source, this looks like a debugging relic from PR #5604. I don't see any reason why it would be useful to log information at this level of detail in production. Even in a debugging context, it's difficult to find other log messages with this in the console.

/cc @matteius who added this

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
