### PR TITLE
lower max-line-length to 117

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ all_files = 1
 [flake8]
 # classes can be lowercase, arguments and variables can be uppercase
 # whenever it makes the code more readable.
-max-line-length = 128
+max-line-length = 125
 extend-ignore =
     D102,  # Missing docstring in public method
     D104,  # Missing docstring in public package

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ all_files = 1
 [flake8]
 # classes can be lowercase, arguments and variables can be uppercase
 # whenever it makes the code more readable.
-max-line-length = 143
+max-line-length = 128
 extend-ignore =
     D102,  # Missing docstring in public method
     D104,  # Missing docstring in public package

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ all_files = 1
 [flake8]
 # classes can be lowercase, arguments and variables can be uppercase
 # whenever it makes the code more readable.
-max-line-length = 121
+max-line-length = 117
 extend-ignore =
     D102,  # Missing docstring in public method
     D104,  # Missing docstring in public package

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ all_files = 1
 [flake8]
 # classes can be lowercase, arguments and variables can be uppercase
 # whenever it makes the code more readable.
-max-line-length = 125
+max-line-length = 124
 extend-ignore =
     D102,  # Missing docstring in public method
     D104,  # Missing docstring in public package

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ all_files = 1
 [flake8]
 # classes can be lowercase, arguments and variables can be uppercase
 # whenever it makes the code more readable.
