### PR TITLE
Update 4.4.0 docs

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -18,6 +18,7 @@ an overview of what's new in Celery 4.4.
 3.5, 3.6, 3.7 & 3.8
 and is also supported on PyPy2 & PyPy3.
 - Kombu 4.6.7
+- Task class definitions can have retry attributes (#5869)
 
 
 4.4.0rc5
@@ -32,7 +33,7 @@ and is also supported on PyPy2 & PyPy3.
 - Add auto expiry for DynamoDB backend (#5805)
 - Store extending result in all backends (#5661)
 - Fix a race condition when publishing a very large chord header (#5850)
-- Improve docs and test matrix 
+- Improve docs and test matrix
 
 4.4.0rc4
 ========

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -798,6 +798,19 @@ makes it easy. Just specify the :attr:`~Task.retry_backoff` argument, like this:
     def x():
         ...
 
+.. versionadded:: 4.4
+
+You can also set `autoretry_for`, `retry_kwargs`, `retry_backoff`, `retry_backoff_max` and `retry_jitter` options in class-based tasks:
+
+.. code-block:: python
+
+    class BaseTaskWithRetry(Task):
+        autoretry_for = (TypeError,)
+        retry_kwargs = {'max_retries': 5}
+        retry_backoff = True
+        retry_backoff_max = 700
+        retry_jitter = False
+
 By default, this exponential backoff will also introduce random jitter_ to
 avoid having all the tasks run at the same moment. It will also cap the
 maximum backoff delay to 10 minutes. All these settings can be customized

--- a/docs/whatsnew-4.4.rst
+++ b/docs/whatsnew-4.4.rst
@@ -155,11 +155,6 @@ SQS Message Broker
 
 To keep up with the current AWS API changes the minimum boto3 version was
 bumped to 1.9.125.
-=======
-Django
-------
-
-Starting from this release, the minimum required version for Django is 1.11.
 
 Configuration
 --------------
@@ -213,6 +208,25 @@ using the URI options. The following URI does just that::
 
 Refer to the `documentation <https://api.mongodb.com/python/current/examples/authentication.html>`_
 for details about the various options.
+
+
+Tasks
+------
+
+Task class definitions can now have retry attributes
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You can now use `autoretry_for`, `retry_kwargs`, `retry_backoff`, `retry_backoff_max` and `retry_jitter` in class-based tasks:
+
+.. code-block:: python
+
+  class BaseTaskWithRetry(Task):
+    autoretry_for = (TypeError,)
+    retry_kwargs = {'max_retries': 5}
+    retry_backoff = True
+    retry_backoff_max = 700
+    retry_jitter = False
+
 
 Canvas
 ------


### PR DESCRIPTION
## Description
Added missing note about "Task class definitions can have retry attributes (#5869)" commit to the changelog

Added info about this feature to tasks docs `docs/userguide/tasks.rst`

Removed note about Django 1.11 requirement since it was introduced in 4.3