### PR TITLE
test_canvas: Add test for chord-in-chain

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -933,6 +933,25 @@ class test_chord:
         res = c.delay()
         assert res.get(timeout=TIMEOUT) == 7
 
+    @pytest.mark.xfail(reason="Issue #6176")
+    def test_chord_in_chain_with_args(self, manager):
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.args[0])
+
+        c1 = chain(
+            chord(
+                [identity.s(), identity.s()],
+                identity.s(),
+            ),
+            identity.s(),
+        )
+        res1 = c1.apply_async(args=(1,))
+        assert res1.get(timeout=TIMEOUT) == [1, 1]
+        res1 = c1.apply(args=(1,))
+        assert res1.get(timeout=TIMEOUT) == [1, 1]
+
     @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
     def test_large_header(self, manager):
         try:


### PR DESCRIPTION
Add test case for the issue where a chord in a chain does not
work when using .apply(). This works fine with .apply_async().

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Adds test case marked as xfail for https://github.com/celery/celery/issues/6176