### PR TITLE
Class-based tasks autoretry

### DIFF
--- a/celery/app/autoretry.py
+++ b/celery/app/autoretry.py
@@ -1,0 +1,50 @@
+from vine.utils import wraps
+
+from celery.exceptions import Ignore, Retry
+from celery.utils.time import get_exponential_backoff_interval
+
+
+def add_autoretry_behaviour(task, **options):
+    autoretry_for = tuple(
+        options.get('autoretry_for',
+                    getattr(task, 'autoretry_for', ()))
+    )
+    retry_kwargs = options.get(
+        'retry_kwargs', getattr(task, 'retry_kwargs', {})
+    )
+    retry_backoff = int(
+        options.get('retry_backoff',
+                    getattr(task, 'retry_backoff', False))
+    )
+    retry_backoff_max = int(
+        options.get('retry_backoff_max',
+                    getattr(task, 'retry_backoff_max', 600))
+    )
+    retry_jitter = options.get(
+        'retry_jitter', getattr(task, 'retry_jitter', True)
+    )
+
+    if autoretry_for and not hasattr(task, '_orig_run'):
+
+        @wraps(task.run)
+        def run(*args, **kwargs):
+            print('running ', task.name)
+            try:
+                return task._orig_run(*args, **kwargs)
+            except Ignore:
+                # If Ignore signal occures task shouldn't be retried,
+                # even if it suits autoretry_for list
+                raise
+            except Retry:
+                raise
+            except autoretry_for as exc:
+                if retry_backoff:
+                    retry_kwargs['countdown'] = \
+                        get_exponential_backoff_interval(
+                            factor=retry_backoff,
+                            retries=task.request.retries,
+                            maximum=retry_backoff_max,
+                            full_jitter=retry_jitter)
+                raise task.retry(exc=exc, **retry_kwargs)
+
+        task._orig_run, task.run = task.run, run

--- a/celery/app/autoretry.py
+++ b/celery/app/autoretry.py
@@ -28,7 +28,6 @@ def add_autoretry_behaviour(task, **options):
 
         @wraps(task.run)
         def run(*args, **kwargs):
-            print('running ', task.name)
             try:
                 return task._orig_run(*args, **kwargs)
             except Ignore:

--- a/celery/app/autoretry.py
+++ b/celery/app/autoretry.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+"""Tasks auto-retry functionality."""
 from vine.utils import wraps
 
 from celery.exceptions import Ignore, Retry
@@ -5,6 +7,8 @@ from celery.utils.time import get_exponential_backoff_interval
 
 
 def add_autoretry_behaviour(task, **options):
