### PR TITLE
Revert "Skip unsupported canvas when using the cache backend"

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import os
 from datetime import datetime, timedelta
 
 import pytest
@@ -618,9 +617,6 @@ class test_chord:
         assert res.get(timeout=TIMEOUT) == [12, 13, 14, 15]
 
     @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
-    @pytest.mark.xfail(os.environ['TEST_BACKEND'] == 'cache+pylibmc',
-                       reason="Not supported yet by the cache backend.",
-                       strict=True)
     def test_nested_group_chain(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()


### PR DESCRIPTION
Reverts celery/celery#5851