### PR TITLE
Run integration suite with memcached results backend.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ matrix:
     env: MATRIX_TOXENV=integration-azureblockblob
     stage: integration
 
+  - python: 3.7
+    env: MATRIX_TOXENV=integration-cache
+    stage: integration
+
   - python: '3.7'
     env: TOXENV=flake8
     stage: lint
@@ -94,6 +98,11 @@ before_install:
           if [[ "$TOXENV" == *dynamodb ]]; then
               docker run -d -p 8000:8000 dwmkerr/dynamodb:38 -inMemory
               while ! nc -zv 127.0.0.1 8000; do sleep 10; done
+          fi
+    - |
+          if [[ "$TOXENV" == *cache ]]; then
+              docker run -d -p 11211:11211 memcached:alpine
+              while ! nc -zv 127.0.0.1 11211; do sleep 1; done
           fi
     - |
           docker run -d -e executable=blob -t -p 10000:10000 --tmpfs /opt/azurite/folder:rw arafato/azurite:2.6.5

--- a/requirements/test-integration.txt
+++ b/requirements/test-integration.txt
@@ -3,4 +3,5 @@ simplejson
 -r extras/dynamodb.txt
 -r extras/azureblockblob.txt
 -r extras/auth.txt
+-r extras/memcache.txt
 pytest-rerunfailures>=6.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {2.7,3.5,3.6,3.7,pypy,pypy3}-unit
-    {2.7,3.5,3.6,3.7,pypy,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob}
+    {2.7,3.5,3.6,3.7,pypy,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache}
 
     flake8
     apicheck
@@ -34,6 +34,9 @@ setenv =
     BOTO_CONFIG = /dev/null
     WORKER_LOGLEVEL = INFO
     PYTHONIOENCODING = UTF-8
+
+    cache: TEST_BROKER=pyamqp://
+    cache: TEST_BACKEND=cache+pylibmc://
 
     rabbitmq: TEST_BROKER=pyamqp://
     rabbitmq: TEST_BACKEND=rpc


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

The memcache result backend has multiple failures/hangings in the canvas tests.
This is the result of not regularly running the tests with the cache results backend in CI.

This PR introduces the cache backend into the integration test suite matrix.


<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->