### PR TITLE
Docs: Use safequote in SQS Getting Started doc

### DIFF
--- a/docs/getting-started/brokers/sqs.rst
+++ b/docs/getting-started/brokers/sqs.rst
@@ -37,10 +37,10 @@ encode the password so it can always be parsed correctly. For example:
 
 .. code-block:: python
 
-    from kombu.utils.url import quote
+    from kombu.utils.url import safequote
     
-    aws_access_key = quote("ABCDEFGHIJKLMNOPQRST")
-    aws_secret_key = quote("ZYXK7NiynGlTogH8Nj+P9nlE73sq3")
+    aws_access_key = safequote("ABCDEFGHIJKLMNOPQRST")
+    aws_secret_key = safequote("ZYXK7NiynG/TogH8Nj+P9nlE73sq3")
     
     broker_url = "sqs://{aws_access_key}:{aws_secret_key}@".format(
         aws_access_key=aws_access_key, aws_secret_key=aws_secret_key,


### PR DESCRIPTION
## Description

`AWS_SECRET_ACCESS_KEY` sometimes includes slashes (`/`) which aren't encoded by kombu's `quote` method. 
There is a good possibility that credentials in `broker_url` contain a slash which of course confuses botocore since slashes describe parts of a path in a url. 
For me the exact thing happened in local environment.

## Solution

I solved it by simply using [`safequote`](https://kombu.readthedocs.io/en/latest/reference/kombu.utils.url.html#kombu.utils.url.safequote) instead of `quote`.

It's a really useful little part of documentation when starting out with celery and sqs, so updating it might help other beginners to still have an easy introduction to Celery.

Thank you all for your effort! I'm happy to contribute my little one here :)

Disclaimer:
Since it's all documentation I didn't run any tests or build the docs at all. I did a quick check but it doesn't look that those small changes could break anything. :) 
But if there is any magic happening with built docs so that I need to adjust anything - let me know.