### PR TITLE
Fix copy-paste error in result_compression docs

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -712,7 +712,7 @@ serialization formats.
 Default: No compression.
 
 Optional compression method used for task results.
-Supports the same options as the :setting:`task_serializer` setting.
+Supports the same options as the :setting:`task_compression` setting.
 
 .. setting:: result_extended
 


### PR DESCRIPTION
## Description

This fixes a copy-paste error in the configuration docs.