### PR TITLE
Include renamed Changelog.rst in source releases.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include CONTRIBUTORS.txt
-include Changelog
+include Changelog.rst
 include LICENSE
 include README.rst
 include MANIFEST.in


### PR DESCRIPTION
Changelog.rst was renamed from Changelog in
fd023ec174bedc2dc65c63a0dc7c85e425ac00c6 but MANIFEST.in was not updated to
include the new name. This fixes the file name so Changelog.rst will show up
in future source releases again.