### PR TITLE
Revert "remove cache back end integrtion test."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ matrix:
     stage: integration
 
   - python: 3.8
+    env: MATRIX_TOXENV=integration-cache
+    stage: integration
+
+  - python: 3.8
     env: MATRIX_TOXENV=integration-cassandra
     stage: integration
 


### PR DESCRIPTION
Reverts celery/celery#5856

There's no need to remove the integration tests for the cache backend.
We will mark the test we cannot fix as xfail for now just as #5851 did.