### PR TITLE
Remove duplicate words from docs

### DIFF
--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -45,7 +45,7 @@ What do I need?
     - PyPy3.6 ❨7.3❩
 
     Celery 4.x was the last version to support Python 2.7,
-    Celery 5.x requires Python 3.6 or newer is required.
+    Celery 5.x requires Python 3.6 or newer.
 
     If you're running an older version of Python, you need to be running
     an older version of Celery:


### PR DESCRIPTION
Remove the duplicate usage of “required” in documentation (specifically, `introduction.rst`).