### PR TITLE
calling eventlib/gevent patching

### DIFF
--- a/celery/__main__.py
+++ b/celery/__main__.py
@@ -2,15 +2,12 @@
 
 import sys
 
-# from . import maybe_patch_concurrency
 
 __all__ = ('main',)
 
 
 def main():
     """Entrypoint to the ``celery`` umbrella command."""
-    # if 'multi' not in sys.argv:
-    #     maybe_patch_concurrency()
     from celery.bin.celery import main as _main
     sys.exit(_main())
 

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -47,8 +47,7 @@ class CLIContext:
     def ERROR(self):
         return self.style("ERROR", fg="red", bold=True)
 
-    @property
-    @functools.lru_cache(None)
+    @cached_property
     def app(self):
         return self._app() or get_current_app()
 

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -48,9 +48,9 @@ class CLIContext:
 
     @cached_property
     def app(self):
-        """Instantiate an app if it wasn't already and return it. This lazy
+        """Instantiate the app if it wasn't already and return it. This lazy
         approach gives opportunity for further initializations before the app
-        is loaded."""
+        is imported."""
         return self._app_factory() or get_current_app()
 
     def style(self, message=None, **kwargs):

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -1,5 +1,4 @@
 """Click customizations for Celery."""
-import functools
 import json
 from collections import OrderedDict
 from pprint import pformat
@@ -33,7 +32,7 @@ class CLIContext:
 
     def __init__(self, app, no_color, workdir, quiet=False):
         """Initialize the CLI context."""
-        self._app = app
+        self._app_factory = app
         self.no_color = no_color
         self.quiet = quiet
         self.workdir = workdir
@@ -49,7 +48,10 @@ class CLIContext:
 
     @cached_property
     def app(self):
-        return self._app() or get_current_app()
+        """Instantiate an app if it wasn't already and return it. This lazy
+        approach gives opportunity for further initializations before the app
+        is loaded."""
+        return self._app_factory() or get_current_app()
 
     def style(self, message=None, **kwargs):
         if self.no_color:

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -1,4 +1,5 @@
 """Click customizations for Celery."""
+import functools
 import json
 from collections import OrderedDict
 from pprint import pformat
@@ -32,7 +33,7 @@ class CLIContext:
 
     def __init__(self, app, no_color, workdir, quiet=False):
         """Initialize the CLI context."""
-        self.app = app or get_current_app()
+        self._app = app
         self.no_color = no_color
         self.quiet = quiet
         self.workdir = workdir
@@ -45,6 +46,11 @@ class CLIContext:
     @cached_property
     def ERROR(self):
         return self.style("ERROR", fg="red", bold=True)
+
+    @property
+    @functools.lru_cache(None)
+    def app(self):
+        return self._app() or get_current_app()
 
     def style(self, message=None, **kwargs):
         if self.no_color:

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -31,10 +31,12 @@ class App(ParamType):
     name = "application"
 
     def convert(self, value, param, ctx):
-        try:
-            return find_app(value)
-        except (ModuleNotFoundError, AttributeError) as e:
-            self.fail(str(e))
+        def lazy():
+            try:
+                return find_app(value)
+            except (ModuleNotFoundError, AttributeError) as e:
+                self.fail(str(e))
+        return lazy
 
 
 APP = App()
