### PR TITLE
Detach now correctly passes options with more than one word.

### DIFF
--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -302,6 +302,7 @@ def worker(ctx, hostname=None, pool_cls=None, app=None, uid=None, gid=None,
         executable = params.pop('executable')
         argv = ['-m', 'celery', 'worker']
         for arg, value in params.items():
+            arg = arg.replace("_", "-")
             if isinstance(value, bool) and value:
                 argv.append(f'--{arg}')
             else:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

When specifying options such as `-E` the detached worker should receive the `--task-events` option.
Instead it got the `--task_events` option which doesn't exist and therefore silently failed.

This fixes #6362.
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->