### PR TITLE
Add retry on recoverable exception for the backend

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -217,6 +217,10 @@ NAMESPACES = Namespace(
         serializer=Option('json'),
         backend_transport_options=Option({}, type='dict'),
         chord_join_timeout=Option(3.0, type='float'),
+        backend_max_sleep_between_retries_ms=Option(10000, type='int'),
+        backend_max_retries=Option(float("inf"), type='float'),
+        backend_base_sleep_between_retries_ms=Option(10, type='int'),
+        backend_always_retry=Option(False, type='bool'),
     ),
     elasticsearch=Namespace(
         __old__=old_ns('celery_elasticsearch'),

--- a/celery/backends/arangodb.py
+++ b/celery/backends/arangodb.py
@@ -144,7 +144,7 @@ class ArangoDbBackend(KeyValueStoreBackend):
             logging.error(err)
             return None
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         """Insert a doc with value into task attribute and _key as key."""
         try:
             logging.debug(

--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -110,7 +110,7 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
         except AzureMissingResourceHttpError:
             return None
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         """Store a value for a given key.
 
         Args:

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -7,6 +7,7 @@
     using K/V semantics like _get and _put.
 """
 from __future__ import absolute_import, unicode_literals
+from future.utils import raise_with_traceback
 
 import datetime
 import sys
@@ -26,7 +27,8 @@ import celery.exceptions
 from celery import current_app, group, maybe_signature, states
 from celery._state import get_current_task
 from celery.exceptions import (ChordError, ImproperlyConfigured,
-                               NotRegistered, TaskRevokedError, TimeoutError)
+                               NotRegistered, TaskRevokedError, TimeoutError,
+                               BackendGetMetaError, BackendStoreError)
 from celery.five import PY3, items
 from celery.result import (GroupResult, ResultBase, ResultSet,
                            allow_join_result, result_from_tuple)
@@ -37,6 +39,7 @@ from celery.utils.serialization import (create_exception_cls,
                                         ensure_serializable,
                                         get_pickleable_exception,
                                         get_pickled_exception)
+from celery.utils.time import get_exponential_backoff_interval
 
 __all__ = ('BaseBackend', 'KeyValueStoreBackend', 'DisabledBackend')
 
@@ -125,6 +128,11 @@ class Backend(object):
         self.accept = conf.result_accept_content if accept is None else accept
         self.accept = conf.accept_content if self.accept is None else self.accept  # noqa: E501
         self.accept = prepare_accept_content(self.accept)
+
+        self.always_retry = conf.get('result_backend_always_retry', False)
+        self.max_sleep_between_retries_ms = conf.get('result_backend_max_sleep_between_retries_ms', 10000)
+        self.base_sleep_between_retries_ms = conf.get('result_backend_base_sleep_between_retries_ms', 10)
+        self.max_retries = conf.get('result_backend_max_retries', float("inf"))
 
         self._pending_results = pending_results_t({}, WeakValueDictionary())
         self._pending_messages = BufferMap(MESSAGE_BUFFER_MAX)
@@ -415,13 +423,40 @@ class Backend(object):
 
         return meta
 
+    def _sleep(self, amount):
+        time.sleep(amount)
+
     def store_result(self, task_id, result, state,
                      traceback=None, request=None, **kwargs):
-        """Update task state and result."""
+        """Update task state and result.
+
+        if always_retry_backend_operation is activated, in the event of a recoverable exception,
+        then retry operation with an exponential backoff until a limit has been reached.
+        """
         result = self.encode_result(result, state)
-        self._store_result(task_id, result, state, traceback,
-                           request=request, **kwargs)
-        return result
+
+        retries = 0
+
+        while True:
+            try:
+                self._store_result(task_id, result, state, traceback,
+                                   request=request, **kwargs)
+                return result
+            except Exception as exc:
+                if self.always_retry and self.exception_safe_to_retry(exc):
+                    if retries < self.max_retries:
+                        retries += 1
+
+                        # get_exponential_backoff_interval computes integers
+                        # and time.sleep accept floats for sub second sleep
+                        sleep_amount = get_exponential_backoff_interval(
+                            self.base_sleep_between_retries_ms, retries,
+                            self.max_sleep_between_retries_ms, True) / 1000
+                        self._sleep(sleep_amount)
+                    else:
+                        raise_with_traceback(BackendStoreError("failed to store result on the backend", task_id=task_id, state=state))
+                else:
+                    raise
 
     def forget(self, task_id):
         self._cache.pop(task_id, None)
@@ -458,15 +493,49 @@ class Backend(object):
                 RuntimeWarning
             )
 
+    def exception_safe_to_retry(self, exc):
+        """Check if an exception is safe to retry.
+
+        Backends have to overload this method with correct predicates dealing with their exceptions.
+
+        By default no exception is safe to retry, it's up to backend implementation
+        to define which exceptions are safe.
+        """
+        return False
+
     def get_task_meta(self, task_id, cache=True):
+        """Get task meta from backend.
+
+        if always_retry_backend_operation is activated, in the event of a recoverable exception,
+        then retry operation with an exponential backoff until a limit has been reached.
+        """
         self._ensure_not_eager()
         if cache:
             try:
                 return self._cache[task_id]
             except KeyError:
                 pass
+        retries = 0
+        while True:
+            try:
+                meta = self._get_task_meta_for(task_id)
+                break
+            except Exception as exc:
+                if self.always_retry and self.exception_safe_to_retry(exc):
+                    if retries < self.max_retries:
+                        retries += 1
 
