### PR TITLE
improv: Make use of ordered sets in Redis opt-in

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -410,6 +410,13 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         # this flag.
         pass
 
+    @cached_property
+    def _chord_zset(self):
+        transport_options = self.app.conf.get(
+            'result_backend_transport_options', {}
+        )
+        return transport_options.get('result_chord_ordered', False)
+
     def on_chord_part_return(self, request, state, result,
                              propagate=None, **kwargs):
         app = self.app
@@ -424,11 +431,19 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         tkey = self.get_key_for_group(gid, '.t')
         result = self.encode_result(result, state)
         with client.pipeline() as pipe:
-            pipeline = pipe \
-                .zadd(jkey,
-                      {self.encode([1, tid, state, result]): group_index}) \
-                .zcount(jkey, '-inf', '+inf') \
-                .get(tkey)
+            if self._chord_zset:
+                pipeline = (pipe
+                    .zadd(jkey, {
+                        self.encode([1, tid, state, result]): group_index
+                    })
+                    .zcount(jkey, '-inf', '+inf')
+                )
+            else:
+                pipeline = (pipe
+                    .rpush(jkey, self.encode([1, tid, state, result]))
+                    .llen(jkey)
+                )
+            pipeline = pipeline.get(tkey)
 
             if self.expires is not None:
                 pipeline = pipeline \
@@ -445,9 +460,11 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             if readycount == total:
                 decode, unpack = self.decode, self._unpack_chord_result
                 with client.pipeline() as pipe:
-                    resl, = pipe \
-                        .zrange(jkey, 0, -1) \
-                        .execute()
+                    if self._chord_zset:
+                        pipeline = pipe.zrange(jkey, 0, -1)
+                    else:
+                        pipeline = pipe.lrange(jkey, 0, total)
+                    resl, = pipeline.execute()
                 try:
                     callback.delay([unpack(tup, decode) for tup in resl])
                     with client.pipeline() as pipe:

--- a/docs/getting-started/brokers/redis.rst
+++ b/docs/getting-started/brokers/redis.rst
@@ -144,3 +144,24 @@ If you experience an error like:
 
 then you may want to configure the :command:`redis-server` to not evict keys
 by setting the ``timeout`` parameter to 0 in the redis configuration file.
+
+Group result ordering
+---------------------
+
+Versions of Celery up to and including 4.4.6 used an unsorted list to store
+result objects for groups in the Redis backend. This can cause those results to
+be be returned in a different order to their associated tasks in the original
+group instantiation.
+
+Celery 4.4.7 and up introduce an opt-in behaviour which fixes this issue and
+ensures that group results are returned in the same order the tasks were
+defined, matching the behaviour of other backends. This change is incompatible
+with workers running versions of Celery without this feature, so the feature
+must be turned on using the boolean `result_chord_ordered` option of the
+:setting:`result_backend_transport_options` setting, like so:
+
+.. code-block:: python
+
+    app.conf.result_backend_transport_options = {
+        'result_chord_ordered': True
+    }

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -856,8 +856,14 @@ class test_chord:
         backend = fail.app.backend
         j_key = backend.get_key_for_group(original_group_id, '.j')
         redis_connection = get_redis_connection()
-        chord_results = [backend.decode(t) for t in
-                         redis_connection.zrange(j_key, 0, 3)]
+        # The redis key is either a list or zset depending on configuration
+        if manager.app.conf.result_backend_transport_options.get(
+            'result_chord_ordered', False
+        ):
+            job_results = redis_connection.zrange(j_key, 0, 3)
+        else:
+            job_results = redis_connection.lrange(j_key, 0, 3)
+        chord_results = [backend.decode(t) for t in job_results]
 
         # Validate group result
         assert [cr[3] for cr in chord_results if cr[2] == states.SUCCESS] == \


### PR DESCRIPTION
## Description

This should ensure that there is no breakage between workers with the
code from #6218 and those without, unless the cluster owner specifically
opts into the new behaviour.

Amends #6218 