### PR TITLE
Change eager retry behaviour

### DIFF
--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -137,7 +137,7 @@ class Retry(TaskPredicate):
     #: :class:`~datetime.datetime`.
     when = None
 
-    def __init__(self, message=None, exc=None, when=None, **kwargs):
+    def __init__(self, message=None, exc=None, when=None, is_eager=False, sig=None, **kwargs):
         from kombu.utils.encoding import safe_repr
         self.message = message
         if isinstance(exc, string_t):
@@ -145,6 +145,8 @@ class Retry(TaskPredicate):
         else:
             self.exc, self.excs = exc, safe_repr(exc) if exc else None
         self.when = when
+        self.is_eager = is_eager
+        self.sig = sig
         super(Retry, self).__init__(self, exc, when, **kwargs)
 
     def humanize(self):

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -364,8 +364,14 @@ class test_task_retries(TasksCase):
         finally:
             self.retry_task_mockapply.pop_request()
 
-    def test_retry_eager(self):
+    def test_retry_without_throw_eager(self):
         assert self.retry_task_without_throw.apply().get() == 42
+
+    def test_retry_eager_should_return_value(self):
+        self.retry_task.max_retries = 3
+        self.retry_task.iterations = 0
+        assert self.retry_task.apply([0xFF, 0xFFFF]).get() == 0xFF
+        assert self.retry_task.iterations == 4
 
     def test_retry_not_eager(self):
         self.retry_task_mockapply.push_request()


### PR DESCRIPTION
Even with raise self.retry, it should return the eventual value
or MaxRetriesExceededError.

If return value of eager apply is Retry exception, retry eagerly
the task signature.