### PR TITLE
update docs for json serializer and add note for int keys serialization

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -209,7 +209,7 @@ class Task(object):
     store_errors_even_if_ignored = None
 
     #: The name of a serializer that are registered with
-    #: :mod:`kombu.serialization.registry`.  Default is `'pickle'`.
+    #: :mod:`kombu.serialization.registry`.  Default is `'json'`.
     serializer = None
 
     #: Hard time limit.

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -447,6 +447,16 @@ json -- JSON is supported in many programming languages, is now
 
     See http://json.org for more information.
 
+    .. note::
+
+      (From Python official docs https://docs.python.org/3.6/library/json.html)
+      Keys in key/value pairs of JSON are always of the type :class:`str`. When
+      a dictionary is converted into JSON, all the keys of the dictionary are
+      coerced to strings. As a result of this, if a dictionary is converted
+      into JSON and then back into a dictionary, the dictionary may not equal
+      the original one. That is, ``loads(dumps(x)) != x`` if x has non-string
+      keys.
+
 pickle -- If you have no desire to support any language other than
     Python, then using the pickle encoding will gain you the support of
     all built-in Python data types (except class instances), smaller


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
Added clarification on json serialization for key conversion. Also fixed mentioned default serializer in kombu wich is `json` now
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
