### PR TITLE
Ensure a single chain object in a chain does not crash

### DIFF
--- a/celery/contrib/testing/app.py
+++ b/celery/contrib/testing/app.py
@@ -34,6 +34,7 @@ class Trap(object):
         # in Python 3.8 and above.
         if name == '_is_coroutine':
             return None
+        print(name)
         raise RuntimeError('Test depends on current_app')
 
 

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -123,6 +123,10 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == [4, 5]
 
+    def test_chain_of_chain_with_a_single_task(self, manager):
+        sig = signature('any_taskname', queue='any_q')
+        chain([chain(sig)]).apply_async()
+
     def test_chain_on_error(self, manager):
         from .tasks import ExpectedException
 

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -269,6 +269,10 @@ class test_chunks(CanvasCase):
 
 class test_chain(CanvasCase):
 
+    def test_chain_of_chain_with_a_single_task(self):
+        s = self.add.s(1, 1)
+        assert chain([chain(s)]).tasks == list(chain(s).tasks)
+
     def test_clone_preserves_state(self):
         x = chain(self.add.s(i, i) for i in range(10))
         assert x.clone().tasks == x.tasks


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Previously `chain([chain(sig)])` would crash.
We now ensure it doesn't.

Fixes #5973.
