### PR TITLE
Database Backend: Use configured serializer, instead of always pickling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ htmlcov/
 coverage.xml
 test.db
 pip-wheel-metadata/
+.vscode/

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -363,7 +363,7 @@ class Backend(object):
 
         meta = {
             'status': state,
-            'result': ensure_bytes(self.encode(result)),
+            'result': result,
             'traceback': traceback,
             'children': self.current_task_children(request),
             'date_done': date_done,

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -363,7 +363,7 @@ class Backend(object):
 
         meta = {
             'status': state,
-            'result': result,
+            'result': ensure_bytes(self.encode(result)),
             'traceback': traceback,
             'children': self.current_task_children(request),
             'date_done': date_done,

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -7,6 +7,8 @@ from contextlib import contextmanager
 
 from vine.utils import wraps
 
+from kombu.utils.encoding import ensure_bytes
+
 from celery import states
 from celery.backends.base import BaseBackend
 from celery.exceptions import ImproperlyConfigured

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -131,7 +131,7 @@ class DatabaseBackend(BaseBackend):
     def _update_result(self, task, result, state, traceback=None,
                        request=None):
 
-        meta = self._get_result_meta(result=result, state=state,
+        meta = self._get_result_meta(result=ensure_bytes(self.encode(result)), state=state,
                                      traceback=traceback, request=request,
                                      format_date=False, encode=True)
 

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -173,7 +173,7 @@ class DatabaseBackend(BaseBackend):
         """Store the result of an executed group."""
         session = self.ResultSession()
         with session_cleanup(session):
-            group = self.taskset_cls(group_id, result)
+            group = self.taskset_cls(group_id, ensure_bytes(self.encode(result)))
             session.add(group)
             session.flush()
             session.commit()
@@ -187,6 +187,7 @@ class DatabaseBackend(BaseBackend):
             group = session.query(self.taskset_cls).filter(
                 self.taskset_cls.taskset_id == group_id).first()
             if group:
+                group.result = self.decode(group.result)
                 return group.to_dict()
 
     @retry

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -158,6 +158,9 @@ class DatabaseBackend(BaseBackend):
                 task = self.task_cls(task_id)
                 task.status = states.PENDING
                 task.result = None
+            else:
+                task.result = self.decode(task.result)
+
             data = task.to_dict()
             if 'args' in data:
                 data['args'] = self.decode(data['args'])

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, unicode_literals
 from datetime import datetime
 
 import sqlalchemy as sa
-from sqlalchemy.types import PickleType
+#from sqlalchemy.types import PickleType
 
 from celery import states
 from celery.five import python_2_unicode_compatible
@@ -26,7 +26,7 @@ class Task(ResultModelBase):
                    primary_key=True, autoincrement=True)
     task_id = sa.Column(sa.String(155), unique=True)
     status = sa.Column(sa.String(50), default=states.PENDING)
-    result = sa.Column(PickleType, nullable=True)
+    result = sa.Column(sa.BLOB, nullable=True)
     date_done = sa.Column(sa.DateTime, default=datetime.utcnow,
                           onupdate=datetime.utcnow, nullable=True)
     traceback = sa.Column(sa.Text, nullable=True)
@@ -83,7 +83,7 @@ class TaskSet(ResultModelBase):
     id = sa.Column(sa.Integer, sa.Sequence('taskset_id_sequence'),
                    autoincrement=True, primary_key=True)
     taskset_id = sa.Column(sa.String(155), unique=True)
-    result = sa.Column(PickleType, nullable=True)
+    result = sa.Column(sa.BLOB, nullable=True)
     date_done = sa.Column(sa.DateTime, default=datetime.utcnow,
                           nullable=True)
 

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, unicode_literals
 from datetime import datetime
 
 import sqlalchemy as sa
-#from sqlalchemy.types import PickleType
 
 from celery import states
 from celery.five import python_2_unicode_compatible

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -25,7 +25,7 @@ class Task(ResultModelBase):
                    primary_key=True, autoincrement=True)
     task_id = sa.Column(sa.String(155), unique=True)
     status = sa.Column(sa.String(50), default=states.PENDING)
-    result = sa.Column(sa.BLOB, nullable=True)
+    result = sa.Column(sa.LargeBinary(length=(2**31)-1), nullable=True)
     date_done = sa.Column(sa.DateTime, default=datetime.utcnow,
                           onupdate=datetime.utcnow, nullable=True)
     traceback = sa.Column(sa.Text, nullable=True)
@@ -82,7 +82,7 @@ class TaskSet(ResultModelBase):
     id = sa.Column(sa.Integer, sa.Sequence('taskset_id_sequence'),
                    autoincrement=True, primary_key=True)
     taskset_id = sa.Column(sa.String(155), unique=True)
-    result = sa.Column(sa.BLOB, nullable=True)
+    result = sa.Column(sa.LargeBinary(length=(2**31)-1), nullable=True)
     date_done = sa.Column(sa.DateTime, default=datetime.utcnow,
                           nullable=True)
 

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -25,7 +25,7 @@ class Task(ResultModelBase):
                    primary_key=True, autoincrement=True)
     task_id = sa.Column(sa.String(155), unique=True)
     status = sa.Column(sa.String(50), default=states.PENDING)