-        meta = self._get_task_meta_for(task_id)
+                        # get_exponential_backoff_interval computes integers
+                        # and time.sleep accept floats for sub second sleep
+                        sleep_amount = get_exponential_backoff_interval(
+                            self.base_sleep_between_retries_ms, retries,
+                            self.max_sleep_between_retries_ms, True) / 1000
+                        self._sleep(sleep_amount)
+                    else:
+                        raise_with_traceback(BackendGetMetaError("failed to get meta", task_id=task_id))
+                else:
+                    raise
+
         if cache and meta.get('status') == states.SUCCESS:
             self._cache[task_id] = meta
         return meta

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -9,7 +9,7 @@
 from __future__ import absolute_import, unicode_literals
 from future.utils import raise_with_traceback
 
-import datetime
+from datetime import datetime, timedelta
 import sys
 import time
 import warnings
@@ -355,7 +355,7 @@ class Backend(object):
     def prepare_expires(self, value, type=None):
         if value is None:
             value = self.app.conf.result_expires
-        if isinstance(value, datetime.timedelta):
+        if isinstance(value, timedelta):
             value = value.total_seconds()
         if value is not None and type:
             return type(value)
@@ -379,7 +379,7 @@ class Backend(object):
                          state, traceback, request, format_date=True,
                          encode=False):
         if state in self.READY_STATES:
-            date_done = datetime.datetime.utcnow()
+            date_done = datetime.utcnow()
             if format_date:
                 date_done = date_done.isoformat()
         else:

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -666,7 +666,7 @@ class BaseKeyValueStoreBackend(Backend):
     def mget(self, keys):
         raise NotImplementedError('Does not support get_many')
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         raise NotImplementedError('Must implement the set method.')
 
     def delete(self, key):
@@ -786,12 +786,12 @@ class BaseKeyValueStoreBackend(Backend):
         if current_meta['status'] == states.SUCCESS:
             return result
 
-        self.set(self.get_key_for_task(task_id), self.encode(meta))
+        self.set(self.get_key_for_task(task_id), self.encode(meta), state)
         return result
 
     def _save_group(self, group_id, result):
         self.set(self.get_key_for_group(group_id),
-                 self.encode({'result': result.as_tuple()}))
+                 self.encode({'result': result.as_tuple()}), states.SUCCESS)
         return result
 
     def _delete_group(self, group_id):

--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -124,7 +124,7 @@ class CacheBackend(KeyValueStoreBackend):
     def mget(self, keys):
         return self.client.get_multi(keys)
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         return self.client.set(key, value, self.expires)
 
     def delete(self, key):

--- a/celery/backends/consul.py
+++ b/celery/backends/consul.py
@@ -70,7 +70,7 @@ class ConsulBackend(KeyValueStoreBackend):
         for key in keys:
             yield self.get(key)
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         """Set a key in Consul.
 
         Before creating the key it will create a session inside Consul

--- a/celery/backends/cosmosdbsql.py
+++ b/celery/backends/cosmosdbsql.py
@@ -181,7 +181,7 @@ class CosmosDBSQLBackend(KeyValueStoreBackend):
         else:
             return document.get("value")
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         """Store a value for a given key.
 
         Args:

--- a/celery/backends/couchbase.py
+++ b/celery/backends/couchbase.py
@@ -106,7 +106,7 @@ class CouchbaseBackend(KeyValueStoreBackend):
         except NotFoundError:
             return None
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         self.connection.set(key, value, ttl=self.expires, format=FMT_AUTO)
 
     def mget(self, keys):

--- a/celery/backends/couchdb.py
+++ b/celery/backends/couchdb.py
@@ -86,7 +86,7 @@ class CouchBackend(KeyValueStoreBackend):
         except pycouchdb.exceptions.NotFound:
             return None
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         key = bytes_to_str(key)
         data = {'_id': key, 'value': value}
         try:

--- a/celery/backends/dynamodb.py
+++ b/celery/backends/dynamodb.py
@@ -486,7 +486,7 @@ class DynamoDBBackend(KeyValueStoreBackend):
         item = self._item_to_dict(item_response)
         return item.get(self._value_field.name)
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         key = string(key)
         request_parameters = self._prepare_put_request(key, value)
         self.client.put_item(**request_parameters)

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -103,7 +103,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
             id=key,
         )
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         body = {
             'result': value,
             '@timestamp': '{0}Z'.format(

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -87,13 +87,14 @@ class ElasticsearchBackend(KeyValueStoreBackend):
 
     def exception_safe_to_retry(self, exc):
         if isinstance(exc, (elasticsearch.exceptions.TransportError)):
+            # 409: Conflict
             # 429: Too Many Requests
             # 500: Internal Server Error
             # 502: Bad Gateway
             # 503: Service Unavailable
             # 504: Gateway Timeout
             # N/A: Low level exception (i.e. socket exception)
-            if exc.status_code in {429, 500, 502, 503, 504, 'N/A'}:
+            if exc.status_code in {409, 429, 500, 502, 503, 504, 'N/A'}:
                 return True
         return super().exception_safe_to_retry(exc)
 
@@ -129,7 +130,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
             )
         except elasticsearch.exceptions.ConflictError:
             # document already exists, update it
-            self._update(id=key, body=body)
+            self._update(key, body, state)
 
     def _index(self, id, body, **kwargs):
         body = {bytes_to_str(k): v for k, v in items(body)}
@@ -142,43 +143,44 @@ class ElasticsearchBackend(KeyValueStoreBackend):
             **kwargs
         )
 
-    def _update(self, id, body, **kwargs):
+    def _update(self, id, body, state, **kwargs):
         body = {bytes_to_str(k): v for k, v in items(body)}
