### PR TITLE
Make 'socket_keepalive' optional variable

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -232,10 +232,13 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             'max_connections': self.max_connections,
             'socket_timeout': socket_timeout and float(socket_timeout),
             'retry_on_timeout': retry_on_timeout or False,
-            'socket_keepalive': socket_keepalive or False,
             'socket_connect_timeout':
                 socket_connect_timeout and float(socket_connect_timeout),
         }
+
+        # absent in redis.connection.UnixDomainSocketConnection
+        if socket_keepalive:
+            self.connparams['socket_keepalive'] = socket_keepalive
 
         # "redis_backend_use_ssl" must be a dict with the keys:
         # 'ssl_cert_reqs', 'ssl_ca_certs', 'ssl_certfile', 'ssl_keyfile'

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1109,15 +1109,20 @@ in seconds (int/float), used by the redis result backend.
 ``redis_retry_on_timeout``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 4.4.1
+
 Default: :const:`False`
 
 To retry reading/writing operations on TimeoutError to the Redis server,
-used by the redis result backend.
+used by the redis result backend. Shouldn't set this variable if using Redis
+connection by unix socket.
 
-.. setting:: socket_keepalive
+.. setting:: redis_socket_keepalive
 
-``socket_keepalive``
+``redis_socket_keepalive``
 ~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 4.4.1
 
 Default: :const:`False`
 

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -324,6 +324,7 @@ class test_RedisBackend:
         assert 'port' not in x.connparams
         assert x.connparams['socket_timeout'] == 30.0
         assert 'socket_connect_timeout' not in x.connparams
+        assert 'socket_keepalive' not in x.connparams
         assert x.connparams['db'] == 3
 
     @skip.unless_module('redis')


### PR DESCRIPTION
I propose make 'socket_keepalive' an optional variable to fix #5994.
Also, I've made changes in User Guide (fixed variable names and added `versionadded`)