### PR TITLE
Fixing issue #6019: unable to use mysql SSL parameters when getting mysql engine

### DIFF
--- a/celery/backends/database/session.py
+++ b/celery/backends/database/session.py
@@ -39,7 +39,9 @@ class SessionManager(object):
                 engine = self._engines[dburi] = create_engine(dburi, **kwargs)
                 return engine
         else:
-            return create_engine(dburi, poolclass=NullPool)
+            kwargs = dict([(k, v) for k, v in kwargs.items() if
+                           not k.startswith('pool')])
+            return create_engine(dburi, poolclass=NullPool, **kwargs)
 
     def create_session(self, dburi, short_lived_sessions=False, **kwargs):
         engine = self.get_engine(dburi, **kwargs)

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -317,6 +317,14 @@ class test_SessionManager:
         engine2 = s.get_engine('dburi', foo=1)
         assert engine2 is engine
 
+    @patch('celery.backends.database.session.create_engine')
+    def test_get_engine_kwargs(self, create_engine):
+        s = SessionManager()
+        engine = s.get_engine('dbur', foo=1, pool_size=5)
+        assert engine is create_engine()
+        engine2 = s.get_engine('dburi', foo=1)
+        assert engine2 is engine
+
     @patch('celery.backends.database.session.sessionmaker')
     def test_create_session_forked(self, sessionmaker):
         s = SessionManager()


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
(Fixes #6019) 

**kwargs for the mysql creat_engine() function were removed in the case that self.forked is False (https://github.com/celery/celery/commit/94dae1b899aae6ae2ca333773fddbc6dd603213c) due to issue #1903. However, this causes other database engine options to not be used, such as the SSL certs when the `ResultSession` is made. This fix ignores args in the database engine options that start with `pool` while still applying the others. A detailed description of this issue can be found at https://github.com/celery/celery/issues/6019. 

https://docs.sqlalchemy.org/en/13/core/engines.html#sqlalchemy.create_engine.params.pool
The SQLalchemy documentation shows all of the possible engine args. 
Here are the ones containing `pool`:
pool
poolclass
pool_logging_name
pool_pre_ping
pool_size
pool_recycle
pool_reset_on_return
pool_timeout
pool_use_lifo 
echo_pool

In the description of `pool_size` it says: "to disable pooling, set poolclass to NullPool instead"
Therefore, none of these `pool` args will be needed since `poolclass` is set to NullPool. 