-        retries = 3
-        while retries > 0:
-            retries -= 1
-            try:
-                res_get = self._get(key=id)
-                if not res_get['found']:
-                    return self._index(id, body, **kwargs)
-                parsed_result = self.decode_result(res_get['_source']['result'])
-                if parsed_result['status'] in states.READY_STATES:
-                    # if stored state is already in ready state, do nothing
-                    return {'result': 'noop'}
 
-                # get current sequence number and primary term
-                # https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
-                seq_no = res_get.get('_seq_no', 1)
-                prim_term = res_get.get('_primary_term', 1)
+        res_get = self._get(key=id)
+        if not res_get['found']:
+            return self._index(id, body, **kwargs)
+        try:
+            meta_present_on_backend = self.decode_result(res_get['_source']['result'])
+        except (TypeError, KeyError):
+            pass
+        else:
+            if meta_present_on_backend['status'] == states.SUCCESS:
+                # if stored state is already in success, do nothing
+                return {'result': 'noop'}
+            elif meta_present_on_backend['status'] in states.READY_STATES and state in states.UNREADY_STATES:
+                # if stored state is in ready state and current not, do nothing
+                return {'result': 'noop'}
 
-                # try to update document with current seq_no and primary_term
-                res = self.server.update(
-                    id=bytes_to_str(id),
-                    index=self.index,
-                    doc_type=self.doc_type,
-                    body={'doc': body},
-                    params={'if_primary_term': prim_term, 'if_seq_no': seq_no},
-                    **kwargs
-                )
-                # result is elastic search update query result
-                # noop = query did not update any document
-                # updated = at least one document got updated
-                if res['result'] != 'noop':
-                    return res
-            except Exception:
-                if retries == 0:
-                    raise
-        raise Exception('too many retries to update backend')
+        # get current sequence number and primary term
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
+        seq_no = res_get.get('_seq_no', 1)
+        prim_term = res_get.get('_primary_term', 1)
+
+        # try to update document with current seq_no and primary_term
+        res = self.server.update(
+            id=bytes_to_str(id),
+            index=self.index,
+            doc_type=self.doc_type,
+            body={'doc': body},
+            params={'if_primary_term': prim_term, 'if_seq_no': seq_no},
+            **kwargs
+        )
+        # result is elastic search update query result
+        # noop = query did not update any document
+        # updated = at least one document got updated
+        if res['result'] == 'noop':
+            raise elasticsearch.exceptions.ConflictError(409, 'conflicting update occurred concurrently', {})
+        return res
 
     def mget(self, keys):
         return [self.get(key) for key in keys]

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -165,6 +165,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
                 res = self.server.update(
                     id=bytes_to_str(id),
                     index=self.index,
+                    doc_type=self.doc_type,
                     body={'doc': body},
                     params={'if_primary_term': prim_term, 'if_seq_no': seq_no},
                     **kwargs

--- a/celery/backends/filesystem.py
+++ b/celery/backends/filesystem.py
@@ -7,7 +7,7 @@ import os
 
 from kombu.utils.encoding import ensure_bytes
 
-from celery import uuid
+from celery import uuid, states
 from celery.backends.base import KeyValueStoreBackend
 from celery.exceptions import ImproperlyConfigured
 
@@ -74,7 +74,7 @@ class FilesystemBackend(KeyValueStoreBackend):
 
     def _do_directory_test(self, key):
         try:
-            self.set(key, b'test value')
+            self.set(key, b'test value', states.SUCCESS)
             assert self.get(key) == b'test value'
             self.delete(key)
         except IOError:
@@ -90,7 +90,7 @@ class FilesystemBackend(KeyValueStoreBackend):
         except FileNotFoundError:
             pass
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         with self.open(self._filename(key), 'wb') as outfile:
             outfile.write(ensure_bytes(value))
 

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -364,7 +364,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             retries, max_retries or 'Inf', humanize_seconds(tts, 'in '))
         return tts
 
-    def set(self, key, value, **retry_policy):
+    def set(self, key, value, state, **retry_policy):
         return self.ensure(self._set, (key, value), **retry_policy)
 
     def _set(self, key, value):

--- a/celery/backends/riak.py
+++ b/celery/backends/riak.py
@@ -141,7 +141,7 @@ class RiakBackend(KeyValueStoreBackend):
     def get(self, key):
         return self.bucket.get(key).data
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         _key = self.bucket.new(key, data=value)
         _key.store()
 

--- a/celery/backends/s3.py
+++ b/celery/backends/s3.py
@@ -68,7 +68,7 @@ class S3Backend(KeyValueStoreBackend):
                 return None
             raise error
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         key = bytes_to_str(key)
         s3_object = self._get_s3_object(key)
         s3_object.put(Body=value)

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -22,6 +22,9 @@ Error Hierarchy
             - :exc:`~celery.exceptions.TaskRevokedError`
             - :exc:`~celery.exceptions.InvalidTaskError`
             - :exc:`~celery.exceptions.ChordError`
+        - :exc:`~celery.exceptions.BackendError`
+            - :exc:`~celery.exceptions.BackendGetMetaError`
+            - :exc:`~celery.exceptions.BackendStoreError`
     - :class:`kombu.exceptions.KombuError`
         - :exc:`~celery.exceptions.OperationalError`
 
