### PR TITLE
reduce timeout in test canvas

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -27,25 +27,28 @@ def is_retryable_exception(exc):
     return isinstance(exc, RETRYABLE_EXCEPTIONS)
 
 
-TIMEOUT = 120
+TIMEOUT = 60
+
+
+flaky = pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
 
 
 class test_link_error:
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_link_error_eager(self):
         exception = ExpectedException("Task expected to fail", "test")
         result = fail.apply(args=("test",), link_error=return_exception.s())
         actual = result.get(timeout=TIMEOUT, propagate=False)
         assert actual == exception
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_link_error(self):
         exception = ExpectedException("Task expected to fail", "test")
         result = fail.apply(args=("test",), link_error=return_exception.s())
         actual = result.get(timeout=TIMEOUT, propagate=False)
         assert actual == exception
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_link_error_callback_error_callback_retries_eager(self):
         exception = ExpectedException("Task expected to fail", "test")
         result = fail.apply(
@@ -54,7 +57,7 @@ class test_link_error:
         )
         assert result.get(timeout=TIMEOUT, propagate=False) == exception
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_link_error_callback_retries(self):
         exception = ExpectedException("Task expected to fail", "test")
         result = fail.apply_async(
@@ -63,7 +66,7 @@ class test_link_error:
         )
         assert result.get(timeout=TIMEOUT, propagate=False) == exception
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_link_error_using_signature_eager(self):
         fail = signature('t.integration.tasks.fail', args=("test",))
         retrun_exception = signature('t.integration.tasks.return_exception')
@@ -74,7 +77,7 @@ class test_link_error:
         assert (fail.apply().get(timeout=TIMEOUT, propagate=False), True) == (
             exception, True)
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_link_error_using_signature(self):
         fail = signature('t.integration.tasks.fail', args=("test",))
         retrun_exception = signature('t.integration.tasks.return_exception')
