### PR TITLE
chg: remove extra bracket

### DIFF
--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -526,7 +526,7 @@ too:
 
 .. code-block:: pycon
 
-    >>> for result, value in res.collect(intermediate=True)):
+    >>> for result, value in res.collect(intermediate=True):
     ....
 
 You can link together as many tasks as you like,


### PR DESCRIPTION
## Description

Remove extra bracket causing incorrect syntax.

`for result, value in res.collect(intermediate=True)):` -> `for result, value in res.collect(intermediate=True):`

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