@@ -78,6 +81,9 @@ __all__ = (
     'NotRegistered', 'AlreadyRegistered', 'TimeoutError',
     'MaxRetriesExceededError', 'TaskRevokedError',
     'InvalidTaskError', 'ChordError',
+
+    # Backend related errors.
+    'BackendError', 'BackendGetMetaError', 'BackendStoreError',
 
     # Billiard task errors.
     'SoftTimeLimitExceeded', 'TimeLimitExceeded',
@@ -260,3 +266,28 @@ SystemTerminate = WorkerTerminate  # noqa: E305 XXX compat
 
 class WorkerShutdown(SystemExit):
     """Signals that the worker should perform a warm shutdown."""
+
+
+class BackendError(Exception):
+    """An issue writing or reading to/from the backend."""
+
+
+class BackendGetMetaError(BackendError):
+    """An issue reading from the backend."""
+
+    def __init__(self, *args, **kwargs):
+        self.task_id = kwargs.get('task_id', "")
+
+    def __repr__(self):
+        return super().__repr__() + " task_id:" + self.task_id
+
+
+class BackendStoreError(BackendError):
+    """An issue writing from the backend."""
+
+    def __init__(self, *args, **kwargs):
+        self.state = kwargs.get('state', "")
+        self.task_id = kwargs.get('task_id', "")
+
+    def __repr__(self):
+        return super().__repr__() + " state:" + self.state + " task_id:" + self.task_id

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -677,6 +677,47 @@ Can be one of the following:
 .. _`S3`: https://aws.amazon.com/s3/
 
 
+.. setting:: result_backend_always_retry
+
+``result_backend_always_retry``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: :const:`False`
+
+If enable, backend will try to retry on the event of recoverable exceptions instead of propagating the exception.
+It will use an exponential backoff sleep time between 2 retries.
+
+
+.. setting:: result_backend_max_sleep_between_retries_ms
+
+``result_backend_max_sleep_between_retries_ms``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: 10000
+
+This specifies the maximum sleep time between two backend operation retry.
+
+
+.. setting:: result_backend_base_sleep_between_retries_ms
+
+``result_backend_base_sleep_between_retries_ms``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: 10
+
+This specifies the base amount of sleep time between two backend operation retry.
+
+
+.. setting:: result_backend_max_retries
+
+``result_backend_max_retries``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: Inf
+
+This is the maximum of retries in case of recoverable exceptions.
+
+
 .. setting:: result_backend_transport_options
 
 ``result_backend_transport_options``

--- a/t/integration/test_backend.py
+++ b/t/integration/test_backend.py
@@ -4,6 +4,7 @@ import os
 
 from case import skip
 
+from celery import states
 from celery.backends.azureblockblob import AzureBlockBlobBackend
 
 
@@ -19,7 +20,7 @@ class test_AzureBlockBlobBackend:
                       for i in range(5)}
 
         for key, value in key_values.items():
-            backend.set(key, value)
+            backend.set(key, value, states.SUCCESS)
 
         actual_values = backend.mget(key_values.keys())
         expected_values = list(key_values.values())

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import pytest
 from case import Mock, call, patch, skip
 
+from celery import states
 from celery.backends import azureblockblob
 from celery.backends.azureblockblob import AzureBlockBlobBackend
 from celery.exceptions import ImproperlyConfigured
@@ -71,7 +72,7 @@ class test_AzureBlockBlobBackend:
 
     @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._client")
     def test_set(self, mock_client):
-        self.backend.set(b"mykey", "myvalue")
+        self.backend.set(b"mykey", "myvalue", states.SUCCESS)
 
         mock_client.create_blob_from_text.assert_called_once_with(
             "celery", "mykey", "myvalue")

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -5,7 +5,7 @@ import types
 from contextlib import contextmanager
 
 import pytest
-from case import ANY, Mock, call, patch, skip
+from case import ANY, Mock, call, patch, skip, sentinel
 from kombu.serialization import prepare_accept_content
 from kombu.utils.encoding import ensure_bytes
 
@@ -14,7 +14,7 @@ from celery import chord, group, signature, states, uuid
 from celery.app.task import Context, Task
 from celery.backends.base import (BaseBackend, DisabledBackend,
                                   KeyValueStoreBackend, _nulldict)
-from celery.exceptions import ChordError, TimeoutError
+from celery.exceptions import ChordError, TimeoutError, BackendStoreError, BackendGetMetaError
 from celery.five import bytes_if_py2, items, range
 from celery.result import result_from_tuple
 from celery.utils import serialization
@@ -968,3 +968,165 @@ class test_as_uri:
 
     def test_as_uri_exclude_password(self):
         assert self.b.as_uri() == 'sch://uuuu:**@hostname.dom/'
