### PR TITLE
Add labels automatically for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug-Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug-Report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug Report
 about: Is something wrong with Celery?
+labels: Issue Type: Bug Report
 ---
 <!--
 Please fill this template entirely and do not erase parts of it.

--- a/.github/ISSUE_TEMPLATE/Documentation-Bug-Report.md
+++ b/.github/ISSUE_TEMPLATE/Documentation-Bug-Report.md
@@ -1,6 +1,7 @@
 ---
 name: Documentation Bug Report
 about: Is something wrong with our documentation?
+labels: Issue Type: Bug Report, Category: Documentation
 ---
 <!--
 Please fill this template entirely and do not erase parts of it.

--- a/.github/ISSUE_TEMPLATE/Enhancement.md
+++ b/.github/ISSUE_TEMPLATE/Enhancement.md
@@ -1,6 +1,7 @@
 ---
 name: Enhancement
 about: Do you want to improve an existing feature?
+labels: Issue Type: Enhancement
 ---
 <!--
 Please fill this template entirely and do not erase parts of it.

--- a/.github/ISSUE_TEMPLATE/Feature-Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature-Request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature Request
 about: Do you need a new feature?
+labels: Issue Type: Feature Request
 ---
 <!--
 Please fill this template entirely and do not erase parts of it.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

I recently discovered that Github can automatically add labels to newly opened issues.
This should save us at least some work during issue triage.