### PR TITLE
do not enable celery.contrib.pytest by default

### DIFF
--- a/requirements/extras/pytest.txt
+++ b/requirements/extras/pytest.txt
@@ -1,0 +1,1 @@
+pytest-celery

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,7 @@
 case>=1.3.1
 pytest~=4.6; python_version < '3.0'
 pytest~=6.0; python_version >= '3.0'
+pytest-celery
 pytest-timeout~=1.4.2
 boto3>=1.9.178
 python-dateutil<2.8.1,>=2.1; python_version < '3.0'

--- a/setup.py
+++ b/setup.py
@@ -213,10 +213,7 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'celery = celery.__main__:main',
-        ],
-        'pytest11': [
-            'celery = celery.contrib.pytest',
-        ],
+        ]
     },
     project_urls={
         "Documentation": "http://docs.celeryproject.org/en/latest/index.html",


### PR DESCRIPTION
Fixes #6280

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
