### PR TITLE
Fix backend utf-8 encoding in s3 backend

### DIFF
--- a/celery/backends/s3.py
+++ b/celery/backends/s3.py
@@ -61,7 +61,8 @@ class S3Backend(KeyValueStoreBackend):
         s3_object = self._get_s3_object(key)
         try:
             s3_object.load()
-            return s3_object.get()['Body'].read().decode('utf-8')
+            data = s3_object.get()['Body'].read()
+            return data if self.content_encoding == 'binary' else data.decode('utf-8')
         except botocore.exceptions.ClientError as error:
             if error.response['Error']['Code'] == "404":
                 return None

--- a/t/unit/backends/test_s3.py
+++ b/t/unit/backends/test_s3.py
@@ -98,6 +98,20 @@ class test_S3Backend:
         assert s3_backend.get(key) == 'another_status'
 
     @mock_s3
+    def test_set_and_get_a_result(self):
+        self._mock_s3_resource()
+
+        self.app.conf.result_serializer = 'pickle'
+        self.app.conf.s3_access_key_id = 'somekeyid'
+        self.app.conf.s3_secret_access_key = 'somesecret'
+        self.app.conf.s3_bucket = 'bucket'
+
+        s3_backend = S3Backend(app=self.app)
+        s3_backend.store_result('foo', 'baar', 'STARTED')
+        value = s3_backend.get_result('foo')
+        assert value == 'baar'
+
+    @mock_s3
     def test_get_a_missing_key(self):
         self._mock_s3_resource()
 


### PR DESCRIPTION
Celery backend uses utf-8 to deserialize results,
which would fail for some serializations like pickle.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
We support multiple serialization formats in the backend like JSON, pickle, msgpack and yaml.
UTF-8 decoding is hardcoded in s3 irrespective of serialization format defined in the configuration, which would lead to error in cases someone uses pickle or other non-utf-8 formats. 
 
