### PR TITLE
Fix a race condition when publishing a very large chord header

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1190,7 +1190,7 @@ class group(Signature):
         try:
             gid = opts['task_id']
         except KeyError:
-            gid = opts['task_id'] = uuid()
+            gid = opts['task_id'] = group_id or uuid()
         if group_id:
             opts['group_id'] = group_id
         if chord:
@@ -1394,8 +1394,7 @@ class chord(Signature):
         options.pop('chord', None)
         options.pop('task_id', None)
 
-        header.freeze(group_id=group_id, chord=body, root_id=root_id)
-        header_result = header(*partial_args, task_id=group_id, **options)
+        header_result = header.freeze(group_id=group_id, chord=body, root_id=root_id)
 
         if len(header_result) > 0:
             app.backend.apply_chord(
@@ -1405,6 +1404,7 @@ class chord(Signature):
                 countdown=countdown,
                 max_retries=max_retries,
             )
+            header_result = header(*partial_args, task_id=group_id, **options)
         # The execution of a chord body is normally triggered by its header's
         # tasks completing. If the header is empty this will never happen, so
         # we execute the body manually here.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Sometimes when publishing a chord with a large header a race condition occurs
when the group result isn't saved before one of the tasks of the header completes.

This regression was introduced in #4443 when the saving of the group result was moved after
publishing the chord's header.

Even after rearranging the code so that `header_result.save()` would come first
there was a problem since the code that freezes the group didn't use the same task_id
as the one that the group was published with.
This is now also fixed.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->