### PR TITLE
Pass ping destination to request

### DIFF
--- a/celery/app/control.py
+++ b/celery/app/control.py
@@ -135,6 +135,8 @@ class Inspect(object):
     registered_tasks = registered
 
     def ping(self, destination=None):
+        if destination:
+            self.destination = destination
         return self._request('ping')
 
     def active_queues(self):


### PR DESCRIPTION
## Description
The destination argument worked fine from CLI but didn't get used when calling ping from Python.