### PR TITLE
Always requeue while worker lost regardless of the redelivered flag

### DIFF
--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -505,8 +505,7 @@ class Request(object):
             )
             ack = self.task.acks_on_failure_or_timeout
             if reject:
-                requeue = not self.delivery_info.get('redelivered')
-                self.reject(requeue=requeue)
+                self.reject(requeue=True)
                 send_failed_event = False
             elif ack:
                 self.acknowledge()

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -505,7 +505,8 @@ class Request(object):
             )
             ack = self.task.acks_on_failure_or_timeout
             if reject:
-                self.reject(requeue=True)
+                requeue = True
+                self.reject(requeue=requeue)
                 send_failed_event = False
             elif ack:
                 self.acknowledge()

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -653,7 +653,7 @@ class test_Request(RequestCase):
         job.delivery_info['redelivered'] = True
         job.on_failure(exc_info)
 
-        assert self.mytask.backend.get_status(job.id) == states.FAILURE
+        assert self.mytask.backend.get_status(job.id) == states.PENDING
 
     def test_on_failure_acks_late(self):
         job = self.xRequest()


### PR DESCRIPTION
## Description

Fixes #5598  #5641 

If `task_reject_on_worker_lost` is set to `True`,   The task which fails due to losing a woker will continue to requeue regardless of the redelivered flag

Previously  a task will be requeued when the  first time it fails due to losing a worker, however,a second worker lost failure doesn't get retried(because of the redelivered flag)


