### PR TITLE
SQS - Reject on failure

### DIFF
--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -510,6 +510,9 @@ class Request(object):
                 send_failed_event = False
             elif ack:
                 self.acknowledge()
+            else:
+                logger.info('!!rejecting the task')
+                self.reject(requeue=False)
 
         # These are special cases where the process would not have had time
         # to write the result.

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -511,7 +511,8 @@ class Request(object):
             elif ack:
                 self.acknowledge()
             else:
-                logger.info('!!rejecting the task')
+                # supporting the behaviour where a task failed and
+                # need to be removed from prefetched local queue
                 self.reject(requeue=False)
 
         # These are special cases where the process would not have had time

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -8,7 +8,6 @@ import socket
 import sys
 from datetime import datetime, timedelta
 from time import time
-from unittest.mock import ANY
 
 import pytest
 from billiard.einfo import ExceptionInfo
@@ -678,8 +677,9 @@ class test_Request(RequestCase):
         except KeyError:
             exc_info = ExceptionInfo()
             job.on_failure(exc_info)
+
         assert job.acknowledged is True
-        job._on_reject.assert_called_with(ANY, ANY, False)
+        job._on_reject.assert_called_with(req_logger, job.connection_errors, False)
 
     def test_on_failure_acks_on_failure_or_timeout_enabled_for_task(self):
         job = self.xRequest()

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -8,6 +8,7 @@ import socket
 import sys
 from datetime import datetime, timedelta
 from time import time
+from unittest.mock import ANY
 
 import pytest
 from billiard.einfo import ExceptionInfo
@@ -669,6 +670,7 @@ class test_Request(RequestCase):
     def test_on_failure_acks_on_failure_or_timeout_disabled_for_task(self):
         job = self.xRequest()
         job.time_start = 1
+        job._on_reject = Mock()
         self.mytask.acks_late = True
         self.mytask.acks_on_failure_or_timeout = False
         try:
@@ -676,7 +678,8 @@ class test_Request(RequestCase):
         except KeyError:
             exc_info = ExceptionInfo()
             job.on_failure(exc_info)
-        assert job.acknowledged is False
+        assert job.acknowledged is True
+        job._on_reject.assert_called_with(ANY, ANY, False)
 
     def test_on_failure_acks_on_failure_or_timeout_enabled_for_task(self):
         job = self.xRequest()

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -704,7 +704,9 @@ class test_Request(RequestCase):
         except KeyError:
             exc_info = ExceptionInfo()
             job.on_failure(exc_info)
-        assert job.acknowledged is False
+        assert job.acknowledged is True
+        job._on_reject.assert_called_with(req_logger, job.connection_errors,
+                                          False)
         self.app.conf.acks_on_failure_or_timeout = True
 
     def test_on_failure_acks_on_failure_or_timeout_enabled(self):


### PR DESCRIPTION
## Description
https://github.com/celery/kombu/issues/1127

Config:
broker acks_late=True 
acks_on_failure_or_timeout=False

Using SQS  worker stop consuming messages after task failure (exception), as the message will not be acked out of the local queue

## Minimally Reproducible Test Case
<!--
Please provide a reproducible test case.
Refer to the Reporting Bugs section in our contribution guide.

We prefer submitting test cases in the form of a PR to our integration test suite.
If you can provide one, please mention the PR number below.
If not, please attach the most minimal code example required to reproduce the issue below.
If the test case is too large, please include a link to a gist or a repository below.
-->


```
from celery import Celery
app.conf.worker_prefetch_multiplier = 1

@app.task(base=BaseAsyncJobTask, acks_late=True, acks_on_failure_or_timeout=False)
def dead_letter_q_task():
    return 1/0

dead_letter_q_task.delay()
dead_letter_q_task.delay()
dead_letter_q_task.delay()
```


# Expected Behavior
I expect all the tasks to be executed, although the first task failed

# Actual Behavior
<!--
Describe in detail what actually happened.
Please include a backtrace and surround it with triple backticks (```).
In addition, include the Celery daemon logs, the broker logs,
the result backend logs and system logs below if they will help us debug
the issue.
-->
The first task was executed, but the rest weren't.

The problem originates from the prefetch multiplier feature, with acks_late=True and acks_on_failure_or_timeout=False flags.

The problem is that the prefetched task is remaining in the local queue although it was failed (because it will not be acked on failure). This causes the mechanism not fetching any more tasks, and workers are not executing anything. 

