### PR TITLE
Fix couchbase version < 3.0.0 as API changed

### DIFF
--- a/requirements/extras/couchbase.txt
+++ b/requirements/extras/couchbase.txt
@@ -1,2 +1,2 @@
-couchbase
-couchbase-cffi;platform_python_implementation=="PyPy"
+couchbase < 3.0.0
+couchbase-cffi < 3.0.0;platform_python_implementation=="PyPy"


### PR DESCRIPTION
Couchbase release May 1st a new major version for Python library.
Let fix this version < 3.0.0 until corresponding code is changed.