### PR TITLE
Update docs regarding Redis Message Priorities

### DIFF
--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -262,7 +262,7 @@ While the Celery Redis transport does honor the priority field, Redis itself has
 no notion of priorities. Please read this note before attempting to implement
 priorities with Redis as you may experience some unexpected behavior.
 
-To start scheduling tasks based on priorities you need configure queue_order_strategy transport option.
+To start scheduling tasks based on priorities you need to configure queue_order_strategy transport option.
 
 .. code-block:: python
     app.conf.broker_transport_options = {

--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -262,6 +262,14 @@ While the Celery Redis transport does honor the priority field, Redis itself has
 no notion of priorities. Please read this note before attempting to implement
 priorities with Redis as you may experience some unexpected behavior.
 
+To start scheduling tasks based on priorities you need configure queue_order_strategy transport option.
+
+.. code-block:: python
+    app.conf.broker_transport_options = {
+        'queue_order_strategy': 'priority',
+    }
+
+
 The priority support is implemented by creating n lists for each queue.
 This means that even though there are 10 (0-9) priority levels, these are
 consolidated into 4 levels by default to save resources. This means that a
@@ -278,6 +286,7 @@ If you want more priority levels you can set the priority_steps transport option
 
     app.conf.broker_transport_options = {
         'priority_steps': list(range(10)),
+        'queue_order_strategy': 'priority',
     }
 
 


### PR DESCRIPTION
## Description

The original documentation about "Redis Message Priorities" is misleading.
I would expect that some kind of priority based scheduling is performed by default.

But that's not true because the `round_robin` queue cycle strategy is used by default. So no matter which priorities your tasks have, they are scheduled in the same way.

see https://github.com/celery/kombu/blob/master/kombu/transport/redis.py#L447

So this PR adds a text which mentions that when you want to use priority based scheduling,
you need to also to change the queue order strategy.