### PR TITLE
Fix #5772 task_default_exchange & task_default_exchange_type not work

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -130,9 +130,9 @@ class Queues(dict):
         return self._add(Queue.from_dict(name, **options))
 
     def _add(self, queue):
+        if queue.exchange is None or queue.exchange.name == '':
+            queue.exchange = self.default_exchange
         if not queue.routing_key:
-            if queue.exchange is None or queue.exchange.name == '':
-                queue.exchange = self.default_exchange
             queue.routing_key = self.default_routing_key
         if self.ha_policy:
             if queue.queue_arguments is None:

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -132,6 +132,20 @@ class test_Queues:
         q.add(Queue('foo'))
         assert q['foo'].exchange.name == 'fff'
 
+    @pytest.mark.parametrize('name,rkey', [
+        ('default', None),
+        ('default', 'routing_key'),
+    ])
+    def test_setting_default_exchange(self, name, rkey):
+        q = Queue(name, routing_key=rkey)
+        self.app.conf.task_queues = {q}
+        self.app.conf.task_default_exchange = 'foo'
+        self.app.conf.task_default_exchange_type = 'topic'
+        queues = dict(self.app.amqp.queues)
+        queue = queues[name]
+        assert queue.exchange.name == 'foo'
+        assert queue.exchange.type == 'topic'
+
     def test_alias(self):
         q = Queues()
         q.add(Queue('foo', alias='barfoo'))

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -132,20 +132,6 @@ class test_Queues:
         q.add(Queue('foo'))
         assert q['foo'].exchange.name == 'fff'
 
-    @pytest.mark.parametrize('name,rkey', [
-        ('default', None),
-        ('default', 'routing_key'),
-    ])
-    def test_setting_default_exchange(self, name, rkey):
-        q = Queue(name, routing_key=rkey)
-        self.app.conf.task_queues = {q}
-        self.app.conf.task_default_exchange = 'foo'
-        self.app.conf.task_default_exchange_type = 'topic'
-        queues = dict(self.app.amqp.queues)
-        queue = queues[name]
-        assert queue.exchange.name == 'foo'
-        assert queue.exchange.type == 'topic'
-
     def test_alias(self):
         q = Queues()
         q.add(Queue('foo', alias='barfoo'))
@@ -200,6 +186,35 @@ class test_default_queues:
         assert queue.exchange.name == exchange or name
         assert queue.exchange.type == 'direct'
         assert queue.routing_key == rkey or name
+
+
+class test_default_exchange:
+
+    @pytest.mark.parametrize('name,exchange,rkey', [
+        ('default', 'foo', None),
+        ('default', 'foo', 'routing_key'),
+    ])
+    def test_setting_default_exchange(self, name, exchange, rkey):
+        q = Queue(name, routing_key=rkey)
+        self.app.conf.task_queues = {q}
+        self.app.conf.task_default_exchange = exchange
+        queues = dict(self.app.amqp.queues)
+        queue = queues[name]
+        assert queue.exchange.name == exchange
+
+    @pytest.mark.parametrize('name,extype,rkey', [
+        ('default', 'direct', None),
+        ('default', 'direct', 'routing_key'),
+        ('default', 'topic', None),
+        ('default', 'topic', 'routing_key'),
+    ])
+    def test_setting_default_exchange_type(self, name, extype, rkey):
+        q = Queue(name, routing_key=rkey)
+        self.app.conf.task_queues = {q}
+        self.app.conf.task_default_exchange_type = extype
+        queues = dict(self.app.amqp.queues)
+        queue = queues[name]
+        assert queue.exchange.type == extype
 
 
 class test_AMQP_proto1:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fix #5772 task_default_exchange & task_default_exchange_type config not work.

The reason for this problem is that celery only set default exchange in `not queue.routing_key` condition, but according to the [document](http://docs.celeryproject.org/en/latest/userguide/routing.html#manual-routing), it should set default exchange with `task_default_exchange` & `task_default_exchange_type` as long as `exchange` is missing for the `Queue`.

https://github.com/celery/celery/blob/a6453043fbfa676cca22c4945f3f165ce8eb4ec0/celery/app/amqp.py#L133