### PR TITLE
[Fix #6240]: Correct conf CELERY_RESULT_EXPIRES to CELERY_TASK_RESULT_EXPIRES in docs

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -113,7 +113,7 @@ have been moved into a new  ``task_`` prefix.
 ``CELERY_MESSAGE_COMPRESSION``             :setting:`result_compression`
 ``CELERY_RESULT_EXCHANGE``                 :setting:`result_exchange`
 ``CELERY_RESULT_EXCHANGE_TYPE``            :setting:`result_exchange_type`
-``CELERY_RESULT_EXPIRES``                  :setting:`result_expires`
+``CELERY_TASK_RESULT_EXPIRES``             :setting:`result_expires`
 ``CELERY_RESULT_PERSISTENT``               :setting:`result_persistent`
 ``CELERY_RESULT_SERIALIZER``               :setting:`result_serializer`
 ``CELERY_RESULT_DBURI``                    Use :setting:`result_backend` instead.


### PR DESCRIPTION
Fix #6240. Correct conf CELERY_RESULT_EXPIRES to CELERY_TASK_RESULT_EXPIRES in docs.

I see @bonkstonk do not submit PR for a long time, so I submit this.