### PR TITLE
Fix raise issue to make exception message more friendly

### DIFF
--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -383,7 +383,7 @@ def find_app(app, symbol_by_name=symbol_by_name, imp=import_from_cwd):
             try:
                 found = sym.celery
                 if isinstance(found, ModuleType):
-                    raise AttributeError()
+                    raise AttributeError("attribute 'celery' is the celery module not the instance of celery")
             except AttributeError:
                 if getattr(sym, '__path__', None):
                     try:

--- a/t/unit/bin/proj/app2.py
+++ b/t/unit/bin/proj/app2.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import, unicode_literals
+
+import celery  # noqa: F401

--- a/t/unit/bin/test_base.py
+++ b/t/unit/bin/test_base.py
@@ -236,6 +236,8 @@ class test_Command:
         assert cmd.find_app('t.unit.bin.proj.hello')
         assert cmd.find_app('t.unit.bin.proj.app:app')
         assert cmd.find_app('t.unit.bin.proj.app.app')
+        with pytest.raises(AttributeError, match='is the celery module'):
+            cmd.find_app('t.unit.bin.proj.app2')
         with pytest.raises(AttributeError):
             cmd.find_app('t.unit.bin')
 


### PR DESCRIPTION
Signed-off-by: Chenyang Yan <memory.yancy@gmail.com>
```
Traceback (most recent call last):
  File "/tmp/venv/site-packages/celery/app/utils.py", line 379, in find_app
    found = sym.app
AttributeError: module 'demo' has no attribute 'app'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/venv/site-packages/celery/bin/base.py", line 289, in execute_from_commandline
    argv = self.setup_app_from_commandline(argv)
  File "/tmp/venv/site-packages/celery/bin/base.py", line 509, in setup_app_from_commandline
    self.app = self.find_app(app)
  File "/tmp/venv/site-packages/celery/bin/base.py", line 531, in find_app
    return find_app(app, symbol_by_name=self.symbol_by_name)
  File "/tmp/venv/site-packages/celery/app/utils.py", line 386, in find_app
    raise AttributeError()
AttributeError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/venv/bin/celery", line 10, in <module>
    sys.exit(main())
  File "/tmp/venv/site-packages/celery/__main__.py", line 16, in main
    _main()
  File "/tmp/venv/site-packages/celery/bin/celery.py", line 322, in main
    cmd.execute_from_commandline(argv)
  File "/tmp/venv/site-packages/celery/bin/celery.py", line 495, in execute_from_commandline
    super(CeleryCommand, self).execute_from_commandline(argv)))
  File "/tmp/venv/site-packages/celery/bin/base.py", line 300, in execute_from_commandline
    msg = e.args[0].capitalize()
IndexError: tuple index out of range
```
A simple demo:
```
In [56]: try: 
    ...:     foo = list().fake 
    ...: except AttributeError: 
    ...:     # fake case for celery.bin.base.Command#setup_app_from_commandline  try...except
    ...:     try: 
    ...:         raise AttributeError() 
    ...:     except AttributeError as e: 
    ...:         print(e.args) 
    ...:             
()
```