### PR TITLE
Fix failure to run integration tests

### DIFF
--- a/requirements/test-ci-default.txt
+++ b/requirements/test-ci-default.txt
@@ -5,7 +5,6 @@
 -r extras/mongodb.txt
 -r extras/yaml.txt
 -r extras/tblib.txt
--r extras/sqs.txt
 -r extras/slmq.txt
 -r extras/msgpack.txt
 -r extras/memcache.txt
@@ -20,4 +19,6 @@
 -r extras/cosmosdbsql.txt
 -r extras/cassandra.txt
 -r extras/azureblockblob.txt
--r extras/s3.txt
+
+# SQS dependencies other than boto
+pycurl

--- a/requirements/test-integration.txt
+++ b/requirements/test-integration.txt
@@ -1,6 +1,5 @@
 simplejson
 -r extras/redis.txt
--r extras/dynamodb.txt
 -r extras/azureblockblob.txt
 -r extras/auth.txt
 -r extras/memcache.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 case>=1.3.1
 pytest>=4.6.0,<5.0.0
-boto3>=1.9.125
+boto3>=1.9.178
 moto==1.3.7
 pre-commit
 -r extras/yaml.txt


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

The boto dependency was duplicated by multiple extra dependencies.
Unfortunately pip does not know how to handle that until pypa/pip#988 is resolved.
Until that's the case, we need to avoid including those extras and install boto globally.

SQS also requires pycurl so we specify that directly.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