@@ -88,17 +91,17 @@ class test_link_error:
 
 class test_chain:
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_simple_chain(self, manager):
         c = add.s(4, 4) | add.s(8) | add.s(16)
         assert c().get(timeout=TIMEOUT) == 32
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_single_chain(self, manager):
         c = chain(add.s(3, 4))()
         assert c.get(timeout=TIMEOUT) == 7
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_complex_chain(self, manager):
         c = (
             add.s(2, 2) | (
@@ -109,7 +112,7 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == [64, 65, 66, 67]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_group_results_in_chain(self, manager):
         # This adds in an explicit test for the special case added in commit
         # 1e3fcaa969de6ad32b52a3ed8e74281e5e5360e6
@@ -145,7 +148,7 @@ class test_chain:
         with pytest.raises(ExpectedException):
             res.parent.get(propagate=True)
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_chain_inside_group_receives_arguments(self, manager):
         c = (
             add.s(5, 6) |
@@ -154,7 +157,7 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == [14, 14]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_eager_chain_inside_task(self, manager):
         from .tasks import chain_add
 
@@ -165,7 +168,7 @@ class test_chain:
 
         chain_add.app.conf.task_always_eager = prev
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_group_chord_group_chain(self, manager):
         from celery.five import bytes_if_py2
 
@@ -192,7 +195,7 @@ class test_chain:
         assert set(redis_messages[4:]) == after_items
         redis_connection.delete('redis-echo')
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_group_result_not_has_cache(self, manager):
         t1 = identity.si(1)
         t2 = identity.si(2)
@@ -202,7 +205,7 @@ class test_chain:
         result = task.delay()
         assert result.get(timeout=TIMEOUT) == [1, 2, [3, 4]]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_second_order_replace(self, manager):
         from celery.five import bytes_if_py2
 
@@ -223,7 +226,7 @@ class test_chain:
                              b'Out A']
         assert redis_messages == expected_messages
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_parent_ids(self, manager, num=10):
         assert_ping(manager)
 
@@ -291,7 +294,7 @@ class test_chain:
         result = c.get()
         assert result == 10
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_groupresult_serialization(self, manager):
         """Test GroupResult is correctly serialized
         to save in the result backend"""
@@ -305,7 +308,7 @@ class test_chain:
         assert len(result) == 2
         assert isinstance(result[0][1], list)
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_chain_of_task_a_group_and_a_chord(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -320,7 +323,7 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == 8
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_chain_of_chords_as_groups_chained_to_a_task_with_two_tasks(self,
                                                                         manager):
         try:
@@ -338,7 +341,7 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == 12
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_chain_of_chords_with_two_tasks(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -354,7 +357,7 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == 12
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_chain_of_a_chord_and_a_group_with_two_tasks(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -370,7 +373,7 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == [6, 6]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_chain_of_a_chord_and_a_task_and_a_group(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -385,7 +388,7 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == [6, 6]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_chain_of_a_chord_and_two_tasks_and_a_group(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -401,7 +404,7 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == [7, 7]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_chain_of_a_chord_and_three_tasks_and_a_group(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -421,14 +424,14 @@ class test_chain:
 
 class test_result_set:
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_result_set(self, manager):
         assert_ping(manager)
 
         rs = ResultSet([add.delay(1, 1), add.delay(2, 2)])
         assert rs.get(timeout=TIMEOUT) == [2, 4]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_result_set_error(self, manager):
         assert_ping(manager)
 
@@ -440,7 +443,7 @@ class test_result_set:
 
 
 class test_group:
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_ready_with_exception(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
@@ -450,7 +453,7 @@ class test_group:
         while not result.ready():
             pass
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_empty_group_result(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
@@ -462,7 +465,7 @@ class test_group:
         task = GroupResult.restore(result.id)
         assert task.results == []
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_parent_ids(self, manager):
         assert_ping(manager)
 
@@ -482,7 +485,7 @@ class test_group:
             assert parent_id == expected_parent_id
             assert value == i + 2
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_nested_group(self, manager):
         assert_ping(manager)
 
@@ -500,7 +503,7 @@ class test_group:
 
         assert res.get(timeout=TIMEOUT) == [11, 101, 1001, 2001]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_large_group(self, manager):
         assert_ping(manager)
 
@@ -525,7 +528,7 @@ def assert_ping(manager):
 
 
 class test_chord:
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_simple_chord_with_a_delay_in_group_save(self, manager, monkeypatch):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -550,7 +553,7 @@ class test_chord:
         result = c()
         assert result.get(timeout=TIMEOUT) == 4
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_redis_subscribed_channels_leak(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
@@ -591,7 +594,7 @@ class test_chord:
         assert channels_after_count == initial_channels_count
         assert set(channels_after) == set(initial_channels)
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_replaced_nested_chord(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -611,7 +614,7 @@ class test_chord:
         res1 = c1()
         assert res1.get(timeout=TIMEOUT) == [29, 38]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_add_to_chord(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
@@ -620,7 +623,7 @@ class test_chord:
         res = c()
         assert sorted(res.get()) == [0, 5, 6, 7]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_add_chord_to_chord(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
@@ -629,7 +632,7 @@ class test_chord:
         res = c()
         assert res.get() == [0, 5 + 6 + 7]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_eager_chord_inside_task(self, manager):
         from .tasks import chord_add
 
@@ -640,7 +643,7 @@ class test_chord:
 
         chord_add.app.conf.task_always_eager = prev
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_group_chain(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
@@ -652,7 +655,7 @@ class test_chord:
         res = c()
         assert res.get(timeout=TIMEOUT) == [12, 13, 14, 15]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     @pytest.mark.xfail(os.environ['TEST_BACKEND'] == 'cache+pylibmc://',
                        reason="Not supported yet by the cache backend.",
                        strict=True,
@@ -680,7 +683,7 @@ class test_chord:
         res = c()
         assert res.get(timeout=TIMEOUT) == 11
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_single_task_header(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -709,7 +712,7 @@ class test_chord:
         res2 = c2()
         assert res2.get(timeout=TIMEOUT) == []
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_nested_chord(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -743,7 +746,7 @@ class test_chord:
         res = c()
         assert [[[[3, 3], 4], 5], 6] == res.get(timeout=TIMEOUT)
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_parent_ids(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
@@ -758,7 +761,7 @@ class test_chord:
         )
         self.assert_parentids_chord(g(), expected_root_id)
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_parent_ids__OR(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
@@ -866,7 +869,7 @@ class test_chord:
         assert len([cr for cr in chord_results if cr[2] != states.SUCCESS]
                    ) == 1
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_parallel_chords(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -880,7 +883,7 @@ class test_chord:
 
         assert r.get(timeout=TIMEOUT) == [10, 10]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_chord_in_chords_with_chains(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -911,7 +914,7 @@ class test_chord:
 
         assert r.get(timeout=TIMEOUT) == 4
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_chain_chord_chain_chord(self, manager):
         # test for #2573
         try:
@@ -956,7 +959,7 @@ class test_chord:
         res1 = c1.apply(args=(1,))
         assert res1.get(timeout=TIMEOUT) == [1, 1]
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_large_header(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -967,7 +970,7 @@ class test_chord:
         res = c.delay()
         assert res.get(timeout=TIMEOUT) == 499500
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_chain_to_a_chord_with_large_header(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
@@ -979,12 +982,12 @@ class test_chord:
         res = c.delay()
         assert res.get(timeout=TIMEOUT) == 1000
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_priority(self, manager):
         c = chain(return_priority.signature(priority=3))()
         assert c.get(timeout=TIMEOUT) == "Priority: 3"
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+    @flaky
     def test_priority_chain(self, manager):
         c = return_priority.signature(priority=3) | return_priority.signature(
             priority=5)

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -9,40 +9,46 @@ from .tasks import (add, add_ignore_result, print_unicode, retry_once,
                     retry_once_priority, sleeping, ClassBasedAutoRetryTask)
 
 
+TIMEOUT = 10
+
+
+flaky = pytest.mark.flaky(reruns=5, reruns_delay=2)
+
+
 class test_class_based_tasks:
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=2)
+    @flaky
     def test_class_based_task_retried(self, celery_session_app,
                                       celery_session_worker):
         task = ClassBasedAutoRetryTask()
         celery_session_app.tasks.register(task)
         res = task.delay()
-        assert res.get(timeout=10) == 1
+        assert res.get(timeout=TIMEOUT) == 1
 
 
 class test_tasks:
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=2)
+    @flaky
     def test_task_accepted(self, manager, sleep=1):
         r1 = sleeping.delay(sleep)
         sleeping.delay(sleep)
         manager.assert_accepted([r1.id])
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=2)
+    @flaky
     def test_task_retried(self):
         res = retry_once.delay()
-        assert res.get(timeout=10) == 1  # retried once
+        assert res.get(timeout=TIMEOUT) == 1  # retried once
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=2)
+    @flaky
     def test_task_retried_priority(self):
         res = retry_once_priority.apply_async(priority=7)
-        assert res.get(timeout=10) == 7  # retried once with priority 7
+        assert res.get(timeout=TIMEOUT) == 7  # retried once with priority 7
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=2)
+    @flaky
     def test_unicode_task(self, manager):
         manager.join(
             group(print_unicode.s() for _ in range(5))(),
-            timeout=10, propagate=True,
+            timeout=TIMEOUT, propagate=True,
         )
 
 


### PR DESCRIPTION
reduce timeout in test canvas

Travis will timout a CI build job that emits no lines for 10 minutes,
and because when TIMEOUT=120,reruns=5: TIMEOUT*reruns = 10 minutes
the whole build is terminated

```
t/integration/test_canvas.py::test_chain::test_group_result_not_has_cache
+++++++++++++++++++++++++++++++++++ Timeout ++++++++++++++++++++++++++++++++++++

~~~~~~~~~~~~~~~~~~~~~ Stack of Thread-1 (139735813543680) ~~~~~~~~~~~~~~~~~~~~~~
  File "/opt/python/3.8.3/lib/python3.8/threading.py", line 890, in _bootstrap
    self._bootstrap_inner()
  File "/opt/python/3.8.3/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/opt/python/3.8.3/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/home/travis/build/celery/celery/celery/worker/worker.py", line 208, in start
    self.blueprint.start(self)
  File "/home/travis/build/celery/celery/celery/bootsteps.py", line 119, in start
    step.start(parent)
  File "/home/travis/build/celery/celery/celery/bootsteps.py", line 369, in start
    return self.obj.start()
  File "/home/travis/build/celery/celery/celery/worker/consumer/consumer.py", line 318, in start
    blueprint.start(self)
  File "/home/travis/build/celery/celery/celery/bootsteps.py", line 119, in start
    step.start(parent)
  File "/home/travis/build/celery/celery/celery/worker/consumer/consumer.py", line 599, in start
    c.loop(*c.loop_args())
  File "/home/travis/build/celery/celery/celery/worker/loops.py", line 83, in asynloop
    next(loop)
  File "/home/travis/build/celery/celery/.tox/3.8-integration-rabbitmq/lib/python3.8/site-packages/kombu/asynchronous/hub.py", line 308, in create_loop
    events = poll(poll_timeout)
  File "/home/travis/build/celery/celery/.tox/3.8-integration-rabbitmq/lib/python3.8/site-packages/kombu/utils/eventio.py", line 84, in poll
    return self._epoll.poll(timeout if timeout is not None else -1)

~~~~~~~~~~~~~~~~~~~~~ Stack of <unknown> (139735944996608) ~~~~~~~~~~~~~~~~~~~~~
  File "/home/travis/build/celery/celery/.tox/3.8-integration-rabbitmq/lib/python3.8/site-packages/execnet/gateway_base.py", line 285, in _perform_spawn
    reply.run()
  File "/home/travis/build/celery/celery/.tox/3.8-integration-rabbitmq/lib/python3.8/site-packages/execnet/gateway_base.py", line 220, in run
    self._result = func(*args, **kwargs)
  File "/home/travis/build/celery/celery/.tox/3.8-integration-rabbitmq/lib/python3.8/site-packages/execnet/gateway_base.py", line 967, in _thread_receiver
    msg = Message.from_io(io)
  File "/home/travis/build/celery/celery/.tox/3.8-integration-rabbitmq/lib/python3.8/site-packages/execnet/gateway_base.py", line 432, in from_io
    header = io.read(9)  # type 1, channel 4, payload 4
  File "/home/travis/build/celery/celery/.tox/3.8-integration-rabbitmq/lib/python3.8/site-packages/execnet/gateway_base.py", line 400, in read
    data = self._read(numbytes - len(buf))

+++++++++++++++++++++++++++++++++++ Timeout ++++++++++++++++++++++++++++++++++++

[gw0] [33mRERUN[0m t/integration/test_canvas.py::test_chain::test_group_result_not_has_cache
```

