### PR TITLE
Fixed Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:bionic
 
 ENV PYTHONIOENCODING UTF-8
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Pypy is installed from a package manager because it takes so long to build.
 RUN apt-get update && apt-get install -y build-essential \
     libcurl4-openssl-dev \
@@ -25,7 +27,8 @@ RUN apt-get update && apt-get install -y build-essential \
     libncursesw5-dev \
     zlib1g-dev \
     pkg-config \
-    libssl-dev
+    libssl-dev \
+    sudo
 
 # Setup variables. Even though changing these may cause unnecessary invalidation of
 # unrelated elements, grouping them together makes the Dockerfile read better.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Changes to Dockerfile for enabling noninteractive image build.

1. Set the build argument to: `ARG DEBIAN_FRONTEND=noninteractive`
With this set, we are able to disable the prompt for `tzdata`, during the build. With this, the timezone will be by default set to `UTC` however, it can be changed/reconfigured later on to reflect appropriate timezone.

2. Add `sudo` to the `apt-get install ...` command, as `sudo` is not included by default. I believe we are using `sudo` in the script `install-couchase.sh`.
Ref - https://github.com/tianon/docker-brew-ubuntu-core/issues/48