### PR TITLE
Preserve order of group results with Redis result backend

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -305,7 +305,7 @@ class AMQP(object):
         )
 
     def as_task_v2(self, task_id, name, args=None, kwargs=None,
-                   countdown=None, eta=None, group_id=None,
+                   countdown=None, eta=None, group_id=None, group_index=None,
                    expires=None, retries=0, chord=None,
                    callbacks=None, errbacks=None, reply_to=None,
                    time_limit=None, soft_time_limit=None,
@@ -363,6 +363,7 @@ class AMQP(object):
                 'eta': eta,
                 'expires': expires,
                 'group': group_id,
+                'group_index': group_index,
                 'retries': retries,
                 'timelimit': [time_limit, soft_time_limit],
                 'root_id': root_id,
@@ -397,7 +398,7 @@ class AMQP(object):
         )
 
     def as_task_v1(self, task_id, name, args=None, kwargs=None,
-                   countdown=None, eta=None, group_id=None,
+                   countdown=None, eta=None, group_id=None, group_index=None,
                    expires=None, retries=0,
                    chord=None, callbacks=None, errbacks=None, reply_to=None,
                    time_limit=None, soft_time_limit=None,
@@ -442,6 +443,7 @@ class AMQP(object):
                 'args': args,
                 'kwargs': kwargs,
                 'group': group_id,
+                'group_index': group_index,
                 'retries': retries,
                 'eta': eta,
                 'expires': expires,

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -720,7 +720,8 @@ class Celery(object):
                   eta=None, task_id=None, producer=None, connection=None,
                   router=None, result_cls=None, expires=None,
                   publisher=None, link=None, link_error=None,
-                  add_to_parent=True, group_id=None, retries=0, chord=None,
+                  add_to_parent=True, group_id=None, group_index=None,
+                  retries=0, chord=None,
                   reply_to=None, time_limit=None, soft_time_limit=None,
                   root_id=None, parent_id=None, route_name=None,
                   shadow=None, chain=None, task_type=None, **options):
