### PR TITLE
pin pytest versions to semver range appropriate for python_version + upgrade pytest to v6 on py3

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 case>=1.3.1
 pytest~=4.6; python_version < '3.0'
-pytest~=5.4; python_version >= '3.0'
+pytest~=6.0; python_version >= '3.0'
 boto3>=1.9.178
 python-dateutil<2.8.1,>=2.1; python_version < '3.0'
 moto==1.3.7

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,6 @@
 case>=1.3.1
-pytest>=4.5.0,<5.3.5
+pytest~=4.6; python_version < '3.0'
+pytest~=5.4; python_version >= '3.0'
 boto3>=1.9.178
 python-dateutil<2.8.1,>=2.1; python_version < '3.0'
 moto==1.3.7

--- a/t/unit/contrib/test_pytest.py
+++ b/t/unit/contrib/test_pytest.py
@@ -1,18 +1,15 @@
 import pytest
 
-try:
-    from pytest import PytestUnknownMarkWarning  # noqa: F401
-
-    pytest_marker_warnings = True
-except ImportError:
-    pytest_marker_warnings = False
-
-
 pytest_plugins = ["pytester"]
+
+try:
+    pytest.fail()
+except BaseException as e:
+    Failed = type(e)
 
 
 @pytest.mark.skipif(
-    not pytest_marker_warnings,
+    not hasattr(pytest, "PytestUnknownMarkWarning"),
     reason="Older pytest version without marker warnings",
 )
 def test_pytest_celery_marker_registration(testdir):
@@ -28,7 +25,7 @@ def test_pytest_celery_marker_registration(testdir):
     )
 
     result = testdir.runpytest('-q')
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, Failed)):
         result.stdout.fnmatch_lines_random(
             "*PytestUnknownMarkWarning: Unknown pytest.mark.celery*"
         )


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
