### PR TITLE
Skip unsupported canvas when using the cache backend

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import os
 from datetime import datetime, timedelta
 
 import pytest
@@ -617,6 +618,9 @@ class test_chord:
         assert res.get(timeout=TIMEOUT) == [12, 13, 14, 15]
 
     @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @pytest.mark.xfail(os.environ['TEST_BACKEND'] == 'cache+pylibmc',
+                       reason="Not supported yet by the cache backend.",
+                       strict=True)
     def test_nested_group_chain(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Since we don't know how to fix the problem discovered when we introduced the cache backend in #5739
and a release is pending I'm going to mark this as xfail.

Ref #5757.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->