### PR TITLE
Fix custom headers propagation for protocol 1 hybrid messages

### DIFF
--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -50,6 +50,7 @@ def hybrid_to_proto2(message, body):
         'kwargsrepr': body.get('kwargsrepr'),
         'origin': body.get('origin'),
     }
+    headers.update(message.headers or {})
 
     embed = {
         'callbacks': body.get('callbacks'),

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -1204,8 +1204,8 @@ class test_create_request_class(RequestCase):
 
     def test_execute_using_pool__defaults_of_hybrid_to_proto2(self):
         weakref_ref = Mock(name='weakref.ref')
-        headers = strategy.hybrid_to_proto2('', {'id': uuid(),
-                                                 'task': self.mytask.name})[1]
+        headers = strategy.hybrid_to_proto2(Mock(headers=None), {'id': uuid(),
+                                            'task': self.mytask.name})[1]
         job = self.zRequest(revoked_tasks=set(), ref=weakref_ref, **headers)
         job.execute_using_pool(self.pool)
         assert job._apply_result

--- a/t/unit/worker/test_strategy.py
+++ b/t/unit/worker/test_strategy.py
@@ -271,7 +271,7 @@ class test_custom_request_for_default_strategy(test_default_strategy_proto2):
 class test_hybrid_to_proto2:
 
     def setup(self):
-        self.message = Mock(name='message')
+        self.message = Mock(name='message', headers={"custom": "header"})
         self.body = {
             'args': (1,),
             'kwargs': {'foo': 'baz'},
@@ -288,3 +288,7 @@ class test_hybrid_to_proto2:
         self.body['retries'] = _custom_value
         _, headers, _, _ = hybrid_to_proto2(self.message, self.body)
         assert headers.get('retries') == _custom_value
+
+    def test_custom_headers(self):
+        _, headers, _, _ = hybrid_to_proto2(self.message, self.body)
+        assert headers.get("custom") == "header"


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This is an attempt to fix custom header propagation that broke for us after migration from Celery 3.X to 4.X.

I believe it is the same issue as described in #4875 

For the hybrid messages of protocol 1, the `message.headers` are ignored, this PR merges them with the rest of the headers extracted from the body.

- Workaround implementation using custom `Request` class - https://github.com/getsentry/sentry/pull/20996

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
