### PR TITLE
Protocol version option for task

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -259,6 +259,9 @@ class AMQP(object):
     def create_task_message(self):
         return self.task_protocols[self.app.conf.task_protocol]
 
+    def create_task_message_with_protocol(self, protocol):
+        return self.task_protocols[protocol]
+
     @cached_property
     def send_task_message(self):
         return self._create_task_sender()

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -757,7 +757,12 @@ class Celery(object):
                     options.setdefault('priority',
                                        parent.request.delivery_info.get('priority'))
 
-        message = amqp.create_task_message(
+        create_task_message_func = amqp.create_task_message
+        if task_type and task_type.protocol != self.conf.task_protocol:
+            create_task_message_func = amqp.create_task_message_with_protocol(
+                task_type.protocol)
+
+        message = create_task_message_func(
             task_id, name, args, kwargs, countdown, eta, group_id,
             expires, retries, chord,
             maybe_list(link), maybe_list(link_error),

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -293,6 +293,9 @@ class Task(object):
     #: Task request stack, the current request will be the topmost.
     request_stack = None
 
+    #: Default task protocol.
+    protocol = None
+
     #: Some may expect a request to exist even if the task hasn't been
     #: called.  This should probably be deprecated.
     _default_request = None
@@ -314,6 +317,7 @@ class Task(object):
         ('reject_on_worker_lost', 'task_reject_on_worker_lost'),
         ('ignore_result', 'task_ignore_result'),
         ('store_errors_even_if_ignored', 'task_store_errors_even_if_ignored'),
+        ('protocol', 'task_protocol'),
     )
 
     _backend = None  # set by backend property.


### PR DESCRIPTION
## Description

Added optional option `protocol` for applying task with different protocol versions
```python
@shared_task(bind=True, protocol=1)
def debug_task(self):
    # this task will execute with protocol = 1 (but for all other tasks protocol will be `protocol_version`)
    pass
```

P.S.: why? gocelery (lib for golang) supports only **1** celery protocol version. But `flower` application normally supports only **2** protocol version