### PR TITLE
Fix #5734 Celery does not consider authMechanism on mongodb backend URLs

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -157,6 +157,10 @@ class MongoBackend(BaseBackend):
             # don't change self.options
             conf = dict(self.options)
             conf['host'] = host
+            if self.user:
+                conf['username'] = self.user
+            if self.password:
+                conf['password'] = self.password
 
             self._connection = MongoClient(**conf)
 

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -220,6 +220,25 @@ class test_MongoBackend:
             )
             assert sentinel.connection == connection
 
+    def test_get_connection_with_authmechanism(self):
+        with patch('pymongo.MongoClient') as mock_Connection:
+            self.app.conf.mongodb_backend_settings = None
+            uri = ('mongodb://'
+                   'celeryuser:celerypassword@'
+                   'localhost:27017/'
+                   'celerydatabase?authMechanism=SCRAM-SHA-256')
+            mb = MongoBackend(app=self.app, url=uri)
+            mock_Connection.return_value = sentinel.connection
+            connection = mb._get_connection()
+            mock_Connection.assert_called_once_with(
+                host=['localhost:27017'],
+                username='celeryuser',
+                password='celerypassword',
+                authmechanism='SCRAM-SHA-256',
+                **mb._prepare_client_options(),
+            )
+            assert sentinel.connection == connection
+
     @patch('celery.backends.mongodb.MongoBackend._get_connection')
     def test_get_database_no_existing(self, mock_get_connection):
         # Should really check for combinations of these two, to be complete.

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -236,7 +236,7 @@ class test_MongoBackend:
                 username='celeryuser',
                 password='celerypassword',
                 authmechanism='SCRAM-SHA-256',
-                **mb._prepare_client_options(),
+                **mb._prepare_client_options()
             )
             assert sentinel.connection == connection
 
@@ -254,7 +254,7 @@ class test_MongoBackend:
             mock_Connection.assert_called_once_with(
                 host=['localhost:27017'],
                 authmechanism='SCRAM-SHA-256',
-                **mb._prepare_client_options(),
+                **mb._prepare_client_options()
             )
 
     @patch('celery.backends.mongodb.MongoBackend._get_connection')


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
Fix #5734 Celery does not consider authMechanism on mongodb backend URLs.

The reason for this issue is that 'username' must be provided if 'authMechanism' is used while connecting to MongoDB by calling MongoClient, but it is missing.
```python
# celery\backends\mongodb.py line 158
            conf = dict(self.options)
            conf['host'] = host

            self._connection = MongoClient(**conf)
```
Username isn't in self.options, so pymongo raises an exception. In order to resolve this issue, I added username and password to conf before connecting.
```python
# celery\backends\mongodb.py line 158
            conf = dict(self.options)
            conf['host'] = host
            if self.user:
                conf['username'] = self.user
            if self.password:
                conf['password'] = self.password

            self._connection = MongoClient(**conf)
```
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
