### PR TITLE
added --range-prefix option to `celery multi`

### DIFF
--- a/celery/apps/multi.py
+++ b/celery/apps/multi.py
@@ -289,10 +289,10 @@ class MultiParser(object):
         prefix = options.pop('--prefix', prefix) or ''
         suffix = options.pop('--suffix', self.suffix) or hostname
         suffix = '' if suffix in ('""', "''") else suffix
-
+        range_prefix = options.pop('--range-prefix', '') or self.range_prefix
         if ranges:
             try:
-                names, prefix = self._get_ranges(names), self.range_prefix
+                names, prefix = self._get_ranges(names), range_prefix
             except ValueError:
                 pass
         self._update_ns_opts(p, names)

--- a/celery/bin/multi.py
+++ b/celery/bin/multi.py
@@ -33,6 +33,12 @@ Examples
     celery worker -n celery2@myhost -c 3
     celery worker -n celery3@myhost -c 3
 
+    $ # override name prefix when using range
+    $ celery multi start 3 --range-prefix worker -c 3
+    celery worker -n worker1@myhost -c 3
+    celery worker -n worker2@myhost -c 3
+    celery worker -n worker3@myhost -c 3
+
     $ # start 3 named workers
     $ celery multi start image video data -c 3
     celery worker -n image@myhost -c 3

--- a/t/unit/bin/test_multi.py
+++ b/t/unit/bin/test_multi.py
@@ -77,6 +77,38 @@ class test_MultiTool:
         assert self.t._handle_reserved_options(
             ['a', '-q', 'b', '--no-color', 'c']) == ['a', 'b', 'c']
 
+    @patch('celery.apps.multi.os.mkdir', new=Mock())
+    def test_range_prefix(self):
+        m = MultiTool()
+        range_prefix = 'worker'
+        workers_count = 2
+        _opt_parser, nodes = m._nodes_from_argv([
+            '{}'.format(workers_count),
+            '--range-prefix={}'.format(range_prefix)])
+        for i, node in enumerate(nodes, start=1):
+            assert node.name.startswith(range_prefix + str(i))
+
+    @patch('celery.apps.multi.os.mkdir', new=Mock())
+    def test_range_prefix_not_set(self):
+        m = MultiTool()
+        default_prefix = 'celery'
+        workers_count = 2
+        _opt_parser, nodes = m._nodes_from_argv([
+            '{}'.format(workers_count),
+            '--range-prefix={}'.format(default_prefix)])
+        for i, node in enumerate(nodes, start=1):
+            assert node.name.startswith(default_prefix + str(i))
+
+    @patch('celery.apps.multi.os.mkdir', new=Mock())
+    def test_range_prefix_not_used_in_named_range(self):
+        m = MultiTool()
+        range_prefix = 'worker'
+        _opt_parser, nodes = m._nodes_from_argv([
+            'a b c',
+            '--range-prefix={}'.format(range_prefix)])
+        for i, node in enumerate(nodes, start=1):
+            assert not node.name.startswith(range_prefix)
+
     def test_start(self):
         self.cluster.start.return_value = [0, 0, 1, 0]
         assert self.t.start('10', '-A', 'proj')

--- a/t/unit/bin/test_multi.py
+++ b/t/unit/bin/test_multi.py
@@ -94,8 +94,7 @@ class test_MultiTool:
         default_prefix = 'celery'
         workers_count = 2
         _opt_parser, nodes = m._nodes_from_argv([
-            '{}'.format(workers_count),
-            '--range-prefix={}'.format(default_prefix)])
+            '{}'.format(workers_count)])
         for i, node in enumerate(nodes, start=1):
             assert node.name.startswith(default_prefix + str(i))
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Currently when running multiple celery workers by `celery multi` command and providing workers as range number, multi uses default range prefix "celery". Added option `--range-prefix` for overriding default range prefix.