### PR TITLE
Note about autodiscover_tasks and periodic tasks

### DIFF
--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -109,7 +109,11 @@ beat schedule list.
 
 
 Setting these up from within the :data:`~@on_after_configure` handler means
-that we'll not evaluate the app at module level when using ``test.s()``.
+that we'll not evaluate the app at module level when using ``test.s()``. Note that 
+:data:`~@on_after_configure` is sent after the app is set up, so tasks outside the
+module where the app is declared (e.g. in a `tasks.py` file located by 
+:meth:`celery.Celery.autodiscover_tasks`) must use a later signal, such as 
+:data:`~@on_after_finalize`.
 
 The :meth:`~@add_periodic_task` function will add the entry to the
 :setting:`beat_schedule` setting behind the scenes, and the same setting


### PR DESCRIPTION
This is particularly important for Django projects that put periodic tasks into each app's `tasks.py` and want to use one as a periodic task.  By the time `autodiscover_tasks()` loads those tasks, the `on_after_configure` Signal has already come and gone, so anything decorated with `@app.on_after_finalize.connect` will never be called.

If there's other documentation on this subject, I could not find it.

It might also be useful to add this scenario to `examples/django/demoapp/tasks.py`.