### PR TITLE
Fixed event capture from building infinite list

### DIFF
--- a/celery/events/receiver.py
+++ b/celery/events/receiver.py
@@ -90,7 +90,8 @@ class EventReceiver(ConsumerMixin):
         unless :attr:`EventDispatcher.should_stop` is set to True, or
         forced via :exc:`KeyboardInterrupt` or :exc:`SystemExit`.
         """
-        return list(self.consume(limit=limit, timeout=timeout, wakeup=wakeup))
+        for _ in self.consume(limit=limit, timeout=timeout, wakeup=wakeup):
+            pass
 
     def wakeup_workers(self, channel=None):
         self.app.control.broadcast('heartbeat',


### PR DESCRIPTION
`consume` is a generator returning an infinite list of `None`s.

Wrapping this in a `list` will slowly build this list, holding it in memory.

This is a very slow leak and is only visible over some time when there is a large volume of events.

Supersedes #5482. 

Fixes #4843.