### PR TITLE
CeleryCommand: Add regression test

### DIFF
--- a/t/unit/bin/test_celery.py
+++ b/t/unit/bin/test_celery.py
@@ -280,6 +280,19 @@ class test_multi:
             multi(self.app).run_from_argv('celery', ['arg'], command='multi')
             m.execute_from_commandline.assert_called_with(['multi', 'arg'])
 
+    def test_execute_from_commandline_preserve_args(self):
+            multi_mock = Mock()
+            m = multi_mock.return_value = Mock()
+            x = CeleryCommand(app=self.app)
+            x.commands['multi'] = multi_mock
+            with pytest.raises(SystemExit):
+                x.execute_from_commandline(['celery', 'multi', 'worker1',
+                                            '-A', 'app'])
+            multi_mock.assert_called()
+            m.run_from_argv.assert_called_with('celery', ['worker1', '-A',
+                                                           'app'],
+                                               command='multi')
+
 
 class test_main:
 


### PR DESCRIPTION
Adds a test to check that the application parameter
handed to celery multi is then passed on to the actual
implementation of the multi command.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This is a regression test to check for the in issue #6285. 
