### PR TITLE
fix pytest plugin registration documentation

### DIFF
--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -105,7 +105,8 @@ Celery initially ships the plugin in a disabled state, to enable it you can eith
 
     * `pip install celery[pytest]`
     * `pip install pytest-celery`
-    * or add `pytest_plugins = 'celery.contrib.pytest'` to your pytest.ini
+    * or add an environment variable `PYTEST_PLUGINS=celery.contrib.pytest`
+    * or add pytest_plugins = ("celery.contrib.pytest", ) to your root conftest.py
 
 
 Marks

--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -106,7 +106,7 @@ Celery initially ships the plugin in a disabled state, to enable it you can eith
     * `pip install celery[pytest]`
     * `pip install pytest-celery`
     * or add an environment variable `PYTEST_PLUGINS=celery.contrib.pytest`
-    * or add pytest_plugins = ("celery.contrib.pytest", ) to your root conftest.py
+    * or add `pytest_plugins = ("celery.contrib.pytest", )` to your root conftest.py
 
 
 Marks


### PR DESCRIPTION


## Description

pytest plugins can't be registered in the pytest.ini
