### PR TITLE
Clean TraceBack to reduce memory leaks for exception task

### DIFF
--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -269,7 +269,7 @@ def traceback_clear(exc=None):
     else:
         _, _, tb = sys.exc_info()
 
-    if sys.version_info >= (3, 4, 0):
+    if sys.version_info >= (3, 5, 0):
         while tb is not None:
             try:
                 tb.tb_frame.clear()

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -273,6 +273,7 @@ def traceback_clear(exc=None):
         while tb is not None:
             try:
                 tb.tb_frame.clear()
+                tb.tb_frame.f_locals
             except RuntimeError:
                 # Ignore the exception raised if the frame is still executing.
                 pass

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -82,7 +82,8 @@ Task %(name)s[%(id)s] retry: %(exc)s\
 """
 
 log_policy_t = namedtuple(
-    'log_policy_t', ('format', 'description', 'severity', 'traceback', 'mail'),
+    'log_policy_t',
+    ('format', 'description', 'severity', 'traceback', 'mail'),
 )
 
 log_policy_reject = log_policy_t(LOG_REJECTED, 'rejected', logging.WARN, 1, 1)
@@ -256,6 +257,30 @@ class TraceInfo(object):
                    extra={'data': context})
 
 
+def traceback_clear(exc=None):
+    # Cleared Tb, but einfo still has a reference to Traceback.
+    # exc cleans up the Traceback at the last moment that can be revealed.
+    tb = None
+    if exc is not None:
+        if hasattr(exc, '__traceback__'):
+            tb = exc.__traceback__
+        else:
+            _, _, tb = sys.exc_info()
+    else:
+        _, _, tb = sys.exc_info()
+
+    if sys.version_info >= (3, 4, 0):
+        while tb is not None:
+            try:
+                tb.tb_frame.clear()
+            except RuntimeError:
+                # Ignore the exception raised if the frame is still executing.
+                pass
+            tb = tb.tb_next
+
+    elif (2, 7, 0) <= sys.version_info < (3, 0, 0):
+        sys.exc_clear()
+
 def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                  Info=TraceInfo, eager=False, propagate=False, app=None,
                  monotonic=monotonic, trace_ok_t=trace_ok_t,
@@ -381,7 +406,6 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                     )
 
                 # -*- TRACE -*-
-                used_exc_in_einfo = None
                 try:
                     R = retval = fun(*args, **kwargs)
                     state = SUCCESS
@@ -389,19 +413,19 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                     I, R = Info(REJECTED, exc), ExceptionInfo(internal=True)
                     state, retval = I.state, I.retval
                     I.handle_reject(task, task_request)
-                    used_exc_in_einfo = exc
+                    traceback_clear(exc)
                 except Ignore as exc:
                     I, R = Info(IGNORED, exc), ExceptionInfo(internal=True)
                     state, retval = I.state, I.retval
                     I.handle_ignore(task, task_request)
-                    used_exc_in_einfo = exc
+                    traceback_clear(exc)
                 except Retry as exc:
                     I, R, state, retval = on_error(
                         task_request, exc, uuid, RETRY, call_errbacks=False)
-                    used_exc_in_einfo = exc
+                    traceback_clear(exc)
                 except Exception as exc:
                     I, R, state, retval = on_error(task_request, exc, uuid)
-                    used_exc_in_einfo = exc
+                    traceback_clear(exc)
                 except BaseException:
                     raise
                 else:
@@ -469,20 +493,6 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                                 'return_value': Rstr,
                                 'runtime': T,
                             })
-                finally:
-                    #Cleared Tb, but einfo still has a reference to Traceback.
-                    # exc cleans up the Traceback at the last moment that can be revealed.
-                    if used_exc_in_einfo is not None:
-                        if hasattr(used_exc_in_einfo,'__traceback__'):
-                            tb = used_exc_in_einfo.__traceback__
-                            while tb is not None:
-                                try:
-                                    tb.tb_frame.clear()
-                                except RuntimeError:
-                                    # Ignore the exception raised if the frame is still executing.
-                                    pass
-                                tb = tb.tb_next
-                    del used_exc_in_einfo
 
                 # -* POST *-
                 if state not in IGNORE_STATES:

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -600,13 +600,6 @@ def report_internal_error(task, exc):
                 exc, exc_info.traceback)))
         return exc_info
     finally:
-        while _tb is not None:
-            try:
-                _tb.tb_frame.clear()
-            except RuntimeError:
-                # Ignore the exception raised if the frame is still executing.
-                pass
-            _tb = _tb.tb_next
         del _tb
 
 

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -256,13 +256,18 @@ class Backend(object):
             self.mark_as_failure(task_id, exc, exception_info.traceback)
             return exception_info
         finally:
-            while tb is not None:
-                try:
-                    tb.tb_frame.clear()
-                except RuntimeError:
-                    # Ignore the exception raised if the frame is still executing.
-                    pass
-                tb = tb.tb_next
+            if sys.version_info >= (3, 4, 0):
+                while tb is not None:
+                    try:
+                        tb.tb_frame.clear()
+                    except RuntimeError:
+                        # Ignore the exception raised if the frame is still executing.
+                        pass
+                    tb = tb.tb_next
+
+            elif (2, 7, 0) <= sys.version_info < (3, 0, 0):
+                sys.exc_clear()
+
             del tb
 
     def prepare_exception(self, exc, serializer=None):

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -260,6 +260,7 @@ class Backend(object):
                 while tb is not None:
                     try:
                         tb.tb_frame.clear()
+                        tb.tb_frame.f_locals
                     except RuntimeError:
                         # Ignore the exception raised if the frame is still executing.
                         pass

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -256,7 +256,7 @@ class Backend(object):
             self.mark_as_failure(task_id, exc, exception_info.traceback)
             return exception_info
         finally:
-            if sys.version_info >= (3, 4, 0):
+            if sys.version_info >= (3, 5, 0):
                 while tb is not None:
                     try:
                         tb.tb_frame.clear()

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -256,6 +256,13 @@ class Backend(object):
             self.mark_as_failure(task_id, exc, exception_info.traceback)
             return exception_info
         finally:
+            while tb is not None:
+                try:
+                    tb.tb_frame.clear()
+                except RuntimeError:
+                    # Ignore the exception raised if the frame is still executing.
+                    pass
+                tb = tb.tb_next
             del tb
 
     def prepare_exception(self, exc, serializer=None):

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -383,10 +383,19 @@ class test_BaseBackend_dict:
         self.b.reload_task_result('task-exists')
         self.b._cache['task-exists'] = {'result': 'task'}
 
+
     def test_fail_from_current_stack(self):
+        import inspect
         self.b.mark_as_failure = Mock()
-        try:
+        frame_list = []
+
+        def raise_dummy():
+            frame_str_temp = str(inspect.currentframe().__repr__)
+            frame_list.append(frame_str_temp)
+            local_value = 1214
             raise KeyError('foo')
+        try:
+            raise_dummy()
         except KeyError as exc:
             self.b.fail_from_current_stack('task_id')
             self.b.mark_as_failure.assert_called()
@@ -394,6 +403,13 @@ class test_BaseBackend_dict:
             assert args[0] == 'task_id'
             assert args[1] is exc
             assert args[2]
+
+            tb_ = exc.__traceback__
+            while tb_ is not None:
+                if str(tb_.tb_frame.__repr__) == frame_list[0]:
+                    assert len(tb_.tb_frame.f_locals) == 0
+                tb_ = tb_.tb_next
+
 
     def test_prepare_value_serializes_group_result(self):
         self.b.serializer = 'json'

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -389,6 +389,9 @@ class test_BaseBackend_dict:
         self.b.mark_as_failure = Mock()
         frame_list = []
 
+        if (2, 7, 0) <= sys.version_info < (3, 0, 0):
+            sys.exc_clear = Mock()
+
         def raise_dummy():
             frame_str_temp = str(inspect.currentframe().__repr__)
             frame_list.append(frame_str_temp)
@@ -404,11 +407,14 @@ class test_BaseBackend_dict:
             assert args[1] is exc
             assert args[2]
 
-            tb_ = exc.__traceback__
-            while tb_ is not None:
-                if str(tb_.tb_frame.__repr__) == frame_list[0]:
-                    assert len(tb_.tb_frame.f_locals) == 0
-                tb_ = tb_.tb_next
+            if sys.version_info >= (3, 4, 0):
+                tb_ = exc.__traceback__
+                while tb_ is not None:
+                    if str(tb_.tb_frame.__repr__) == frame_list[0]:
+                        assert len(tb_.tb_frame.f_locals) == 0
+                    tb_ = tb_.tb_next
+            elif (2, 7, 0) <= sys.version_info < (3, 0, 0):
+                sys.exc_clear.assert_called()
 
 
     def test_prepare_value_serializes_group_result(self):

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -407,7 +407,7 @@ class test_BaseBackend_dict:
             assert args[1] is exc
             assert args[2]
 
-            if sys.version_info >= (3, 4, 0):
+            if sys.version_info >= (3, 5, 0):
                 tb_ = exc.__traceback__
                 while tb_ is not None:
                     if str(tb_.tb_frame.__repr__) == frame_list[0]:

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -167,7 +167,7 @@ class test_trace(TraceCase):
         except KeyError as exc:
             traceback_clear(exc)
 
-            if sys.version_info >= (3, 4, 0):
+            if sys.version_info >= (3, 5, 0):
                 tb_ = exc.__traceback__
                 while tb_ is not None:
                     if str(tb_.tb_frame.__repr__) == frame_list[0]:
@@ -181,7 +181,7 @@ class test_trace(TraceCase):
         except KeyError as exc:
             traceback_clear()
 
-            if sys.version_info >= (3, 4, 0):
+            if sys.version_info >= (3, 5, 0):
                 tb_ = exc.__traceback__
                 while tb_ is not None:
                     if str(tb_.tb_frame.__repr__) == frame_list[0]:
@@ -195,7 +195,7 @@ class test_trace(TraceCase):
         except KeyError as exc:
             traceback_clear(str(exc))
 
-            if sys.version_info >= (3, 4, 0):
+            if sys.version_info >= (3, 5, 0):
                 tb_ = exc.__traceback__
                 while tb_ is not None:
                     if str(tb_.tb_frame.__repr__) == frame_list[0]:

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -326,6 +326,7 @@ class test_trace(TraceCase):
         _, info = self.trace(self.raises, (exc,), {})
         assert info.state == states.RETRY
         assert info.retval is exc
+        mock_traceback_clear.assert_called()
 
     @patch('celery.app.trace.traceback_clear')
     def test_trace_exception(self, mock_traceback_clear):
@@ -333,6 +334,7 @@ class test_trace(TraceCase):
         _, info = self.trace(self.raises, (exc,), {})
         assert info.state == states.FAILURE
         assert info.retval is exc
+        mock_traceback_clear.assert_called()
 
     def test_trace_task_ret__no_content_type(self):
         _trace_task_ret(

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -12,7 +12,9 @@ from celery.app.trace import (TraceInfo, _fast_trace_task, _trace_task_ret,
                               log_policy_internal, log_policy_reject,
                               log_policy_unexpected,
                               reset_worker_optimizations,
-                              setup_worker_optimizations, trace_task)
+                              setup_worker_optimizations, trace_task,
+                              traceback_clear)
+
 from celery.exceptions import Ignore, Reject, Retry
 
 
@@ -150,7 +152,32 @@ class test_trace(TraceCase):
         with pytest.raises(MemoryError):
             self.trace(add, (2, 2), {}, eager=False)
 
-    def test_when_Ignore(self):
+    def test_traceback_clear(self):
+        import inspect, sys
+        sys.exc_clear = Mock()
+        frame_list =[]
+
+        def raise_dummy():
+            frame_str_temp = str(inspect.currentframe().__repr__)
+            frame_list.append(frame_str_temp)
+            local_value = 1214
+            raise KeyError('foo')
+        try:
+            raise_dummy()
+        except KeyError as exc:
+            traceback_clear(exc)
+
+            if sys.version_info >= (3, 4, 0):
+                tb_ = exc.__traceback__
+                while tb_ is not None:
+                    if str(tb_.tb_frame.__repr__) == frame_list[0]:
+                        assert len(tb_.tb_frame.f_locals) == 0
+                    tb_ = tb_.tb_next
+            elif (2, 7, 0) <= sys.version_info < (3, 0, 0):
+                sys.exc_clear.assert_called()
+
+    @patch('celery.app.trace.traceback_clear')
+    def test_when_Ignore(self, mock_traceback_clear):
 
         @self.app.task(shared=False)
         def ignored():
@@ -158,8 +185,10 @@ class test_trace(TraceCase):
 
         retval, info = self.trace(ignored, (), {})
         assert info.state == states.IGNORED
+        mock_traceback_clear.assert_called()
 
-    def test_when_Reject(self):
+    @patch('celery.app.trace.traceback_clear')
+    def test_when_Reject(self, mock_traceback_clear):
 
         @self.app.task(shared=False)
         def rejecting():
@@ -167,6 +196,7 @@ class test_trace(TraceCase):
 
         retval, info = self.trace(rejecting, (), {})
         assert info.state == states.REJECTED
+        mock_traceback_clear.assert_called()
 
     def test_backend_cleanup_raises(self):
         self.add.backend.process_cleanup = Mock()
@@ -262,13 +292,15 @@ class test_trace(TraceCase):
         with pytest.raises(SystemExit):
             self.trace(self.raises, (SystemExit(),), {})
 
-    def test_trace_Retry(self):
+    @patch('celery.app.trace.traceback_clear')
+    def test_trace_Retry(self, mock_traceback_clear):
         exc = Retry('foo', 'bar')
         _, info = self.trace(self.raises, (exc,), {})
         assert info.state == states.RETRY
         assert info.retval is exc
 
-    def test_trace_exception(self):
+    @patch('celery.app.trace.traceback_clear')
+    def test_trace_exception(self, mock_traceback_clear):
         exc = KeyError('foo')
         _, info = self.trace(self.raises, (exc,), {})
         assert info.state == states.FAILURE

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -176,6 +176,34 @@ class test_trace(TraceCase):
             elif (2, 7, 0) <= sys.version_info < (3, 0, 0):
                 sys.exc_clear.assert_called()
 
+        try:
+            raise_dummy()
+        except KeyError as exc:
+            traceback_clear()
+
+            if sys.version_info >= (3, 4, 0):
+                tb_ = exc.__traceback__
+                while tb_ is not None:
+                    if str(tb_.tb_frame.__repr__) == frame_list[0]:
+                        assert len(tb_.tb_frame.f_locals) == 0
+                    tb_ = tb_.tb_next
+            elif (2, 7, 0) <= sys.version_info < (3, 0, 0):
+                sys.exc_clear.assert_called()
+
+        try:
+            raise_dummy()
+        except KeyError as exc:
+            traceback_clear(str(exc))
+
+            if sys.version_info >= (3, 4, 0):
+                tb_ = exc.__traceback__
+                while tb_ is not None:
+                    if str(tb_.tb_frame.__repr__) == frame_list[0]:
+                        assert len(tb_.tb_frame.f_locals) == 0
+                    tb_ = tb_.tb_next
+            elif (2, 7, 0) <= sys.version_info < (3, 0, 0):
+                sys.exc_clear.assert_called()
+
     @patch('celery.app.trace.traceback_clear')
     def test_when_Ignore(self, mock_traceback_clear):
 

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -859,18 +859,10 @@ class test_Request(RequestCase):
             assert isinstance(res, ExceptionInfo)
 
     def test_worker_task_trace_handle_retry(self):
-        import inspect
         tid = uuid()
         self.mytask.push_request(id=tid)
-        frame_list = []
-
-        def raise_dummy():
-            frame_str_temp = str(inspect.currentframe().__repr__)
-            frame_list.append(frame_str_temp)
-            local_value = 1214
-            raise ValueError('foo')
         try:
-            raise_dummy()
+            raise ValueError('foo')
         except Exception as exc:
             try:
                 raise Retry(str(exc), exc=exc)
@@ -884,29 +876,16 @@ class test_Request(RequestCase):
                     self.mytask, self.mytask.request, store_errors=True,
                 )
                 assert self.mytask.backend.get_status(tid) == states.RETRY
-            tb_ = exc.__traceback__
-            while tb_ is not None:
-                if str(tb_.tb_frame.__repr__) == frame_list[0]:
-                    assert len(tb_.tb_frame.f_locals) == 0
-                tb_ = tb_.tb_next
         finally:
             self.mytask.pop_request()
 
     def test_worker_task_trace_handle_failure(self):
-        import inspect
         tid = uuid()
         self.mytask.push_request()
         try:
             self.mytask.request.id = tid
-            frame_list = []
-
-            def raise_dummy():
-                frame_str_temp = str(inspect.currentframe().__repr__)
-                frame_list.append(frame_str_temp)
-                local_value = 1214
-                raise ValueError('foo')
             try:
-                raise_dummy()
+                raise ValueError('foo')
             except Exception as exc:
                 w = TraceInfo(states.FAILURE, exc)
                 w.handle_failure(
@@ -917,12 +896,6 @@ class test_Request(RequestCase):
                     self.mytask, self.mytask.request, store_errors=True,
                 )
                 assert self.mytask.backend.get_status(tid) == states.FAILURE
-
-                tb_ = exc.__traceback__
-                while tb_ is not None:
-                    if str(tb_.tb_frame.__repr__) == frame_list[0]:
-                        assert len(tb_.tb_frame.f_locals) == 0
-                    tb_ = tb_.tb_next
         finally:
             self.mytask.pop_request()
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Fixes: #6023

It seems that a frame leak is occurring in the use of the e value returned by 'Execption as e'. Del tb is not enough. So we clean up the traceback in the last part that can be explicit.