+    """Wrap task's `run` method with auto-retry functionality"""
+
     autoretry_for = tuple(
         options.get('autoretry_for',
                     getattr(task, 'autoretry_for', ()))

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -478,6 +478,7 @@ class Celery(object):
             task_cls = type(task)
             task.name = self.gen_task_name(
                 task_cls.__name__, task_cls.__module__)
+        add_autoretry_behaviour(task)
         self.tasks[task.name] = task
         task._app = self
         task.bind(self)

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -2,6 +2,7 @@
 """Actual App instance implementation."""
 from __future__ import absolute_import, unicode_literals
 
+import inspect
 import os
 import threading
 import warnings
@@ -474,6 +475,7 @@ class Celery(object):
             style task classes, you should not need to use this for
             new projects.
         """
+        task = inspect.isclass(task) and task() or task
         if not task.name:
             task_cls = type(task)
             task.name = self.gen_task_name(

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -16,14 +16,13 @@ from kombu.utils.compat import register_after_fork
 from kombu.utils.objects import cached_property
 from kombu.utils.uuid import uuid
 from vine import starpromise
-from vine.utils import wraps
 
 from celery import platforms, signals
 from celery._state import (_announce_app_finalized, _deregister_app,
                            _register_app, _set_current_app, _task_stack,
                            connect_on_app_finalize, get_current_app,
                            get_current_worker_task, set_default_app)
-from celery.exceptions import AlwaysEagerIgnored, ImproperlyConfigured, Ignore, Retry
+from celery.exceptions import AlwaysEagerIgnored, ImproperlyConfigured
 from celery.five import (UserDict, bytes_if_py2, python_2_unicode_compatible,
                          values)
 from celery.loaders import get_loader_cls
@@ -35,8 +34,7 @@ from celery.utils.functional import first, head_from_fun, maybe_list
 from celery.utils.imports import gen_task_name, instantiate, symbol_by_name
 from celery.utils.log import get_logger
 from celery.utils.objects import FallbackContext, mro_lookup
-from celery.utils.time import (get_exponential_backoff_interval, timezone,
-                               to_utc)
+from celery.utils.time import timezone, to_utc
 
 # Load all builtin tasks
 from . import builtins  # noqa
@@ -44,6 +42,7 @@ from . import backends
 from .annotations import prepare as prepare_annotations
 from .defaults import DEFAULT_SECURITY_DIGEST, find_deprecated_settings
 from .registry import TaskRegistry
+from .autoretry import add_autoretry_behaviour
 from .utils import (AppPickler, Settings, _new_key_to_old, _old_key_to_new,
                     _unpickle_app, _unpickle_app_v2, appstr, bugreport,
                     detect_settings)
@@ -462,49 +461,7 @@ class Celery(object):
                 pass
             self._tasks[task.name] = task
             task.bind(self)  # connects task to this app
-
-            autoretry_for = tuple(
-                options.get('autoretry_for',
-                            getattr(task, 'autoretry_for', ()))
-            )
-            retry_kwargs = options.get(
-                'retry_kwargs', getattr(task, 'retry_kwargs', {})
-            )
-            retry_backoff = int(
-                options.get('retry_backoff',
-                            getattr(task, 'retry_backoff', False))
-            )
-            retry_backoff_max = int(
-                options.get('retry_backoff_max',
-                            getattr(task, 'retry_backoff_max', 600))
-            )
-            retry_jitter = options.get(
-                'retry_jitter', getattr(task, 'retry_jitter', True)
-            )
-
-            if autoretry_for and not hasattr(task, '_orig_run'):
-
-                @wraps(task.run)
-                def run(*args, **kwargs):
-                    try:
-                        return task._orig_run(*args, **kwargs)
-                    except Ignore:
-                        # If Ignore signal occures task shouldn't be retried,
-                        # even if it suits autoretry_for list
-                        raise
-                    except Retry:
-                        raise
-                    except autoretry_for as exc:
-                        if retry_backoff:
-                            retry_kwargs['countdown'] = \
-                                get_exponential_backoff_interval(
-                                    factor=retry_backoff,
-                                    retries=task.request.retries,
-                                    maximum=retry_backoff_max,
-                                    full_jitter=retry_jitter)
-                        raise task.retry(exc=exc, **retry_kwargs)
-
-                task._orig_run, task.run = task.run, run
+            add_autoretry_behaviour(task, **options)
         else:
             task = self._tasks[name]
         return task

--- a/celery/app/registry.py
+++ b/celery/app/registry.py
@@ -6,6 +6,7 @@ import inspect
 from importlib import import_module
 
 from celery._state import get_current_app
+from celery.app.autoretry import add_autoretry_behaviour
 from celery.exceptions import InvalidTaskError, NotRegistered
 from celery.five import items
 
@@ -31,6 +32,7 @@ class TaskRegistry(dict):
                 'Task class {0!r} must specify .name attribute'.format(
                     type(task).__name__))
         self[task.name] = inspect.isclass(task) and task() or task
+        add_autoretry_behaviour(task)
 
     def unregister(self, name):
         """Unregister task by name.

--- a/celery/app/registry.py
+++ b/celery/app/registry.py
@@ -31,8 +31,9 @@ class TaskRegistry(dict):
             raise InvalidTaskError(
                 'Task class {0!r} must specify .name attribute'.format(
                     type(task).__name__))
-        self[task.name] = inspect.isclass(task) and task() or task
+        task = inspect.isclass(task) and task() or task
         add_autoretry_behaviour(task)
+        self[task.name] = task
 
     def unregister(self, name):
         """Unregister task by name.

--- a/celery/contrib/pytest.py
+++ b/celery/contrib/pytest.py
@@ -74,7 +74,7 @@ def celery_session_app(request,
         yield app
 
 
-@pytest.fixture(scope='sesion')
+@pytest.fixture(scope='session')
 def celery_class_based_tasks():
     return []
 

--- a/celery/contrib/pytest.py
+++ b/celery/contrib/pytest.py
@@ -78,6 +78,7 @@ def celery_session_app(request,
 def celery_session_worker(request,
                           celery_session_app,
                           celery_includes,
+                          celery_class_tasks,
                           celery_worker_pool,
                           celery_worker_parameters):
     # type: (Any, Celery, Sequence[str], str, Any) -> WorkController
@@ -85,6 +86,8 @@ def celery_session_worker(request,
     if not NO_WORKER:
         for module in celery_includes:
             celery_session_app.loader.import_task_module(module)
+        for class_task in celery_class_tasks:
+            celery_session_app.tasks.register(class_task)
         with worker.start_worker(celery_session_app,
                                  pool=celery_worker_pool,
                                  **celery_worker_parameters) as w:
@@ -171,7 +174,7 @@ def celery_app(request,
         yield app
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def celery_class_tasks():
     return []
 
@@ -180,7 +183,6 @@ def celery_class_tasks():
 def celery_worker(request,
                   celery_app,
                   celery_includes,
-                  celery_class_tasks,
                   celery_worker_pool,
                   celery_worker_parameters):
     # type: (Any, Celery, Sequence[str], str, Any) -> WorkController
@@ -188,8 +190,6 @@ def celery_worker(request,
     if not NO_WORKER:
         for module in celery_includes:
             celery_app.loader.import_task_module(module)
-        for class_task in celery_class_tasks:
-            celery_app.tasks.register(class_task)
         with worker.start_worker(celery_app,
                                  pool=celery_worker_pool,
                                  **celery_worker_parameters) as w:

--- a/celery/contrib/pytest.py
+++ b/celery/contrib/pytest.py
@@ -74,10 +74,16 @@ def celery_session_app(request,
         yield app
 
 
+@pytest.fixture(scope='sesion')
+def celery_class_based_tasks():
+    return []
+
+
 @pytest.fixture(scope='session')
 def celery_session_worker(request,
                           celery_session_app,
                           celery_includes,
+                          celery_class_based_tasks,
                           celery_worker_pool,
                           celery_worker_parameters):
     # type: (Any, Celery, Sequence[str], str, Any) -> WorkController
@@ -85,6 +91,8 @@ def celery_session_worker(request,
     if not NO_WORKER:
         for module in celery_includes:
             celery_session_app.loader.import_task_module(module)
+        for class_based_task in celery_class_based_tasks:
+            celery_session_app.tasks.register(class_based_task)
         with worker.start_worker(celery_session_app,
                                  pool=celery_worker_pool,
                                  **celery_worker_parameters) as w:

--- a/celery/contrib/pytest.py
+++ b/celery/contrib/pytest.py
@@ -75,15 +75,9 @@ def celery_session_app(request,
 
 
 @pytest.fixture(scope='session')
-def celery_class_based_tasks():
-    return []
-
-
-@pytest.fixture(scope='session')
 def celery_session_worker(request,
                           celery_session_app,
                           celery_includes,
-                          celery_class_based_tasks,
                           celery_worker_pool,
                           celery_worker_parameters):
     # type: (Any, Celery, Sequence[str], str, Any) -> WorkController
@@ -91,8 +85,6 @@ def celery_session_worker(request,
     if not NO_WORKER:
         for module in celery_includes:
             celery_session_app.loader.import_task_module(module)
-        for class_based_task in celery_class_based_tasks:
-            celery_session_app.tasks.register(class_based_task)
         with worker.start_worker(celery_session_app,
                                  pool=celery_worker_pool,
                                  **celery_worker_parameters) as w:
@@ -180,9 +172,15 @@ def celery_app(request,
 
 
 @pytest.fixture()
+def celery_class_tasks():
+    return []
+
+
+@pytest.fixture()
 def celery_worker(request,
                   celery_app,
                   celery_includes,
+                  celery_class_tasks,
                   celery_worker_pool,
                   celery_worker_parameters):
     # type: (Any, Celery, Sequence[str], str, Any) -> WorkController
@@ -190,6 +188,8 @@ def celery_worker(request,
     if not NO_WORKER:
         for module in celery_includes:
             celery_app.loader.import_task_module(module)
+        for class_task in celery_class_tasks:
+            celery_app.tasks.register(class_task)
         with worker.start_worker(celery_app,
                                  pool=celery_worker_pool,
                                  **celery_worker_parameters) as w:

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -73,3 +73,9 @@ def manager(app, celery_session_worker):
 def ZZZZ_set_app_current(app):
     app.set_current()
     app.set_default()
+
+
+@pytest.fixture(scope='session')
+def celery_class_tasks():
+    from t.integration.tasks import ClassBasedAutoRetryTask
+    return [ClassBasedAutoRetryTask]

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from time import sleep
 
-from celery import chain, chord, group, shared_task
+from celery import chain, chord, group, shared_task, Task
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
 
@@ -235,3 +235,15 @@ def chord_error(*args):
 @shared_task(bind=True)
 def return_priority(self, *_args):
     return "Priority: %s" % self.request.delivery_info['priority']
+
+
+class ClassBasedAutoRetryTask(Task):
+    name = 'auto_retry_class_task'
+    autoretry_for = (ValueError,)
+    retry_kwargs = {'max_retries': 1}
+    retry_backoff = True
+
+    def run(self):
+        if self.request.retries:
+            return self.request.retries
+        raise ValueError()

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -247,5 +247,7 @@ class ClassBasedAutoRetryTask(Task):
     iterations = 0
 
     def run(self, x, y):
-        self.iterations += 1
+        if self.request.retries:
+            return self.request.retries
+
         return x / y

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from time import sleep
 
-from celery import chain, chord, group, shared_task
+from celery import chain, chord, group, shared_task, Task
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
 
@@ -235,3 +235,17 @@ def chord_error(*args):
 @shared_task(bind=True)
 def return_priority(self, *_args):
     return "Priority: %s" % self.request.delivery_info['priority']
+
+
+class ClassBasedAutoRetryTask(Task):
+    name = 'ClassBasedAutoRetryTask'
+    autoretry_for = (ZeroDivisionError,)
+    retry_kwargs = {'max_retries': 5}
+    retry_backoff = True
+    retry_backoff_max = 700
+    retry_jitter = False
+    iterations = 0
+
+    def run(self, x, y):
+        self.iterations += 1
+        return x / y

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from time import sleep
 
-from celery import chain, chord, group, shared_task, Task
+from celery import chain, chord, group, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
 
@@ -235,19 +235,3 @@ def chord_error(*args):
 @shared_task(bind=True)
 def return_priority(self, *_args):
     return "Priority: %s" % self.request.delivery_info['priority']
-
-
-class ClassBasedAutoRetryTask(Task):
-    name = 'ClassBasedAutoRetryTask'
-    autoretry_for = (ZeroDivisionError,)
-    retry_kwargs = {'max_retries': 5}
-    retry_backoff = True
-    retry_backoff_max = 700
-    retry_jitter = False
-    iterations = 0
-
-    def run(self, x, y):
-        if self.request.retries:
-            return self.request.retries
-
-        return x / y

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -9,7 +9,7 @@ from .tasks import (add, add_ignore_result, print_unicode, retry_once,
                     retry_once_priority, sleeping, ClassBasedAutoRetryTask)
 
 
-@pytest.fixture(scope='sesion')
+@pytest.fixture(scope='session')
 def celery_class_based_tasks():
     return [ClassBasedAutoRetryTask]
 

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -9,6 +9,10 @@ from .tasks import (add, add_ignore_result, print_unicode, retry_once,
                     retry_once_priority, sleeping, ClassBasedAutoRetryTask)
 
 
+@pytest.fixture(scope='sesion')
+def celery_class_based_tasks():
+    return [ClassBasedAutoRetryTask]
+
 
 class test_tasks:
 

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -39,8 +39,8 @@ class test_tasks:
     def test_class_based_task_retried(self, app):
         task = ClassBasedAutoRetryTask()
         app.tasks.register(task)
-        task.delay(1, 0)
-        assert task.iterations == 6
+        res = task.delay(1, 0)
+        assert res.get(timeout=10) == 1  # retried once
 
 
 class tests_task_redis_result_backend:


### PR DESCRIPTION
## Description

Currently auto-retry functionality is added to tasks in `Celery._task_from_fun` method and not applied to class based tasks.  Added applying auto-retry behaviour when class based task is registered in tasks registry.

Fixes #6117