### PR TITLE
Changed multi-line string in fixups/django for a warning

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -199,5 +199,5 @@ class DjangoWorkerFixup(object):
 
     def on_worker_ready(self, **kwargs):
         if self._settings.DEBUG:
-            warnings.warn('Using settings.DEBUG leads to a memory leak, never '
-                          'use this setting in production environments!')
+            warnings.warn('''Using settings.DEBUG leads to a memory
+            leak, never use this setting in production environments!''')


### PR DESCRIPTION
This string wasn't rendering properly and was printing the python statement too. Although the change isn't as pretty code-wise, it gets rid of an annoyance for the user.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
