### PR TITLE
Have appveyor build relevant versions of Python.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,11 @@ environment:
     # a later point release.
     # See: https://www.appveyor.com/docs/installed-software#python
 
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+      WINDOWS_SDK_VERSION: "v7.0"
+
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,7 @@ install:
   - "%PYTHON%/python -m pip install -U pip setuptools"
   - "%PYTHON%/Scripts/pip.exe install -U eventlet"
   - "%PYTHON%/Scripts/pip.exe install -U -r requirements/extras/thread.txt"
+  - "%PYTHON%/Scripts/pip.exe install -U -r requirements/test-ci-default.txt"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,21 +12,23 @@ environment:
     # a later point release.
     # See: https://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
-      WINDOWS_SDK_VERSION: "v7.0"
+      WINDOWS_SDK_VERSION: "v7.1"
 
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
+      WINDOWS_SDK_VERSION: "v7.1"
+      
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "64"
+      WINDOWS_SDK_VERSION: "v7.1"
+      
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
 

--- a/requirements/extras/sqs.txt
+++ b/requirements/extras/sqs.txt
@@ -1,2 +1,2 @@
 boto3>=1.9.125
-pycurl
+pycurl==7.43.0.2  # Latest version with wheel built (for appveyor)

--- a/requirements/test-ci-default.txt
+++ b/requirements/test-ci-default.txt
@@ -21,4 +21,4 @@
 -r extras/azureblockblob.txt
 
 # SQS dependencies other than boto
-pycurl
+pycurl==7.43.0.2  # Latest version with wheel built (for appveyor)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,7 @@
 case>=1.3.1
 pytest>=4.6.0,<5.0.0
 boto3>=1.9.178
+python-dateutil<2.8.1,>=2.1; python_version < '3.0'
 moto==1.3.7
 pre-commit
 -r extras/yaml.txt


### PR DESCRIPTION
## Description
Recent PR's fail their AppVeyor builds.   Python 2 is failing with a warning that AppVeyor will remove support after January 1st, and python 3.4 build is failing on our own setup.py requirement that " Celery 4.0 requires CPython 3.5 or later".

> DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support

```
Traceback (most recent call last):
  File "setup.py", line 239, in <module>
    'celery = celery.contrib.pytest',
  File "C:\Python27\lib\site-packages\setuptools\__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "C:\Python27\lib\distutils\core.py", line 151, in setup
    dist.run_commands()
  File "C:\Python27\lib\distutils\dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "C:\Python27\lib\distutils\dist.py", line 972, in run_command
    cmd_obj.run()
  File "C:\Python27\lib\site-packages\setuptools\command\test.py", line 225, in run
    installed_dists = self.install_dists(self.distribution)
  File "C:\Python27\lib\site-packages\setuptools\command\test.py", line 209, in install_dists
    tr_d = dist.fetch_build_eggs(dist.tests_require or [])
  File "C:\Python27\lib\site-packages\setuptools\dist.py", line 721, in fetch_build_eggs
    replace_conflicting=True,
  File "C:\Python27\lib\site-packages\pkg_resources\__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (python-dateutil 2.8.1 (c:\projects\celery\.eggs\python_dateutil-2.8.1-py2.7.egg), Requirement.parse('python-dateutil<2.8.1,>=2.1'), set(['botocore']))
```

See also for python 3.4:  https://ci.appveyor.com/project/ask/celery/builds/29484693/job/dsnjeiykm2u4262d
```
Executing: C:\Python34/python setup.py test
Traceback (most recent call last):
  File "setup.py", line 50, in <module>
    raise Exception(E_UNSUPPORTED_PYTHON % (PYIMP, '3.5'))
Exception: 
----------------------------------------
 Celery 4.0 requires CPython 3.5 or later
----------------------------------------
- For CPython 2.6, PyPy 1.x, Jython 2.6, CPython 3.2->3.3; use Celery 3.1:
    $ pip install 'celery<4'
- For CPython 2.5, Jython 2.5; use Celery 3.0:
    $ pip install 'celery<3.1'
- For CPython 2.4; use Celery 2.2:
    $ pip install 'celery<2.3'
Command exited with code 1
```