### PR TITLE
Customize the retry interval of chord_unlock tasks

### DIFF
--- a/celery/app/builtins.py
+++ b/celery/app/builtins.py
@@ -48,7 +48,7 @@ def add_unlock_chord_task(app):
     from celery.result import allow_join_result, result_from_tuple
 
     @app.task(name='celery.chord_unlock', max_retries=None, shared=False,
-              default_retry_delay=1, ignore_result=True, lazy=False, bind=True)
+              default_retry_delay=app.conf.result_chord_retry_interval, ignore_result=True, lazy=False, bind=True)
     def unlock_chord(self, group_id, callback, interval=None,
                      max_retries=None, result=None,
                      Result=app.AsyncResult, GroupResult=app.GroupResult,

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -216,6 +216,7 @@ NAMESPACES = Namespace(
         extended=Option(False, type='bool'),
         serializer=Option('json'),
         backend_transport_options=Option({}, type='dict'),
+        chord_retry_interval=Option(1.0, type='float'),
         chord_join_timeout=Option(3.0, type='float'),
         backend_max_sleep_between_retries_ms=Option(10000, type='int'),
         backend_max_retries=Option(float("inf"), type='float'),

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -823,6 +823,15 @@ Default: 3.0.
 
 The timeout in seconds (int/float) when joining a group's results within a chord.
 
+.. setting:: result_chord_retry_interval
+
+``result_chord_retry_interval``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: 1.0.
+
+Default interval for retrying chord tasks.
+
 .. _conf-database-result-backend:
 
 Database backend settings

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -174,6 +174,19 @@ class test_unlock_chord_task(ChordCase):
             # did retry
             retry.assert_called_with(countdown=10, max_retries=30)
 
+    def test_when_not_ready_with_configured_chord_retry_interval(self):
+        class NeverReady(TSR):
+            is_ready = False
+
+        self.app.conf.result_chord_retry_interval, prev = 42, self.app.conf.result_chord_retry_interval
+        try:
+            with self._chord_context(NeverReady, max_retries=30) as (cb, retry, _):
+                cb.type.apply_async.assert_not_called()
+                # did retry
+                retry.assert_called_with(countdown=42, max_retries=30)
+        finally:
+            self.app.conf.result_chord_retry_interval = prev
+
     def test_is_in_registry(self):
         assert 'celery.chord_unlock' in self.app.tasks
 


### PR DESCRIPTION
By default chord_unlock tasks have interval set to 1.
This patch adds a way to configure this default value for all chords.