### PR TITLE
fix: Make development docker image build again

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:bionic
 
 ENV PYTHONIOENCODING UTF-8
 
@@ -66,11 +66,11 @@ RUN chmod gu+x /entrypoint
 # Define the local pyenvs
 RUN pyenv local python3.8 python3.7 python3.6 python3.5 python2.7
 
-RUN pyenv exec python2.7 -m pip install --upgrade pip setuptools && \
-    pyenv exec python3.5 -m pip install --upgrade pip setuptools && \
-    pyenv exec python3.6 -m pip install --upgrade pip setuptools && \
-    pyenv exec python3.7 -m pip install --upgrade pip setuptools && \
-    pyenv exec python3.8 -m pip install --upgrade pip setuptools
+RUN pyenv exec python2.7 -m pip install --upgrade pip setuptools wheel && \
+    pyenv exec python3.5 -m pip install --upgrade pip setuptools wheel && \
+    pyenv exec python3.6 -m pip install --upgrade pip setuptools wheel && \
+    pyenv exec python3.7 -m pip install --upgrade pip setuptools wheel && \
+    pyenv exec python3.8 -m pip install --upgrade pip setuptools wheel
 
 # Setup one celery environment for basic development use
 RUN pyenv exec python3.8 -m pip install \
@@ -105,7 +105,6 @@ RUN pyenv exec python3.8 -m pip install \
   -r requirements/dev.txt \
   -r requirements/test.txt \
   -r requirements/test-ci-default.txt \
-  -r requirements/docs.txt \
   -r requirements/test-integration.txt \
   -r requirements/pkgutils.txt
 


### PR DESCRIPTION
## Description

 * Change the image base back to `ubuntu:bionic` since couchbase doesn't
   yet provide packages for focal
 * Ensure `wheel` is available since some packages need it when building
 * Don't install the doc dependencies in Python 2.7 since Sphinx >= 2.0
   doesn't support it

Fixes #6227