### PR TITLE
remove pytest-rerunfailures

### DIFF
--- a/requirements/test-integration.txt
+++ b/requirements/test-integration.txt
@@ -3,4 +3,3 @@ simplejson
 -r extras/azureblockblob.txt
 -r extras/auth.txt
 -r extras/memcache.txt
-pytest-rerunfailures>=6.0


### PR DESCRIPTION
we should use @pytest.mark.flaky on the tests that need it instead

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
