### PR TITLE
Add Python 3.8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - '3.5'
   - '3.6'
   - '3.7'
+  - '3.8'
 os:
     - linux
 stages:
@@ -20,39 +21,39 @@ env:
 
 matrix:
   include:
-  - python: 3.7
+  - python: 3.8
     env: MATRIX_TOXENV=integration-rabbitmq
     stage: integration
 
-  - python: 3.7
+  - python: 3.8
     env: MATRIX_TOXENV=integration-redis
     stage: integration
 
-  - python: 3.7
+  - python: 3.8
     env: MATRIX_TOXENV=integration-dynamodb
     stage: integration
 
-  - python: 3.7
+  - python: 3.8
     env: MATRIX_TOXENV=integration-azureblockblob
     stage: integration
 
-  - python: 3.7
+  - python: 3.8
     env: MATRIX_TOXENV=integration-cache
     stage: integration
 
-  - python: '3.7'
+  - python: '3.8'
     env: TOXENV=flake8
     stage: lint
-  - python: '3.7'
+  - python: '3.8'
     env: TOXENV=apicheck
     stage: lint
-  - python: '3.7'
+  - python: '3.8'
     env: TOXENV=configcheck
     stage: lint
-  - python: '3.7'
+  - python: '3.8'
     env: TOXENV=bandit
     stage: lint
-  - python: '3.7'
+  - python: '3.8'
     env: TOXENV=pydocstyle
     stage: lint
   - python: '2.7'

--- a/celery/contrib/testing/app.py
+++ b/celery/contrib/testing/app.py
@@ -30,6 +30,10 @@ class Trap(object):
     """
 
     def __getattr__(self, name):
+        # Workaround to allow unittest.mock to patch this object
+        # in Python 3.8 and above.
+        if name == '_is_coroutine':
+            return None
         raise RuntimeError('Test depends on current_app')
 
 

--- a/requirements/extras/tblib.txt
+++ b/requirements/extras/tblib.txt
@@ -1,1 +1,2 @@
-tblib>=1.3.0
+tblib>=1.5.0;python_version>='3.8.0'
+tblib>=1.3.0;python_version<'3.8.0'

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -254,31 +254,26 @@ class test_AsyncResult:
 
         with pytest.raises(KeyError):
             notb.get()
-        try:
+        with pytest.raises(KeyError) as excinfo:
             withtb.get()
-        except KeyError:
-            tb = traceback.format_exc()
-            assert '  File "foo.py", line 2, in foofunc' not in tb
-            assert '  File "bar.py", line 3, in barfunc' not in tb
-            assert 'KeyError:' in tb
-            assert "'blue'" in tb
-        else:
-            raise AssertionError('Did not raise KeyError.')
+
+        tb = [t.strip() for t in traceback.format_tb(excinfo.tb)]
+        assert 'File "foo.py", line 2, in foofunc' not in tb
+        assert 'File "bar.py", line 3, in barfunc' not in tb
+        assert excinfo.value.args[0] == 'blue'
+        assert excinfo.typename == 'KeyError'
 
     @skip.unless_module('tblib')
     def test_raising_remote_tracebacks(self):
         withtb = self.app.AsyncResult(self.task5['id'])
         self.app.conf.task_remote_tracebacks = True
-        try:
+        with pytest.raises(KeyError) as excinfo:
             withtb.get()
-        except KeyError:
-            tb = traceback.format_exc()
-            assert '  File "foo.py", line 2, in foofunc' in tb
-            assert '  File "bar.py", line 3, in barfunc' in tb
-            assert 'KeyError:' in tb
-            assert "'blue'" in tb
-        else:
-            raise AssertionError('Did not raise KeyError.')
+        tb = [t.strip() for t in traceback.format_tb(excinfo.tb)]
+        assert 'File "foo.py", line 2, in foofunc' in tb
+        assert 'File "bar.py", line 3, in barfunc' in tb
+        assert excinfo.value.args[0] == 'blue'
+        assert excinfo.typename == 'KeyError'
 
     def test_str(self):
         ok_res = self.app.AsyncResult(self.task1['id'])

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {2.7,3.5,3.6,3.7,pypy,pypy3}-unit
-    {2.7,3.5,3.6,3.7,pypy,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache}
+    {2.7,3.5,3.6,3.7,3.8,pypy,pypy3}-unit
+    {2.7,3.5,3.6,3.7,3.8,pypy,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache}
 
     flake8
     apicheck
@@ -17,7 +17,7 @@ deps=
     -r{toxinidir}/requirements/docs.txt
     -r{toxinidir}/requirements/pkgutils.txt
 
-    2.7,3.5,3.6,3.7: -r{toxinidir}/requirements/test-ci-default.txt
+    2.7,3.5,3.6,3.7,3.8: -r{toxinidir}/requirements/test-ci-default.txt
     pypy,pypy3: -r{toxinidir}/requirements/test-ci-base.txt
 
     integration: -r{toxinidir}/requirements/test-integration.txt
@@ -28,8 +28,8 @@ deps=
 sitepackages = False
 recreate = False
 commands =
-    unit: py.test -xv --cov=celery --cov-report=xml --cov-report term {posargs}
-    integration: py.test -xsv t/integration {posargs}
+    unit: pytest -xv --cov=celery --cov-report=xml --cov-report term {posargs}
+    integration: pytest -xsv t/integration {posargs}
 setenv =
     BOTO_CONFIG = /dev/null
     WORKER_LOGLEVEL = INFO
@@ -59,6 +59,7 @@ basepython =
     3.5: python3.5
     3.6: python3.6
     3.7: python3.7
+    3.8: python3.8
     pypy: pypy
     pypy3: pypy3
     flake8,apicheck,linkcheck,configcheck,pydocstyle,bandit: python3.7


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This PR adds Python 3.8 support to Celery.
This means Celery 4.4 will support 3.8 as well.

Fixes #5761.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->