### PR TITLE
Remove redis fanout caveats

### DIFF
--- a/docs/getting-started/brokers/redis.rst
+++ b/docs/getting-started/brokers/redis.rst
@@ -100,46 +100,6 @@ If you are using Sentinel, you should specify the master_name using the :setting
 Caveats
 =======
 
-.. _redis-caveat-fanout-prefix:
-
-Fanout prefix
--------------
-
-Broadcast messages will be seen by all virtual hosts by default.
-
-You have to set a transport option to prefix the messages so that
-they will only be received by the active virtual host:
-
-.. code-block:: python
-
-    app.conf.broker_transport_options = {'fanout_prefix': True}
-
-Note that you won't be able to communicate with workers running older
-versions or workers that doesn't have this setting enabled.
-
-This setting will be the default in the future, so better to migrate
-sooner rather than later.
-
-.. _redis-caveat-fanout-patterns:
-
-Fanout patterns
----------------
-
-Workers will receive all task related events by default.
-
-To avoid this you must set the ``fanout_patterns`` fanout option so that
-the workers may only subscribe to worker related events:
-
-.. code-block:: python
-
-    app.conf.broker_transport_options = {'fanout_patterns': True}
-
-Note that this change is backward incompatible so all workers in the
-cluster must have this option enabled, or else they won't be able to
-communicate.
-
-This option will be enabled by default in the future.
-
 Visibility timeout
 ------------------
 


### PR DESCRIPTION
The fanout_prefix and fanout_patterns transport options were made the default in Celery 4.0 
https://docs.celeryproject.org/en/stable/history/whatsnew-4.0.html#redis-events-not-backward-compatible

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
