### PR TITLE
Correcting Attribute Name for Task Name

### DIFF
--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -132,7 +132,7 @@ class DatabaseBackend(BaseBackend):
         task.status = state
         task.traceback = traceback
         if self.app.conf.find_value_for_key('extended', 'result'):
-            task.name = getattr(request, 'task_name', None)
+            task.name = getattr(request, 'task', None)
             task.args = ensure_bytes(
                 self.encode(getattr(request, 'args', None))
             )

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -231,7 +231,7 @@ class test_DatabaseBackend_result_extended():
         tid = uuid()
 
         request = Context(args=args, kwargs=kwargs,
-                          task_name='mytask', retries=2,
+                          task='mytask', retries=2,
                           hostname='celery@worker_1',
                           delivery_info={'routing_key': 'celery'})
 


### PR DESCRIPTION
As per Celery issue #5714, the attribute name is incorrect, resulting in 
`None` being stored in place of the task name.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fixes #5714