### PR TITLE
Link to task options in task decorator docs

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -369,6 +369,9 @@ class Celery(object):
     def task(self, *args, **opts):
         """Decorator to create a task class out of any callable.
 
+        See :ref:`Task options<task-options>` for a list of the
+        arguments that can be passed to this decorator.
+
         Examples:
             .. code-block:: python
 


### PR DESCRIPTION
I had a hard time finding where this was documented. It would be better if `task` had a useful function signature, but that's harder.