### PR TITLE
Remove autoscale force_scale methods

### DIFF
--- a/celery/worker/autoscale.py
+++ b/celery/worker/autoscale.py
@@ -112,21 +112,6 @@ class Autoscaler(bgThread):
                 self.min_concurrency = min
             return self.max_concurrency, self.min_concurrency
 
-    def force_scale_up(self, n):
-        with self.mutex:
-            new = self.processes + n
-            if new > self.max_concurrency:
-                self._update_consumer_prefetch_count(new)
-                self.max_concurrency = new
-            self._grow(n)
-
-    def force_scale_down(self, n):
-        with self.mutex:
-            new = self.processes - n
-            if new < self.min_concurrency:
-                self.min_concurrency = max(new, 0)
-            self._shrink(min(n, self.processes))
-
     def scale_up(self, n):
         self._last_scale_up = monotonic()
         return self._grow(n)

--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -469,7 +469,7 @@ def memdump(state, samples=10, **kwargs):  # pragma: no cover
 def pool_grow(state, n=1, **kwargs):
     """Grow pool by n processes/threads."""
     if state.consumer.controller.autoscaler:
-        state.consumer.controller.autoscaler.force_scale_up(n)
+        return nok("pool_grow is not supported with autoscale. Adjust autoscale range instead.")
     else:
         state.consumer.pool.grow(n)
         state.consumer._update_prefetch_count(n)
@@ -483,7 +483,7 @@ def pool_grow(state, n=1, **kwargs):
 def pool_shrink(state, n=1, **kwargs):
     """Shrink pool by n processes/threads."""
     if state.consumer.controller.autoscaler:
-        state.consumer.controller.autoscaler.force_scale_down(n)
+        return nok("pool_shrink is not supported with autoscale. Adjust autoscale range instead.")
     else:
         state.consumer.pool.shrink(n)
         state.consumer._update_prefetch_count(-n)

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -335,10 +335,10 @@ class test_ControlPanel:
         panel.state.consumer = Mock()
         panel.state.consumer.controller = Mock()
         sc = panel.state.consumer.controller.autoscaler = Mock()
-        panel.handle('pool_grow')
-        sc.force_scale_up.assert_called()
-        panel.handle('pool_shrink')
-        sc.force_scale_down.assert_called()
+        r = panel.handle('pool_grow')
+        assert 'error' in r
+        r = panel.handle('pool_shrink')
+        assert 'error' in r
 
     def test_add__cancel_consumer(self):
 

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -334,7 +334,6 @@ class test_ControlPanel:
 
         panel.state.consumer = Mock()
         panel.state.consumer.controller = Mock()
-        sc = panel.state.consumer.controller.autoscaler = Mock()
         r = panel.handle('pool_grow')
         assert 'error' in r
         r = panel.handle('pool_shrink')


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

A semi-related follow up to https://github.com/celery/celery/pull/6069

I noticed that there are two methods: [force_scale_up](https://github.com/celery/celery/blob/master/celery/worker/autoscale.py#L115) and [force_scale_down](https://github.com/celery/celery/blob/master/celery/worker/autoscale.py#L123) which are used in the [pool_grow](https://github.com/celery/celery/blob/master/celery/worker/control.py#L472) and [pool_shrink](https://github.com/celery/celery/blob/master/celery/worker/control.py#L486) remote control commands but I don't think they really work and am proposing that they be removed.

As an example, if you have an autoscale range of 6,3 and you have 4 tasks being worked on (and thus 4 processes running) and you try to force_scale_up a process will be added for a short period of time until [this check](https://github.com/celery/celery/blob/master/celery/worker/autoscale.py#L89) runs again, at which point the lack of tasks to sustain the 5 processes will bump the process count down to 4 processes and we are back where we started.  

Same goes for scaling down.  Only in this case when you try to scale down you get a `Value Error` [here](https://github.com/celery/celery/blob/master/celery/worker/autoscale.py#L147-L148) because there are 4 tasks running and thus can't shrink the pool.

It seems like `force_scale_up` and `force_scale_down` are in conflict with the basic purpose and functioning of autoscale.  There shouldn't be any forcing up and forcing down when the purpose of autoscale is to vary the process count based on the workload.  And given that the workload does indeed drive the process pool size, any attempts to force up or force down don't work anyways.

I'm interested in any thoughts on this as I may be missing something here.

In order to reproduce this behavior:

In `tasks.py`:
```
from celery import Celery
import time

app = Celery('tasks', broker='redis://localhost', include=['tasks'])

@app.task
def my_task(item_id):
    print("Processing item {}".format(item_id))
    time.sleep(10000)

def send_tasks():
    for i in range(4):
        my_task.apply_async((i,))
```
In one window run your worker:
`celery worker -A tasks --autoscale=6,3 --loglevel=DEBUG`


Then from another window, to run 4 long running tasks:
`python3 -c"from tasks import send_tasks;send_tasks()"`

Then to bump up a process run:
`celery -A tasks control pool_grow 1`

Within 30 seconds (or whatever you have set for `AUTOSCALE_KEEPALIVE`) the 5 processes will bump back down to 4.

Then to bump down run the following:
`celery -A tasks control pool_shrink 1`

and in the worker window you'll see:
`Autoscaler won't scale down: all processes busy.`

