### PR TITLE
Drainer tests, put a lower constraint on number of intervals

### DIFF
--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -120,7 +120,7 @@ class DrainerTests(object):
         self.teardown_thread(liveness_thread)
 
         assert p.ready, 'Should have terminated with promise being ready'
-        assert on_interval.call_count < liveness_mock.call_count, \
+        assert on_interval.call_count <= liveness_mock.call_count, \
             'Should have served liveness_mock while waiting for event'
 
     def test_drain_timeout(self):


### PR DESCRIPTION
liveness should iterate 10 times per interval while drain_events only
once. However, as it may use thread that may be scheduled out of
order, we may end up in some situation where liveness and drain_events
were called the same amount of time.

Lowering the constraint from < to <= to avoid failing the tests.