### PR TITLE
Support configuring schema of a PostgreSQL database

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -244,6 +244,7 @@ NAMESPACES = Namespace(
         short_lived_sessions=Option(
             False, type='bool', old={'celery_result_db_short_lived_sessions'},
         ),
+        table_schemas=Option(type='dict'),
         table_names=Option(type='dict', old={'celery_result_db_tablenames'}),
     ),
     task=Namespace(

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -88,6 +88,10 @@ class DatabaseBackend(BaseBackend):
             'short_lived_sessions',
             conf.database_short_lived_sessions)
 
+        schemas = conf.database_table_schemas or {}
+        self.task_cls.__table__.schema = schemas.get('task')
+        self.taskset_cls.__table__.schema = schemas.get('group')
+
         tablenames = conf.database_table_names or {}
         self.task_cls.__table__.name = tablenames.get('task',
                                                       'celery_taskmeta')

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -846,6 +846,25 @@ going stale through inactivity. For example, intermittent errors like
 `(OperationalError) (2006, 'MySQL server has gone away')` can be fixed by enabling
 short lived sessions. This option only affects the database backend.
 
+.. setting:: database_table_schemas
+
+``database_table_schemas``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``{}`` (empty mapping).
+
+When SQLAlchemy is configured as the result backend, Celery automatically
+creates two tables to store result meta-data for tasks. This setting allows
+you to customize the schema of the tables:
+
+.. code-block:: python
+
+    # use custom schema for the database result backend.
+    database_table_schemas = {
+        'task': 'celery',
+        'group': 'celery',
+    }
+
 .. setting:: database_table_names
 
 ``database_table_names``

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -217,7 +217,6 @@ class test_DatabaseBackend:
         assert 'foo', repr(TaskSet('foo' in None))
 
 
-
 @skip.unless_module('sqlalchemy')
 @skip.if_pypy()
 @skip.if_jython()

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -79,6 +79,15 @@ class test_DatabaseBackend:
         with pytest.raises(ImproperlyConfigured):
             DatabaseBackend(app=self.app)
 
+    def test_table_schema_config(self):
+        self.app.conf.database_table_schemas = {
+            'task': 'foo',
+            'group': 'bar',
+        }
+        tb = DatabaseBackend(self.uri, app=self.app)
+        assert tb.task_cls.__table__.schema == 'foo'
+        assert tb.taskset_cls.__table__.schema == 'bar'
+
     def test_missing_task_id_is_PENDING(self):
         tb = DatabaseBackend(self.uri, app=self.app)
         assert tb.get_state('xxx-does-not-exist') == states.PENDING
@@ -206,6 +215,7 @@ class test_DatabaseBackend:
 
     def test_TaskSet__repr__(self):
         assert 'foo', repr(TaskSet('foo' in None))
+
 
 
 @skip.unless_module('sqlalchemy')


### PR DESCRIPTION
These changes make it possible to configure the schema in which the result tables should be created when using a PostgreSQL database as result backend. 

Fixes #1013 