### PR TITLE
Add internal_error signal

### DIFF
--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -522,6 +522,7 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
         except MemoryError:
             raise
         except Exception as exc:
+            _signal_internal_error(task, uuid, args, kwargs, request, exc)
             if eager:
                 raise
             R = report_internal_error(task, exc)
@@ -540,7 +541,29 @@ def trace_task(task, uuid, args, kwargs, request=None, **opts):
             task.__trace__ = build_tracer(task.name, task, **opts)
         return task.__trace__(uuid, args, kwargs, request)
     except Exception as exc:
+        _signal_internal_error(task, uuid, args, kwargs, request, exc)
         return trace_ok_t(report_internal_error(task, exc), None, 0.0, None)
+
+
+def _signal_internal_error(task, uuid, args, kwargs, request, exc):
+    """Send a special `internal_error` signal to the app for outside body errors"""
+    try:
+        _, _, tb = sys.exc_info()
+        einfo = ExceptionInfo()
+        einfo.exception = get_pickleable_exception(einfo.exception)
+        einfo.type = get_pickleable_etype(einfo.type)
+        signals.task_internal_error.send(
+            sender=task,
+            task_id=uuid,
+            args=args,
+            kwargs=kwargs,
+            request=request,
+            exception=exc,
+            traceback=tb,
+            einfo=einfo,
+        )
+    finally:
+        del tb
 
 
 def _trace_task_ret(name, uuid, request, body, content_type,

--- a/celery/signals.py
+++ b/celery/signals.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, unicode_literals
 from .utils.dispatch import Signal
 
 __all__ = (
-    'before_task_publish', 'after_task_publish',
+    'before_task_publish', 'after_task_publish', 'task_internal_error',
     'task_prerun', 'task_postrun', 'task_success',
     'task_retry', 'task_failure', 'task_revoked', 'celeryd_init',
     'celeryd_after_setup', 'worker_init', 'worker_process_init',
@@ -65,7 +65,12 @@ task_failure = Signal(
         'task_id', 'exception', 'args', 'kwargs', 'traceback', 'einfo',
     },
 )
-task_revoked = Signal(
+task_internal_error = Signal(
+    name='task_internal_error',
+    providing_args={
+        'task_id', 'args', 'kwargs', 'request', 'exception', 'traceback', 'einfo'
+    }
+)task_revoked = Signal(
     name='task_revoked',
     providing_args={
         'request', 'terminated', 'signum', 'expired',

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -6,42 +6,53 @@ from kombu.exceptions import EncodeError
 
 from celery import group, signals, states, uuid
 from celery.app.task import Context
-from celery.app.trace import (TraceInfo, _fast_trace_task, _trace_task_ret,
-                              build_tracer, get_log_policy, get_task_name,
-                              log_policy_expected, log_policy_ignore,
-                              log_policy_internal, log_policy_reject,
-                              log_policy_unexpected,
-                              reset_worker_optimizations,
-                              setup_worker_optimizations, trace_task,
-                              traceback_clear)
+from celery.app.trace import (
+    TraceInfo,
+    _fast_trace_task,
+    _trace_task_ret,
+    build_tracer,
+    get_log_policy,
+    get_task_name,
+    log_policy_expected,
+    log_policy_ignore,
+    log_policy_internal,
+    log_policy_reject,
+    log_policy_unexpected,
+    reset_worker_optimizations,
+    setup_worker_optimizations,
+    trace_task,
+    traceback_clear,
+)
 
 from celery.exceptions import Ignore, Reject, Retry
 
 
-def trace(app, task, args=(), kwargs={},
-          propagate=False, eager=True, request=None, **opts):
-    t = build_tracer(task.name, task,
-                     eager=eager, propagate=propagate, app=app, **opts)
+def trace(
+    app, task, args=(), kwargs={}, propagate=False, eager=True, request=None, **opts
+):
+    t = build_tracer(task.name, task, eager=eager, propagate=propagate, app=app, **opts)
     ret = t('id-1', args, kwargs, request)
     return ret.retval, ret.info
 
 
 class TraceCase:
-
     def setup(self):
         @self.app.task(shared=False)
         def add(x, y):
             return x + y
+
         self.add = add
 
         @self.app.task(shared=False, ignore_result=True)
         def add_cast(x, y):
             return x + y
+
         self.add_cast = add_cast
 
         @self.app.task(shared=False)
         def raises(exc):
             raise exc
+
         self.raises = raises
 
     def trace(self, *args, **kwargs):
@@ -49,14 +60,12 @@ class TraceCase:
 
 
 class test_trace(TraceCase):
-
     def test_trace_successful(self):
         retval, info = self.trace(self.add, (2, 2), {})
         assert info is None
         assert retval == 4
 
     def test_trace_on_success(self):
-
         @self.app.task(shared=False, on_success=Mock())
         def add_with_success(x, y):
             return x + y
@@ -71,15 +80,12 @@ class test_trace(TraceCase):
         assert get_log_policy(self.add, einfo, Ignore()) is log_policy_ignore
 
         self.add.throws = (TypeError,)
-        assert (get_log_policy(self.add, einfo, KeyError()) is
-                log_policy_unexpected)
-        assert (get_log_policy(self.add, einfo, TypeError()) is
-                log_policy_expected)
+        assert get_log_policy(self.add, einfo, KeyError()) is log_policy_unexpected
+        assert get_log_policy(self.add, einfo, TypeError()) is log_policy_expected
 
         einfo2 = Mock(name='einfo2')
         einfo2.internal = True
-        assert (get_log_policy(self.add, einfo2, KeyError()) is
-                log_policy_internal)
+        assert get_log_policy(self.add, einfo2, KeyError()) is log_policy_internal
 
     def test_get_task_name(self):
         assert get_task_name(Context({}), 'default') == 'default'
@@ -88,7 +94,6 @@ class test_trace(TraceCase):
         assert get_task_name(Context({'shadow': 'test'}), 'default') == 'test'
 
     def test_trace_after_return(self):
-
         @self.app.task(shared=False, after_return=Mock())
         def add_with_after_return(x, y):
             return x + y
@@ -124,10 +129,10 @@ class test_trace(TraceCase):
             signals.task_success.receivers[:] = []
 
     def test_when_chord_part(self):
-
         @self.app.task(shared=False)
         def add(x, y):
             return x + y
+
         add.backend = Mock()
 
         request = {'chord': uuid()}
@@ -140,10 +145,10 @@ class test_trace(TraceCase):
         assert not args[3]
 
     def test_when_backend_cleanup_raises(self):
-
         @self.app.task(shared=False)
         def add(x, y):
             return x + y
+
         add.backend = Mock(name='backend')
         add.backend.process_cleanup.side_effect = KeyError()
         self.trace(add, (2, 2), {}, eager=False)
@@ -154,14 +159,16 @@ class test_trace(TraceCase):
 
     def test_traceback_clear(self):
         import inspect, sys
+
         sys.exc_clear = Mock()
-        frame_list =[]
+        frame_list = []
 
         def raise_dummy():
             frame_str_temp = str(inspect.currentframe().__repr__)
             frame_list.append(frame_str_temp)
             local_value = 1214
             raise KeyError('foo')
+
         try:
             raise_dummy()
         except KeyError as exc:
@@ -206,7 +213,6 @@ class test_trace(TraceCase):
 
     @patch('celery.app.trace.traceback_clear')
     def test_when_Ignore(self, mock_traceback_clear):
-
         @self.app.task(shared=False)
         def ignored():
             raise Ignore()
@@ -217,7 +223,6 @@ class test_trace(TraceCase):
 
     @patch('celery.app.trace.traceback_clear')
     def test_when_Reject(self, mock_traceback_clear):
-
         @self.app.task(shared=False)
         def rejecting():
             raise Reject()
@@ -249,8 +254,7 @@ class test_trace(TraceCase):
         maybe_signature.return_value = sig
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         sig.apply_async.assert_called_with(
-            (4, ), parent_id='id-1', root_id='root',
-            chain=[sig2], priority=None
+            (4,), parent_id='id-1', root_id='root', chain=[sig2], priority=None
         )
 
     @patch('celery.canvas.maybe_signature')
@@ -258,13 +262,15 @@ class test_trace(TraceCase):
         self.app.conf.task_inherit_parent_priority = True
         sig = Mock(name='sig')
         sig2 = Mock(name='sig2')
-        request = {'chain': [sig2, sig], 'root_id': 'root',
-                   'delivery_info': {'priority': 42}}
+        request = {
+            'chain': [sig2, sig],
+            'root_id': 'root',
+            'delivery_info': {'priority': 42},
+        }
         maybe_signature.return_value = sig
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         sig.apply_async.assert_called_with(
-            (4, ), parent_id='id-1', root_id='root',
-            chain=[sig2], priority=42
+            (4,), parent_id='id-1', root_id='root', chain=[sig2], priority=42
         )
 
     @patch('celery.canvas.maybe_signature')
@@ -287,11 +293,10 @@ class test_trace(TraceCase):
 
         def passt(s, *args, **kwargs):
             return s
+
         maybe_signature.side_effect = passt
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
-        group_.assert_called_with(
-            (4,), parent_id='id-1', root_id='root', priority=None
-        )
+        group_.assert_called_with((4,), parent_id='id-1', root_id='root', priority=None)
         sig3.apply_async.assert_called_with(
             (4,), parent_id='id-1', root_id='root', priority=None
         )
@@ -307,6 +312,7 @@ class test_trace(TraceCase):
 
         def passt(s, *args, **kwargs):
             return s
+
         maybe_signature.side_effect = passt
         retval, _ = self.trace(self.add, (2, 2), {}, request=request)
         sig1.apply_async.assert_called_with(
@@ -338,8 +344,7 @@ class test_trace(TraceCase):
 
     def test_trace_task_ret__no_content_type(self):
         _trace_task_ret(
-            self.add.name, 'id1', {}, ((2, 2), {}, {}), None, None,
-            app=self.app,
+            self.add.name, 'id1', {}, ((2, 2), {}, {}), None, None, app=self.app,
         )
 
     def test_fast_trace_task__no_content_type(self):
@@ -347,17 +352,24 @@ class test_trace(TraceCase):
             self.add.name, self.add, app=self.app,
         )
         _fast_trace_task(
-            self.add.name, 'id1', {}, ((2, 2), {}, {}), None, None,
-            app=self.app, _loc=[self.app.tasks, {}, 'hostname']
+            self.add.name,
+            'id1',
+            {},
+            ((2, 2), {}, {}),
+            None,
+            None,
+            app=self.app,
+            _loc=[self.app.tasks, {}, 'hostname'],
         )
 
     def test_trace_exception_propagate(self):
         with pytest.raises(KeyError):
             self.trace(self.raises, (KeyError('foo'),), {}, propagate=True)
 
+    @patch('celery.app.trace.signals.task_internal_error.send')
     @patch('celery.app.trace.build_tracer')
     @patch('celery.app.trace.report_internal_error')
-    def test_outside_body_error(self, report_internal_error, build_tracer):
+    def test_outside_body_error(self, report_internal_error, build_tracer, send):
         tracer = Mock()
         tracer.side_effect = KeyError('foo')
         build_tracer.return_value = tracer
@@ -368,11 +380,11 @@ class test_trace(TraceCase):
 
         trace_task(xtask, 'uuid', (), {})
         assert report_internal_error.call_count
+        assert send.call_count
         assert xtask.__trace__ is tracer
 
 
 class test_TraceInfo(TraceCase):
-
     class TI(TraceInfo):
         __slots__ = TraceInfo.__slots__ + ('__dict__',)
 
@@ -381,7 +393,8 @@ class test_TraceInfo(TraceCase):
         x.handle_failure = Mock()
         x.handle_error_state(self.add_cast, self.add_cast.request)
         x.handle_failure.assert_called_with(
-            self.add_cast, self.add_cast.request,
+            self.add_cast,
+            self.add_cast.request,
             store_errors=self.add_cast.store_errors_even_if_ignored,
             call_errbacks=True,
         )
@@ -396,10 +409,10 @@ class test_TraceInfo(TraceCase):
 
 
 class test_stackprotection:
-
     def test_stackprotection(self):
         setup_worker_optimizations(self.app)
         try:
+
             @self.app.task(shared=False, bind=True)
             def foo(self, i):
                 if i:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

There is no special signal for an out of body error which can be the
result of a bad result backend.

We want to add a new signal `task_internal_error` which will call the signal handler in case of an out of body error.

