### PR TITLE
Fix potential race condition in distributed mode leading to duplicated tasks

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -768,6 +768,17 @@ class BaseKeyValueStoreBackend(Backend):
                                      traceback=traceback, request=request)
         meta['task_id'] = bytes_to_str(task_id)
 
+        # Retrieve metadata from the backend, if the status
+        # is a success then we ignore any following update to the state.
+        # This solves a task deduplication issue because of network
+        # partitioning or lost workers. This issue involved a race condition
+        # making a lost task overwrite the last successful result in the
+        # result backend.
+        current_meta = self._get_task_meta_for(task_id)
+
+        if current_meta['status'] == states.SUCCESS:
+            return result
+
         self.set(self.get_key_for_task(task_id), self.encode(meta))
         return result
 

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -635,6 +635,20 @@ class test_KeyValueStoreBackend:
         stored_meta = self.b.decode(self.b.get(self.b.get_key_for_task(tid)))
         assert stored_meta['group_id'] == request.group
 
+    def test_store_result_race_second_write_should_ignore_if_previous_success(self):
+        tid = uuid()
+        state = 'SUCCESS'
+        result = 10
+        request = Context(group='gid', children=[])
+        self.b.store_result(
+            tid, state=state, result=result, request=request,
+        )
+        self.b.store_result(
+            tid, state=states.FAILURE, result=result, request=request,
+        )
+        stored_meta = self.b.decode(self.b.get(self.b.get_key_for_task(tid)))
+        assert stored_meta['status'] == states.SUCCESS
+
     def test_strip_prefix(self):
         x = self.b.get_key_for_task('x1b34')
         assert self.b._strip_prefix(x) == 'x1b34'


### PR DESCRIPTION
## Description
In some circumstances like a network partitioning, some tasks might
be duplicated. Sometimes, this lead to a race condition where a lost
task overwrites the result of the last successful task in the backend.

In order to avoid this race condition we prevent updating the result if
it's already in successful state.

This fix has been done for KV backends only and therefore won't work
with other backends.