@@ -760,7 +761,7 @@ class Celery(object):
                                        parent.request.delivery_info.get('priority'))
 
         message = amqp.create_task_message(
-            task_id, name, args, kwargs, countdown, eta, group_id,
+            task_id, name, args, kwargs, countdown, eta, group_id, group_index,
             expires, retries, chord,
             maybe_list(link), maybe_list(link_error),
             reply_to or self.oid, time_limit, soft_time_limit,

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -83,6 +83,7 @@ class Context(object):
     correlation_id = None
     taskset = None   # compat alias to group
     group = None
+    group_index = None
     chord = None
     chain = None
     utc = None
@@ -116,6 +117,7 @@ class Context(object):
             'root_id': self.root_id,
             'parent_id': self.parent_id,
             'group_id': self.group,
+            'group_index': self.group_index,
             'chord': self.chord,
             'chain': self.chain,
             'link': self.callbacks,
@@ -891,6 +893,7 @@ class Task(object):
         sig.set(
             chord=chord,
             group_id=self.request.group,
+            group_index=self.request.group_index,
             root_id=self.request.root_id,
         )
         sig.freeze(self.request.id)
@@ -917,6 +920,7 @@ class Task(object):
             raise ValueError('Current task is not member of any chord')
         sig.set(
             group_id=self.request.group,
+            group_index=self.request.group_index,
             chord=self.request.chord,
             root_id=self.request.root_id,
         )

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -425,8 +425,8 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         result = self.encode_result(result, state)
         with client.pipeline() as pipe:
             pipeline = pipe \
-                .zadd(jkey, group_index,
-                      self.encode([1, tid, state, result])) \
+                .zadd(jkey,
+                      {self.encode([1, tid, state, result]): group_index}) \
                 .zcount(jkey, '-inf', '+inf') \
                 .get(tkey)
 

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -413,9 +413,11 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
     def on_chord_part_return(self, request, state, result,
                              propagate=None, **kwargs):
         app = self.app
-        tid, gid = request.id, request.group
+        tid, gid, group_index = request.id, request.group, request.group_index
         if not gid or not tid:
             return
+        if group_index is None:
+            group_index = '+inf'
 
         client = self.client
         jkey = self.get_key_for_group(gid, '.j')
@@ -423,8 +425,9 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         result = self.encode_result(result, state)
         with client.pipeline() as pipe:
             pipeline = pipe \
-                .rpush(jkey, self.encode([1, tid, state, result])) \
-                .llen(jkey) \
+                .zadd(jkey, group_index,
+                      self.encode([1, tid, state, result])) \
+                .zcount(jkey, '-inf', '+inf') \
                 .get(tkey)
 
             if self.expires is not None:
@@ -443,7 +446,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
                 decode, unpack = self.decode, self._unpack_chord_result
                 with client.pipeline() as pipe:
                     resl, = pipe \
-                        .lrange(jkey, 0, total) \
+                        .zrangebyscore(jkey, '-inf', '+inf') \
                         .execute()
                 try:
                     callback.delay([unpack(tup, decode) for tup in resl])

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -446,7 +446,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
                 decode, unpack = self.decode, self._unpack_chord_result
                 with client.pipeline() as pipe:
                     resl, = pipe \
-                        .zrangebyscore(jkey, '-inf', '+inf') \
+                        .zrange(jkey, 0, -1) \
                         .execute()
                 try:
                     callback.delay([unpack(tup, decode) for tup in resl])

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -276,7 +276,7 @@ class Signature(dict):
     partial = clone
 
     def freeze(self, _id=None, group_id=None, chord=None,
-               root_id=None, parent_id=None):
+               root_id=None, parent_id=None, group_index=None):
         """Finalize the signature by adding a concrete task id.
 
         The task won't be called and you shouldn't call the signature
@@ -303,6 +303,8 @@ class Signature(dict):
             opts['group_id'] = group_id
         if chord:
             opts['chord'] = chord
+        if group_index is not None:
+            opts['group_index'] = group_index
         # pylint: disable=too-many-function-args
         #   Borks on this, as it's a property.
         return self.AsyncResult(tid)
@@ -674,19 +676,21 @@ class _chain(Signature):
             return results[0]
 
     def freeze(self, _id=None, group_id=None, chord=None,
-               root_id=None, parent_id=None):
+               root_id=None, parent_id=None, group_index=None):
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         _, results = self._frozen = self.prepare_steps(
             self.args, self.kwargs, self.tasks, root_id, parent_id, None,
             self.app, _id, group_id, chord, clone=False,
+            group_index=group_index,
         )
         return results[0]
 
     def prepare_steps(self, args, kwargs, tasks,
                       root_id=None, parent_id=None, link_error=None, app=None,
                       last_task_id=None, group_id=None, chord_body=None,
-                      clone=True, from_dict=Signature.from_dict):
+                      clone=True, from_dict=Signature.from_dict,
+                      group_index=None):
         app = app or self.app
         # use chain message field for protocol 2 and later.
         # this avoids pickle blowing the stack on the recursion
@@ -763,6 +767,7 @@ class _chain(Signature):
                 res = task.freeze(
                     last_task_id,
                     root_id=root_id, group_id=group_id, chord=chord_body,
+                    group_index=group_index,
                 )
             else:
                 res = task.freeze(root_id=root_id)
@@ -1189,7 +1194,7 @@ class group(Signature):
         return options, group_id, options.get('root_id')
 
     def freeze(self, _id=None, group_id=None, chord=None,
-               root_id=None, parent_id=None):
+               root_id=None, parent_id=None, group_index=None):
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         opts = self.options
@@ -1201,6 +1206,8 @@ class group(Signature):
             opts['group_id'] = group_id
         if chord:
             opts['chord'] = chord
+        if group_index is not None:
+            opts['group_index'] = group_index
         root_id = opts.setdefault('root_id', root_id)
         parent_id = opts.setdefault('parent_id', parent_id)
         new_tasks = []
@@ -1221,6 +1228,7 @@ class group(Signature):
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         stack = deque(self.tasks)
+        i = 0
         while stack:
             task = maybe_signature(stack.popleft(), app=self._app).clone()
             if isinstance(task, group):
@@ -1229,7 +1237,9 @@ class group(Signature):
                 new_tasks.append(task)
                 yield task.freeze(group_id=group_id,
                                   chord=chord, root_id=root_id,
-                                  parent_id=parent_id)
+                                  parent_id=parent_id,
+                                  group_index=i)
+                i += 1
 
     def __repr__(self):
         if self.tasks:
@@ -1308,17 +1318,16 @@ class chord(Signature):
         return self.apply_async((), {'body': body} if body else {}, **options)
 
     def freeze(self, _id=None, group_id=None, chord=None,
-               root_id=None, parent_id=None):
+               root_id=None, parent_id=None, group_index=None):
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         if not isinstance(self.tasks, group):
             self.tasks = group(self.tasks, app=self.app)
         header_result = self.tasks.freeze(
             parent_id=parent_id, root_id=root_id, chord=self.body)
-
         body_result = self.body.freeze(
-            _id, root_id=root_id, chord=chord, group_id=group_id)
-
+            _id, root_id=root_id, chord=chord, group_id=group_id,
+            group_index=group_index)
         # we need to link the body result back to the group result,
         # but the body may actually be a chain,
         # so find the first result without a parent

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1228,7 +1228,7 @@ class group(Signature):
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         stack = deque(self.tasks)
-        i = 0
+        group_index = 0
         while stack:
             task = maybe_signature(stack.popleft(), app=self._app).clone()
             if isinstance(task, group):
@@ -1238,8 +1238,8 @@ class group(Signature):
                 yield task.freeze(group_id=group_id,
                                   chord=chord, root_id=root_id,
                                   parent_id=parent_id,
-                                  group_index=i)
-                i += 1
+                                  group_index=group_index)
+                group_index += 1
 
     def __repr__(self):
         if self.tasks:

--- a/celery/utils/abstract.py
+++ b/celery/utils/abstract.py
@@ -118,7 +118,8 @@ class CallableSignature(CallableTask):  # pragma: no cover
         pass
 
     @abstractmethod
-    def freeze(self, id=None, group_id=None, chord=None, root_id=None):
+    def freeze(self, id=None, group_id=None, chord=None, root_id=None,
+               group_index=None):
         pass
 
     @abstractmethod

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -629,7 +629,7 @@ class Request(object):
     @cached_property
     def group_index(self):
         # used by backend.on_chord_part_return to order return values in group
-        return self.request_dict['group_index']
+        return self.request_dict.get('group_index')
 
 
 def create_request_cls(base, task, pool, hostname, eventer,

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -629,7 +629,7 @@ class Request(object):
     @cached_property
     def group_index(self):
         # used by backend.on_chord_part_return to order return values in group
-        return self.request_dict.get('group_index')
+        return self._request_dict.get('group_index')
 
 
 def create_request_cls(base, task, pool, hostname, eventer,

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -626,6 +626,11 @@ class Request(object):
         request.update(**embed or {})
         return Context(request)
 
+    @cached_property
+    def group_index(self):
+        # used by backend.on_chord_part_return to order return values in group
+        return self.request_dict['group_index']
+
 
 def create_request_cls(base, task, pool, hostname, eventer,
                        ref=ref, revoked_tasks=revoked_tasks,

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -618,7 +618,7 @@ class test_chord:
 
         c = group([add_to_all_to_chord.s([1, 2, 3], 4)]) | identity.s()
         res = c()
-        assert res.get() == [0, 5, 6, 7]
+        assert sorted(res.get()) == [0, 5, 6, 7]
 
     @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
     def test_add_chord_to_chord(self, manager):

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -853,7 +853,7 @@ class test_chord:
         j_key = backend.get_key_for_group(original_group_id, '.j')
         redis_connection = get_redis_connection()
         chord_results = [backend.decode(t) for t in
-                         redis_connection.lrange(j_key, 0, 3)]
+                         redis_connection.zrange(j_key, 0, 3)]
 
         # Validate group result
         assert [cr[3] for cr in chord_results if cr[2] == states.SUCCESS] == \

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -121,10 +121,7 @@ class Redis(mock.MockCallbacks):
         self._get_sorted_set(key).append((float(score), value))
 
     def zrangebyscore(self, key, start, stop):
-        start = float(start)
-        stop = float(stop)
-        return [value for score, value in sorted(self.keyspace.get(key, []))
-                if start <= score <= stop]
+        return list(sorted(self.keyspace.get(key, [])))[start:stop]
 
     def zcount(self, key, start, stop):
         return len(self.zrangebyscore(key, start, stop))

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -776,6 +776,23 @@ class test_chord(CanvasCase):
         x.kwargs['body'] = None
         assert 'without body' in repr(x)
 
+    def test_freeze_tasks_body_is_group(self):
+        # Confirm that `group index` is passed from a chord to elements of its
+        # body when the chord itself is encapsulated in a group
+        body_elem = self.add.s()
+        chord_body = group([body_elem])
+        chord_obj = chord(self.add.s(), body=chord_body)
+        top_group = group([chord_obj])
+        # We expect the body to be the signature we passed in before we freeze
+        (embedded_body_elem, ) = chord_obj.body.tasks
+        assert embedded_body_elem is body_elem
+        assert embedded_body_elem.options == dict()
+        # When we freeze the chord, its body will be clones and options set
+        top_group.freeze()
+        (embedded_body_elem, ) = chord_obj.body.tasks
+        assert embedded_body_elem is not body_elem
+        assert embedded_body_elem.options["group_index"] == 0   # 0th task
+
     def test_freeze_tasks_is_not_group(self):
         x = chord([self.add.s(2, 2)], body=self.add.s(), app=self.app)
         x.freeze()

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -1067,6 +1067,11 @@ class test_Request(RequestCase):
         job = self.xRequest(id=uuid(), group=gid)
         assert job.group == gid
 
+    def test_group_index(self):
+        group_index = 42
+        job = self.xRequest(id=uuid(), group_index=group_index)
+        assert job.group_index == group_index
+
 
 class test_create_request_class(RequestCase):
 


### PR DESCRIPTION
## Description

This PR is an alternate to #4858 authored by @lpsinger and fixes #3781. It ensures
that the order of results from a canvas group task wrapper matches the order of the
individual encapsulated tasks when using Redis as a results backend.