### PR TITLE
Add missing parenthesis to example in docs

### DIFF
--- a/docs/internals/protocol.rst
+++ b/docs/internals/protocol.rst
@@ -79,7 +79,7 @@ This example sends a task message using version 2 of the protocol:
     args = (2, 2)
     kwargs = {}
     basic_publish(
-        message=json.dumps((args, kwargs, None),
+        message=json.dumps((args, kwargs, None)),
         application_headers={
             'lang': 'py',
             'task': 'proj.tasks.add',


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
It fixes missing parenthesis in the protocol example in docs