### PR TITLE
treat internal errors as failure

### DIFF
--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -543,7 +543,7 @@ def trace_task(task, uuid, args, kwargs, request=None, **opts):
         return task.__trace__(uuid, args, kwargs, request)
     except Exception as exc:
         _signal_internal_error(task, uuid, args, kwargs, request, exc)
-        return trace_ok_t(report_internal_error(task, exc), None, 0.0, None)
+        return trace_ok_t(report_internal_error(task, exc), TraceInfo(FAILURE, exc), 0.0, None)
 
 
 def _signal_internal_error(task, uuid, args, kwargs, request, exc):

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -367,10 +367,15 @@ class Request(object):
             'logfile': logfile,
             'is_eager': False,
         }, **embed or {})
-        retval = trace_task(self.task, self.id, self._args, self._kwargs, request,
-                            hostname=self._hostname, loader=self._app.loader,
-                            app=self._app)[0]
-        self.acknowledge()
+
+        retval, I, _, _ = trace_task(self.task, self.id, self._args, self._kwargs, request,
+                                     hostname=self._hostname, loader=self._app.loader,
+                                     app=self._app)
+
+        if I:
+            self.reject(requeue=False)
+        else:
+            self.acknowledge()
         return retval
 
     def maybe_expire(self):

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import pytest
+from billiard.einfo import ExceptionInfo
 from case import Mock, patch
 from kombu.exceptions import EncodeError
 
@@ -23,6 +24,7 @@ from celery.app.trace import (
     trace_task,
     traceback_clear,
 )
+from celery.backends.base import BaseDictBackend
 
 from celery.exceptions import Ignore, Reject, Retry
 
@@ -155,6 +157,18 @@ class test_trace(TraceCase):
         add.backend.process_cleanup.assert_called_with()
         add.backend.process_cleanup.side_effect = MemoryError()
         with pytest.raises(MemoryError):
+            self.trace(add, (2, 2), {}, eager=False)
+
+    def test_when_backend_raises_exception(self):
+        @self.app.task(shared=False)
+        def add(x, y):
+            return x + y
+
+        add.backend = Mock(name='backend')
+        add.backend.mark_as_done.side_effect = Exception()
+        add.backend.mark_as_failure.side_effect = Exception("failed mark_as_failure")
+
+        with pytest.raises(Exception):
             self.trace(add, (2, 2), {}, eager=False)
 
     def test_traceback_clear(self):
@@ -381,6 +395,27 @@ class test_trace(TraceCase):
         assert report_internal_error.call_count
         assert send.call_count
         assert xtask.__trace__ is tracer
+
+    def test_backend_error_should_report_failure(self):
+        """check internal error is reported as failure.
+
+        In case of backend error, an exception may bubble up from trace and be
+        caught by trace_task.
+        """
+
+        @self.app.task(shared=False)
+        def xtask():
+            pass
+
+        xtask.backend = BaseDictBackend(app=self.app)
+        xtask.backend.mark_as_done = Mock()
+        xtask.backend.mark_as_done.side_effect = Exception()
+        xtask.backend.mark_as_failure = Mock()
+        xtask.backend.mark_as_failure.side_effect = Exception()
+
+        ret, info, _, _ = trace_task(xtask, 'uuid', (), {}, app=self.app)
+        assert info is not None
+        assert isinstance(ret, ExceptionInfo)
 
 
 class test_TraceInfo(TraceCase):


### PR DESCRIPTION
this way, task may be rejected and not acknowledged in case of
unrecoverable error by the backend or any other celery components.

Handle result correctly in request direct execution outside a pool.