### PR TITLE
Revert "Revert "Skip unsupported canvas when using the cache backend""

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -8,7 +8,7 @@ import pytest
 
 from celery import chain, chord, group, signature
 from celery.backends.base import BaseKeyValueStoreBackend
-from celery.exceptions import TimeoutError
+from celery.exceptions import TimeoutError, ChordError
 from celery.result import AsyncResult, GroupResult, ResultSet
 from .conftest import get_active_redis_channels, get_redis_connection
 from .tasks import (ExpectedException, add, add_chord_to_chord, add_replaced,
@@ -650,7 +650,8 @@ class test_chord:
     @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
     @pytest.mark.xfail(os.environ['TEST_BACKEND'] == 'cache+pylibmc',
                        reason="Not supported yet by the cache backend.",
-                       strict=True)
+                       strict=True,
+                       raises=ChordError)
     def test_nested_group_chain(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import os
 from datetime import datetime, timedelta
 from time import sleep
 
@@ -647,6 +648,9 @@ class test_chord:
         assert res.get(timeout=TIMEOUT) == [12, 13, 14, 15]
 
     @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @pytest.mark.xfail(os.environ['TEST_BACKEND'] == 'cache+pylibmc',
+                       reason="Not supported yet by the cache backend.",
+                       strict=True)
     def test_nested_group_chain(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -648,7 +648,7 @@ class test_chord:
         assert res.get(timeout=TIMEOUT) == [12, 13, 14, 15]
 
     @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
-    @pytest.mark.xfail(os.environ['TEST_BACKEND'] == 'cache+pylibmc',
+    @pytest.mark.xfail(os.environ['TEST_BACKEND'] == 'cache+pylibmc://',
                        reason="Not supported yet by the cache backend.",
                        strict=True,
                        raises=ChordError)


### PR DESCRIPTION
Reverts celery/celery#5854