### PR TITLE
Pass `interval` to `get_many`

### DIFF
--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -200,6 +200,7 @@ class AsyncBackendMixin(object):
         return self.result_consumer._wait_for_pending(
             result, timeout=timeout,
             on_interval=on_interval, on_message=on_message,
+            **kwargs,
         )
 
     @property

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -200,7 +200,7 @@ class AsyncBackendMixin(object):
         return self.result_consumer._wait_for_pending(
             result, timeout=timeout,
             on_interval=on_interval, on_message=on_message,
-            **kwargs,
+            **kwargs
         )
 
     @property

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -114,7 +114,7 @@ class ResultConsumer(BaseResultConsumer):
         self._consume_from(initial_task_id)
 
     def on_wait_for_pending(self, result, **kwargs):
-        for meta in result._iter_meta():
+        for meta in result._iter_meta(**kwargs):
             if meta is not None:
                 self.on_state_change(meta, None)
 

--- a/celery/result.py
+++ b/celery/result.py
@@ -834,9 +834,9 @@ class ResultSet(ResultBase):
                 acc[order_index[task_id]] = value
         return acc
 
-    def _iter_meta(self):
+    def _iter_meta(self, **kwargs):
         return (meta for _, meta in self.backend.get_many(
-            {r.id for r in self.results}, max_iterations=1,
+            {r.id for r in self.results}, max_iterations=1, **kwargs,
         ))
 
     def _failed_join_report(self):

--- a/celery/result.py
+++ b/celery/result.py
@@ -836,7 +836,7 @@ class ResultSet(ResultBase):
 
     def _iter_meta(self, **kwargs):
         return (meta for _, meta in self.backend.get_many(
-            {r.id for r in self.results}, max_iterations=1, **kwargs,
+            {r.id for r in self.results}, max_iterations=1, **kwargs
         ))
 
     def _failed_join_report(self):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

`kwargs` is not passed to `_iter_meta`, `_wait_for_pending`.  Due to this, options like `interval` are ignored.

Fixes #5930 