-max-line-length = 124
+max-line-length = 121
 extend-ignore =
     D102,  # Missing docstring in public method
     D104,  # Missing docstring in public package

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -1068,7 +1068,12 @@ class test_backend_retries:
             b._sleep = Mock()
             b._get_task_meta_for = Mock()
             b._get_task_meta_for.return_value = {
-                'status': states.RETRY, 'result': {"exc_type": "Exception", "exc_message": ["failed"], "exc_module": "builtins"}
+                'status': states.RETRY,
+                'result': {
+                    "exc_type": "Exception",
+                    "exc_message": ["failed"],
+                    "exc_module": "builtins",
+                },
             }
             b._store_result = Mock()
             b._store_result.side_effect = [
@@ -1092,7 +1097,12 @@ class test_backend_retries:
             b._sleep = Mock()
             b._get_task_meta_for = Mock()
             b._get_task_meta_for.return_value = {
-                'status': states.RETRY, 'result': {"exc_type": "Exception", "exc_message": ["failed"], "exc_module": "builtins"}
+                'status': states.RETRY,
+                'result': {
+                    "exc_type": "Exception",
+                    "exc_message": ["failed"],
+                    "exc_module": "builtins",
+                },
             }
             b._store_result = Mock()
             b._store_result.side_effect = [
@@ -1115,7 +1125,12 @@ class test_backend_retries:
             b._sleep = Mock()
             b._get_task_meta_for = Mock()
             b._get_task_meta_for.return_value = {
-                'status': states.RETRY, 'result': {"exc_type": "Exception", "exc_message": ["failed"], "exc_module": "builtins"}
+                'status': states.RETRY,
+                'result': {
+                    "exc_type": "Exception",
+                    "exc_message": ["failed"],
+                    "exc_module": "builtins",
+                },
             }
             b._store_result = Mock()
             b._store_result.side_effect = [

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -758,7 +758,12 @@ class test_ElasticsearchBackend:
                 raise Exception("failed")
             except Exception as exc:
                 einfo = ExceptionInfo()
-                result_meta = x._get_result_meta(x.encode_result(exc, states.FAILURE), states.FAILURE, einfo.traceback, None)
+                result_meta = x._get_result_meta(
+                    x.encode_result(exc, states.FAILURE),
+                    states.FAILURE,
+                    einfo.traceback,
+                    None,
+                )
                 assert x.encode(result_meta) == result_meta
         finally:
             self.app.conf.elasticsearch_save_meta_as_text = prev
@@ -800,7 +805,12 @@ class test_ElasticsearchBackend:
                 raise Exception("failed")
             except Exception as exc:
                 einfo = ExceptionInfo()
-                result_meta = x._get_result_meta(x.encode_result(exc, states.FAILURE), states.FAILURE, einfo.traceback, None)
+                result_meta = x._get_result_meta(
+                    x.encode_result(exc, states.FAILURE),
+                    states.FAILURE,
+                    einfo.traceback,
+                    None,
+                )
                 assert x.decode(x.encode(result_meta)) == result_meta
         finally:
             self.app.conf.elasticsearch_save_meta_as_text = prev

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -18,6 +18,16 @@ from celery.backends.elasticsearch import ElasticsearchBackend
 from celery.exceptions import ImproperlyConfigured
 
 
+_RESULT_RETRY = (
+    '{"status":"RETRY","result":'
+    '{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}'
+)
+_RESULT_FAILURE = (
+    '{"status":"FAILURE","result":'
+    '{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}'
+)
+
+
 @skip.unless_module('elasticsearch')
 class test_ElasticsearchBackend:
 
@@ -115,9 +125,7 @@ class test_ElasticsearchBackend:
 
         x._server.get.return_value = {
             'found': True,
-            '_source': {
-                'result': """{"status":"RETRY","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
-            },
+            '_source': {"result": _RESULT_RETRY},
             '_seq_no': 2,
             '_primary_term': 1,
         }
@@ -157,9 +165,7 @@ class test_ElasticsearchBackend:
 
         x._server.get.return_value = {
             'found': True,
-            '_source': {
-                'result': """{"status":"RETRY","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
-            },
+            '_source': {"result": _RESULT_RETRY},
             '_seq_no': 2,
             '_primary_term': 1,
         }
@@ -204,9 +210,7 @@ class test_ElasticsearchBackend:
 
         x._server.get.return_value = {
             'found': True,
-            '_source': {
-                'result': """{"status":"FAILURE","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
-            },
+            '_source': {"result": _RESULT_FAILURE},
             '_seq_no': 2,
             '_primary_term': 1,
         }
@@ -282,9 +286,7 @@ class test_ElasticsearchBackend:
 
         x._server.get.return_value = {
             'found': True,
-            '_source': {
-                'result': """{"status":"FAILURE","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
-            },
+            '_source': {"result": _RESULT_FAILURE},
             '_seq_no': 2,
             '_primary_term': 1,
         }
@@ -315,6 +317,33 @@ class test_ElasticsearchBackend:
         base_datetime_mock.utcnow.return_value = expected_done_dt
 
         self.app.conf.result_backend_always_retry, prev = True, self.app.conf.result_backend_always_retry
+        x_server_get_side_effect = [
+            {
+                'found': True,
+                '_source': {'result': _RESULT_RETRY},
+                '_seq_no': 2,
+                '_primary_term': 1,
+            },
+            {
+                'found': True,
+                '_source': {'result': _RESULT_RETRY},
+                '_seq_no': 2,
+                '_primary_term': 1,
+            },
+            {
+                'found': True,
+                '_source': {'result': _RESULT_FAILURE},
+                '_seq_no': 3,
+                '_primary_term': 1,
+            },
+            {
+                'found': True,
+                '_source': {'result': _RESULT_FAILURE},
+                '_seq_no': 3,
+                '_primary_term': 1,
+            },
+        ]
+
         try:
             x = ElasticsearchBackend(app=self.app)
 
@@ -326,42 +355,7 @@ class test_ElasticsearchBackend:
             x._sleep = sleep_mock
             x._server = Mock()
             x._server.index.side_effect = exceptions.ConflictError(409, "concurrent update", {})
-
-            x._server.get.side_effect = [
-                {
-                    'found': True,
-                    '_source': {
-                        'result': """{"status":"RETRY","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
-                    },
-                    '_seq_no': 2,
-                    '_primary_term': 1,
-                },
-                {
-                    'found': True,
-                    '_source': {
-                        'result': """{"status":"RETRY","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
-                    },
-                    '_seq_no': 2,
-                    '_primary_term': 1,
-                },
-                {
-                    'found': True,
-                    '_source': {
-                        'result': """{"status":"FAILURE","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
-                    },
-                    '_seq_no': 3,
-                    '_primary_term': 1,
-                },
-                {
-                    'found': True,
-                    '_source': {
-                        'result': """{"status":"FAILURE","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
-                    },
-                    '_seq_no': 3,
-                    '_primary_term': 1,
-                },
-            ]
-
+            x._server.get.side_effect = x_server_get_side_effect
             x._server.update.side_effect = [
                 {'result': 'noop'},
                 {'result': 'updated'}
@@ -453,9 +447,7 @@ class test_ElasticsearchBackend:
             x._server.get.side_effect = [
                 {
                     'found': True,
-                    '_source': {
-                        'result': """{"status":"RETRY","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
-                    },
+                    '_source': {"result": _RESULT_RETRY},
                     '_seq_no': 2,
                     '_primary_term': 1,
                 },
@@ -526,9 +518,7 @@ class test_ElasticsearchBackend:
             x._server.get.side_effect = [
                 {
                     'found': True,
-                    '_source': {
-                        'result': """{"status":"RETRY","result":{"exc_type":"Exception","exc_message":["failed"],"exc_module":"builtins"}}"""
-                    },
+                    '_source': {'result': _RESULT_RETRY},
                     '_seq_no': 2,
                     '_primary_term': 1,
                 },

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -234,7 +234,13 @@ class test_unlock_chord_task(ChordCase):
 
         with patch.object(ch, 'run') as run:
             ch.apply_async(task_id=sentinel.task_id)
-            run.assert_called_once_with(group(mul.s(1, 1), mul.s(2, 2)), mul.s(), (), task_id=sentinel.task_id, interval=10)
+            run.assert_called_once_with(
+                group(mul.s(1, 1), mul.s(2, 2)),
+                mul.s(),
+                (),
+                task_id=sentinel.task_id,
+                interval=10,
+            )
 
 
 class test_chord(ChordCase):

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -138,8 +138,9 @@ def test_remaining():
 
     """
     Case 3: DST check
-    Suppose start (which is last_run_time) is in EST while next_run is in EDT, then
-    check whether the `next_run` is actually the time specified in the start (i.e. there is not an hour diff due to DST).
+    Suppose start (which is last_run_time) is in EST while next_run is in EDT,
+    then check whether the `next_run` is actually the time specified in the
+    start (i.e. there is not an hour diff due to DST).
     In 2019, DST starts on March 10
     """
     start = eastern_tz.localize(datetime(month=3, day=9, year=2019, hour=10, minute=0))         # EST


### PR DESCRIPTION
Anything above 120 is almost universally considered egregious, [117 is now the longest line in the codebase below that limit](https://github.com/graingert/celery/blob/be5e8c0f33997b140547d54fb0084a1653178fc9/celery/backends/base.py#L458)

I think we could safely lower the line length further as that line would look much nicer black-style:
```python
                        raise_with_context(
                            BackendStoreError(
                                "failed to store result on the backend",
                                task_id=task_id,
                                state=state,
                            ),
                        )
```

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