+
+
+class test_backend_retries:
+
+    def test_should_retry_exception(self):
+        assert not BaseBackend(app=self.app).exception_safe_to_retry(Exception("test"))
+
+    def test_get_failed_never_retries(self):
+        self.app.conf.result_backend_always_retry, prev = False, self.app.conf.result_backend_always_retry
+
+        expected_exc = Exception("failed")
+        try:
+            b = BaseBackend(app=self.app)
+            b.exception_safe_to_retry = lambda exc: True
+            b._sleep = Mock()
+            b._get_task_meta_for = Mock()
+            b._get_task_meta_for.side_effect = [
+                expected_exc,
+                {'status': states.SUCCESS, 'result': 42}
+            ]
+            try:
+                b.get_task_meta(sentinel.task_id)
+                assert False
+            except Exception as exc:
+                assert b._sleep.call_count == 0
+                assert exc == expected_exc
+        finally:
+            self.app.conf.result_backend_always_retry = prev
+
+    def test_get_with_retries(self):
+        self.app.conf.result_backend_always_retry, prev = True, self.app.conf.result_backend_always_retry
+
+        try:
+            b = BaseBackend(app=self.app)
+            b.exception_safe_to_retry = lambda exc: True
+            b._sleep = Mock()
+            b._get_task_meta_for = Mock()
+            b._get_task_meta_for.side_effect = [
+                Exception("failed"),
+                {'status': states.SUCCESS, 'result': 42}
+            ]
+            res = b.get_task_meta(sentinel.task_id)
+            assert res == {'status': states.SUCCESS, 'result': 42}
+            assert b._sleep.call_count == 1
+        finally:
+            self.app.conf.result_backend_always_retry = prev
+
+    def test_get_reaching_max_retries(self):
+        self.app.conf.result_backend_always_retry, prev = True, self.app.conf.result_backend_always_retry
+        self.app.conf.result_backend_max_retries, prev_max_retries = 0, self.app.conf.result_backend_max_retries
+
+        try:
+            b = BaseBackend(app=self.app)
+            b.exception_safe_to_retry = lambda exc: True
+            b._sleep = Mock()
+            b._get_task_meta_for = Mock()
+            b._get_task_meta_for.side_effect = [
+                Exception("failed"),
+                {'status': states.SUCCESS, 'result': 42}
+            ]
+            try:
+                b.get_task_meta(sentinel.task_id)
+                assert False
+            except BackendGetMetaError:
+                assert b._sleep.call_count == 0
+        finally:
+            self.app.conf.result_backend_always_retry = prev
+            self.app.conf.result_backend_max_retries = prev_max_retries
+
+    def test_get_unsafe_exception(self):
+        self.app.conf.result_backend_always_retry, prev = True, self.app.conf.result_backend_always_retry
+
+        expected_exc = Exception("failed")
+        try:
+            b = BaseBackend(app=self.app)
+            b._sleep = Mock()
+            b._get_task_meta_for = Mock()
+            b._get_task_meta_for.side_effect = [
+                expected_exc,
+                {'status': states.SUCCESS, 'result': 42}
+            ]
+            try:
+                b.get_task_meta(sentinel.task_id)
+                assert False
+            except Exception as exc:
+                assert b._sleep.call_count == 0
+                assert exc == expected_exc
+        finally:
+            self.app.conf.result_backend_always_retry = prev
+
+    def test_store_result_never_retries(self):
+        self.app.conf.result_backend_always_retry, prev = False, self.app.conf.result_backend_always_retry
+
+        expected_exc = Exception("failed")
+        try:
+            b = BaseBackend(app=self.app)
+            b.exception_safe_to_retry = lambda exc: True
+            b._sleep = Mock()
+            b._get_task_meta_for = Mock()
+            b._get_task_meta_for.return_value = {
+                'status': states.RETRY, 'result': {"exc_type": "Exception", "exc_message": ["failed"], "exc_module": "builtins"}
+            }
+            b._store_result = Mock()
+            b._store_result.side_effect = [
+                expected_exc,
+                42
+            ]
+            try:
+                b.store_result(sentinel.task_id, 42, states.SUCCESS)
+            except Exception as exc:
+                assert b._sleep.call_count == 0
+                assert exc == expected_exc
+        finally:
+            self.app.conf.result_backend_always_retry = prev
+
+    def test_store_result_with_retries(self):
+        self.app.conf.result_backend_always_retry, prev = True, self.app.conf.result_backend_always_retry
+
+        try:
+            b = BaseBackend(app=self.app)
+            b.exception_safe_to_retry = lambda exc: True
+            b._sleep = Mock()
+            b._get_task_meta_for = Mock()
+            b._get_task_meta_for.return_value = {
+                'status': states.RETRY, 'result': {"exc_type": "Exception", "exc_message": ["failed"], "exc_module": "builtins"}
+            }
+            b._store_result = Mock()
+            b._store_result.side_effect = [
+                Exception("failed"),
+                42
+            ]
+            res = b.store_result(sentinel.task_id, 42, states.SUCCESS)
+            assert res == 42
+            assert b._sleep.call_count == 1
+        finally:
+            self.app.conf.result_backend_always_retry = prev
+
+    def test_store_result_reaching_max_retries(self):
+        self.app.conf.result_backend_always_retry, prev = True, self.app.conf.result_backend_always_retry
+        self.app.conf.result_backend_max_retries, prev_max_retries = 0, self.app.conf.result_backend_max_retries
+
+        try:
+            b = BaseBackend(app=self.app)
+            b.exception_safe_to_retry = lambda exc: True
+            b._sleep = Mock()
+            b._get_task_meta_for = Mock()
+            b._get_task_meta_for.return_value = {
+                'status': states.RETRY, 'result': {"exc_type": "Exception", "exc_message": ["failed"], "exc_module": "builtins"}
+            }
+            b._store_result = Mock()
+            b._store_result.side_effect = [
+                Exception("failed"),
+                42
+            ]
+            try:
+                b.store_result(sentinel.task_id, 42, states.SUCCESS)
+                assert False
+            except BackendStoreError:
+                assert b._sleep.call_count == 0
+        finally:
+            self.app.conf.result_backend_always_retry = prev
+            self.app.conf.result_backend_max_retries = prev_max_retries

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -317,7 +317,7 @@ class KVBackend(KeyValueStoreBackend):
     def get(self, key):
         return self.db.get(key)
 
-    def set(self, key, value):
+    def set(self, key, value, state):
         self.db[key] = value
 
     def mget(self, keys):
@@ -908,7 +908,7 @@ class test_KeyValueStoreBackend_interface:
 
     def test_set(self):
         with pytest.raises(NotImplementedError):
-            KeyValueStoreBackend(self.app).set('a', 1)
+            KeyValueStoreBackend(self.app).set('a', 1, states.SUCCESS)
 
     def test_incr(self):
         with pytest.raises(NotImplementedError):

