### PR TITLE
Increases max results size for MySQL backend

### DIFF
--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -14,8 +14,8 @@ from celery.exceptions import ImproperlyConfigured
 from celery.five import range
 from celery.utils.time import maybe_timedelta
 
-from .models import Task, TaskExtended, TaskSet
 from .session import SessionManager
+from .models import task_storage_factory
 
 try:
     from sqlalchemy.exc import DatabaseError, InvalidRequestError
@@ -68,9 +68,6 @@ class DatabaseBackend(BaseBackend):
     # to not bombard the database with queries.
     subpolling_interval = 0.5
 
-    task_cls = Task
-    taskset_cls = TaskSet
-
     def __init__(self, dburi=None, engine_options=None, url=None, **kwargs):
         # The `url` argument was added later and is used by
         # the app to set backend by url (celery.app.backends.by_url)
@@ -78,8 +75,10 @@ class DatabaseBackend(BaseBackend):
                                               url=url, **kwargs)
         conf = self.app.conf
 
-        if self.extended_result:
-            self.task_cls = TaskExtended
+        self.task_cls, self.taskset_cls = task_storage_factory(
+            conf.get('database_large_result_storage'),
+            self.extended_result
+        )
 
         self.url = url or dburi or conf.database_url
         self.engine_options = dict(

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y build-essential \
     llvm \
     libncurses5-dev \
     libsqlite3-dev \
+    libmysqlclient-dev \
     wget \
     pypy \
     python-openssl \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       REDIS_HOST: redis
       WORKER_LOGLEVEL: DEBUG
       AZUREBLOCKBLOB_URL: azureblockblob://DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;
+      MYSQL_URL: mysql://root:c313ry@mysql/resultsdb
       PYTHONPATH: /home/developer/celery
     tty: true
     volumes:
@@ -25,6 +26,7 @@ services:
       - redis
       - dynamodb
       - azurite
+      - mysql
 
   rabbit:
     image: rabbitmq:3.8.0
@@ -37,3 +39,11 @@ services:
 
   azurite:
     image: arafato/azurite:2.6.5
+
+  mysql:
+    image: mysql
+    restart: always
+    environment:
+      - MYSQL_DATABASE=resultsdb
+      - MYSQL_ROOT_PASSWORD=c313ry
+

--- a/requirements/extras/database-integration.txt
+++ b/requirements/extras/database-integration.txt
@@ -1,0 +1,2 @@
+-r sqlalchemy.txt
+mysqlclient

--- a/requirements/test-integration.txt
+++ b/requirements/test-integration.txt
@@ -3,5 +3,6 @@ simplejson
 -r extras/dynamodb.txt
 -r extras/azureblockblob.txt
 -r extras/auth.txt
+-r extras/database-integration.txt
 -r extras/memcache.txt
 pytest-rerunfailures>=6.0

--- a/t/integration/test_backend.py
+++ b/t/integration/test_backend.py
@@ -3,8 +3,14 @@ from __future__ import absolute_import, unicode_literals
 import os
 
 from case import skip
+from pytest import fixture
+from uuid import uuid1
 
+from sqlalchemy import create_engine
+
+from celery import states
 from celery.backends.azureblockblob import AzureBlockBlobBackend
+from celery.backends.database import DatabaseBackend
 
 
 @skip.unless_module("azure")
@@ -35,3 +41,44 @@ class test_AzureBlockBlobBackend:
             url=os.environ["AZUREBLOCKBLOB_URL"])
 
         assert backend.get(b"doesNotExist") is None
+
+
+@skip.unless_module("sqlalchemy")
+@skip.unless_module("MySQLdb")
+@skip.unless_environ("MYSQL_URL")
+class test_DatabaseMySQLBackend:
+
+    @fixture(scope='function')
+    def extended_app(self, app):
+        app.conf.result_serializer = 'pickle'
+        app.conf.database_large_result_storage = True
+        yield app
+
+    @fixture(scope='class')
+    def mysql_url(self):
+        yield os.environ["MYSQL_URL"]
+    
+    def clear_db(self, url):
+        engine = create_engine(url)
+        engine.execute('DROP TABLE IF EXISTS celery_taskmeta;')
+        engine.execute('DROP TABLE IF EXISTS celery_tasksetmeta;')
+        engine.dispose()
+
+    # def test_store_result(self, mysql_url, app):
+    #     self.clear_db(mysql_url)
+    #     tb = DatabaseBackend(mysql_url, app=app)
+    #     tb.store_result(uuid1(), {'fizz': 'buzz'}, states.SUCCESS)
+
+    def test_store_extended_result(self, mysql_url, extended_app):
+
+        self.clear_db(mysql_url)
+        tb = DatabaseBackend(mysql_url, app=extended_app)
+
+        print vars(tb)
+        # By default, celery stores results in MySQL in a BLOB column, with
+        # max length 2**16 - 1.
+        # See: https://dev.mysql.com/doc/refman/5.5/en/storage-requirements.html#data-types-storage-reqs-strings
+        long_result = 'a'*2**17
+
+        tb.store_result(uuid1, long_result, states.SUCCESS)
+


### PR DESCRIPTION
Fixes #461 

The database result backend stores data in a of type [`PickleType`](https://docs.sqlalchemy.org/en/13/core/type_basics.html#sqlalchemy.types.PickleType) column. When materialized on a MySQL database, this creates a [`BLOB`](https://dev.mysql.com/doc/refman/5.7/en/blob.html), which has a max row size of 2^16 bytes == 65 kB. 

This PR increases the max result size to 4GB when stored in MySQL by changing the backing column type from `BLOB` to `LONGBLOB`. It takes advantage of the fact that PickleType is implemented as a SqlAlchemy [`TypeDecorator`](https://docs.sqlalchemy.org/en/13/core/custom_types.html#augmenting-existing-types); so we can just override how the type determine its base implementation given a database dialect, whist still maintaining all the well tested un/marshaling code in `PickleType`.

