### PR TITLE
Fix windows build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,26 +16,31 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.0"
+      TOXENV: "2.7-unit"
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
+      TOXENV: "3.5-unit"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
-      
+      TOXENV: "3.6-unit"
+
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
-      
+      TOXENV: "3.7-unit"
+
     - PYTHON: "C:\\Python38-x64"
       PYTHON_VERSION: "3.8.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
+      TOXENV: "3.8-unit"
 
 
 init:
@@ -43,15 +48,14 @@ init:
 
 install:
   - "powershell extra\\appveyor\\install.ps1"
-  - "%PYTHON%/python -m pip install -U pip setuptools"
+  - "%PYTHON%/python -m pip install -U pip setuptools tox"
   - "%PYTHON%/Scripts/pip.exe install -U eventlet"
   - "%PYTHON%/Scripts/pip.exe install -U -r requirements/extras/thread.txt"
-  - "%PYTHON%/Scripts/pip.exe install -U -r requirements/test-ci-default.txt"
 
 build: off
 
 test_script:
-  - "%WITH_COMPILER% %PYTHON%/python setup.py test"
+  - "%WITH_COMPILER% %PYTHON%/Scripts/tox -v -- -v"
 
 after_test:
   - "%WITH_COMPILER% %PYTHON%/python setup.py bdist_wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,12 +12,6 @@ environment:
     # a later point release.
     # See: https://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
-      WINDOWS_SDK_VERSION: "v7.0"
-      TOXENV: "2.7-unit"
-
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"

--- a/celery/apps/multi.py
+++ b/celery/apps/multi.py
@@ -151,8 +151,8 @@ class Node(object):
                 return d[opt]
             except KeyError:
                 pass
-        path_split = value.split("/")
-        dir_path = "/".join(path_split[0:-1])
+        value = os.path.normpath(value)
+        dir_path = os.path.dirname(value)
         if not os.path.exists(dir_path):
             os.makedirs(dir_path)
         return d.setdefault(alt[0], value)

--- a/celery/contrib/testing/app.py
+++ b/celery/contrib/testing/app.py
@@ -32,7 +32,7 @@ class Trap(object):
     def __getattr__(self, name):
         # Workaround to allow unittest.mock to patch this object
         # in Python 3.8 and above.
-        if name == '_is_coroutine':
+        if name == '_is_coroutine' or name == '__func__':
             return None
         print(name)
         raise RuntimeError('Test depends on current_app')

--- a/requirements/extras/couchbase.txt
+++ b/requirements/extras/couchbase.txt
@@ -1,2 +1,2 @@
-couchbase < 3.0.0
+couchbase < 3.0.0; platform_system != "Windows"
 couchbase-cffi < 3.0.0;platform_python_implementation=="PyPy"

--- a/requirements/extras/memcache.txt
+++ b/requirements/extras/memcache.txt
@@ -1,1 +1,1 @@
-pylibmc
+pylibmc; platform_system != "Windows"

--- a/t/unit/apps/test_multi.py
+++ b/t/unit/apps/test_multi.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import errno
 import signal
 import sys
+import os
 
 import pytest
 from case import Mock, call, patch, skip
@@ -113,8 +114,8 @@ class test_multi_args:
 
         def _args(name, *args):
             return args + (
-                '--pidfile=/var/run/celery/{}.pid'.format(name),
-                '--logfile=/var/log/celery/{}%I.log'.format(name),
+                '--pidfile={}.pid'.format(os.path.join(os.path.normpath('/var/run/celery/'), name)),
+                '--logfile={}%I.log'.format(os.path.join(os.path.normpath('/var/log/celery/'), name)),
                 '--executable={0}'.format(sys.executable),
                 '',
             )
@@ -194,10 +195,10 @@ class test_Node:
             '--executable={0}'.format(n.executable),
             '-O fair',
             '-n foo@bar.com',
-            '--logfile=/var/log/celery/foo%I.log',
+            '--logfile={}'.format(os.path.normpath('/var/log/celery/foo%I.log')),
             '-Q q1,q2',
             '--max-tasks-per-child=30',
-            '--pidfile=/var/run/celery/foo.pid',
+            '--pidfile={}'.format(os.path.normpath('/var/run/celery/foo.pid')),
             '',
         ])
 
@@ -275,7 +276,7 @@ class test_Node:
 
     def test_logfile(self):
         assert self.node.logfile == self.expander.return_value
-        self.expander.assert_called_with('/var/log/celery/%n%I.log')
+        self.expander.assert_called_with(os.path.normpath('/var/log/celery/%n%I.log'))
 
 
 class test_Cluster:
@@ -375,8 +376,8 @@ class test_Cluster:
         assert sorted(node_0.argv) == sorted([
             '',
             '--executable={0}'.format(node_0.executable),
-            '--logfile=/var/log/celery/foo%I.log',
-            '--pidfile=/var/run/celery/foo.pid',
+            '--logfile={}'.format(os.path.normpath('/var/log/celery/foo%I.log')),
+            '--pidfile={}'.format(os.path.normpath('/var/run/celery/foo.pid')),
             '-m celery worker --detach',
             '-n foo@e.com',
         ])
@@ -386,8 +387,8 @@ class test_Cluster:
         assert sorted(node_1.argv) == sorted([
             '',
             '--executable={0}'.format(node_1.executable),
-            '--logfile=/var/log/celery/bar%I.log',
-            '--pidfile=/var/run/celery/bar.pid',
+            '--logfile={}'.format(os.path.normpath('/var/log/celery/bar%I.log')),
+            '--pidfile={}'.format(os.path.normpath('/var/run/celery/bar.pid')),
             '-m celery worker --detach',
             '-n bar@e.com',
         ])
@@ -404,8 +405,8 @@ class test_Cluster:
 
             def read_pid(self):
                 try:
-                    return {'/var/run/celery/foo.pid': 10,
-                            '/var/run/celery/bar.pid': 11}[self.path]
+                    return {os.path.normpath('/var/run/celery/foo.pid'): 10,
+                            os.path.normpath('/var/run/celery/bar.pid'): 11}[self.path]
                 except KeyError:
                     raise ValueError()
         self.Pidfile.side_effect = pids

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -792,6 +792,7 @@ class test_WorkController(ConsumerCase):
         )
         assert worker.autoscaler
 
+    @skip.if_win32()
     @pytest.mark.nothreads_not_lingering
     @mock.sleepdeprived(module=autoscale)
     def test_with_autoscaler_file_descriptor_safety(self):
@@ -841,6 +842,7 @@ class test_WorkController(ConsumerCase):
         worker.terminate()
         worker.pool.terminate()
 
+    @skip.if_win32()
     @pytest.mark.nothreads_not_lingering
     @mock.sleepdeprived(module=autoscale)
     def test_with_file_descriptor_safety(self):

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,6 @@ basepython =
     flake8,apicheck,linkcheck,configcheck,pydocstyle,bandit: python3.8
     flakeplus: python2.7
 usedevelop = True
-install_command = {toxinidir}/tox_install_command.sh {opts} {packages}
 
 [testenv:apicheck]
 setenv =

--- a/tox_install_command.sh
+++ b/tox_install_command.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-pip --disable-pip-version-check install "$@"
-
-if [[ "${TRAVIS_PYTHON_VERSION}" == "3.7" ]]; then
-  # We have to uninstall the typing package which comes along with
-  # the couchbase package in order to prevent an error on CI for Python 3.7.
-  pip uninstall typing -y
-fi


### PR DESCRIPTION
those libraries depends on native libraries libcouchbase and libmemcached
that are not installed on Appveyor.
As only unit tests runs on Appveyor, it should be fine
