### PR TITLE
[docs] Update Wiki link in "resources"

### DIFF
--- a/docs/includes/resources.txt
+++ b/docs/includes/resources.txt
@@ -36,7 +36,7 @@ to our issue tracker at https://github.com/celery/celery/issues/
 Wiki
 ====
 
-https://wiki.github.com/celery/celery/
+https://github.com/celery/celery/wiki
 
 .. _contributing-short:
 


### PR DESCRIPTION

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
In the page linked below, the link to wiki is outdated. Fixed that. 

https://docs.celeryproject.org/en/stable/getting-started/resources.html