### PR TITLE
return list instead set in CommaSeparatedList

### DIFF
--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -168,7 +168,7 @@ class CommaSeparatedList(ParamType):
     name = "comma separated list"
 
     def convert(self, value, param, ctx):
-        return set(text.str_to_list(value))
+        return text.str_to_list(value)
 
 
 class Json(ParamType):


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.

-->
_broadcast method of kombu Mailbox does not support set
https://github.com/celery/kombu/blob/7b2578b19ba4b1989b722f6f6e7efee2a1a4d86a/kombu/pidbox.py#L319


Fixes [#6399 ](https://github.com/celery/celery/issues/6399)