### PR TITLE
fix Python 3.7 compatibility for 3.1 branch

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -39,7 +39,7 @@ from billiard import pool as _pool
 from billiard.compat import buf_t, setblocking, isblocking
 from billiard.einfo import ExceptionInfo
 from billiard.queues import _SimpleQueue
-from kombu.async import READ, WRITE, ERR
+from kombu.asynchronous import READ, WRITE, ERR
 from kombu.serialization import pickle as _pickle
 from kombu.utils import fxrange
 from kombu.utils.compat import get_errno

--- a/celery/tests/utils/test_timer2.py
+++ b/celery/tests/utils/test_timer2.py
@@ -53,7 +53,7 @@ class test_Schedule(Case):
 
         s = timer2.Schedule(on_error=on_error)
 
-        with patch('kombu.async.timer.to_timestamp') as tot:
+        with patch('kombu.asynchronous.timer.to_timestamp') as tot:
             tot.side_effect = OverflowError()
             s.enter_at(timer2.Entry(lambda: None, (), {}),
                        eta=datetime.now())
@@ -125,7 +125,7 @@ class test_Timer(Case):
         finally:
             t.stop()
 
-    @patch('kombu.async.timer.logger')
+    @patch('kombu.asynchronous.timer.logger')
     def test_apply_entry_error_handled(self, logger):
         t = timer2.Timer()
         t.schedule.on_error = None

--- a/celery/tests/worker/test_hub.py
+++ b/celery/tests/worker/test_hub.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-from kombu.async import Hub, READ, WRITE, ERR
-from kombu.async.debug import callback_for, repr_flag, _rcb
-from kombu.async.semaphore import DummyLock, LaxBoundedSemaphore
+from kombu.asynchronous import Hub, READ, WRITE, ERR
+from kombu.asynchronous.debug import callback_for, repr_flag, _rcb
+from kombu.asynchronous.semaphore import DummyLock, LaxBoundedSemaphore
 
 from celery.five import range
 from celery.tests.case import Case, Mock, call, patch
@@ -138,7 +138,7 @@ class test_Hub(Case):
         self.assertEqual(_rcb(f), f.__name__)
         self.assertEqual(_rcb('foo'), 'foo')
 
-    @patch('kombu.async.hub.poll')
+    @patch('kombu.asynchronous.hub.poll')
     def test_start_stop(self, poll):
         hub = Hub()
         poll.assert_called_with()
@@ -197,7 +197,7 @@ class test_Hub(Case):
 
         eback.side_effect = ValueError('foo')
         hub.scheduler = iter([(0, eback)])
-        with patch('kombu.async.hub.logger') as logger:
+        with patch('kombu.asynchronous.hub.logger') as logger:
             with self.assertRaises(StopIteration):
                 hub.fire_timers()
             self.assertTrue(logger.error.called)

--- a/celery/tests/worker/test_loops.py
+++ b/celery/tests/worker/test_loops.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import socket
 
-from kombu.async import Hub, READ, WRITE, ERR
+from kombu.asynchronous import Hub, READ, WRITE, ERR
 
 from celery.bootsteps import CLOSE, RUN
 from celery.exceptions import InvalidTaskError, WorkerShutdown, WorkerTerminate

--- a/celery/tests/worker/test_worker.py
+++ b/celery/tests/worker/test_worker.py
@@ -1096,7 +1096,7 @@ class test_WorkController(AppCase):
         pool.create(w)
 
     def test_Pool_create(self):
-        from kombu.async.semaphore import LaxBoundedSemaphore
+        from kombu.asynchronous.semaphore import LaxBoundedSemaphore
         w = Mock()
         w._conninfo.connection_errors = w._conninfo.channel_errors = ()
         w.hub = Mock()

--- a/celery/utils/timer2.py
+++ b/celery/utils/timer2.py
@@ -16,7 +16,7 @@ from itertools import count
 from time import sleep
 
 from celery.five import THREAD_TIMEOUT_MAX
-from kombu.async.timer import Entry, Timer as Schedule, to_timestamp, logger
+from kombu.asynchronous.timer import Entry, Timer as Schedule, to_timestamp, logger
 
 TIMER_DEBUG = os.environ.get('TIMER_DEBUG')
 

--- a/celery/worker/autoscale.py
+++ b/celery/worker/autoscale.py
@@ -18,7 +18,7 @@ import threading
 
 from time import sleep
 
-from kombu.async.semaphore import DummyLock
+from kombu.asynchronous.semaphore import DummyLock
 
 from celery import bootsteps
 from celery.five import monotonic

--- a/celery/worker/components.py
+++ b/celery/worker/components.py
@@ -11,9 +11,9 @@ from __future__ import absolute_import
 import atexit
 import warnings
 
-from kombu.async import Hub as _Hub, get_event_loop, set_event_loop
-from kombu.async.semaphore import DummyLock, LaxBoundedSemaphore
-from kombu.async.timer import Timer as _Timer
+from kombu.asynchronous import Hub as _Hub, get_event_loop, set_event_loop
+from kombu.asynchronous.semaphore import DummyLock, LaxBoundedSemaphore
+from kombu.asynchronous.timer import Timer as _Timer
 
 from celery import bootsteps
 from celery._state import _set_task_join_will_block

--- a/celery/worker/consumer.py
+++ b/celery/worker/consumer.py
@@ -24,7 +24,7 @@ from time import sleep
 
 from billiard.common import restart_state
 from billiard.exceptions import RestartFreqExceeded
-from kombu.async.semaphore import DummyLock
+from kombu.asynchronous.semaphore import DummyLock
 from kombu.common import QoS, ignore_errors
 from kombu.syn import _detect_environment
 from kombu.utils.compat import get_errno

--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 import logging
 
-from kombu.async.timer import to_timestamp
+from kombu.asynchronous.timer import to_timestamp
 from kombu.utils.encoding import safe_repr
 
 from celery.utils.log import get_logger


### PR DESCRIPTION
Backported Python 3.7 compatibility fixes to the 3.1 branch.
We are running this code in production without issues so I don't see why we can't make it available to everybody still running Celery 3.