### PR TITLE
Add links to configuration docs from Django first steps

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -273,3 +273,4 @@ Shady Rafehi, 2019/02/20
 Fabio Todaro, 2019/06/13
 Shashank Parekh, 2019/07/11
 Arel Cordero, 2019/08/29
+Kyle Johnson, 2019/09/23

--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -88,7 +88,8 @@ from the Django settings; but you can also separate them if wanted.
 
     app.config_from_object('django.conf:settings', namespace='CELERY')
 
-The uppercase name-space means that all Celery configuration options
+The uppercase name-space means that all
+:ref:`Celery configuration options <configuration>`
 must be specified in uppercase instead of lowercase, and start with
 ``CELERY_``, so for example the :setting:`task_always_eager` setting
 becomes ``CELERY_TASK_ALWAYS_EAGER``, and the :setting:`broker_url`
@@ -220,6 +221,9 @@ To use this with your project you need to follow these steps:
                 'LOCATION': 'my_cache_table',
             }
         }
+
+    For additional configuration options, view the
+    :ref:`conf-result-backend` reference.
 
 
 ``django-celery-beat`` - Database-backed Periodic Tasks with Admin interface.


### PR DESCRIPTION
This adds two links from the Django first steps page in the docs to the celery configuration reference for easier access/visibility.