### PR TITLE
fix indentation for note block in calling.rst

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -275,3 +275,4 @@ Shashank Parekh, 2019/07/11
 Arel Cordero, 2019/08/29
 Kyle Johnson, 2019/09/23
 Dipankar Achinta, 2019/10/24
+Sardorbek Imomaliev, 2020/01/24

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -449,13 +449,13 @@ json -- JSON is supported in many programming languages, is now
 
     .. note::
 
-      (From Python official docs https://docs.python.org/3.6/library/json.html)
-      Keys in key/value pairs of JSON are always of the type :class:`str`. When
-      a dictionary is converted into JSON, all the keys of the dictionary are
-      coerced to strings. As a result of this, if a dictionary is converted
-      into JSON and then back into a dictionary, the dictionary may not equal
-      the original one. That is, ``loads(dumps(x)) != x`` if x has non-string
-      keys.
+        (From Python official docs https://docs.python.org/3.6/library/json.html)
+        Keys in key/value pairs of JSON are always of the type :class:`str`. When
+        a dictionary is converted into JSON, all the keys of the dictionary are
+        coerced to strings. As a result of this, if a dictionary is converted
+        into JSON and then back into a dictionary, the dictionary may not equal
+        the original one. That is, ``loads(dumps(x)) != x`` if x has non-string
+        keys.
 
 pickle -- If you have no desire to support any language other than
     Python, then using the pickle encoding will gain you the support of


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
Note block was wrongly indented in #5932. And added myself to contributors
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
