### PR TITLE
Add uptime to the stats inspect command

### DIFF
--- a/celery/worker/worker.py
+++ b/celery/worker/worker.py
@@ -17,6 +17,8 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 
+from datetime import datetime
+
 from billiard import cpu_count
 from kombu.utils.compat import detect_environment
 
@@ -93,6 +95,7 @@ class WorkController(object):
     def __init__(self, app=None, hostname=None, **kwargs):
         self.app = app or self.app
         self.hostname = default_nodename(hostname)
+        self.startup_time = datetime.utcnow()
         self.app.loader.init_worker()
         self.on_before_init(**kwargs)
         self.setup_defaults(**kwargs)
@@ -296,9 +299,11 @@ class WorkController(object):
             return reload_from_cwd(sys.modules[module], reloader)
 
     def info(self):
+        uptime = datetime.utcnow() - self.startup_time
         return {'total': self.state.total_count,
                 'pid': os.getpid(),
-                'clock': str(self.app.clock)}
+                'clock': str(self.app.clock),
+                'uptime': round(uptime.total_seconds())}
 
     def rusage(self):
         if resource is None:

--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -924,6 +924,10 @@ The output will include the following fields:
     Value of the workers logical clock. This is a positive integer and should
     be increasing every time you receive statistics.
 
+- ``uptime``
+
+    Numbers of seconds since the worker controller was started
+
 - ``pid``
 
     Process id of the worker instance (Main process).


### PR DESCRIPTION
## Description

Being able to see the uptime of a worker remotely would be a nice addition.
This code adds a "uptime" key to the stats inspect command.

Kind regards
Jerome
