### PR TITLE
Retry after race during schema creation in database backend

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -277,3 +277,4 @@ Kyle Johnson, 2019/09/23
 Dipankar Achinta, 2019/10/24
 Sardorbek Imomaliev, 2020/01/24
 Maksym Shalenyi, 2020/07/30
+Frazer McLean, 2020/09/29

--- a/celery/backends/database/session.py
+++ b/celery/backends/database/session.py
@@ -14,6 +14,8 @@ ResultModelBase = declarative_base()
 
 __all__ = ('SessionManager',)
 
+PREPARE_MODELS_MAX_RETRIES = 10
+
 
 def _after_fork_cleanup_session(session):
     session._after_fork()
@@ -59,13 +61,12 @@ class SessionManager:
             # create them, which is a race condition. If it raises an error
             # in one iteration, the next may pass all the existence checks
             # and the call will succeed.
-            max_retries = 10
             retries = 0
             while True:
                 try:
                     ResultModelBase.metadata.create_all(engine)
                 except DatabaseError:
-                    if retries < max_retries:
+                    if retries < PREPARE_MODELS_MAX_RETRIES:
                         sleep_amount_ms = get_exponential_backoff_interval(
                             10, retries, 1000, True
                         )

--- a/celery/backends/database/session.py
+++ b/celery/backends/database/session.py
@@ -1,9 +1,14 @@
 """SQLAlchemy session."""
+import time
+
 from kombu.utils.compat import register_after_fork
 from sqlalchemy import create_engine
+from sqlalchemy.exc import DatabaseError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
+
+from celery.utils.time import get_exponential_backoff_interval
 
 ResultModelBase = declarative_base()
 
@@ -50,7 +55,26 @@ class SessionManager:
 
     def prepare_models(self, engine):
         if not self.prepared:
-            ResultModelBase.metadata.create_all(engine)
+            # SQLAlchemy will check if the items exist before trying to
+            # create them, which is a race condition. If it raises an error
+            # in one iteration, the next may pass all the existence checks
+            # and the call will succeed.
+            max_retries = 10
+            retries = 0
+            while True:
+                try:
+                    ResultModelBase.metadata.create_all(engine)
+                except DatabaseError:
+                    if retries < max_retries:
+                        sleep_amount_ms = get_exponential_backoff_interval(
+                            10, retries, 1000, True
+                        )
+                        time.sleep(sleep_amount_ms / 1000)
+                        retries += 1
+                    else:
+                        raise
+                else:
+                    break
             self.prepared = True
 
     def session_factory(self, dburi, **kwargs):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fixes #6296

This race condition does not commonly present, since the schema creation only needs to happen once per database. It's more likely to appear in e.g. a test suite that uses a new database each time.

For context of the sleep times I chose, the schema creation takes ~50 ms on my laptop.

I did a simulated test run of 50 concurrent calls to `MetaData.create_all` repeated 200 times and the number of retries was:

- 0 retries: 8717x
- 1 retry:   1279x
- 2 retries  4x
