### PR TITLE
Preserve callbacks when replacing a task with a chain

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -886,8 +886,8 @@ class Task:
             for t in reversed(self.request.chain):
                 sig |= signature(t, app=self.app)
             sig.set(
-                link=options['link'],
-                link_error=options['link_error']
+                link=options.get('link', None),
+                link_error=options.get('link_error', None)
             )
 
         sig.set(

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -882,8 +882,13 @@ class Task:
             )
 
         if self.request.chain:
+            options = sig.options.copy()
             for t in reversed(self.request.chain):
                 sig |= signature(t, app=self.app)
+            sig.set(
+                link=options['link'],
+                link_error=options['link_error']
+            )
 
         sig.set(
             chord=chord,

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -883,6 +883,7 @@ class Task:
 
         if self.request.chain:
             options = sig.options.copy()
+            sig.freeze(self.request.id)
             for t in reversed(self.request.chain):
                 sig |= signature(t, app=self.app)
             sig.set(

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -882,14 +882,19 @@ class Task:
             )
 
         if self.request.chain:
-            options = sig.options.copy()
+            # We need to freeze the new signature with the current task's ID to
+            # ensure that we don't disassociate the new chain from the existing
+            # task IDs which would break previously constructed results
+            # objects.
             sig.freeze(self.request.id)
+            if "link" in sig.options:
+                final_task_links = sig.tasks[-1].options.setdefault("link", [])
+                final_task_links.extend(maybe_list(sig.options["link"]))
+            # Construct the new remainder of the task by chaining the signature
+            # we're being replaced by with signatures constructed from the
+            # chain elements in the current request.
             for t in reversed(self.request.chain):
                 sig |= signature(t, app=self.app)
-            sig.set(
-                link=options.get('link', None),
-                link_error=options.get('link_error', None)
-            )
 
         sig.set(
             chord=chord,

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -22,7 +22,7 @@ def add(x, y):
 
 
 @shared_task
-def raise_error():
+def raise_error(*args):
     """Deliberately raise an error."""
     raise ValueError("deliberate error")
 
@@ -74,6 +74,22 @@ def tsum(nums):
 def add_replaced(self, x, y):
     """Add two numbers (via the add task)."""
     raise self.replace(add.s(x, y))
+
+
+@shared_task(bind=True)
+def replace_with_chain(self, *args):
+    c = chain(add.s(4, 5), add.s(1))
+    c.link(redis_echo.si("link called"))
+
+    return self.replace(c)
+
+
+@shared_task(bind=True)
+def replace_with_chain_which_raises(self, *args):
+    c = chain(add.s(4, 5), raise_error.s())
+    c.link_error(redis_echo.si("link_error called"))
+
+    return self.replace(c)
 
 
 @shared_task(bind=True)
@@ -143,7 +159,8 @@ def retry_once(self, *args, expires=60.0, max_retries=1, countdown=0.1):
 
 
 @shared_task(bind=True, expires=60.0, max_retries=1)
-def retry_once_priority(self, *args, expires=60.0, max_retries=1, countdown=0.1):
+def retry_once_priority(self, *args, expires=60.0, max_retries=1,
+                        countdown=0.1):
     """Task that fails and is retried. Returns the priority."""
     if self.request.retries:
         return self.request.delivery_info['priority']
@@ -160,7 +177,6 @@ def redis_echo(message):
 
 @shared_task(bind=True)
 def second_order_replace1(self, state=False):
-
     redis_connection = get_redis_connection()
     if not state:
         redis_connection.rpush('redis-echo', 'In A')

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -414,6 +414,7 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == [8, 8]
 
+    @flaky
     def test_nested_chain_group_lone(self, manager):
         """
         Test that a lone group in a chain completes.

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -465,7 +465,18 @@ class test_chain:
 
         assert res.get(timeout=TIMEOUT) == 13
 
-        redis_messages = list(redis_connection.lrange('redis-echo', 0, -1))
+        redis_messages = []
+        for _ in range(10):
+            redis_messages = list(
+                redis_connection.lrange('redis-echo', 0, -1)
+            )
+
+            # Avoid race condition in CI where the test finishes
+            # before the link callback is called
+            if not redis_messages:
+                sleep(0.5)
+            else:
+                break
 
         assert redis_messages == [b'link called']
 
@@ -484,7 +495,18 @@ class test_chain:
         with pytest.raises(ValueError):
             res.get(timeout=TIMEOUT)
 
-        redis_messages = list(redis_connection.lrange('redis-echo', 0, -1))
+        redis_messages = []
+        for _ in range(10):
+            redis_messages = list(
+                redis_connection.lrange('redis-echo', 0, -1)
+            )
+
+            # Avoid race condition in CI where the test finishes
+            # before the link_error callback is called
+            if not redis_messages:
+                sleep(0.5)
+            else:
+                break
 
         assert redis_messages == [b'link_error called']
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

When replacing a task in the middle of a chain with a chain that has `link` callbacks, they are not executed anymore.

Example:
```python
@task
def add(a, b):
  return a + b

@task(bind=True)
def callback(*args, **kwargs):
  print("callback")

@task
def replace_with_chain(self, *args, **kwargs):
  c = chain(add.s(4, 5), add.s(1))
  c.link(callback.s)

  return self.replace(c)

chain(add.s(1,2), replace_with_chain.s(), add.s(3))
```