@@ -107,9 +109,9 @@ def celery(ctx, app, broker, result_backend, loader, config, workdir,
     ctx.obj = CLIContext(app=app, no_color=no_color, workdir=workdir, quiet=quiet)
 
     # User options
-    worker.params.extend(ctx.obj.app.user_options.get('worker', []))
-    beat.params.extend(ctx.obj.app.user_options.get('beat', []))
-    events.params.extend(ctx.obj.app.user_options.get('events', []))
+    # worker.params.extend(ctx.obj.app.user_options.get('worker', []))
+    # beat.params.extend(ctx.obj.app.user_options.get('beat', []))
+    # events.params.extend(ctx.obj.app.user_options.get('events', []))
 
 
 @celery.command(cls=CeleryCommand)

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -31,12 +31,12 @@ class App(ParamType):
     name = "application"
 
     def convert(self, value, param, ctx):
-        def lazy():
+        def factory():
             try:
                 return find_app(value)
             except (ModuleNotFoundError, AttributeError) as e:
                 self.fail(str(e))
-        return lazy
+        return factory
 
 
 APP = App()

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -17,6 +17,39 @@ from celery.utils.nodenames import default_nodename, host_format, node_format
 logger = get_logger(__name__)
 
 
+def maybe_patch_concurrency(library):
+    """Patches gevent/eventlet libraries."""
+
+    def patch_eventlet():
+        import eventlet.debug
+
+        eventlet.monkey_patch()
+        blockdetect = float(os.environ.get('EVENTLET_NOBLOCK', 0))
+        if blockdetect:
+            eventlet.debug.hub_blocking_detection(blockdetect, blockdetect)
+
+    def patch_gevent():
+        import gevent.monkey
+        import gevent.signal
+
+        gevent.monkey.patch_all()
+        if gevent.version_info[0] == 0:  # pragma: no cover
+            # Signals aren't working in gevent versions <1.0,
+            # and aren't monkey patched by patch_all()
+            import signal
+
+            signal.signal = gevent.signal
+
+    patches = {
+        'eventlet': patch_eventlet,
+        'gevent': patch_gevent
+    }
+
+    patcher = patches.get(library)
+    if patcher:
+        patcher()
+
+
 class CeleryBeat(ParamType):
     """Celery Beat flag."""
 
@@ -32,6 +65,7 @@ class CeleryBeat(ParamType):
 
 class WorkersPool(click.Choice):
     """Workers pool option."""
+
     name = "pool"
 
     def __init__(self):
@@ -41,42 +75,10 @@ class WorkersPool(click.Choice):
     def convert(self, value, param, ctx):
         # Pools like eventlet/gevent needs to patch libs as early
         # as possible.
-        patches = {
-            'eventlet': self._patch_eventlet,
-            'gevent': self._patch_gevent
-        }
-
-        try:
-            patcher = patches[value]
-        except KeyError:
-            pass
-        else:
-            patcher()
+        maybe_patch_concurrency(value)
 
         return concurrency.get_implementation(
             value) or ctx.obj.app.conf.worker_pool
-
-    @staticmethod
-    def _patch_eventlet():
-        import eventlet.debug
-
-        eventlet.monkey_patch()
-        blockdetect = float(os.environ.get('EVENTLET_NOBLOCK', 0))
-        if blockdetect:
-            eventlet.debug.hub_blocking_detection(blockdetect, blockdetect)
-
-    @staticmethod
-    def _patch_gevent():
-        import gevent.monkey
-        import gevent.signal
-
-        gevent.monkey.patch_all()
-        if gevent.version_info[0] == 0:  # pragma: no cover
-            # Signals aren't working in gevent versions <1.0,
-            # and aren't monkey patched by patch_all()
-            import signal
-
-            signal.signal = gevent.signal
 
 
 class Hostname(StringParamType):

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -33,12 +33,6 @@ def maybe_patch_concurrency(library):
         import gevent.signal
 
         gevent.monkey.patch_all()
-        if gevent.version_info[0] == 0:  # pragma: no cover
-            # Signals aren't working in gevent versions <1.0,
-            # and aren't monkey patched by patch_all()
-            import signal
-
-            signal.signal = gevent.signal
 
     patches = {
         'eventlet': patch_eventlet,

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -166,7 +166,7 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
               '--statedb',
               cls=CeleryOption,
               type=click.Path(),
-              callback=lambda ctx, _, value: value or ctx.obj.app.conf.worker_state_db,
+              # callback=lambda ctx, _, value: value or ctx.obj.app.conf.worker_state_db,
               help_group="Worker Options",
               help="Path to the state database. The extension '.db' may be"
                    "appended to the filename.")
@@ -187,7 +187,7 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
 @click.option('--prefetch-multiplier',
               type=int,
               metavar="<prefetch multiplier>",
-              callback=lambda ctx, _, value: value or ctx.obj.app.conf.worker_prefetch_multiplier,
+              # callback=lambda ctx, _, value: value or ctx.obj.app.conf.worker_prefetch_multiplier,
               cls=CeleryOption,
               help_group="Worker Options",
               help="Set custom prefetch multiplier value"
@@ -196,7 +196,7 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
               '--concurrency',
               type=int,
               metavar="<concurrency>",
-              callback=lambda ctx, _, value: value or ctx.obj.app.conf.worker_concurrency,
+              # callback=lambda ctx, _, value: value or ctx.obj.app.conf.worker_concurrency,
               cls=CeleryOption,
               help_group="Pool Options",
               help="Number of child processes processing the queue.  "
@@ -294,7 +294,7 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
 @click.option('-s',
               '--schedule-filename',
               '--schedule',
-              callback=lambda ctx, _, value: value or ctx.obj.app.conf.beat_schedule_filename,
+              # callback=lambda ctx, _, value: value or ctx.obj.app.conf.beat_schedule_filename,
               cls=CeleryOption,
               help_group="Embedded Beat Options")
 @click.option('--scheduler',
@@ -355,6 +355,8 @@ def worker(ctx, hostname=None, pool_cls=None, app=None, uid=None, gid=None,
                           hostname=hostname)
         return
     maybe_drop_privileges(uid=uid, gid=gid)
+
+    app = app()
     worker = app.Worker(
         hostname=hostname, pool_cls=pool_cls, loglevel=loglevel,
         logfile=logfile,  # node format handled by celery.app.log.setup

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -367,7 +367,7 @@ def worker(ctx, hostname=None, pool_cls=None, uid=None, gid=None,
         worker_concurrency=worker_concurrency or
                            app.conf.worker_concurrency,
         beat_schedule_filename=beat_schedule_filename or
-                               app.conf.beat_schedule_filename
+                               app.conf.beat_schedule_filename,
         **kwargs)
     worker.start()
     return worker.exitcode

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -163,6 +163,7 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
               '--statedb',
               cls=CeleryOption,
               type=click.Path(),
+              callback=lambda ctx, _, value: value or ctx.obj.app.conf.worker_state_db,
               help_group="Worker Options",
               help="Path to the state database. The extension '.db' may be"
                    "appended to the filename.")
@@ -183,6 +184,7 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
 @click.option('--prefetch-multiplier',
               type=int,
               metavar="<prefetch multiplier>",
+              callback=lambda ctx, _, value: value or ctx.obj.app.conf.worker_prefetch_multiplier,
               cls=CeleryOption,
               help_group="Worker Options",
               help="Set custom prefetch multiplier value"
@@ -191,6 +193,7 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
               '--concurrency',
               type=int,
               metavar="<concurrency>",
+              callback=lambda ctx, _, value: value or ctx.obj.app.conf.worker_concurrency,
               cls=CeleryOption,
               help_group="Pool Options",
               help="Number of child processes processing the queue.  "
@@ -289,6 +292,7 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
 @click.option('-s',
               '--schedule-filename',
               '--schedule',
+              callback=lambda ctx, _, value: value or ctx.obj.app.conf.beat_schedule_filename,
               cls=CeleryOption,
               help_group="Embedded Beat Options")
 @click.option('--scheduler',
@@ -371,17 +375,12 @@ def worker(ctx, hostname=None, pool_cls=None, uid=None, gid=None,
                           hostname=hostname)
         return
     maybe_drop_privileges(uid=uid, gid=gid)
-    statedb = statedb or ctx.obj.app.conf.worker_state_db
-
     worker = app.Worker(
         hostname=hostname, pool_cls=pool_cls, loglevel=loglevel,
         logfile=logfile,  # node format handled by celery.app.log.setup
         pidfile=node_format(pidfile, hostname),
         statedb=node_format(statedb, hostname),
         no_color=ctx.obj.no_color,
-        prefetch_multiplier=prefetch_multiplier or app.conf.worker_prefetch_multiplier,
-        worker_concurrency=worker_concurrency or app.conf.worker_concurrency,
-        beat_schedule_filename=beat_schedule_filename or app.conf.beat_schedule_filename,
         **kwargs)
     worker.start()
     return worker.exitcode

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -302,8 +302,6 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
 @click.pass_context
 def worker(ctx, hostname=None, pool_cls=None, uid=None, gid=None,
            loglevel=None, logfile=None, pidfile=None, statedb=None,
-           prefetch_multiplier=None, worker_concurrency=None,
-           beat_schedule_filename=None,
            user_extra_params=None,
            **kwargs):
     """Start worker instance.

--- a/t/unit/concurrency/test_eventlet.py
+++ b/t/unit/concurrency/test_eventlet.py
@@ -37,8 +37,8 @@ class test_aaa_eventlet_patch(EventletCase):
 
     def test_aaa_is_patched(self):
         with patch('eventlet.monkey_patch', create=True) as monkey_patch:
-            from celery import maybe_patch_concurrency
-            maybe_patch_concurrency(['x', '-P', 'eventlet'])
+            from celery.bin.worker import maybe_patch_concurrency
+            maybe_patch_concurrency('eventlet')
             monkey_patch.assert_called_with()
 
     @patch('eventlet.debug.hub_blocking_detection', create=True)
@@ -46,8 +46,8 @@ class test_aaa_eventlet_patch(EventletCase):
     def test_aaa_blockdetecet(
             self, monkey_patch, hub_blocking_detection, patching):
         patching.setenv('EVENTLET_NOBLOCK', '10.3')
-        from celery import maybe_patch_concurrency
-        maybe_patch_concurrency(['x', '-P', 'eventlet'])
+        from celery.bin.worker import maybe_patch_concurrency
+        maybe_patch_concurrency('eventlet')
         monkey_patch.assert_called_with()
         hub_blocking_detection.assert_called_with(10.3, 10.3)
 

--- a/t/unit/concurrency/test_gevent.py
+++ b/t/unit/concurrency/test_gevent.py
@@ -19,8 +19,8 @@ class test_gevent_patch:
         patch_all = self.patching('gevent.monkey.patch_all')
         import gevent
         gevent.version_info = (1, 0, 0)
-        from celery import maybe_patch_concurrency
-        maybe_patch_concurrency(['x', '-P', 'gevent'])
+        from celery.bin.worker import maybe_patch_concurrency
+        maybe_patch_concurrency('gevent')
         patch_all.assert_called()
 
 


### PR DESCRIPTION
## Description

eventlet gPidbox is not running in 5.0.0rc1, as described here: [#6225](https://github.com/celery/celery/issues/6225)

Following the move to Click ([https://github.com/celery/celery/pull/5718](5718)), I noticed that the patching code was commented out.
I'm not sure if the proposed way is a valid way to port the import patching, or the maintainers had other design in mind, but this fix is working for me.