### PR TITLE
Use gevent and eventlet wait() functions to remove busy-wait

### DIFF
--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -8,7 +8,6 @@ from time import sleep
 from weakref import WeakKeyDictionary
 
 from kombu.utils.compat import detect_environment
-from kombu.utils.objects import cached_property
 
 from celery import states
 from celery.exceptions import TimeoutError
@@ -44,7 +43,7 @@ class Drainer(object):
     def stop(self):
         pass
 
-    def drain_events_until(self, p, timeout=None, on_interval=None, wait=None):
+    def drain_events_until(self, p, timeout=None, interval=1, on_interval=None, wait=None):
         wait = wait or self.result_consumer.drain_events
         time_start = monotonic()
 
@@ -53,7 +52,7 @@ class Drainer(object):
             if timeout and monotonic() - time_start >= timeout:
                 raise socket.timeout()
             try:
-                yield self.wait_for(p, wait, timeout=1)
+                yield self.wait_for(p, wait, timeout=interval)
             except socket.timeout:
                 pass
             if on_interval:
@@ -97,10 +96,11 @@ class greenletDrainer(Drainer):
 @register_drainer('eventlet')
 class eventletDrainer(greenletDrainer):
 
-    @cached_property
-    def spawn(self):
-        from eventlet import spawn
-        return spawn
+    def spawn(self, func):
+        from eventlet import spawn, sleep
+        g = spawn(func)
+        sleep(0)
+        return g
 
     def wait_for(self, p, wait, timeout=None):
         self.start()
@@ -111,10 +111,11 @@ class eventletDrainer(greenletDrainer):
 @register_drainer('gevent')
 class geventDrainer(greenletDrainer):
 
-    @cached_property
-    def spawn(self):
-        from gevent import spawn
-        return spawn
+    def spawn(self, func):
+        from gevent import spawn, sleep
+        g = spawn(func)
+        sleep(0)
+        return g
 
     def wait_for(self, p, wait, timeout=None):
         import gevent

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -1,3 +1,4 @@
+import os
 import socket
 import time
 import threading
@@ -8,6 +9,12 @@ from vine import promise
 
 from celery.backends.asynchronous import BaseResultConsumer
 from celery.backends.base import Backend
+
+
+@pytest.fixture(autouse=True)
+def setup_eventlet():
+    # By default eventlet will patch the DNS resolver when imported.
+    os.environ.update(EVENTLET_NO_GREENDNS='yes')
 
 
 class DrainerTests(object):

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -1,0 +1,122 @@
+import socket
+import time
+import threading
+
+import pytest
+from case import patch, skip, Mock
+from vine import promise
+
+from celery.backends.asynchronous import BaseResultConsumer
+from celery.backends.base import Backend
+
+
+class DrainerTests(object):
+    """
+    Base test class for the Default / Gevent / Eventlet drainers.
+    """
+
+    interval = 0.1  # Check every tenth of a second
+
+    def get_drainer(self, environment):
+        with patch('celery.backends.asynchronous.detect_environment') as d:
+            d.return_value = environment
+            backend = Backend(self.app)
+            consumer = BaseResultConsumer(backend, self.app, backend.accept,
+                                          pending_results={},
+                                          pending_messages={})
+            return consumer.drainer
+
+    @pytest.fixture(autouse=True)
+    def setup_drainer(self):
+        raise NotImplementedError
+
+    @pytest.fixture(autouse=True)
+    def setup_drain_events(self):
+        drain_events = self.patching(
+            'celery.backends.asynchronous.BaseResultConsumer.drain_events')
+        drain_events.side_effect = self.result_consumer_drain_events
+
+    def result_consumer_drain_events(self, timeout=None):
+        """
+        Subclasses should override this method to define the behavior of
+        drainer.result_consumer.drain_events.
+        """
+        raise NotImplementedError
+
+    def fulfill_promise_after(self, p, after_seconds):
+        """
+        Subclasses should override this method to fulfill the promise after a number of seconds
+        have passed.
+        """
+        raise NotImplementedError
+
+    def test_drain_backend_checks_on_interval(self):
+        p = promise()
+
+        def fulfill_promise_thread():
+            # Should run on_interval twice - once (no results) then a second time after the
+            # promise is seen to be ready.
+            time.sleep(self.interval * 2 - (self.interval / 2))
+            p('done')
+
+        threading.Thread(target=fulfill_promise_thread).start()
+
+        on_interval = Mock()
+        for _ in self.drainer.drain_events_until(p,
+                                                 on_interval=on_interval,
+                                                 interval=self.interval):
+            pass
+
+        assert p.ready, 'Should have terminated with promise being ready'
+        assert on_interval.call_count == 2, 'Should only have called on_interval twice'
+
+    def test_drain_backend_timeout(self):
+        p = promise()
+        on_interval = Mock()
+
+        # Looking for 6 checks against the on_interval mock
+        timeout = (self.interval * 5) + self.interval / 2
+        with pytest.raises(socket.timeout):
+            for _ in self.drainer.drain_events_until(p,
+                                                     on_interval=on_interval,
+                                                     interval=self.interval,
+                                                     timeout=timeout):
+                pass
+
+        assert not p.ready
+        assert on_interval.call_count == 6, 'Should have called on_interval six times'
+
+
+@skip.unless_module('eventlet')
+class test_EventletDrainer(DrainerTests):
+    @pytest.fixture(autouse=True)
+    def setup_drainer(self):
+        self.drainer = self.get_drainer('eventlet')
+
+    def fulfill_promise_after(self, p, after_seconds):
+        import eventlet
+        eventlet.spawn_after(after_seconds, lambda: p('done'))
+
+    def result_consumer_drain_events(self, timeout=None):
+        import eventlet
+        eventlet.sleep(0)
+
+
+class test_Drainer(DrainerTests):
+    @pytest.fixture(autouse=True)
+    def setup_drainer(self):
+        self.drainer = self.get_drainer('default')
+
+    def result_consumer_drain_events(self, timeout=None):
+        time.sleep(timeout)
+
+
+@skip.unless_module('gevent')
+class test_GeventDrainer(DrainerTests):
+    @pytest.fixture(autouse=True)
+    def setup_drainer(self):
+        self.drainer = self.get_drainer('gevent')
+
+    def result_consumer_drain_events(self, timeout=None):
+        import gevent
+        gevent.sleep(0)


### PR DESCRIPTION
Fixes issue #4999.

## Description

Calling AsyncResult.get() in a gevent context would cause the async Drainer to repeatedly call wait_for until the result was completed (in a CPU-consuming spin loop).  I've updated the code to have a specific implementation for gevent and eventlet that will cause wait_for to only return every "timeout" # of seconds, rather than returning immediately.

## Things I'd Like Feedback On

* The way I did this for the Eventlet interface was to rely on the private _exit_event member of the GreenThread instance; to do this without relying on a private member would require some additional changes to the backend Drainer interface so that we could wait for an eventlet-specific event in wait_for().  I can do this, just wanted to get some feedback before jumping in.
* Another option for this diff would be to use the threading.Event on the greenlet and call `self._shutdown.wait(timeout=timeout)` in the `wait_for` method of the Greenlet.  Pros are that would avoid needing to do different things between gevent/eventlet, but I'm not sure if that will behave correctly if the threading library isn't monkeypatched.  (EDIT: looks like it doesn't, pushed a test case)