### PR TITLE
Revert "Revert "Revert "Added handle of SIGTERM in BaseTask in celery/task.py to prevent kill the task" (#5577)" (#5586)"

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -2,7 +2,6 @@
 """Task implementation: request context and the task base class."""
 from __future__ import absolute_import, unicode_literals
 
-import signal
 import sys
 
 from billiard.einfo import ExceptionInfo
@@ -21,7 +20,6 @@ from celery.result import EagerResult, denied_join_result
 from celery.utils import abstract
 from celery.utils.functional import mattrgetter, maybe_list
 from celery.utils.imports import instantiate
-from celery.utils.log import get_logger
 from celery.utils.nodenames import gethostname
 from celery.utils.serialization import raise_with_context
 
@@ -388,12 +386,6 @@ class Task(object):
         setattr(cls, attr, meth)
 
     def __call__(self, *args, **kwargs):
-        logger = get_logger(__name__)
-
-        def handle_sigterm(signum, frame):
-            logger.info('SIGTERM received, waiting till the task finished')
-
-        signal.signal(signal.SIGTERM, handle_sigterm)
         _task_stack.push(self)
         self.push_request(args=args, kwargs=kwargs)
         try:


### PR DESCRIPTION
## Description

Fixes https://github.com/celery/celery/issues/5775

Reverts https://github.com/celery/celery/commit/f79894e0a2c7156fd0ca5e8e3b652b6a46a7e8e7 and reverts part of https://github.com/celery/celery/commit/8cf8fae70630954cff3448485588bbe2a77ff3ab

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
