### PR TITLE
Fix: Accept and swallow `kwargs` to handle unexpected keyword arguments

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -414,7 +414,7 @@ class AsyncResult(ResultBase):
             return self._maybe_set_cache(self.backend.get_task_meta(self.id))
         return self._cache
 
-    def _iter_meta(self):
+    def _iter_meta(self, **kwargs):
         return iter([self._get_task_meta()])
 
     def _set_cache(self, d):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

#5931 passed `kwargs` to `ResultSet._iter_meta()`, but missed `AsyncResult._iter_meta()`.

See https://github.com/celery/celery/commit/3b564c7c2ffbc8e215ca46e5606023d56785c2a0#commitcomment-37579455

Since `ResultSet._iter_meta()` didn't originally accept arguments, this PR simply accepts and swallows `kwargs`.
