### PR TITLE
🐛 Correctly handle configuring the serializer for always_eager mode.

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -546,7 +546,7 @@ class Task(object):
             with app.producer_or_acquire(producer) as eager_producer:
                 serializer = options.get('serializer')
                 if serializer is None:
-                    if eager_producer.serializer
+                    if eager_producer.serializer:
                         serializer = eager_producer.serializer 
                     else:
                         serializer = app.conf.task_serializer

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -544,11 +544,12 @@ class Task(object):
         app = self._get_app()
         if app.conf.task_always_eager:
             with app.producer_or_acquire(producer) as eager_producer:
-                serializer = options.get(
-                    'serializer',
-                    (eager_producer.serializer if eager_producer.serializer
-                     else app.conf.task_serializer)
-                )
+                serializer = options.get('serializer')
+                if serializer is None:
+                    if eager_producer.serializer
+                        serializer = eager_producer.serializer 
+                    else:
+                        serializer = app.conf.task_serializer
                 body = args, kwargs
                 content_type, content_encoding, data = serialization.dumps(
                     body, serializer,

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1223,12 +1223,21 @@ class test_apply_async(TasksCase):
 
     def test_always_eager_with_task_serializer_option(self):
         self.app.conf.task_always_eager = True
+        self.app.conf.task_serializer = 'pickle'
+
+        @self.app.task
+        def task(*args, **kwargs):
+            pass
+        task.apply_async((1, 2, 3, 4, {1}))
+
+    def test_always_eager_uses_task_serializer_setting(self):
+        self.app.conf.task_always_eager = True
 
         @self.app.task(serializer='pickle')
         def task(*args, **kwargs):
             pass
         task.apply_async((1, 2, 3, 4, {1}))
-
+        
     def test_task_with_ignored_result(self):
         with patch.object(self.app, 'send_task') as send_task:
             self.task_with_ignored_result.apply_async()


### PR DESCRIPTION
options['serializer'] will always exist, because it is initialized from an mattrgetter. Even if unset, it will be present in the options dict with a value of None.
