### PR TITLE
Specify minimum version of Sphinx for Celery extension

### DIFF
--- a/celery/contrib/sphinx.py
+++ b/celery/contrib/sphinx.py
@@ -7,6 +7,8 @@ Introduction
 Usage
 -----
 
+The Celery extension for Sphinx requires Sphinx 2.0 or later.
+
 Add the extension to your :file:`docs/conf.py` configuration module:
 
 .. code-block:: python


### PR DESCRIPTION
The Sphinx extension requires Sphinx 2 or later due to #6032.