### PR TITLE
Use is_alive instead of isAlive for Python 3.9 compatibility.

### DIFF
--- a/celery/utils/timer2.py
+++ b/celery/utils/timer2.py
@@ -102,7 +102,7 @@ class Timer(threading.Thread):
             self.running = False
 
     def ensure_started(self):
-        if not self.running and not self.isAlive():
+        if not self.running and not self.is_alive():
             if self.on_start:
                 self.on_start(self)
             self.start()


### PR DESCRIPTION
## Description

Use `is_alive` instead of `isAlive` for Python 3.9 compatibility.

Fixes #5897 
