### PR TITLE
Fixed loglevel info->INFO in docs

### DIFF
--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -247,7 +247,7 @@ development it is useful to be able to start a worker instance by using the
 
 .. code-block:: console
 
-    $ celery -A proj worker -l info
+    $ celery -A proj worker -l INFO
 
 For a complete listing of the command-line options available,
 use the help command:

--- a/docs/getting-started/next-steps.rst
+++ b/docs/getting-started/next-steps.rst
@@ -74,7 +74,7 @@ The :program:`celery` program can be used to start the worker (you need to run t
 
 .. code-block:: console
 
-    $ celery -A proj worker -l info
+    $ celery -A proj worker -l INFO
 
 When the worker starts you should see a banner and some messages::
 
@@ -152,7 +152,7 @@ start one or more workers in the background:
 
 .. code-block:: console
 
-    $ celery multi start w1 -A proj -l info
+    $ celery multi start w1 -A proj -l INFO
     celery multi v4.0.0 (latentcall)
     > Starting nodes...
         > w1.halcyon.local: OK
@@ -161,7 +161,7 @@ You can restart it too:
 
 .. code-block:: console
 
-    $ celery  multi restart w1 -A proj -l info
+    $ celery  multi restart w1 -A proj -l INFO
     celery multi v4.0.0 (latentcall)
     > Stopping nodes...
         > w1.halcyon.local: TERM -> 64024
@@ -176,7 +176,7 @@ or stop it:
 
 .. code-block:: console
 
-    $ celery multi stop w1 -A proj -l info
+    $ celery multi stop w1 -A proj -l INFO
 
 The ``stop`` command is asynchronous so it won't wait for the
 worker to shutdown. You'll probably want to use the ``stopwait`` command
@@ -185,7 +185,7 @@ before exiting:
 
 .. code-block:: console
 
-    $ celery multi stopwait w1 -A proj -l info
+    $ celery multi stopwait w1 -A proj -l INFO
 
 .. note::
 
@@ -202,7 +202,7 @@ you're encouraged to put these in a dedicated directory:
 
     $ mkdir -p /var/run/celery
     $ mkdir -p /var/log/celery
-    $ celery multi start w1 -A proj -l info --pidfile=/var/run/celery/%n.pid \
+    $ celery multi start w1 -A proj -l INFO --pidfile=/var/run/celery/%n.pid \
                                             --logfile=/var/log/celery/%n%I.log
 
 With the multi command you can start multiple workers, and there's a powerful
@@ -211,7 +211,7 @@ for example:
 
 .. code-block:: console
 
-    $ celery multi start 10 -A proj -l info -Q:1-3 images,video -Q:4,5 data \
+    $ celery multi start 10 -A proj -l INFO -Q:1-3 images,video -Q:4,5 data \
         -Q default -L:4,5 debug
 
 For more examples see the :mod:`~celery.bin.multi` module in the API

--- a/docs/userguide/application.rst
+++ b/docs/userguide/application.rst
@@ -257,7 +257,7 @@ You can then specify the configuration module to use via the environment:
 
 .. code-block:: console
 
-    $ CELERY_CONFIG_MODULE="celeryconfig.prod" celery worker -l info
+    $ CELERY_CONFIG_MODULE="celeryconfig.prod" celery worker -l INFO
 
 .. _app-censored-config:
 
@@ -431,7 +431,7 @@ chain breaks:
 
 .. code-block:: console
 
-    $ CELERY_TRACE_APP=1 celery worker -l info
+    $ CELERY_TRACE_APP=1 celery worker -l INFO
 
 
 .. topic:: Evolving the API

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -692,7 +692,7 @@ the workers :option:`-Q <celery worker -Q>` argument:
 
 .. code-block:: console
 
-    $ celery -A proj worker -l info -Q celery,priority.high
+    $ celery -A proj worker -l INFO -Q celery,priority.high
 
 .. seealso::
 

--- a/docs/userguide/debugging.rst
+++ b/docs/userguide/debugging.rst
@@ -110,7 +110,7 @@ For example starting the worker with:
 
 .. code-block:: console
 
-    $ CELERY_RDBSIG=1 celery worker -l info
+    $ CELERY_RDBSIG=1 celery worker -l INFO
 
 You can start an rdb session for any of the worker processes by executing:
 

--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -23,7 +23,7 @@ You can start the worker in the foreground by executing the command:
 
 .. code-block:: console
 
-    $ celery -A proj worker -l info
+    $ celery -A proj worker -l INFO
 
 For a full list of available command-line options see
 :mod:`~celery.bin.worker`, or simply do:
@@ -108,7 +108,7 @@ is by using `celery multi`:
 
 .. code-block:: console
 
-    $ celery multi start 1 -A proj -l info -c4 --pidfile=/var/run/celery/%n.pid
+    $ celery multi start 1 -A proj -l INFO -c4 --pidfile=/var/run/celery/%n.pid
     $ celery multi restart 1 --pidfile=/var/run/celery/%n.pid
 
 For production deployments you should be using init-scripts or a process
@@ -410,7 +410,7 @@ argument to :program:`celery worker`:
 
 .. code-block:: console
 
-    $ celery -A proj worker -l info --statedb=/var/run/celery/worker.state
+    $ celery -A proj worker -l INFO --statedb=/var/run/celery/worker.state
 
 or if you use :program:`celery multi` you want to create one file per
 worker instance so use the `%n` format to expand the current node
@@ -418,7 +418,7 @@ name:
 
 .. code-block:: console
 
-    celery multi start 2 -l info --statedb=/var/run/celery/%n.state
+    celery multi start 2 -l INFO --statedb=/var/run/celery/%n.state
 
 
 See also :ref:`worker-files`
@@ -611,7 +611,7 @@ separated list of queues to the :option:`-Q <celery worker -Q>` option:
 
 .. code-block:: console
 
-    $ celery -A proj worker -l info -Q foo,bar,baz
+    $ celery -A proj worker -l INFO -Q foo,bar,baz
 
 If the queue name is defined in :setting:`task_queues` it will use that
 configuration, but if it's not defined in the list of queues Celery will

--- a/examples/app/myapp.py
+++ b/examples/app/myapp.py
@@ -2,7 +2,7 @@
 
 Usage::
 
-   (window1)$ python myapp.py worker -l info
+   (window1)$ python myapp.py worker -l INFO
 
    (window2)$ python
    >>> from myapp import add
@@ -13,13 +13,13 @@ Usage::
 You can also specify the app to use with the `celery` command,
 using the `-A` / `--app` option::
 
-    $ celery -A myapp worker -l info
+    $ celery -A myapp worker -l INFO
 
 With the `-A myproj` argument the program will search for an app
 instance in the module ``myproj``.  You can also specify an explicit
 name using the fully qualified form::
 
-    $ celery -A myapp:app worker -l info
+    $ celery -A myapp:app worker -l INFO
 
 """
 

--- a/examples/django/README.rst
+++ b/examples/django/README.rst
@@ -46,7 +46,7 @@ Starting the worker
 
 .. code-block:: console
 
-    $ celery -A proj worker -l info
+    $ celery -A proj worker -l INFO
 
 Running a task
 ===================

--- a/examples/eventlet/README.rst
+++ b/examples/eventlet/README.rst
@@ -18,7 +18,7 @@ Before you run any of the example tasks you need to start
 the worker::
 
     $ cd examples/eventlet
-    $ celery worker -l info --concurrency=500 --pool=eventlet
+    $ celery worker -l INFO --concurrency=500 --pool=eventlet
 
 As usual you need to have RabbitMQ running, see the Celery getting started
 guide if you haven't installed it yet.

--- a/examples/periodic-tasks/myapp.py
+++ b/examples/periodic-tasks/myapp.py
@@ -3,10 +3,10 @@
 Usage::
 
    # The worker service reacts to messages by executing tasks.
-   (window1)$ python myapp.py worker -l info
+   (window1)$ python myapp.py worker -l INFO
 
    # The beat service sends messages at scheduled intervals.
-   (window2)$ python myapp.py beat -l info
+   (window2)$ python myapp.py beat -l INFO
 
    # XXX To diagnose problems use -l debug:
    (window2)$ python myapp.py beat -l debug
@@ -18,13 +18,13 @@ Usage::
 You can also specify the app to use with the `celery` command,
 using the `-A` / `--app` option::
 
-    $ celery -A myapp worker -l info
+    $ celery -A myapp worker -l INFO
 
 With the `-A myproj` argument the program will search for an app
 instance in the module ``myproj``.  You can also specify an explicit
 name using the fully qualified form::
 
-    $ celery -A myapp:app worker -l info
+    $ celery -A myapp:app worker -l INFO
 
 """
 

--- a/examples/security/mysecureapp.py
+++ b/examples/security/mysecureapp.py
@@ -14,7 +14,7 @@ Usage::
 
    cd examples/security
 
-   (window1)$ python mysecureapp.py worker -l info
+   (window1)$ python mysecureapp.py worker -l INFO
 
    (window2)$ cd examples/security
    (window2)$ python


### PR DESCRIPTION
Simple fixes for docs.
From `celery -A proj worker -l info` to `celery -A proj worker -l INFO`

PS Ci builds are successful :)

![image](https://user-images.githubusercontent.com/13070119/95769936-4a515e00-0cc1-11eb-8125-e0cbcb90a3b3.png)