-    result = sa.Column(sa.LargeBinary(length=(2**31)-1), nullable=True)
+    result = sa.Column(sa.LargeBinary(length=(2 ** 31) - 1), nullable=True)
     date_done = sa.Column(sa.DateTime, default=datetime.utcnow,
                           onupdate=datetime.utcnow, nullable=True)
     traceback = sa.Column(sa.Text, nullable=True)
@@ -82,7 +82,7 @@ class TaskSet(ResultModelBase):
     id = sa.Column(sa.Integer, sa.Sequence('taskset_id_sequence'),
                    autoincrement=True, primary_key=True)
     taskset_id = sa.Column(sa.String(155), unique=True)
-    result = sa.Column(sa.LargeBinary(length=(2**31)-1), nullable=True)
+    result = sa.Column(sa.LargeBinary(length=(2 ** 31) - 1), nullable=True)
     date_done = sa.Column(sa.DateTime, default=datetime.utcnow,
                           nullable=True)
 

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -65,7 +65,7 @@ def result_serializer(request):
 @skip.if_jython()
 @pytest.mark.usefixtures('result_serializer')
 class test_DatabaseBackend:
-    
+
     def setup(self):
         self.uri = 'sqlite:///test.db'
 

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -32,6 +32,9 @@ class SomeClass(object):
     def __eq__(self, cmp):
         return self.data == cmp.data
 
+    def __json__(self):
+        return {'data': self.data}
+
 
 @skip.unless_module('sqlalchemy')
 class test_session_cleanup:
@@ -113,6 +116,163 @@ class test_DatabaseBackend:
         rindb = tb.get_result(tid2)
         assert rindb.get('foo') == 'baz'
         assert rindb.get('bar').data == 12345
