### PR TITLE
Very minor tweak to comment to improve docs

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -780,7 +780,7 @@ class Task(object):
         return EagerResult(task_id, retval, state, traceback=tb)
 
     def AsyncResult(self, task_id, **kwargs):
-        """Get AsyncResult instance for this kind of task.
+        """Get AsyncResult instance for the specified task.
 
         Arguments:
             task_id (str): Task id to get result for.


### PR DESCRIPTION
As discussed here: 

https://stackoverflow.com/questions/58816271/celery-task-asyncresult-takes-task-id-but-is-documented-to-get-asyncresult-inst

this comment seems to flow to a very confusing and misleading piece of documentation here:

https://docs.celeryproject.org/en/latest/reference/celery.app.task.html#celery.app.task.Task.AsyncResult
