### PR TITLE
celery#5736, Fix disable_sync_subtasks not respected in ResultSet

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -769,6 +769,7 @@ class ResultSet(ResultBase):
             value = result.get(
                 timeout=remaining, propagate=propagate,
                 interval=interval, no_ack=no_ack, on_interval=on_interval,
+                disable_sync_subtasks=disable_sync_subtasks,
             )
             if callback:
                 callback(result.id, value)

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -468,6 +468,17 @@ class test_ResultSet:
         b.supports_native_join = True
         x.get()
         x.join_native.assert_called()
+    
+    @patch('celery.result.task_join_will_block')
+    def test_get_sync_subtask_option(self, task_join_will_block):
+        task_join_will_block.return_value = True
+        x = self.app.ResultSet([self.app.AsyncResult(str(t)) for t in [1, 2, 3]])
+        b = x.results[0].backend = Mock()
+        b.supports_native_join = False
+        with pytest.raises(RuntimeError):
+            x.get()
+        with pytest.raises(TimeoutError):
+            x.get(disable_sync_subtasks=False, timeout=0.1)
 
     def test_join_native_with_group_chain_group(self):
         """Test group(chain(group)) case, join_native can be run correctly.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Fixes #5736