### PR TITLE
Preserve the task priority in case of a retry

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -595,10 +595,13 @@ class Task(object):
         args = request.args if args is None else args
         kwargs = request.kwargs if kwargs is None else kwargs
         options = request.as_execution_options()
+        delivery_info = request.delivery_info or {}
+        priority = delivery_info.get('priority')
+        if priority is not None:
+            options['priority'] = priority
         if queue:
             options['queue'] = queue
         else:
-            delivery_info = request.delivery_info or {}
             exchange = delivery_info.get('exchange')
             routing_key = delivery_info.get('routing_key')
             if exchange == '' and routing_key:

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -145,6 +145,15 @@ def retry_once(self, *args, expires=60.0, max_retries=1, countdown=0.1):
                      max_retries=max_retries)
 
 
+@shared_task(bind=True, expires=60.0, max_retries=1)
+def retry_once_priority(self, *args, expires=60.0, max_retries=1, countdown=0.1):
+    """Task that fails and is retried. Returns the priority."""
+    if self.request.retries:
+        return self.request.delivery_info['priority']
+    raise self.retry(countdown=countdown,
+                     max_retries=max_retries)
+
+
 @shared_task
 def redis_echo(message):
     """Task that appends the message to a redis list."""

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -5,7 +5,7 @@ import pytest
 from celery import group
 
 from .conftest import get_active_redis_channels
-from .tasks import add, add_ignore_result, print_unicode, retry_once, sleeping
+from .tasks import add, add_ignore_result, print_unicode, retry_once, retry_once_priority, sleeping
 
 
 class test_tasks:
@@ -20,6 +20,11 @@ class test_tasks:
     def test_task_retried(self):
         res = retry_once.delay()
         assert res.get(timeout=10) == 1  # retried once
+
+    @pytest.mark.flaky(reruns=5, reruns_delay=2)
+    def test_task_retried_priority(self):
+        res = retry_once_priority.apply_async(priority=7)
+        assert res.get(timeout=10) == 7  # retried once with priority 7
 
     @pytest.mark.flaky(reruns=5, reruns_delay=2)
     def test_unicode_task(self, manager):

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -212,6 +212,22 @@ class test_task_retries(TasksCase):
         self.retry_task.apply([0xFF, 0xFFFF], {'max_retries': 10})
         assert self.retry_task.iterations == 11
 
+    def test_retry_priority(self):
+        priority = 7
+        
+        # Technically, task.priority doesn't need to be set here
+        # since push_request() doesn't populate the delivery_info
+        # with it. However, setting task.priority here also doesn't
+        # cause any problems.
+        self.retry_task.priority = priority
+
+        self.retry_task.push_request()
+        self.retry_task.request.delivery_info = {
+            'priority': priority
+        }
+        sig = self.retry_task.signature_from_request()
+        assert sig.options['priority'] == priority
+
     def test_retry_no_args(self):
         self.retry_task_noargs.max_retries = 3
         self.retry_task_noargs.iterations = 0


### PR DESCRIPTION
#5441  Description

Currently, the task priority is lost in case a task needs to be retried. This patch preserves the task priority during a retry.

This fixes #5654 