### PR TITLE
Restore the celery worker --without-{gossip,mingle,heartbeat} flags

### DIFF
--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -231,15 +231,15 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
               cls=CeleryOption,
               help_group="Queue Options")
 @click.option('--without-gossip',
-              default=False,
+              is_flag=True,
               cls=CeleryOption,
               help_group="Features")
 @click.option('--without-mingle',
-              default=False,
+              is_flag=True,
               cls=CeleryOption,
               help_group="Features")
 @click.option('--without-heartbeat',
-              default=False,
+              is_flag=True,
               cls=CeleryOption,
               help_group="Features", )
 @click.option('--heartbeat-interval',


### PR DESCRIPTION
## Description

In the previously used argparse arguments framework, these three options were
used as flags.

Since 5.0.0, they are options which need to take an argument (whose only
sensible value would be "true"). The error message coming up is also (very)
hard to understand, when running the celery worker command with an odd number
of flags:

  Error: Unable to parse extra configuration from command line.
  Reason: not enough values to unpack (expected 2, got 1)

When the celery worker is run with an even number of flags, the last one is
considered as an argument of the previous one, which is a subtle bug.
