### PR TITLE
Fixed problem with conflicting autoretry_for task parameter and Task.replace()

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -23,7 +23,7 @@ from celery._state import (_announce_app_finalized, _deregister_app,
                            _register_app, _set_current_app, _task_stack,
                            connect_on_app_finalize, get_current_app,
                            get_current_worker_task, set_default_app)
-from celery.exceptions import AlwaysEagerIgnored, ImproperlyConfigured
+from celery.exceptions import AlwaysEagerIgnored, ImproperlyConfigured, Ignore
 from celery.five import (UserDict, bytes_if_py2, python_2_unicode_compatible,
                          values)
 from celery.loaders import get_loader_cls
@@ -485,6 +485,10 @@ class Celery(object):
                 def run(*args, **kwargs):
                     try:
                         return task._orig_run(*args, **kwargs)
+                    except Ignore:
+                        # If Ignore signal occures task shouldn't be retried,
+                        # even if it suits autoretry_for list
+                        raise
                     except autoretry_for as exc:
                         if retry_backoff:
                             retry_kwargs['countdown'] = \

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -271,7 +271,12 @@ class TasksCase:
         def task_replaced_by_other_task(self):
             return self.replace(task_replacing_another_task.si())
 
+        @self.app.task(bind=True, autoretry_for=(Exception,))
+        def task_replaced_by_other_task_with_autoretry(self):
+            return self.replace(task_replacing_another_task.si())
+
         self.task_replaced_by_other_task = task_replaced_by_other_task
+        self.task_replaced_by_other_task_with_autoretry = task_replaced_by_other_task_with_autoretry
 
         # Remove all messages from memory-transport
         from kombu.transport.memory import Channel
@@ -929,6 +934,10 @@ class test_tasks(TasksCase):
     def test_replace_run(self):
         with pytest.raises(Ignore):
             self.task_replaced_by_other_task.run()
+
+    def test_replace_run_with_autoretry(self):
+        with pytest.raises(Ignore):
+            self.task_replaced_by_other_task_with_autoretry.run()
 
     def test_replace_delay(self):
         res = self.task_replaced_by_other_task.delay()


### PR DESCRIPTION
## Description
When task has `autoretry_for=(Exception,)` attribute, it catches `celery.exceptions.Ignore` exception and makes retries of original task. This behavior is incorrect as it leads to multiple executions of task, even if it succeeds.

How to reproduce:
```python
@shared_task(queue='second')
def executed_task():
    print('hello world')

@shared_task(queue='first', autoretry_for=(Exception,), bind=True)
def replaced_task(self):
    sig = executed_task.s()
    return self.replace(sig)

if __name__ == '__main__':
    replaced_task.delay()
```
1. `replace_task.delay()` writes task to broker
2. `replaced_task` executes, plans `executed_task` over `apply_async` and raises `Ignore` exception
3. `autoretry_for` catches `Ignore` exception and plans retry of `replaced_task`
4. Repeat from step 2 until retry attempts end...
As a result, `executed_task` is called several times.
