### PR TITLE
Fix/correct minor doc typos

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -913,7 +913,7 @@ You can also use `hub`_ to create pull requests. Example: https://theiconic.tech
 Status Labels
 ~~~~~~~~~~~~~~
 
-There are `different labels _` used to easily manage github issues and PRs.
+There are `different labels`_ used to easily manage github issues and PRs.
 Most of these labels make it easy to categorize each issue with important
 details. For instance, you might see a ``Component:canvas`` label on an issue or PR.
 The ``Component:canvas`` label means the issue or PR corresponds to the canvas functionality.
@@ -963,7 +963,7 @@ Here is a summary of such statuses:
 
 - **Status: Needs Test Coverage**
 
-  Celery uses `codecov _` to verify code coverage. Please make sure PRs do not
+  Celery uses `codecov`_ to verify code coverage. Please make sure PRs do not
   decrease code coverage. This label will identify PRs which need code coverage.
 
 - **Status: Needs Test Case**

--- a/docs/userguide/concurrency/eventlet.rst
+++ b/docs/userguide/concurrency/eventlet.rst
@@ -25,7 +25,7 @@ change how you run your code, not how you write it.
 Celery supports Eventlet as an alternative execution pool implementation and
 in some cases superior to prefork. However, you need to ensure one task doesn't
 block the event loop too long. Generally, CPU-bound operations don't go well
-with Evenetlet. Also note that some libraries, usually with C extensions,
+with Eventlet. Also note that some libraries, usually with C extensions,
 cannot be monkeypatched and therefore cannot benefit from using Eventlet.
 Please refer to their documentation if you are not sure. For example, pylibmc
 does not allow cooperation with Eventlet but psycopg2 does when both of them


### PR DESCRIPTION
## Description

Correct minor documentation typos:

* Evenetlet -> Eventlet
* Contributing Links