### PR TITLE
put back KeyValueStoreBackend.set method without state

### DIFF
--- a/celery/backends/arangodb.py
+++ b/celery/backends/arangodb.py
@@ -144,7 +144,7 @@ class ArangoDbBackend(KeyValueStoreBackend):
             logging.error(err)
             return None
 
-    def set(self, key, value, state):
+    def set(self, key, value):
         """Insert a doc with value into task attribute and _key as key."""
         try:
             logging.debug(

--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -110,7 +110,7 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
         except AzureMissingResourceHttpError:
             return None
 
-    def set(self, key, value, state):
+    def set(self, key, value):
         """Store a value for a given key.
 
         Args:

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -735,7 +735,10 @@ class BaseKeyValueStoreBackend(Backend):
     def mget(self, keys):
         raise NotImplementedError('Does not support get_many')
 
-    def set(self, key, value, state):
+    def _set_with_state(self, key, value, state):
+        return self.set(key, value)
+
+    def set(self, key, value):
         raise NotImplementedError('Must implement the set method.')
 
     def delete(self, key):
@@ -855,12 +858,12 @@ class BaseKeyValueStoreBackend(Backend):
         if current_meta['status'] == states.SUCCESS:
             return result
 
-        self.set(self.get_key_for_task(task_id), self.encode(meta), state)
+        self._set_with_state(self.get_key_for_task(task_id), self.encode(meta), state)
         return result
 
     def _save_group(self, group_id, result):
-        self.set(self.get_key_for_group(group_id),
-                 self.encode({'result': result.as_tuple()}), states.SUCCESS)
+        self._set_with_state(self.get_key_for_group(group_id),
+                             self.encode({'result': result.as_tuple()}), states.SUCCESS)
         return result
 
     def _delete_group(self, group_id):

--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -124,7 +124,7 @@ class CacheBackend(KeyValueStoreBackend):
     def mget(self, keys):
         return self.client.get_multi(keys)
 
-    def set(self, key, value, state):
+    def set(self, key, value):
         return self.client.set(key, value, self.expires)
 
     def delete(self, key):

--- a/celery/backends/consul.py
+++ b/celery/backends/consul.py
@@ -70,7 +70,7 @@ class ConsulBackend(KeyValueStoreBackend):
         for key in keys:
             yield self.get(key)
 
-    def set(self, key, value, state):
+    def set(self, key, value):
         """Set a key in Consul.
 
         Before creating the key it will create a session inside Consul

--- a/celery/backends/cosmosdbsql.py
+++ b/celery/backends/cosmosdbsql.py
@@ -181,7 +181,7 @@ class CosmosDBSQLBackend(KeyValueStoreBackend):
         else:
             return document.get("value")
 
-    def set(self, key, value, state):
+    def set(self, key, value):
         """Store a value for a given key.
 
         Args:

--- a/celery/backends/couchbase.py
+++ b/celery/backends/couchbase.py
@@ -106,7 +106,7 @@ class CouchbaseBackend(KeyValueStoreBackend):
         except NotFoundError:
             return None
 
-    def set(self, key, value, state):
+    def set(self, key, value):
         self.connection.set(key, value, ttl=self.expires, format=FMT_AUTO)
 
     def mget(self, keys):

--- a/celery/backends/couchdb.py
+++ b/celery/backends/couchdb.py
@@ -86,7 +86,7 @@ class CouchBackend(KeyValueStoreBackend):
         except pycouchdb.exceptions.NotFound:
             return None
 
-    def set(self, key, value, state):
+    def set(self, key, value):
         key = bytes_to_str(key)
         data = {'_id': key, 'value': value}
         try:

--- a/celery/backends/dynamodb.py
+++ b/celery/backends/dynamodb.py
@@ -486,7 +486,7 @@ class DynamoDBBackend(KeyValueStoreBackend):
         item = self._item_to_dict(item_response)
         return item.get(self._value_field.name)
 
-    def set(self, key, value, state):
+    def set(self, key, value):
         key = string(key)
         request_parameters = self._prepare_put_request(key, value)
         self.client.put_item(**request_parameters)

--- a/celery/backends/filesystem.py
+++ b/celery/backends/filesystem.py
@@ -7,7 +7,7 @@ import os
 
 from kombu.utils.encoding import ensure_bytes
 
-from celery import uuid, states
+from celery import uuid
 from celery.backends.base import KeyValueStoreBackend
 from celery.exceptions import ImproperlyConfigured
 
@@ -74,7 +74,7 @@ class FilesystemBackend(KeyValueStoreBackend):
 
     def _do_directory_test(self, key):
         try:
-            self.set(key, b'test value', states.SUCCESS)
+            self.set(key, b'test value')
             assert self.get(key) == b'test value'
             self.delete(key)
         except IOError:
@@ -90,7 +90,7 @@ class FilesystemBackend(KeyValueStoreBackend):
         except FileNotFoundError:
             pass
 
-    def set(self, key, value, state):
+    def set(self, key, value):
         with self.open(self._filename(key), 'wb') as outfile:
             outfile.write(ensure_bytes(value))
 

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -364,7 +364,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             retries, max_retries or 'Inf', humanize_seconds(tts, 'in '))
         return tts
 
-    def set(self, key, value, state, **retry_policy):
+    def set(self, key, value, **retry_policy):
         return self.ensure(self._set, (key, value), **retry_policy)
 
     def _set(self, key, value):

--- a/celery/backends/riak.py
+++ b/celery/backends/riak.py
@@ -141,7 +141,7 @@ class RiakBackend(KeyValueStoreBackend):
     def get(self, key):
         return self.bucket.get(key).data
 
-    def set(self, key, value, state):
+    def set(self, key, value):
         _key = self.bucket.new(key, data=value)
         _key.store()
 

--- a/celery/backends/s3.py
+++ b/celery/backends/s3.py
@@ -68,7 +68,7 @@ class S3Backend(KeyValueStoreBackend):
                 return None
             raise error
 
-    def set(self, key, value, state):
+    def set(self, key, value):
         key = bytes_to_str(key)
         s3_object = self._get_s3_object(key)
         s3_object.put(Body=value)

--- a/t/integration/test_backend.py
+++ b/t/integration/test_backend.py
@@ -20,7 +20,7 @@ class test_AzureBlockBlobBackend:
                       for i in range(5)}
 
         for key, value in key_values.items():
-            backend.set(key, value, states.SUCCESS)
+            backend._set_with_state(key, value, states.SUCCESS)
 
         actual_values = backend.mget(key_values.keys())
         expected_values = list(key_values.values())

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -72,7 +72,7 @@ class test_AzureBlockBlobBackend:
 
     @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._client")
     def test_set(self, mock_client):
-        self.backend.set(b"mykey", "myvalue", states.SUCCESS)
+        self.backend._set_with_state(b"mykey", "myvalue", states.SUCCESS)
 
         mock_client.create_blob_from_text.assert_called_once_with(
             "celery", "mykey", "myvalue")

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -317,7 +317,7 @@ class KVBackend(KeyValueStoreBackend):
     def get(self, key):
         return self.db.get(key)
 
-    def set(self, key, value, state):
+    def _set_with_state(self, key, value, state):
         self.db[key] = value
 
     def mget(self, keys):
@@ -908,7 +908,7 @@ class test_KeyValueStoreBackend_interface:
 
     def test_set(self):
         with pytest.raises(NotImplementedError):
-            KeyValueStoreBackend(self.app).set('a', 1, states.SUCCESS)
+            KeyValueStoreBackend(self.app)._set_with_state('a', 1, states.SUCCESS)
 
     def test_incr(self):
         with pytest.raises(NotImplementedError):

--- a/t/unit/backends/test_cache.py
+++ b/t/unit/backends/test_cache.py
@@ -99,8 +99,8 @@ class test_CacheBackend:
         deps.delete.assert_called_with()
 
     def test_mget(self):
-        self.tb.set('foo', 1, states.SUCCESS)
-        self.tb.set('bar', 2, states.SUCCESS)
+        self.tb._set_with_state('foo', 1, states.SUCCESS)
+        self.tb._set_with_state('bar', 2, states.SUCCESS)
 
         assert self.tb.mget(['foo', 'bar']) == {'foo': 1, 'bar': 2}
 

--- a/t/unit/backends/test_cosmosdbsql.py
+++ b/t/unit/backends/test_cosmosdbsql.py
@@ -109,7 +109,7 @@ class test_DocumentDBBackend:
 
     @patch(MODULE_TO_MOCK + ".CosmosDBSQLBackend._client")
     def test_set(self, mock_client):
-        self.backend.set(b"mykey", "myvalue", states.SUCCESS)
+        self.backend._set_with_state(b"mykey", "myvalue", states.SUCCESS)
 
         mock_client.CreateDocument.assert_called_once_with(
             "dbs/celerydb/colls/celerycol",

--- a/t/unit/backends/test_couchbase.py
+++ b/t/unit/backends/test_couchbase.py
@@ -69,7 +69,7 @@ class test_CouchbaseBackend:
         x._connection = MagicMock()
         x._connection.set = MagicMock()
         # should return None
-        assert x.set(sentinel.key, sentinel.value, states.SUCCESS) is None
+        assert x._set_with_state(sentinel.key, sentinel.value, states.SUCCESS) is None
 
     def test_set_expires(self):
         self.app.conf.couchbase_backend_settings = None
@@ -78,7 +78,7 @@ class test_CouchbaseBackend:
         x._connection = MagicMock()
         x._connection.set = MagicMock()
         # should return None
-        assert x.set(sentinel.key, sentinel.value, states.SUCCESS) is None
+        assert x._set_with_state(sentinel.key, sentinel.value, states.SUCCESS) is None
 
     def test_delete(self):
         self.app.conf.couchbase_backend_settings = {}

--- a/t/unit/backends/test_couchdb.py
+++ b/t/unit/backends/test_couchdb.py
@@ -64,7 +64,7 @@ class test_CouchBackend:
         x = CouchBackend(app=self.app)
         x._connection = Mock()
 
-        x.set(key, 'value', states.SUCCESS)
+        x._set_with_state(key, 'value', states.SUCCESS)
 
         x._connection.save.assert_called_once_with({'_id': '1f3fab',
                                                     'value': 'value'})
@@ -76,7 +76,7 @@ class test_CouchBackend:
         x._connection.save.side_effect = (pycouchdb.exceptions.Conflict, None)
         get = x._connection.get = MagicMock()
 
-        x.set(key, 'value', states.SUCCESS)
+        x._set_with_state(key, 'value', states.SUCCESS)
 
         x._connection.get.assert_called_once_with('1f3fab')
         x._connection.get('1f3fab').__setitem__.assert_called_once_with(

--- a/t/unit/backends/test_dynamodb.py
+++ b/t/unit/backends/test_dynamodb.py
@@ -474,7 +474,7 @@ class test_DynamoDBBackend:
 
         # should return None
         with patch('celery.backends.dynamodb.time', self._mock_time):
-            assert self.backend.set(sentinel.key, sentinel.value, states.SUCCESS) is None
+            assert self.backend._set_with_state(sentinel.key, sentinel.value, states.SUCCESS) is None
 
         assert self.backend._client.put_item.call_count == 1
         _, call_kwargs = self.backend._client.put_item.call_args
@@ -497,7 +497,7 @@ class test_DynamoDBBackend:
 
         # should return None
         with patch('celery.backends.dynamodb.time', self._mock_time):
-            assert self.backend.set(sentinel.key, sentinel.value, states.SUCCESS) is None
+            assert self.backend._set_with_state(sentinel.key, sentinel.value, states.SUCCESS) is None
 
         assert self.backend._client.put_item.call_count == 1
         _, call_kwargs = self.backend._client.put_item.call_args

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -243,7 +243,7 @@ class test_RedisResultConsumer:
         meta = {'task_id': 'initial', 'status': states.SUCCESS}
         consumer = self.get_consumer()
         consumer.start('initial')
-        consumer.backend.set(b'celery-task-meta-initial', json.dumps(meta), states.SUCCESS)
+        consumer.backend._set_with_state(b'celery-task-meta-initial', json.dumps(meta), states.SUCCESS)
         consumer._pubsub.get_message.side_effect = ConnectionError()
         consumer.drain_events()
         parent_on_state_change.assert_called_with(meta, None)
@@ -578,7 +578,7 @@ class test_RedisBackend:
 
     def test_set_no_expire(self):
         self.b.expires = None
-        self.b.set('foo', 'bar', states.SUCCESS)
+        self.b._set_with_state('foo', 'bar', states.SUCCESS)
 
     def create_task(self):
         tid = uuid()

--- a/t/unit/backends/test_riak.py
+++ b/t/unit/backends/test_riak.py
@@ -77,7 +77,7 @@ class test_RiakBackend:
         self.backend._bucket = MagicMock()
         self.backend._bucket.set = MagicMock()
         # should return None
-        assert self.backend.set(sentinel.key, sentinel.value, states.SUCCESS) is None
+        assert self.backend._set_with_state(sentinel.key, sentinel.value, states.SUCCESS) is None
 
     def test_delete(self):
         self.app.conf.couchbase_backend_settings = {}

--- a/t/unit/backends/test_s3.py
+++ b/t/unit/backends/test_s3.py
@@ -94,7 +94,7 @@ class test_S3Backend:
         self.app.conf.s3_bucket = 'bucket'
 
         s3_backend = S3Backend(app=self.app)
-        s3_backend.set(key, 'another_status', states.SUCCESS)
+        s3_backend._set_with_state(key, 'another_status', states.SUCCESS)
 
         assert s3_backend.get(key) == 'another_status'
 
@@ -150,7 +150,7 @@ class test_S3Backend:
         self.app.conf.s3_bucket = 'bucket'
 
         s3_backend = S3Backend(app=self.app)
-        s3_backend.set('uuid', 'another_status', states.SUCCESS)
+        s3_backend._set_with_state('uuid', 'another_status', states.SUCCESS)
         assert s3_backend.get('uuid') == 'another_status'
 
         s3_backend.delete('uuid')
@@ -169,7 +169,7 @@ class test_S3Backend:
 
         with pytest.raises(ClientError,
                            match=r'.*The specified bucket does not exist'):
-            s3_backend.set('uuid', 'another_status', states.SUCCESS)
+            s3_backend._set_with_state('uuid', 'another_status', states.SUCCESS)
 
     def _mock_s3_resource(self):
         # Create AWS s3 Bucket for moto.


### PR DESCRIPTION
It turns out it was breaking some other projects.
wrapping set method with _set_with_state, this way it will not break existing Backend.
while enabling this feature for other Backend.

Currently, only ElasticsearchBackend supports this feature.

It protects concurrent update to corrupt state in the backend.
Existing success cannot be overriden, nor a ready state by a non ready state.
i.e. a Retry state cannot override a Success or Failure.
As a result, chord_unlock task will not loop forever due to missing ready state on the backend.

Fixes https://github.com/celery/celery/issues/6155
Fixes https://github.com/celery/django-celery-results/issues/150
