### PR TITLE
Adding `worker_process_shutdown` to __all__

### DIFF
--- a/celery/signals.py
+++ b/celery/signals.py
@@ -20,10 +20,10 @@ __all__ = (
     'task_prerun', 'task_postrun', 'task_success',
     'task_retry', 'task_failure', 'task_revoked', 'celeryd_init',
     'celeryd_after_setup', 'worker_init', 'worker_process_init',
-    'worker_ready', 'worker_shutdown', 'worker_shutting_down',
-    'setup_logging', 'after_setup_logger', 'after_setup_task_logger',
-    'beat_init', 'beat_embedded_init', 'heartbeat_sent',
-    'eventlet_pool_started', 'eventlet_pool_preshutdown',
+    'worker_process_shutdown', 'worker_ready', 'worker_shutdown', 
+    'worker_shutting_down', 'setup_logging', 'after_setup_logger', 
+    'after_setup_task_logger','beat_init', 'beat_embedded_init', 
+    'heartbeat_sent', 'eventlet_pool_started', 'eventlet_pool_preshutdown',
     'eventlet_pool_postshutdown', 'eventlet_pool_apply',
 )
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
Adding `worker_process_shutdown` to __all__, since it's missing.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
