### PR TITLE
bugfix: when set config result_expires = 0, chord.get will hang.

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -436,7 +436,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
                 if self._chord_zset
                 else pipe.rpush(jkey, encoded).llen(jkey)
             ).get(tkey)
-            if self.expires is not None:
+            if self.expires:
                 pipeline = pipeline \
                     .expire(jkey, self.expires) \
                     .expire(tkey, self.expires)


### PR DESCRIPTION
`EXPIRE key 0` will delete a key in redis, then chord will never get the
result.

fix: https://github.com/celery/celery/issues/5237



## Description

From the doc:
> A value of None or 0 means results will never expire (depending on backend specifications).

https://docs.celeryproject.org/en/stable/userguide/configuration.html#std-setting-result_expires

But here only checked with `None`, `0` was missed.