### PR TITLE
[Fixes Issue #6017] --> Added Multi default logfiles and pidfiles paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,10 @@ matrix:
     env: TOXENV=pypy3
 
 before_install:
+    - sudo mkdir -p /var/log/celery
+    - sudo mkdir -p /var/run/celery
+    - sudo chown travis /var/log/celery
+    - sudo chown travis /var/run/celery
     - sudo apt install libcurl4-openssl-dev libssl-dev gnutls-dev
     - if [[ -v MATRIX_TOXENV ]]; then export TOXENV=${TRAVIS_PYTHON_VERSION}-${MATRIX_TOXENV}; fi; env
     - |

--- a/celery/apps/multi.py
+++ b/celery/apps/multi.py
@@ -140,8 +140,8 @@ class Node(object):
 
     def _annotate_with_default_opts(self, options):
         options['-n'] = self.name
-        self._setdefaultopt(options, ['--pidfile', '-p'], '%n.pid')
-        self._setdefaultopt(options, ['--logfile', '-f'], '%n%I.log')
+        self._setdefaultopt(options, ['--pidfile', '-p'], '/var/run/celery/%n.pid')
+        self._setdefaultopt(options, ['--logfile', '-f'], '/var/log/celery/%n%I.log')
         self._setdefaultopt(options, ['--executable'], sys.executable)
         return options
 
@@ -151,6 +151,10 @@ class Node(object):
                 return d[opt]
             except KeyError:
                 pass
+        path_split = value.split("/")
+        dir_path = "/".join(path_split[0:-1])
+        if not os.path.exists(dir_path):
+            os.makedirs(dir_path)
         return d.setdefault(alt[0], value)
 
     def _prepare_expander(self):

--- a/t/unit/apps/test_multi.py
+++ b/t/unit/apps/test_multi.py
@@ -113,8 +113,8 @@ class test_multi_args:
 
         def _args(name, *args):
             return args + (
-                '--pidfile={0}.pid'.format(name),
-                '--logfile={0}%I.log'.format(name),
+                '--pidfile=/var/run/celery/{}.pid'.format(name),
+                '--logfile=/var/log/celery/{}%I.log'.format(name),
                 '--executable={0}'.format(sys.executable),
                 '',
             )
@@ -176,7 +176,7 @@ class test_Node:
         self.p = Mock(name='p')
         self.p.options = {
             '--executable': 'python',
-            '--logfile': 'foo.log',
+            '--logfile': '/var/log/celery/foo.log',
         }
         self.p.namespaces = {}
         self.node = Node('foo@bar.com', options={'-A': 'proj'})
@@ -194,10 +194,10 @@ class test_Node:
             '--executable={0}'.format(n.executable),
             '-O fair',
             '-n foo@bar.com',
-            '--logfile=foo%I.log',
+            '--logfile=/var/log/celery/foo%I.log',
             '-Q q1,q2',
             '--max-tasks-per-child=30',
-            '--pidfile=foo.pid',
+            '--pidfile=/var/run/celery/foo.pid',
             '',
         ])
 
@@ -275,7 +275,7 @@ class test_Node:
 
     def test_logfile(self):
         assert self.node.logfile == self.expander.return_value
-        self.expander.assert_called_with('%n%I.log')
+        self.expander.assert_called_with('/var/log/celery/%n%I.log')
 
 
 class test_Cluster:
@@ -375,8 +375,8 @@ class test_Cluster:
         assert sorted(node_0.argv) == sorted([
             '',
             '--executable={0}'.format(node_0.executable),
-            '--logfile=foo%I.log',
-            '--pidfile=foo.pid',
+            '--logfile=/var/log/celery/foo%I.log',
+            '--pidfile=/var/run/celery/foo.pid',
             '-m celery worker --detach',
             '-n foo@e.com',
         ])
@@ -386,8 +386,8 @@ class test_Cluster:
         assert sorted(node_1.argv) == sorted([
             '',
             '--executable={0}'.format(node_1.executable),
-            '--logfile=bar%I.log',
-            '--pidfile=bar.pid',
+            '--logfile=/var/log/celery/bar%I.log',
+            '--pidfile=/var/run/celery/bar.pid',
             '-m celery worker --detach',
             '-n bar@e.com',
         ])
@@ -404,8 +404,8 @@ class test_Cluster:
 
             def read_pid(self):
                 try:
-                    return {'foo.pid': 10,
-                            'bar.pid': 11}[self.path]
+                    return {'/var/run/celery/foo.pid': 10,
+                            '/var/run/celery/bar.pid': 11}[self.path]
                 except KeyError:
                     raise ValueError()
         self.Pidfile.side_effect = pids


### PR DESCRIPTION
[Description]:
--> Changed the default paths for log files & pid files to be '/var/log/celery' and '/var/run/celery'
--> Handled by creating the respective paths if not exist.
--> Used os.makedir(path,if_exists=True)

[Unit Test Added]:
--> .travis.yml - config updated with 'before install'.
--> t/unit/apps/test_multi.py - Changed the default log files & pid files paths wherever required.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
