### PR TITLE
Display a custom error message whenever an attempt to use -A or --app as a sub-command option was made

### DIFF
--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -39,8 +39,7 @@ class CLIContext:
 
     @cached_property
     def OK(self):
-        return self.style("OK", fg="green", bold=True)    \
-
+        return self.style("OK", fg="green", bold=True)
 
     @cached_property
     def ERROR(self):
@@ -72,7 +71,7 @@ class CLIContext:
             kwargs['color'] = False
             click.echo(message, **kwargs)
         else:
-            click.echo(message, **kwargs)
+            click.secho(message, **kwargs)
 
     def pretty(self, n):
         if isinstance(n, list):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This should clarify to all our users what has changed and how to fix the problem they are having.

Fixes #6363

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->