### PR TITLE
chord: merge init options with run options

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1352,8 +1352,14 @@ class chord(Signature):
             with allow_join_result():
                 return self.apply(args, kwargs,
                                   body=body, task_id=task_id, **options)
+
+        merged_options = dict(self.options, **options) if options else self.options
+        option_task_id = merged_options.pop("task_id", None)
+        if task_id is None:
+            task_id = option_task_id
+
         # chord([A, B, ...], C)
-        return self.run(tasks, body, args, task_id=task_id, **options)
+        return self.run(tasks, body, args, task_id=task_id, **merged_options)
 
     def apply(self, args=None, kwargs=None,
               propagate=True, body=None, **options):

--- a/t/unit/tasks/unit_tasks.py
+++ b/t/unit/tasks/unit_tasks.py
@@ -1,0 +1,6 @@
+from celery import shared_task
+
+
+@shared_task
+def mul(x, y):
+    return x * y


### PR DESCRIPTION
This way, it's possible to define chord options at creations such as interval that will be used when called.