### PR TITLE
pytest-timeout fixes - apply only to flaky tests, ignore pytest_timeout in lingering thread check

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ addopts = --strict-markers
 testpaths = t/unit/
 python_classes = test_*
 xfail_strict=true
-timeout = 300
 
 [build_sphinx]
 source-dir = docs/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [tool:pytest]
+addopts = --strict-markers
 testpaths = t/unit/
 python_classes = test_*
 xfail_strict=true

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -30,7 +30,12 @@ def is_retryable_exception(exc):
 TIMEOUT = 60
 
 
-flaky = pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+_flaky = pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+_timeout = pytest.mark.timeout(timeout=300)
+
+
+def flaky(fn):
+    return _timeout(_flaky(fn))
 
 
 class test_link_error:

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -12,7 +12,12 @@ from .tasks import (add, add_ignore_result, print_unicode, retry_once,
 TIMEOUT = 10
 
 
-flaky = pytest.mark.flaky(reruns=5, reruns_delay=2)
+_flaky = pytest.mark.flaky(reruns=5, reruns_delay=2)
+_timeout = pytest.mark.timeout(timeout=300)
+
+
+def flaky(fn):
+    return _timeout(_flaky(fn))
 
 
 class test_class_based_tasks:

--- a/t/unit/conftest.py
+++ b/t/unit/conftest.py
@@ -133,7 +133,11 @@ def AAA_disable_multiprocessing():
 
 
 def alive_threads():
-    return [thread for thread in threading.enumerate() if thread.is_alive()]
+    return [
+        thread
+        for thread in threading.enumerate()
+        if not thread.name.startswith("pytest_timeout ") and thread.is_alive()
+    ]
 
 
 @pytest.fixture(autouse=True)

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -793,7 +793,6 @@ class test_WorkController(ConsumerCase):
         assert worker.autoscaler
 
     @skip.if_win32()
-    @pytest.mark.nothreads_not_lingering
     @mock.sleepdeprived(module=autoscale)
     def test_with_autoscaler_file_descriptor_safety(self):
         # Given: a test celery worker instance with auto scaling
@@ -843,7 +842,6 @@ class test_WorkController(ConsumerCase):
         worker.pool.terminate()
 
     @skip.if_win32()
-    @pytest.mark.nothreads_not_lingering
     @mock.sleepdeprived(module=autoscale)
     def test_with_file_descriptor_safety(self):
         # Given: a test celery worker instance


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
