### PR TITLE
Fix examples of starting a worker in comments

### DIFF
--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -273,10 +273,10 @@ def worker(ctx, hostname=None, pool_cls=None, app=None, uid=None, gid=None,
 
     Examples
     --------
-    $ celery worker --app=proj -l info
-    $ celery worker -A proj -l info -Q hipri,lopri
-    $ celery worker -A proj --concurrency=4
-    $ celery worker -A proj --concurrency=1000 -P eventlet
+    $ celery --app=proj worker -l INFO
+    $ celery -A proj worker -l INFO -Q hipri,lopri
+    $ celery -A proj worker --concurrency=4
+    $ celery -A proj worker --concurrency=1000 -P eventlet
     $ celery worker --autoscale=10,0
 
     """


### PR DESCRIPTION
Gotcha: 
Now you have to use
```
celery --app=proj worker
```
