### PR TITLE
Warn when deprecated settings are used

### DIFF
--- a/celery/app/log.py
+++ b/celery/app/log.py
@@ -9,12 +9,14 @@ related compatibility fixes, and so on.
 import logging
 import os
 import sys
+import warnings
 from logging.handlers import WatchedFileHandler
 
 from kombu.utils.encoding import set_default_encoding_file
 
 from celery import signals
 from celery._state import get_current_task
+from celery.exceptions import CDeprecationWarning, CPendingDeprecationWarning
 from celery.local import class_property
 from celery.platforms import isatty
 from celery.utils.log import (ColorFormatter, LoggingProxy, get_logger,
@@ -70,6 +72,9 @@ class Logging:
             CELERY_LOG_LEVEL=str(loglevel) if loglevel else '',
             CELERY_LOG_FILE=str(logfile) if logfile else '',
         )
+        warnings.filterwarnings('always', category=CDeprecationWarning)
+        warnings.filterwarnings('always', category=CPendingDeprecationWarning)
+        logging.captureWarnings(True)
         return handled
 
     def redirect_stdouts(self, loglevel=None, name='celery.redirected'):

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -140,6 +140,14 @@ class Worker(WorkController):
         if not self._custom_logging and self.redirect_stdouts:
             app.log.redirect_stdouts(self.redirect_stdouts_level)
 
+        # TODO: Remove the following code in Celery 6.0
+        if app.conf.maybe_warn_deprecated_settings():
+            logger.warning(
+                "Please run `celery upgrade settings path/to/settings.py` "
+                "to avoid these warnings and to allow a smoother upgrade "
+                "to Celery 6.0."
+            )
+
     def emit_banner(self):
         # Dump configuration to screen so we have some basic information
         # for when users sends bug reports.

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -47,12 +47,14 @@ names, are the renaming of some prefixes, like ``celery_beat_`` to ``beat_``,
 ``celeryd_`` to ``worker_``, and most of the top level ``celery_`` settings
 have been moved into a new  ``task_`` prefix.
 
-.. note::
+.. warning::
 
-    Celery will still be able to read old configuration files, so
-    there's no rush in moving to the new settings format. Furthermore,
-    we provide the ``celery upgrade`` command that should handle plenty
-    of cases (including :ref:`Django <latentcall-django-admonition>`).
+    Celery will still be able to read old configuration files until Celery 6.0.
+    Afterwards, support for the old configuration files will be removed.
+    We provide the ``celery upgrade`` command that should handle
+    plenty of cases (including :ref:`Django <latentcall-django-admonition>`).
+
+    Please migrate to the new configuration scheme as soon as possible.
 
 
 ========================================== ==============================================

--- a/docs/whatsnew-5.0.rst
+++ b/docs/whatsnew-5.0.rst
@@ -116,7 +116,7 @@ please do so now.
 We elected to extend the deprecation period until 6.0 since
 we did not loudly warn about using these deprecated settings.
 
-Please refer to the :ref:`migration guide <v400-upgrade-settings>` for instructions.
+Please refer to the :ref:`migration guide <conf-old-settings-map>` for instructions.
 
 Step 3: Read the important notes in this document
 -------------------------------------------------


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

We deprecated settings in 4.0 but did not warn about the deprecation.
This PR enables displaying deprecation pending warnings and deprecation warnings to our users.
It also prints which settings are deprecated and what should be used instead and instructs the users to run `celery upgrade settings`.

Ref #6327.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->