### PR TITLE
Avoid race condition in elasticsearch backend

### DIFF
--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -140,6 +140,7 @@ class test_ElasticsearchBackend:
             doc_type=x.doc_type,
             index=x.index,
             body=body,
+            params={'op_type': 'create'},
             kwarg1='test1'
         )
 
@@ -165,6 +166,7 @@ class test_ElasticsearchBackend:
             doc_type=x.doc_type,
             index=x.index,
             body={"field1": "value1"},
+            params={'op_type': 'create'},
             kwarg1='test1'
         )
 


### PR DESCRIPTION
if a task is retried, the task retry may work concurrently to current task.
store_result may come out of order.
it may cause a non ready state (Retry) to override a ready state (Success, Failure).
If this happens, it will block indefinitely pending any chord depending on this task.

this change makes document updates safe for concurrent writes.

https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html