--- a/t/unit/backends/test_cache.py
+++ b/t/unit/backends/test_cache.py
@@ -99,8 +99,8 @@ class test_CacheBackend:
         deps.delete.assert_called_with()
 
     def test_mget(self):
-        self.tb.set('foo', 1)
-        self.tb.set('bar', 2)
+        self.tb.set('foo', 1, states.SUCCESS)
+        self.tb.set('bar', 2, states.SUCCESS)
 
         assert self.tb.mget(['foo', 'bar']) == {'foo': 1, 'bar': 2}
 

--- a/t/unit/backends/test_cosmosdbsql.py
+++ b/t/unit/backends/test_cosmosdbsql.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import pytest
 from case import Mock, call, patch, skip
 
+from celery import states
 from celery.backends import cosmosdbsql
 from celery.backends.cosmosdbsql import CosmosDBSQLBackend
 from celery.exceptions import ImproperlyConfigured
@@ -108,7 +109,7 @@ class test_DocumentDBBackend:
 
     @patch(MODULE_TO_MOCK + ".CosmosDBSQLBackend._client")
     def test_set(self, mock_client):
-        self.backend.set(b"mykey", "myvalue")
+        self.backend.set(b"mykey", "myvalue", states.SUCCESS)
 
         mock_client.CreateDocument.assert_called_once_with(
             "dbs/celerydb/colls/celerycol",

--- a/t/unit/backends/test_couchbase.py
+++ b/t/unit/backends/test_couchbase.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import pytest
 from case import MagicMock, Mock, patch, sentinel, skip
 
+from celery import states
 from celery.app import backends
 from celery.backends import couchbase as module
 from celery.backends.couchbase import CouchbaseBackend
@@ -68,7 +69,7 @@ class test_CouchbaseBackend:
         x._connection = MagicMock()
         x._connection.set = MagicMock()
         # should return None
-        assert x.set(sentinel.key, sentinel.value) is None
+        assert x.set(sentinel.key, sentinel.value, states.SUCCESS) is None
 
     def test_set_expires(self):
         self.app.conf.couchbase_backend_settings = None
@@ -77,7 +78,7 @@ class test_CouchbaseBackend:
         x._connection = MagicMock()
         x._connection.set = MagicMock()
         # should return None
-        assert x.set(sentinel.key, sentinel.value) is None
+        assert x.set(sentinel.key, sentinel.value, states.SUCCESS) is None
 
     def test_delete(self):
         self.app.conf.couchbase_backend_settings = {}

--- a/t/unit/backends/test_couchdb.py
+++ b/t/unit/backends/test_couchdb.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import pytest
 from case import MagicMock, Mock, sentinel, skip
 
+from celery import states
 from celery.app import backends
 from celery.backends import couchdb as module
 from celery.backends.couchdb import CouchBackend
@@ -63,7 +64,7 @@ class test_CouchBackend:
         x = CouchBackend(app=self.app)
         x._connection = Mock()
 
-        x.set(key, 'value')
+        x.set(key, 'value', states.SUCCESS)
 
         x._connection.save.assert_called_once_with({'_id': '1f3fab',
                                                     'value': 'value'})
@@ -75,7 +76,7 @@ class test_CouchBackend:
         x._connection.save.side_effect = (pycouchdb.exceptions.Conflict, None)
         get = x._connection.get = MagicMock()
 
-        x.set(key, 'value')
+        x.set(key, 'value', states.SUCCESS)
 
         x._connection.get.assert_called_once_with('1f3fab')
         x._connection.get('1f3fab').__setitem__.assert_called_once_with(

--- a/t/unit/backends/test_dynamodb.py
+++ b/t/unit/backends/test_dynamodb.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 import pytest
 from case import MagicMock, Mock, patch, sentinel, skip
 
+from celery import states
 from celery.backends import dynamodb as module
 from celery.backends.dynamodb import DynamoDBBackend
 from celery.exceptions import ImproperlyConfigured
@@ -473,7 +474,7 @@ class test_DynamoDBBackend:
 
         # should return None
         with patch('celery.backends.dynamodb.time', self._mock_time):
-            assert self.backend.set(sentinel.key, sentinel.value) is None
+            assert self.backend.set(sentinel.key, sentinel.value, states.SUCCESS) is None
 
         assert self.backend._client.put_item.call_count == 1
         _, call_kwargs = self.backend._client.put_item.call_args
@@ -496,7 +497,7 @@ class test_DynamoDBBackend:
 
         # should return None
         with patch('celery.backends.dynamodb.time', self._mock_time):
-            assert self.backend.set(sentinel.key, sentinel.value) is None
+            assert self.backend.set(sentinel.key, sentinel.value, states.SUCCESS) is None
 
         assert self.backend._client.put_item.call_count == 1
         _, call_kwargs = self.backend._client.put_item.call_args

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -57,6 +57,17 @@ class test_ElasticsearchBackend:
             index=x.index,
         )
 
+    def test_get_task_not_found(self):
+        x = ElasticsearchBackend(app=self.app)
+        x._server = Mock()
+        x._server.get.side_effect = [
+            exceptions.NotFoundError(404, '{"_index":"celery","_type":"_doc","_id":"toto","found":false}',
+                                     {'_index': 'celery', '_type': '_doc', '_id': 'toto', 'found': False})
+        ]
+
+        res = x.get(sentinel.task_id)
+        assert res is None
+
     def test_delete(self):
         x = ElasticsearchBackend(app=self.app)
         x._server = Mock()

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -1,7 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
 import pytest
-from case import Mock, patch, sentinel, skip
+from case import Mock, patch, sentinel, skip, call
+from celery import states
+import datetime
+from elasticsearch import exceptions
+from kombu.utils.encoding import bytes_to_str
 
 from celery.app import backends
 from celery.backends import elasticsearch as module
@@ -71,6 +75,240 @@ class test_ElasticsearchBackend:
 
         assert backend is ElasticsearchBackend
         assert url_ == url
+
+    @patch('celery.backends.elasticsearch.datetime')
+    def test_index_conflict(self, datetime_mock):
+        expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
+        datetime_mock.utcnow.return_value = expected_dt
+
+        x = ElasticsearchBackend(app=self.app)
+        x._server = Mock()
+        x._server.index.side_effect = [
+            exceptions.ConflictError(409, "concurrent update", {})
+        ]
+
+        x._server.get.return_value = {
+            'found': True,
+            '_source': {
+                'result': """{"status":"RETRY","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
+            },
+            '_seq_no': 2,
+            '_primary_term': 1,
+        }
+
+        x._server.update.return_value = {
+            'result': 'updated'
+        }
+
+        x.set(sentinel.task_id, sentinel.result, sentinel.state)
+
+        assert x._server.get.call_count == 1
+        x._server.index.assert_called_once_with(
+            id=sentinel.task_id,
+            index=x.index,
+            doc_type=x.doc_type,
+            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'},
+            params={'op_type': 'create'},
+        )
+        x._server.update.assert_called_once_with(
+            id=sentinel.task_id,
+            index=x.index,
+            doc_type=x.doc_type,
+            body={'doc': {'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'}},
+            params={'if_seq_no': 2, 'if_primary_term': 1}
+        )
+
+    @patch('celery.backends.elasticsearch.datetime')
+    def test_index_conflict_with_existing_success(self, datetime_mock):
+        expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
+        datetime_mock.utcnow.return_value = expected_dt
+
+        x = ElasticsearchBackend(app=self.app)
+        x._server = Mock()
+        x._server.index.side_effect = [
+            exceptions.ConflictError(409, "concurrent update", {})
+        ]
+
+        x._server.get.return_value = {
+            'found': True,
+            '_source': {
+                'result': """{"status":"SUCCESS","result":42}"""
+            },
+            '_seq_no': 2,
+            '_primary_term': 1,
+        }
+
+        x._server.update.return_value = {
+            'result': 'updated'
+        }
+
+        x.set(sentinel.task_id, sentinel.result, sentinel.state)
+
+        assert x._server.get.call_count == 1
+        x._server.index.assert_called_once_with(
+            id=sentinel.task_id,
+            index=x.index,
+            doc_type=x.doc_type,
+            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'},
+            params={'op_type': 'create'},
+        )
+        x._server.update.assert_not_called()
+
+    @patch('celery.backends.elasticsearch.datetime')
+    def test_index_conflict_with_existing_ready_state(self, datetime_mock):
+        expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
+        datetime_mock.utcnow.return_value = expected_dt
+
+        x = ElasticsearchBackend(app=self.app)
+        x._server = Mock()
+        x._server.index.side_effect = [
+            exceptions.ConflictError(409, "concurrent update", {})
+        ]
+
+        x._server.get.return_value = {
+            'found': True,
+            '_source': {
+                'result': """{"status":"FAILURE","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
+            },
+            '_seq_no': 2,
+            '_primary_term': 1,
+        }
+
+        x._server.update.return_value = {
+            'result': 'updated'
+        }
+
+        x.set(sentinel.task_id, sentinel.result, states.RETRY)
+
+        assert x._server.get.call_count == 1
+        x._server.index.assert_called_once_with(
+            id=sentinel.task_id,
+            index=x.index,
+            doc_type=x.doc_type,
+            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'},
+            params={'op_type': 'create'},
+        )
+        x._server.update.assert_not_called()
+
+    @patch('celery.backends.elasticsearch.datetime')
+    @patch('celery.backends.base.datetime')
+    def test_backend_concurrent_update(self, base_datetime_mock, es_datetime_mock):
+        expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
+        es_datetime_mock.utcnow.return_value = expected_dt
+
+        expected_done_dt = datetime.datetime(2020, 6, 1, 18, 45, 34, 654321, None)
+        base_datetime_mock.utcnow.return_value = expected_done_dt
+
+        self.app.conf.result_backend_always_retry, prev = True, self.app.conf.result_backend_always_retry
+        try:
+            x = ElasticsearchBackend(app=self.app)
+
+            task_id = str(sentinel.task_id)
+            encoded_task_id = bytes_to_str(x.get_key_for_task(task_id))
+            result = str(sentinel.result)
+
+            sleep_mock = Mock()
+            x._sleep = sleep_mock
+            x._server = Mock()
+            x._server.index.side_effect = exceptions.ConflictError(409, "concurrent update", {})
+
+            x._server.get.side_effect = [
+                {
+                    'found': True,
+                    '_source': {
+                        'result': """{"status":"RETRY","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
+                    },
+                    '_seq_no': 2,
+                    '_primary_term': 1,
+                },
+                {
+                    'found': True,
+                    '_source': {
+                        'result': """{"status":"RETRY","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
+                    },
+                    '_seq_no': 2,
+                    '_primary_term': 1,
+                },
+                {
+                    'found': True,
+                    '_source': {
+                        'result': """{"status":"FAILURE","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
+                    },
+                    '_seq_no': 3,
+                    '_primary_term': 1,
+                },
+                {
+                    'found': True,
+                    '_source': {
+                        'result': """{"status":"FAILURE","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
+                    },
+                    '_seq_no': 3,
+                    '_primary_term': 1,
+                },
+            ]
+
+            x._server.update.side_effect = [
+                {'result': 'noop'},
+                {'result': 'updated'}
+            ]
+            result_meta = x._get_result_meta(result, states.SUCCESS, None, None)
+            result_meta['task_id'] = bytes_to_str(task_id)
+
+            expected_result = x.encode(result_meta)
+
+            x.store_result(task_id, result, states.SUCCESS)
+            x._server.index.assert_has_calls([
+                call(
+                    id=encoded_task_id,
+                    index=x.index,
+                    doc_type=x.doc_type,
+                    body={
+                        'result': expected_result,
+                        '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                    },
+                    params={'op_type': 'create'}
+                ),
+                call(
+                    id=encoded_task_id,
+                    index=x.index,
+                    doc_type=x.doc_type,
+                    body={
+                        'result': expected_result,
+                        '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                    },
+                    params={'op_type': 'create'}
+                ),
+            ])
+            x._server.update.assert_has_calls([
+                call(
+                    id=encoded_task_id,
+                    index=x.index,
+                    doc_type=x.doc_type,
+                    body={
+                        'doc': {
+                            'result': expected_result,
+                            '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                        }
+                    },
+                    params={'if_seq_no': 2, 'if_primary_term': 1}
+                ),
+                call(
+                    id=encoded_task_id,
+                    index=x.index,
+                    doc_type=x.doc_type,
+                    body={
+                        'doc': {
+                            'result': expected_result,
+                            '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                        }
+                    },
+                    params={'if_seq_no': 3, 'if_primary_term': 1}
+                ),
+            ])
+
+            assert sleep_mock.call_count == 1
+        finally:
+            self.app.conf.result_backend_always_retry = prev
 
     def test_backend_params_by_url(self):
         url = 'elasticsearch://localhost:9200/index/doc_type'

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -243,7 +243,7 @@ class test_RedisResultConsumer:
         meta = {'task_id': 'initial', 'status': states.SUCCESS}
         consumer = self.get_consumer()
         consumer.start('initial')
-        consumer.backend.set(b'celery-task-meta-initial', json.dumps(meta))
+        consumer.backend.set(b'celery-task-meta-initial', json.dumps(meta), states.SUCCESS)
         consumer._pubsub.get_message.side_effect = ConnectionError()
         consumer.drain_events()
         parent_on_state_change.assert_called_with(meta, None)
@@ -578,7 +578,7 @@ class test_RedisBackend:
 
     def test_set_no_expire(self):
         self.b.expires = None
-        self.b.set('foo', 'bar')
+        self.b.set('foo', 'bar', states.SUCCESS)
 
     def create_task(self):
         tid = uuid()

--- a/t/unit/backends/test_riak.py
+++ b/t/unit/backends/test_riak.py
@@ -6,6 +6,7 @@ import sys
 import pytest
 from case import MagicMock, Mock, patch, sentinel, skip
 
+from celery import states
 from celery.exceptions import ImproperlyConfigured
 
 try:
@@ -76,7 +77,7 @@ class test_RiakBackend:
         self.backend._bucket = MagicMock()
         self.backend._bucket.set = MagicMock()
         # should return None
-        assert self.backend.set(sentinel.key, sentinel.value) is None
+        assert self.backend.set(sentinel.key, sentinel.value, states.SUCCESS) is None
 
     def test_delete(self):
         self.app.conf.couchbase_backend_settings = {}

--- a/t/unit/backends/test_s3.py
+++ b/t/unit/backends/test_s3.py
@@ -6,6 +6,7 @@ from botocore.exceptions import ClientError
 from case import patch
 from moto import mock_s3
 
+from celery import states
 from celery.backends.s3 import S3Backend
 from celery.exceptions import ImproperlyConfigured
 
@@ -93,7 +94,7 @@ class test_S3Backend:
         self.app.conf.s3_bucket = 'bucket'
 
         s3_backend = S3Backend(app=self.app)
-        s3_backend.set(key, 'another_status')
+        s3_backend.set(key, 'another_status', states.SUCCESS)
 
         assert s3_backend.get(key) == 'another_status'
 
@@ -149,7 +150,7 @@ class test_S3Backend:
         self.app.conf.s3_bucket = 'bucket'
 
         s3_backend = S3Backend(app=self.app)
-        s3_backend.set('uuid', 'another_status')
+        s3_backend.set('uuid', 'another_status', states.SUCCESS)
         assert s3_backend.get('uuid') == 'another_status'
 
         s3_backend.delete('uuid')
@@ -168,7 +169,7 @@ class test_S3Backend:
 
         with pytest.raises(ClientError,
                            match=r'.*The specified bucket does not exist'):
-            s3_backend.set('uuid', 'another_status')
+            s3_backend.set('uuid', 'another_status', states.SUCCESS)
 
     def _mock_s3_resource(self):
         # Create AWS s3 Bucket for moto.


### PR DESCRIPTION
acks.late makes celery acknowledge messages only after processing and
storing result on the backend.

However, in case of backend unreachable, it will shadow a Retry
exception and put the task as failed in the backend not retrying the
task and acknoledging it on the broker.

With this new result_backend_always_retry setting, if the backend
exception is recoverable (to be defined per backend implementation),
it will retry the backend operation with an exponential backoff.


In addition, make ES retry storing updates in a better way

if existing value in the backend is success, then do nothing.
if it is a ready status, then update it only if new value is a ready status as well.
else update it.

This way, a SUCCESS cannot be overriden so that we do not loose
results but any ready state other than success (FAILURE, REVOKED) can
be overriden by another ready status (i.e. a SUCCESS)