### PR TITLE
Expose retry_policy for Redis result backend

### DIFF
--- a/docs/getting-started/brokers/redis.rst
+++ b/docs/getting-started/brokers/redis.rst
@@ -94,6 +94,21 @@ If you are using Sentinel, you should specify the master_name using the :setting
 
     app.conf.result_backend_transport_options = {'master_name': "mymaster"}
 
+Connection timeouts
+^^^^^^^^^^^^^^^^^^^
+
+To configure the connection timeouts for the Redis result backend, use the ``retry_policy`` key under :setting:`result_backend_transport_options`:
+
+
+.. code-block:: python
+
+    app.conf.result_backend_transport_options = {
+        'retry_policy': {
+           'timeout': 5.0
+        }
+    }
+
+See :func:`~kombu.utils.functional.retry_over_time` for the possible retry policy options.
 
 .. _redis-caveats:
 


### PR DESCRIPTION
Rather than adding a new top-level config option, I have used a new key
in the already existing setting `result_backend_transport_options`.

Fixes #6166



<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->