### PR TITLE
test_canvas: Add test for chain-in-chain

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1158,6 +1158,25 @@ class test_chord:
         res1 = c1.apply(args=(1,))
         assert res1.get(timeout=TIMEOUT) == [1, 1]
 
+    @pytest.mark.xfail(reason="Issue #6200")
+    def test_chain_in_chain_with_args(self):
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.args[0])
+
+        c1 = chain(  # NOTE: This chain should have only 1 chain inside it
+            chain(
+                identity.s(),
+                identity.s(),
+            ),
+        )
+
+        res1 = c1.apply_async(args=(1,))
+        assert res1.get(timeout=TIMEOUT) == 1
+        res1 = c1.apply(args=(1,))
+        assert res1.get(timeout=TIMEOUT) == 1
+
     @flaky
     def test_large_header(self, manager):
         try:


### PR DESCRIPTION
Add test case for the issue where a chain in a chain does not
work when using .apply(). This works fine with .apply_async().

The inner chain should have only 1 item.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Related to: https://github.com/celery/celery/issues/6200