+
+    def test_mark_as_started(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tid = uuid()
+        tb.mark_as_started(tid)
+        assert tb.get_state(tid) == states.STARTED
+
+    def test_mark_as_revoked(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tid = uuid()
+        tb.mark_as_revoked(tid)
+        assert tb.get_state(tid) == states.REVOKED
+
+    def test_mark_as_retry(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tid = uuid()
+        try:
+            raise KeyError('foo')
+        except KeyError as exception:
+            import traceback
+            trace = '\n'.join(traceback.format_stack())
+            tb.mark_as_retry(tid, exception, traceback=trace)
+            assert tb.get_state(tid) == states.RETRY
+            assert isinstance(tb.get_result(tid), KeyError)
+            assert tb.get_traceback(tid) == trace
+
+    def test_mark_as_failure(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+
+        tid3 = uuid()
+        try:
+            raise KeyError('foo')
+        except KeyError as exception:
+            import traceback
+            trace = '\n'.join(traceback.format_stack())
+            tb.mark_as_failure(tid3, exception, traceback=trace)
+            assert tb.get_state(tid3) == states.FAILURE
+            assert isinstance(tb.get_result(tid3), KeyError)
+            assert tb.get_traceback(tid3) == trace
+
+    def test_forget(self):
+        tb = DatabaseBackend(self.uri, backend='memory://', app=self.app)
+        tid = uuid()
+        tb.mark_as_done(tid, {'foo': 'bar'})
+        tb.mark_as_done(tid, {'foo': 'bar'})
+        x = self.app.AsyncResult(tid, backend=tb)
+        x.forget()
+        assert x.result is None
+
+    def test_process_cleanup(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tb.process_cleanup()
+
+    @pytest.mark.usefixtures('depends_on_current_app')
+    def test_reduce(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        assert loads(dumps(tb))
+
+    def test_save__restore__delete_group(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+
+        tid = uuid()
+        res = {'something': 'special'}
+        assert tb.save_group(tid, res) == res
+
+        res2 = tb.restore_group(tid)
+        assert res2 == res
+
+        tb.delete_group(tid)
+        assert tb.restore_group(tid) is None
+
+        assert tb.restore_group('xxx-nonexisting-id') is None
+
+    def test_cleanup(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        for i in range(10):
+            tb.mark_as_done(uuid(), 42)
+            tb.save_group(uuid(), {'foo': 'bar'})
+        s = tb.ResultSession()
+        for t in s.query(Task).all():
+            t.date_done = datetime.now() - tb.expires * 2
+        for t in s.query(TaskSet).all():
+            t.date_done = datetime.now() - tb.expires * 2
+        s.commit()
+        s.close()
+
+        tb.cleanup()
+
+    def test_Task__repr__(self):
+        assert 'foo' in repr(Task('foo'))
+
+    def test_TaskSet__repr__(self):
+        assert 'foo', repr(TaskSet('foo' in None))
+
+
+@skip.unless_module('sqlalchemy')
+@skip.if_pypy()
+@skip.if_jython()
+class test_DatabaseBackend_json_serializer:
+
+    def setup(self):
+        self.uri = 'sqlite:///test.db'
+        self.app.conf.result_serializer = 'json'
+
+    def test_retry_helper(self):
+        from celery.backends.database import DatabaseError
+
+        calls = [0]
+
+        @retry
+        def raises():
+            calls[0] += 1
+            raise DatabaseError(1, 2, 3)
+
+        with pytest.raises(DatabaseError):
+            raises(max_retries=5)
+        assert calls[0] == 5
+
+    def test_missing_dburi_raises_ImproperlyConfigured(self):
+        self.app.conf.database_url = None
+        with pytest.raises(ImproperlyConfigured):
+            DatabaseBackend(app=self.app)
+
+    def test_missing_task_id_is_PENDING(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        assert tb.get_state('xxx-does-not-exist') == states.PENDING
+
+    def test_missing_task_meta_is_dict_with_pending(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        meta = tb.get_task_meta('xxx-does-not-exist-at-all')
+        assert meta['status'] == states.PENDING
+        assert meta['task_id'] == 'xxx-does-not-exist-at-all'
+        assert meta['result'] is None
+        assert meta['traceback'] is None
+
+    def test_mark_as_done(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+
+        tid = uuid()
+
+        assert tb.get_state(tid) == states.PENDING
+        assert tb.get_result(tid) is None
+
+        tb.mark_as_done(tid, 42)
+        assert tb.get_state(tid) == states.SUCCESS
+        assert tb.get_result(tid) == 42
+
+    def test_is_serialized(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+
+        tid2 = uuid()
+        result = {'foo': 'baz', 'bar': SomeClass(12345)}
+        tb.mark_as_done(tid2, result)
+        # is serialized properly.
+        rindb = tb.get_result(tid2)
+        assert rindb.get('foo') == 'baz'
+        assert rindb.get('bar').get('data') == 12345
 
     def test_mark_as_started(self):
         tb = DatabaseBackend(self.uri, app=self.app)

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -54,14 +54,20 @@ class test_session_cleanup:
         session.close.assert_called_with()
 
 
+@pytest.fixture(params=['pickle', 'json'])
+def result_serializer(request):
+    if request.instance:
+        request.instance.app.conf.result_serializer = request.param
+
+
 @skip.unless_module('sqlalchemy')
 @skip.if_pypy()
 @skip.if_jython()
+@pytest.mark.usefixtures('result_serializer')
 class test_DatabaseBackend:
-
+    
     def setup(self):
         self.uri = 'sqlite:///test.db'
-        self.app.conf.result_serializer = 'pickle'
 
     def test_retry_helper(self):
         from celery.backends.database import DatabaseError
@@ -105,6 +111,109 @@ class test_DatabaseBackend:
         tb.mark_as_done(tid, 42)
         assert tb.get_state(tid) == states.SUCCESS
         assert tb.get_result(tid) == 42
+
+    def test_mark_as_started(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tid = uuid()
+        tb.mark_as_started(tid)
+        assert tb.get_state(tid) == states.STARTED
+
+    def test_mark_as_revoked(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tid = uuid()
+        tb.mark_as_revoked(tid)
+        assert tb.get_state(tid) == states.REVOKED
+
+    def test_mark_as_retry(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tid = uuid()
+        try:
+            raise KeyError('foo')
+        except KeyError as exception:
+            import traceback
+            trace = '\n'.join(traceback.format_stack())
+            tb.mark_as_retry(tid, exception, traceback=trace)
+            assert tb.get_state(tid) == states.RETRY
+            assert isinstance(tb.get_result(tid), KeyError)
+            assert tb.get_traceback(tid) == trace
+
+    def test_mark_as_failure(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+
+        tid3 = uuid()
+        try:
+            raise KeyError('foo')
+        except KeyError as exception:
+            import traceback
+            trace = '\n'.join(traceback.format_stack())
+            tb.mark_as_failure(tid3, exception, traceback=trace)
+            assert tb.get_state(tid3) == states.FAILURE
+            assert isinstance(tb.get_result(tid3), KeyError)
+            assert tb.get_traceback(tid3) == trace
+
+    def test_forget(self):
+        tb = DatabaseBackend(self.uri, backend='memory://', app=self.app)
+        tid = uuid()
+        tb.mark_as_done(tid, {'foo': 'bar'})
+        tb.mark_as_done(tid, {'foo': 'bar'})
+        x = self.app.AsyncResult(tid, backend=tb)
+        x.forget()
+        assert x.result is None
+
+    def test_process_cleanup(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tb.process_cleanup()
+
+    @pytest.mark.usefixtures('depends_on_current_app')
+    def test_reduce(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        assert loads(dumps(tb))
+
+    def test_save__restore__delete_group(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+
+        tid = uuid()
+        res = {'something': 'special'}
+        assert tb.save_group(tid, res) == res
+
+        res2 = tb.restore_group(tid)
+        assert res2 == res
+
+        tb.delete_group(tid)
+        assert tb.restore_group(tid) is None
+
+        assert tb.restore_group('xxx-nonexisting-id') is None
+
+    def test_cleanup(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        for i in range(10):
+            tb.mark_as_done(uuid(), 42)
+            tb.save_group(uuid(), {'foo': 'bar'})
+        s = tb.ResultSession()
+        for t in s.query(Task).all():
+            t.date_done = datetime.now() - tb.expires * 2
+        for t in s.query(TaskSet).all():
+            t.date_done = datetime.now() - tb.expires * 2
+        s.commit()
+        s.close()
+
+        tb.cleanup()
+
+    def test_Task__repr__(self):
+        assert 'foo' in repr(Task('foo'))
+
+    def test_TaskSet__repr__(self):
+        assert 'foo', repr(TaskSet('foo' in None))
+
+
+@skip.unless_module('sqlalchemy')
+@skip.if_pypy()
+@skip.if_jython()
+class test_DatabaseBackend_pickle_serializer:
+
+    def setup(self):
+        self.uri = 'sqlite:///test.db'
+        self.app.conf.result_serializer = 'pickle'
 
     def test_is_pickled(self):
         tb = DatabaseBackend(self.uri, app=self.app)
@@ -117,99 +226,6 @@ class test_DatabaseBackend:
         assert rindb.get('foo') == 'baz'
         assert rindb.get('bar').data == 12345
 
-    def test_mark_as_started(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        tid = uuid()
-        tb.mark_as_started(tid)
-        assert tb.get_state(tid) == states.STARTED
-
-    def test_mark_as_revoked(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        tid = uuid()
-        tb.mark_as_revoked(tid)
-        assert tb.get_state(tid) == states.REVOKED
-
-    def test_mark_as_retry(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        tid = uuid()
-        try:
-            raise KeyError('foo')
-        except KeyError as exception:
-            import traceback
-            trace = '\n'.join(traceback.format_stack())
-            tb.mark_as_retry(tid, exception, traceback=trace)
-            assert tb.get_state(tid) == states.RETRY
-            assert isinstance(tb.get_result(tid), KeyError)
-            assert tb.get_traceback(tid) == trace
-
-    def test_mark_as_failure(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-
-        tid3 = uuid()
-        try:
-            raise KeyError('foo')
-        except KeyError as exception:
-            import traceback
-            trace = '\n'.join(traceback.format_stack())
-            tb.mark_as_failure(tid3, exception, traceback=trace)
-            assert tb.get_state(tid3) == states.FAILURE
-            assert isinstance(tb.get_result(tid3), KeyError)
-            assert tb.get_traceback(tid3) == trace
-
-    def test_forget(self):
-        tb = DatabaseBackend(self.uri, backend='memory://', app=self.app)
-        tid = uuid()
-        tb.mark_as_done(tid, {'foo': 'bar'})
-        tb.mark_as_done(tid, {'foo': 'bar'})
-        x = self.app.AsyncResult(tid, backend=tb)
-        x.forget()
-        assert x.result is None
-
-    def test_process_cleanup(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        tb.process_cleanup()
-
-    @pytest.mark.usefixtures('depends_on_current_app')
-    def test_reduce(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        assert loads(dumps(tb))
-
-    def test_save__restore__delete_group(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-
-        tid = uuid()
-        res = {'something': 'special'}
-        assert tb.save_group(tid, res) == res
-
-        res2 = tb.restore_group(tid)
-        assert res2 == res
-
-        tb.delete_group(tid)
-        assert tb.restore_group(tid) is None
-
-        assert tb.restore_group('xxx-nonexisting-id') is None
-
-    def test_cleanup(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        for i in range(10):
-            tb.mark_as_done(uuid(), 42)
-            tb.save_group(uuid(), {'foo': 'bar'})
-        s = tb.ResultSession()
-        for t in s.query(Task).all():
-            t.date_done = datetime.now() - tb.expires * 2
-        for t in s.query(TaskSet).all():
-            t.date_done = datetime.now() - tb.expires * 2
-        s.commit()
-        s.close()
-
-        tb.cleanup()
-
-    def test_Task__repr__(self):
-        assert 'foo' in repr(Task('foo'))
-
-    def test_TaskSet__repr__(self):
-        assert 'foo', repr(TaskSet('foo' in None))
-
 
 @skip.unless_module('sqlalchemy')
 @skip.if_pypy()
@@ -219,49 +235,6 @@ class test_DatabaseBackend_json_serializer:
     def setup(self):
         self.uri = 'sqlite:///test.db'
         self.app.conf.result_serializer = 'json'
-
-    def test_retry_helper(self):
-        from celery.backends.database import DatabaseError
-
-        calls = [0]
-
-        @retry
-        def raises():
-            calls[0] += 1
-            raise DatabaseError(1, 2, 3)
-
-        with pytest.raises(DatabaseError):
-            raises(max_retries=5)
-        assert calls[0] == 5
-
-    def test_missing_dburi_raises_ImproperlyConfigured(self):
-        self.app.conf.database_url = None
-        with pytest.raises(ImproperlyConfigured):
-            DatabaseBackend(app=self.app)
-
-    def test_missing_task_id_is_PENDING(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        assert tb.get_state('xxx-does-not-exist') == states.PENDING
-
-    def test_missing_task_meta_is_dict_with_pending(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        meta = tb.get_task_meta('xxx-does-not-exist-at-all')
-        assert meta['status'] == states.PENDING
-        assert meta['task_id'] == 'xxx-does-not-exist-at-all'
-        assert meta['result'] is None
-        assert meta['traceback'] is None
-
-    def test_mark_as_done(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-
-        tid = uuid()
-
-        assert tb.get_state(tid) == states.PENDING
-        assert tb.get_result(tid) is None
-
-        tb.mark_as_done(tid, 42)
-        assert tb.get_state(tid) == states.SUCCESS
-        assert tb.get_result(tid) == 42
 
     def test_is_serialized(self):
         tb = DatabaseBackend(self.uri, app=self.app)
@@ -273,99 +246,6 @@ class test_DatabaseBackend_json_serializer:
         rindb = tb.get_result(tid2)
         assert rindb.get('foo') == 'baz'
         assert rindb.get('bar').get('data') == 12345
-
-    def test_mark_as_started(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        tid = uuid()
-        tb.mark_as_started(tid)
-        assert tb.get_state(tid) == states.STARTED
-
-    def test_mark_as_revoked(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        tid = uuid()
-        tb.mark_as_revoked(tid)
-        assert tb.get_state(tid) == states.REVOKED
-
-    def test_mark_as_retry(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        tid = uuid()
-        try:
-            raise KeyError('foo')
-        except KeyError as exception:
-            import traceback
-            trace = '\n'.join(traceback.format_stack())
-            tb.mark_as_retry(tid, exception, traceback=trace)
-            assert tb.get_state(tid) == states.RETRY
-            assert isinstance(tb.get_result(tid), KeyError)
-            assert tb.get_traceback(tid) == trace
-
-    def test_mark_as_failure(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-
-        tid3 = uuid()
-        try:
-            raise KeyError('foo')
-        except KeyError as exception:
-            import traceback
-            trace = '\n'.join(traceback.format_stack())
-            tb.mark_as_failure(tid3, exception, traceback=trace)
-            assert tb.get_state(tid3) == states.FAILURE
-            assert isinstance(tb.get_result(tid3), KeyError)
-            assert tb.get_traceback(tid3) == trace
-
-    def test_forget(self):
-        tb = DatabaseBackend(self.uri, backend='memory://', app=self.app)
-        tid = uuid()
-        tb.mark_as_done(tid, {'foo': 'bar'})
-        tb.mark_as_done(tid, {'foo': 'bar'})
-        x = self.app.AsyncResult(tid, backend=tb)
-        x.forget()
-        assert x.result is None
-
-    def test_process_cleanup(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        tb.process_cleanup()
-
-    @pytest.mark.usefixtures('depends_on_current_app')
-    def test_reduce(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        assert loads(dumps(tb))
-
-    def test_save__restore__delete_group(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-
-        tid = uuid()
-        res = {'something': 'special'}
-        assert tb.save_group(tid, res) == res
-
-        res2 = tb.restore_group(tid)
-        assert res2 == res
-
-        tb.delete_group(tid)
-        assert tb.restore_group(tid) is None
-
-        assert tb.restore_group('xxx-nonexisting-id') is None
-
-    def test_cleanup(self):
-        tb = DatabaseBackend(self.uri, app=self.app)
-        for i in range(10):
-            tb.mark_as_done(uuid(), 42)
-            tb.save_group(uuid(), {'foo': 'bar'})
-        s = tb.ResultSession()
-        for t in s.query(Task).all():
-            t.date_done = datetime.now() - tb.expires * 2
-        for t in s.query(TaskSet).all():
-            t.date_done = datetime.now() - tb.expires * 2
-        s.commit()
-        s.close()
-
-        tb.cleanup()
-
-    def test_Task__repr__(self):
-        assert 'foo' in repr(Task('foo'))
-
-    def test_TaskSet__repr__(self):
-        assert 'foo', repr(TaskSet('foo' in None))
 
 
 @skip.unless_module('sqlalchemy')


### PR DESCRIPTION
Rebases the changes defined on #2881 (since they are almost 4 years old)  and refactors them a bit.
Original PR's comment:

> Use the BLOB as an sa.BLOB
> Serialise the result an add to the db as bytes

