### PR TITLE
Revert pytest timeout

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -429,13 +429,21 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         jkey = self.get_key_for_group(gid, '.j')
         tkey = self.get_key_for_group(gid, '.t')
         result = self.encode_result(result, state)
-        encoded = self.encode([1, tid, state, result])
         with client.pipeline() as pipe:
-            pipeline = (
-                pipe.zadd(jkey, {encoded: group_index}).zcount(jkey, "-inf", "+inf")
-                if self._chord_zset
-                else pipe.rpush(jkey, encoded).llen(jkey)
-            ).get(tkey)
+            if self._chord_zset:
+                pipeline = (pipe
+                    .zadd(jkey, {
+                        self.encode([1, tid, state, result]): group_index
+                    })
+                    .zcount(jkey, '-inf', '+inf')
+                )
+            else:
+                pipeline = (pipe
+                    .rpush(jkey, self.encode([1, tid, state, result]))
+                    .llen(jkey)
+                )
+            pipeline = pipeline.get(tkey)
+
             if self.expires is not None:
                 pipeline = pipeline \
                     .expire(jkey, self.expires) \

--- a/requirements/test-ci-base.txt
+++ b/requirements/test-ci-base.txt
@@ -1,4 +1,5 @@
 pytest-cov
+pytest-sugar
 pytest-travis-fold
 codecov
 -r extras/redis.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,6 @@
 case>=1.3.1
 pytest~=4.6; python_version < '3.0'
 pytest~=6.0; python_version >= '3.0'
-pytest-timeout~=1.4.2
 boto3>=1.9.178
 python-dateutil<2.8.1,>=2.1; python_version < '3.0'
 moto==1.3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,6 @@
 testpaths = t/unit/
 python_classes = test_*
 xfail_strict=true
-timeout = 300
 
 [build_sphinx]
 source-dir = docs/


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

see 94f85cdc145b3c992b337166ca43eac75b625eab
It looks like pytest-timeout causes:

```
    ================================== FAILURES
    _________ test_signal_handlers.test_send_worker_shutting_down_signal
    self = <t.unit.bin.test_worker.test_signal_handlers object at
    0x000000DC4C6C9710>
    >   ???
    E   Failed: DID NOT RAISE <class 'celery.exceptions.WorkerShutdown'>
    t\unit\bin\test_worker.py:669: Failed
    ============================== warnings summary
```

revert for now

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
