### PR TITLE
Update class-based task retry docs

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -805,13 +805,13 @@ via options documented below.
 
 .. versionadded:: 4.4
 
-You can also set `autoretry_for`, `retry_kwargs`, `retry_backoff`, `retry_backoff_max` and `retry_jitter` options in class-based tasks:
+You can also set `autoretry_for`, `max_retries`, `retry_backoff`, `retry_backoff_max` and `retry_jitter` options in class-based tasks:
 
 .. code-block:: python
 
     class BaseTaskWithRetry(Task):
         autoretry_for = (TypeError,)
-        retry_kwargs = {'max_retries': 5}
+        max_retries = 5
         retry_backoff = True
         retry_backoff_max = 700
         retry_jitter = False
@@ -822,12 +822,10 @@ You can also set `autoretry_for`, `retry_kwargs`, `retry_backoff`, `retry_backof
     during the execution of the task, the task will automatically be retried.
     By default, no exceptions will be autoretried.
 
-.. attribute:: Task.retry_kwargs
+.. attribute:: Task.max_retries
 
-    A dictionary. Use this to customize how autoretries are executed.
-    Note that if you use the exponential backoff options below, the `countdown`
-    task option will be determined by Celery's autoretry system, and any
-    `countdown` included in this dictionary will be ignored.
+    A number. Maximum number of retries before giving up. A value of ``None``
+    means task will retry forever.
 
 .. attribute:: Task.retry_backoff
 


### PR DESCRIPTION
## Description
Updated Task Retrying docs.

Option `retry_kwargs` is not supported by class-based tasks. But you can change `max_retries` option with corresponding attribute.