### PR TITLE
Remove doubling of prefetch_count increase when prefetch_multiplier gt 1

### DIFF
--- a/celery/worker/autoscale.py
+++ b/celery/worker/autoscale.py
@@ -153,7 +153,7 @@ class Autoscaler(bgThread):
         diff = new_max - self.max_concurrency
         if diff:
             self.worker.consumer._update_prefetch_count(
-                diff * self.worker.consumer.prefetch_multiplier
+                diff
             )
 
     def info(self):

--- a/t/unit/worker/test_autoscale.py
+++ b/t/unit/worker/test_autoscale.py
@@ -183,6 +183,15 @@ class test_Autoscaler:
         x.update(15, 7)
         worker.consumer._update_prefetch_count.assert_called_with(10)
 
+    def test_prefetch_count_on_updates_prefetch_multiplier_gt_one(self):
+        worker = Mock(name='worker')
+        x = autoscale.Autoscaler(self.pool, 10, 3, worker=worker)
+        x.worker.consumer.prefetch_multiplier = 4
+        x.update(5, None)
+        worker.consumer._update_prefetch_count.assert_called_with(-5)
+        x.update(15, 7)
+        worker.consumer._update_prefetch_count.assert_called_with(10)
+
     def test_prefetch_count_on_force_up(self):
         worker = Mock(name='worker')
         x = autoscale.Autoscaler(self.pool, 10, 3, worker=worker)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This is a follow up to: https://github.com/celery/celery/pull/6069

In the linked PR one of the changes was to update the prefetch_count (number of tasks a worker pre-fetches or "claims") when the autoscale range is adjusted.  In order to calculate the amount of the increase the diff in processes was multiplied by the consumer prefetch_multiplier.  I overlooked that the value passed to `consumer._update_prefetch_count` is [subsequently multiplied by the consumer prefetch_multiplier](https://github.com/celery/celery/blob/master/celery/worker/consumer/consumer.py#L264-L267) so we end up with a doubling of the intended increase of prefetch_count.

The implications of this aren't dramatic because for those who set prefetch multiplier = 1 to avoid prefetching, there would still be no prefetching because there is no double counting when the factor is 1.  For those that did want prefetching AND adjusted their autoscaling settings via remote control command then their prefetch_count would be greater than intended.  This PR will correct this.

