### PR TITLE
removed extra slashes in CELERY_BROKER_URL

### DIFF
--- a/examples/django/proj/settings.py
+++ b/examples/django/proj/settings.py
@@ -9,7 +9,7 @@ import os
 
 # Celery settings
 
-CELERY_BROKER_URL = 'amqp://guest:guest@localhost//'
+CELERY_BROKER_URL = 'amqp://guest:guest@localhost'
 
 #: Only add pickle to this list if your broker is secured
 #: from unwanted access (see userguide/security.html)


### PR DESCRIPTION
The Celery broker URL in settings.py had 2 slashes in the end which are not required and can be misleading.
so I changed :-
CELERY_BROKER_URL = 'amqp://guest:guest@localhost//' to CELERY_BROKER_URL = 'amqp://guest:guest@localhost'

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
