### PR TITLE
merge in place the apps beat schedule in the default Schedule class.

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -408,6 +408,7 @@ class Scheduler(object):
 
     def setup_schedule(self):
         self.install_default_entries(self.data)
+        self.merge_inplace(self.app.conf.beat_schedule)
 
     def _do_sync(self):
         try:


### PR DESCRIPTION
This change was recommended in https://github.com/celery/celery/issues/3862 and the issue came up again recently.  I checked the code that was referenced and sure enough, merging in the app's schedule only happens in the PersistentScheduler, hence this change.  