### PR TITLE
docs: Document Redis commands used by celery

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -149,7 +149,10 @@ class ResultConsumer(BaseResultConsumer):
 
 
 class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
-    """Redis task result store."""
+    """
+    Redis task result store. It makes use of the following commands:
+    GET, MGET, DEL, INCRBY, EXPIRE, SET, SETEX
+    """
 
     ResultConsumer = ResultConsumer
 


### PR DESCRIPTION
## Description

Answers need in #3953, it adds a list of Redis commands that are used by Celery.

- I listed GET, MGET, DEL, INCRBY, EXPIRE, SET, SETEX. I only found those so I'm not sure if there are more.
- I didn't want to add further information such as the fact that `SETEX` is used only when [result_expires](https://docs.celeryproject.org/en/latest/userguide/configuration.html#result-expires) is set (may be wrong but I think this is how it was done when I read the code) but I may do so if required, open-discussion anyway !

Screenshot:
![image](https://user-images.githubusercontent.com/11685232/69915133-07412000-144c-11ea-8d6d-08b462c05973.png)
