### PR TITLE
Upgraded pycurl to the latest version that supports wheel.

### DIFF
--- a/requirements/extras/sqs.txt
+++ b/requirements/extras/sqs.txt
@@ -1,2 +1,2 @@
 boto3>=1.9.125
-pycurl==7.43.0.2  # Latest version with wheel built (for appveyor)
+pycurl==7.43.0.5  # Latest version with wheel built (for appveyor)

--- a/requirements/test-ci-default.txt
+++ b/requirements/test-ci-default.txt
@@ -21,4 +21,4 @@
 -r extras/azureblockblob.txt
 
 # SQS dependencies other than boto
-pycurl==7.43.0.2  # Latest version with wheel built (for appveyor)
+pycurl==7.43.0.5  # Latest version with wheel built (for appveyor)


### PR DESCRIPTION
## Description

The version of pycurl is pinned by #5887.

However pycurl 7.43.0.2 has problem to install.
https://github.com/pycurl/pycurl/issues/526

And the latest version of pycurl 7.43.0.5 fixes this problem and also supports wheel.
https://pypi.org/project/pycurl/7.43.0.5/#files