### PR TITLE
Added as_list function to AsyncResult class

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -129,6 +129,14 @@ class AsyncResult(ResultBase):
         parent = self.parent
         return (self.id, parent and parent.as_tuple()), None
 
+    def as_list(self):
+        results = []
+        parent = self.parent
+        results.append(self.id)
+        if parent is not None:
+            results.extend(parent.as_list())
+        return results
+
     def forget(self):
         """Forget the result of this task and its parents."""
         self._cache = None

--- a/celery/result.py
+++ b/celery/result.py
@@ -130,6 +130,7 @@ class AsyncResult(ResultBase):
         return (self.id, parent and parent.as_tuple()), None
 
     def as_list(self):
+        """  Returns as a list of task IDs. """
         results = []
         parent = self.parent
         results.append(self.id)

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -1073,6 +1073,12 @@ class test_tuples:
         x = result_from_tuple([uid, []], app=self.app)
         assert x.id == uid
 
+    def test_as_list(self):
+        uid = uuid()
+        x = self.app.AsyncResult(uid)
+        assert x.id == x.as_list()[0]
+        assert isinstance(x.as_list(), list)
+
     def test_GroupResult(self):
         x = self.app.GroupResult(
             uuid(), [self.app.AsyncResult(uuid()) for _ in range(10)],


### PR DESCRIPTION
An as_list function flattens and returns the task IDs of multiple tasks registered in chain. 
There is a similar function as_tuple, but it's nested if it contains None so getting the task id is hard.

Test code:

* sub_tasks.py
* pipenv run celery worker -A sub_tasks

```
import time
from celery import Celery

app = Celery('sub_tasks', backend='redis://localhost', broker='redis://localhost')

@app.task
def add(x, y):
    time.sleep(10)
    return x + y

@app.task
def multi(x, y):
    return x * y

@app.task
def total(ary):
    return sum(ary)
```

* chain_test.py

```
import json
from celery import chain
from sub_tasks import add, multi

tasks = chain(
    add.s(1, 2),
    add.s(4),
    multi.s(10)
).apply_async()

print(tasks.as_list())
print(tasks.as_tuple())
```

* pipenv run python chain_test.py

```
['81bf2757-6e3d-4140-80d2-1ac2b826111e', '2a0d1691-e50b-4c84-8aa2-572e589f62e8', '20bbd73f-40c4-4b3d-94a1-1ca943d5a747']       
(('81bf2757-6e3d-4140-80d2-1ac2b826111e', (('2a0d1691-e50b-4c84-8aa2-572e589f62e8', (('20bbd73f-40c4-4b3d-94a1-1ca943d5a747', None), None)), None)), None)
```

Celery version is 4.4.4.
Thanks.