### PR TITLE
Chain-in-chord that fails before the last task in the chain now triggers chord error handling

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -170,6 +170,13 @@ class Backend(object):
         if request:
             if request.chord:
                 self.on_chord_part_return(request, state, exc)
+            elif request.chain and 'chord' in request.chain[-1]['options']:
+                from celery.app.task import Context
+                failed_ctx = Context(request.chain[-1])
+                failed_ctx.update(failed_ctx.options)
+                failed_ctx.id = failed_ctx.options['task_id']
+                failed_ctx.group = failed_ctx.options['group_id']
+                self.on_chord_part_return(failed_ctx, state, exc)
             if call_errbacks and request.errbacks:
                 self._call_task_errbacks(request, exc, traceback)
 

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -862,7 +862,6 @@ class test_chord:
         assert len([cr for cr in chord_results if cr[2] != states.SUCCESS]
                    ) == 1
 
-    @pytest.xfail("Issue #6220")
     def test_chain_in_chord_on_error(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
@@ -878,8 +877,8 @@ class test_chord:
                 chord_error.s()),
         )
         res = c1()
-        with pytest.raises(ExpectedException):
-            res.get(propagate=True, timeout=10)
+        with pytest.raises(ChordError):
+            res.get(propagate=True, timeout=TIMEOUT)
 
     @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
     def test_parallel_chords(self, manager):


### PR DESCRIPTION
Marked with xfail for now.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fixes #6220.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
