### PR TITLE
[ES backend] add 401 as safe for retry

### DIFF
--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -88,6 +88,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
 
     def exception_safe_to_retry(self, exc):
         if isinstance(exc, (elasticsearch.exceptions.TransportError)):
+            # 401: Unauthorized
             # 409: Conflict
             # 429: Too Many Requests
             # 500: Internal Server Error
@@ -95,7 +96,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
             # 503: Service Unavailable
             # 504: Gateway Timeout
             # N/A: Low level exception (i.e. socket exception)
-            if exc.status_code in {409, 429, 500, 502, 503, 504, 'N/A'}:
+            if exc.status_code in {401, 409, 429, 500, 502, 503, 504, 'N/A'}:
                 return True
         return False
 


### PR DESCRIPTION
if authentication mechanism is temporarily unavailable ES API may return 401 Unauthorized.
Resulting in lost result because it was not retried in this case.