### PR TITLE
Add task_internal_error signal

### DIFF
--- a/celery/signals.py
+++ b/celery/signals.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, unicode_literals
 from .utils.dispatch import Signal
 
 __all__ = (
-    'before_task_publish', 'after_task_publish',
+    'before_task_publish', 'after_task_publish', 'task_internal_error',
     'task_prerun', 'task_postrun', 'task_success',
     'task_retry', 'task_failure', 'task_revoked', 'celeryd_init',
     'celeryd_after_setup', 'worker_init', 'worker_process_init',
@@ -65,7 +65,12 @@ task_failure = Signal(
         'task_id', 'exception', 'args', 'kwargs', 'traceback', 'einfo',
     },
 )
-task_revoked = Signal(
+task_internal_error = Signal(
+    name='task_internal_error',
+    providing_args={
+        'task_id', 'args', 'kwargs', 'request', 'exception', 'traceback', 'einfo'
+    }
+)task_revoked = Signal(
     name='task_revoked',
     providing_args={
         'request', 'terminated', 'signum', 'expired',

--- a/celery/signals.py
+++ b/celery/signals.py
@@ -70,7 +70,8 @@ task_internal_error = Signal(
     providing_args={
         'task_id', 'args', 'kwargs', 'request', 'exception', 'traceback', 'einfo'
     }
-)task_revoked = Signal(
+)
+task_revoked = Signal(
     name='task_revoked',
     providing_args={
         'request', 'terminated', 'signum', 'expired',

--- a/docs/userguide/signals.rst
+++ b/docs/userguide/signals.rst
@@ -289,7 +289,46 @@ Provides arguments:
 
     The :class:`billiard.einfo.ExceptionInfo` instance.
 
-.. signal:: task_received
+``task_internal_error``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Dispatched when an internal Celery error occurs while executing the task.
+
+Sender is the task object executed.
+
+.. signal:: task_internal_error
+
+Provides arguments:
+
+* ``task_id``
+
+    Id of the task.
+
+* ``args``
+
+    Positional arguments the task was called with.
+
+* ``kwargs``
+
+    Keyword arguments the task was called with.
+
+* ``request``
+
+    The original request dictionary.
+    This is provided as the ``task.request`` may not be ready by the time
+    the exception is raised.
+
+* ``exception``
+
+    Exception instance raised.
+
+* ``traceback``
+
+    Stack trace object.
+
+* ``einfo``
+
+    The :class:`billiard.einfo.ExceptionInfo` instance.
 
 ``task_received``
 ~~~~~~~~~~~~~~~~~
@@ -297,6 +336,8 @@ Provides arguments:
 Dispatched when a task is received from the broker and is ready for execution.
 
 Sender is the consumer object.
+
+.. signal:: task_received
 
 Provides arguments:
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

There is no special signal for an out of body error which can be the
result of a bad result backend.

We want to add a new signal task_internal_error which will call the signal handler in case of an out of body error.

Superceeds #6027