### PR TITLE
Remove mutable arguments in assert_routes_to_queue

### DIFF
--- a/t/unit/app/test_routes.py
+++ b/t/unit/app/test_routes.py
@@ -51,7 +51,13 @@ class RouteCase:
         self.mytask = mytask
 
     def assert_routes_to_queue(self, queue, router, name,
-                               args=[], kwargs={}, options={}):
+                               args=None, kwargs=None, options=None):
+        if options is None:
+            options = {}
+        if kwargs is None:
+            kwargs = {}
+        if args is None:
+            args = []
         assert router.route(options, name, args, kwargs)['queue'].name == queue
 
     def assert_routes_to_default_queue(self, router, name, *args, **kwargs):


### PR DESCRIPTION
Just a quick cleanup of mutable arguments to ensure that the tests that use this helper don't rely on this bad behavior.