### PR TITLE
Fixbug: self.result may not be a subclass of BaseException

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -1016,7 +1016,8 @@ class EagerResult(AsyncResult):
             return self.result
         elif self.state in states.PROPAGATE_STATES:
             if propagate:
-                raise self.result
+                raise self.result if isinstance(
+                    self.result, Exception) else Exception(self.result)
             return self.result
     wait = get  # XXX Compat (remove 5.0)
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
Exceptions must be old-style classes or derived from BaseException,
but here self.result may not be a subclass of BaseException, it can cause TypeError.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
