### PR TITLE
Fix random distribution of jitter for exponential backoff

### DIFF
--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -397,10 +397,10 @@ def get_exponential_backoff_interval(
 ):
     """Calculate the exponential backoff wait time."""
     # Will be zero if factor equals 0
-    countdown = factor * (2 ** retries)
+    countdown = min(maximum, factor * (2 ** retries))
     # Full jitter according to
     # https://www.awsarchitectureblog.com/2015/03/backoff.html
     if full_jitter:
         countdown = random.randrange(countdown + 1)
     # Adjust according to maximum wait time and account for negative values.
-    return max(0, min(maximum, countdown))
+    return max(0, countdown)

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -355,3 +355,10 @@ class test_get_exponential_backoff_interval:
             retries=3,
             maximum=100
         ) == 0
+
+    @patch('random.randrange')
+    def test_valid_random_range(self, rr):
+        rr.return_value = 0
+        maximum = 100
+        get_exponential_backoff_interval(factor=40, retries=10, maximum=maximum, full_jitter=True)
+        rr.assert_called_once_with(maximum + 1)


### PR DESCRIPTION
random.randrange should be called with the actual so that all numbers
have equivalent probability, otherwise maximum value does have a way
higher probability of occuring.