### PR TITLE
Fix inspect_command documentation

### DIFF
--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -1157,7 +1157,7 @@ for example one that reads the current prefetch count:
 
     from celery.worker.control import inspect_command
 
-    @inspect_command
+    @inspect_command()
     def current_prefetch_count(state):
         return {'prefetch_count': state.consumer.qos.value}
 


### PR DESCRIPTION
The `inspect_command` must be used as `@inspect_command()` not `@inspect_command`.