### PR TITLE
Add Task to __all__ in celery.__init__.py

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -28,7 +28,7 @@ __keywords__ = 'task job queue distributed messaging actor'
 # -eof meta-
 
 __all__ = (
-    'Celery', 'bugreport', 'shared_task', 'task',
+    'Celery', 'bugreport', 'shared_task', 'task', 'Task',
     'current_app', 'current_task', 'maybe_signature',
     'chain', 'chord', 'chunks', 'group', 'signature',
     'xmap', 'xstarmap', 'uuid',


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
It will add Task to `__all__`.
Resolves 'Task' is not declared in `__all__` warning when importing Task from celery.