### PR TITLE
 Fix labels on Github issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug-Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug-Report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Is something wrong with Celery?
-labels: Issue Type: Bug Report
+labels: "Issue Type: Bug Report"
 ---
 <!--
 Please fill this template entirely and do not erase parts of it.

--- a/.github/ISSUE_TEMPLATE/Documentation-Bug-Report.md
+++ b/.github/ISSUE_TEMPLATE/Documentation-Bug-Report.md
@@ -1,7 +1,7 @@
 ---
 name: Documentation Bug Report
 about: Is something wrong with our documentation?
-labels: Issue Type: Bug Report, Category: Documentation
+labels: "Issue Type: Bug Report, Category: Documentation"
 ---
 <!--
 Please fill this template entirely and do not erase parts of it.

--- a/.github/ISSUE_TEMPLATE/Enhancement.md
+++ b/.github/ISSUE_TEMPLATE/Enhancement.md
@@ -1,7 +1,7 @@
 ---
 name: Enhancement
 about: Do you want to improve an existing feature?
-labels: Issue Type: Enhancement
+labels: "Issue Type: Enhancement"
 ---
 <!--
 Please fill this template entirely and do not erase parts of it.

--- a/.github/ISSUE_TEMPLATE/Feature-Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature-Request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Do you need a new feature?
-labels: Issue Type: Feature Request
+labels: "Issue Type: Feature Request"
 ---
 <!--
 Please fill this template entirely and do not erase parts of it.


### PR DESCRIPTION
Fixes #5938, which broke most of the issue templates.

Currently, navigating to https://github.com/celery/celery/issues/new/choose now only displays the "Minor Version Release Checklist" template:

![Screenshot from 2020-02-04 12-53-40](https://user-images.githubusercontent.com/49076/73772021-66255d00-474d-11ea-8959-949b7f2b9749.png)

This pull request escapes the labels in the template files (so that their colons don't cause the template to break) ~~and changes the "Documentation Bug Report" template to only use one label (since using multiple escaped labels also breaks the template)~~.