### PR TITLE
Fix autoretry_for with explicit retry

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -23,7 +23,7 @@ from celery._state import (_announce_app_finalized, _deregister_app,
                            _register_app, _set_current_app, _task_stack,
                            connect_on_app_finalize, get_current_app,
                            get_current_worker_task, set_default_app)
-from celery.exceptions import AlwaysEagerIgnored, ImproperlyConfigured, Ignore
+from celery.exceptions import AlwaysEagerIgnored, ImproperlyConfigured, Ignore, Retry
 from celery.five import (UserDict, bytes_if_py2, python_2_unicode_compatible,
                          values)
 from celery.loaders import get_loader_cls
@@ -491,6 +491,8 @@ class Celery(object):
                     except Ignore:
                         # If Ignore signal occures task shouldn't be retried,
                         # even if it suits autoretry_for list
+                        raise
+                    except Retry:
                         raise
                     except autoretry_for as exc:
                         if retry_backoff:

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -95,7 +95,7 @@ class TasksCase:
         self.retry_task_noargs = retry_task_noargs
 
         @self.app.task(bind=True, max_retries=3, iterations=0, shared=False)
-        def retry_task_without_throw(self, **kwargs):
+        def retry_task_return_without_throw(self, **kwargs):
             self.iterations += 1
             try:
                 if self.request.retries >= 3:
@@ -105,7 +105,33 @@ class TasksCase:
             except Exception as exc:
                 return self.retry(exc=exc, throw=False)
 
-        self.retry_task_without_throw = retry_task_without_throw
+        self.retry_task_return_without_throw = retry_task_return_without_throw
+
+        @self.app.task(bind=True, max_retries=3, iterations=0, shared=False)
+        def retry_task_return_with_throw(self, **kwargs):
+            self.iterations += 1
+            try:
+                if self.request.retries >= 3:
+                    return 42
+                else:
+                    raise Exception("random code exception")
+            except Exception as exc:
+                return self.retry(exc=exc, throw=True)
+
+        self.retry_task_return_with_throw = retry_task_return_with_throw
+
+        @self.app.task(bind=True, max_retries=3, iterations=0, shared=False)
+        def retry_task_raise_without_throw(self, **kwargs):
+            self.iterations += 1
+            try:
+                if self.request.retries >= 3:
+                    return 42
+                else:
+                    raise Exception("random code exception")
+            except Exception as exc:
+                raise self.retry(exc=exc, throw=False)
+
+        self.retry_task_raise_without_throw = retry_task_raise_without_throw
 
         @self.app.task(bind=True, max_retries=3, iterations=0,
                        base=MockApplyTask, shared=False)
@@ -365,7 +391,13 @@ class test_task_retries(TasksCase):
             self.retry_task_mockapply.pop_request()
 
     def test_retry_without_throw_eager(self):
-        assert self.retry_task_without_throw.apply().get() == 42
+        assert self.retry_task_return_without_throw.apply().get() == 42
+
+    def test_raise_without_throw_eager(self):
+        assert self.retry_task_raise_without_throw.apply().get() == 42
+
+    def test_return_with_throw_eager(self):
+        assert self.retry_task_return_with_throw.apply().get() == 42
 
     def test_retry_eager_should_return_value(self):
         self.retry_task.max_retries = 3


### PR DESCRIPTION
Fixes #6135
 
If autoretry_for is set too broad on Exception, then autoretry may get a Retry.
If that's the case, rethrow directly instead of wrapping it in another Retry to avoid loosing new args.