### PR TITLE
update predefined-queues documentation

### DIFF
--- a/docs/getting-started/brokers/sqs.rst
+++ b/docs/getting-started/brokers/sqs.rst
@@ -141,8 +141,12 @@ pass a map of queue names to URLs using the :setting:`predefined_queue_urls`
 setting::
 
     broker_transport_options = {
-        'predefined_queue_urls': {
-            'my-q': 'https://ap-southeast-2.queue.amazonaws.com/123456/my-q'
+        'predefined_queues': {
+            'my-q': {
+                'url': 'https://ap-southeast-2.queue.amazonaws.com/123456/my-q',
+                'access_key_id': 'xxx',
+                'secret_access_key': 'xxx',
+            }
         }
     }
 


### PR DESCRIPTION
Suggested version of configuration does not work. 
Additionally I'd like to mention, that `access_key_id` and `secret_access_key` are mandatory fields and not allowing you to go with defaults AWS_* env variables.
I can contribute for this variables to be optional

Also I'm not sure if security token will apply, could you please advice how to do it?

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
