### PR TITLE
Give up sending a worker-offline message if transport is not connected

### DIFF
--- a/celery/worker/heartbeat.py
+++ b/celery/worker/heartbeat.py
@@ -39,14 +39,14 @@ class Heart(object):
         self._send_sent_signal = (
             heartbeat_sent.send if heartbeat_sent.receivers else None)
 
-    def _send(self, event):
+    def _send(self, event, retry=True):
         if self._send_sent_signal is not None:
             self._send_sent_signal(sender=self)
         return self.eventer.send(event, freq=self.interval,
                                  active=len(active_requests),
                                  processed=all_total_count[0],
                                  loadavg=load_average(),
-                                 retry=True,
+                                 retry=retry,
                                  **SOFTWARE_INFO)
 
     def start(self):
@@ -61,4 +61,4 @@ class Heart(object):
             self.timer.cancel(self.tref)
             self.tref = None
         if self.eventer.enabled:
-            self._send('worker-offline')
+            self._send('worker-offline', retry=False)

--- a/t/unit/worker/test_heartbeat.py
+++ b/t/unit/worker/test_heartbeat.py
@@ -16,7 +16,7 @@ class MockDispatcher(object):
         self.enabled = True
 
     def send(self, msg, **_fields):
-        self.sent.append(msg)
+        self.sent.append((msg, _fields))
         if self.heart:
             if self.next_iter > 10:
                 self.heart._shutdown.set()
@@ -66,6 +66,7 @@ class test_Heart:
         h = Heart(timer, eventer)
         h.start()
         assert not h.tref
+        assert not eventer.sent
 
     def test_stop_when_disabled(self):
         timer = MockTimer()
@@ -73,3 +74,22 @@ class test_Heart:
         eventer.enabled = False
         h = Heart(timer, eventer)
         h.stop()
+        assert not eventer.sent
+
+    def test_message_retries(self):
+        timer = MockTimer()
+        eventer = MockDispatcher()
+        eventer.enabled = True
+        h = Heart(timer, eventer, interval=1)
+
+        h.start()
+        assert eventer.sent[-1][0] == "worker-online"
+
+        # Invoke a heartbeat
+        h.tref[1](*h.tref[2], **h.tref[3])
+        assert eventer.sent[-1][0] == "worker-heartbeat"
+        assert eventer.sent[-1][1]["retry"]
+
+        h.stop()
+        assert eventer.sent[-1][0] == "worker-offline"
+        assert not eventer.sent[-1][1]["retry"]


### PR DESCRIPTION
## Description
If a celery worker is segmented from a cluster and is told to die, it will try very aggressively to connect to the transport that may or not exist at this point. This can add a bit of time to shutdown procedures and usually ends up just getting sigkill'd by the init/supervisor regardless.
This change makes it so that the `worker-offline` is still sent, but if it is lost, just accept it and die peacefully by setting `retry=False` on the `worker-offline` message.
In cases where a cluster is still fully operational from the segmented worker, it will track the worker as lost by heartbeats instead of the offline message.
