### PR TITLE
Order supported Python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ What do I need?
 
 Celery version 4.4.0 runs on,
 
-- Python (2.7, 3.8, 3.5, 3.6, 3.7)
+- Python (2.7, 3.5, 3.6, 3.7, 3.8)
 - PyPy2.7 (7.2)
 - PyPy3.5 (7.1)
 - PyPy3.6 (7.6)


### PR DESCRIPTION
I initially thought there was no 3.8 support mentioned, but after a second look it turns out that it was just not ordered :)