### PR TITLE
The test_nested_group_chain test can run without native_join support

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -623,8 +623,6 @@ class test_chord:
         except NotImplementedError as e:
             raise pytest.skip(e.args[0])
 
-        if not manager.app.backend.supports_native_join:
-            raise pytest.skip('Requires native join support.')
         c = chain(
             add.si(1, 0),
             group(


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
I just checked this using #5834 and the test passes.
Cassandra does not have native joins but does support chords.
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->