### PR TITLE
fix: Pass back real result for single task chains

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -413,6 +413,16 @@ class test_chain:
         res = c()
         assert res.get(timeout=TIMEOUT) == [8, 8]
 
+    def test_nested_chain_group_lone(self, manager):
+        """
+        Test that a lone group in a chain completes.
+        """
+        sig = chain(
+            group(identity.s(42), identity.s(42)),  # [42, 42]
+        )
+        res = sig.delay()
+        assert res.get(timeout=TIMEOUT) == [42, 42]
+
 
 class test_result_set:
 
@@ -503,6 +513,14 @@ class test_group:
         res = c.delay()
 
         assert res.get(timeout=TIMEOUT) == list(range(1000))
+
+    def test_group_lone(self, manager):
+        """
+        Test that a simple group completes.
+        """
+        sig = group(identity.s(42), identity.s(42))     # [42, 42]
+        res = sig.delay()
+        assert res.get(timeout=TIMEOUT) == [42, 42]
 
 
 def assert_ids(r, expected_value, expected_root_id, expected_parent_id):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -534,6 +534,48 @@ class test_chain(CanvasCase):
         assert len(tasks) == 2
 
         assert x.apply().get() == 3
+
+    @pytest.mark.usefixtures('depends_on_current_app')
+    def test_chain_single_child_result(self):
+        child_sig = self.add.si(1, 1)
+        chain_sig = chain(child_sig)
+        assert chain_sig.tasks[0] is child_sig
+
+        with patch.object(
+            # We want to get back the result of actually applying the task
+            child_sig, "apply_async",
+        ) as mock_apply, patch.object(
+            # The child signature may be clone by `chain.prepare_steps()`
+            child_sig, "clone", return_value=child_sig,
+        ):
+            res = chain_sig()
+        # `_prepare_chain_from_options()` sets this `chain` kwarg with the
+        # subsequent tasks which would be run - nothing in this case
+        mock_apply.assert_called_once_with(chain=[])
+        assert res is mock_apply.return_value
+
+    @pytest.mark.usefixtures('depends_on_current_app')
+    def test_chain_single_child_group_result(self):
+        child_sig = self.add.si(1, 1)
+        # The group will `clone()` the child during instantiation so mock it
+        with patch.object(child_sig, "clone", return_value=child_sig):
+            group_sig = group(child_sig)
+        # Now we can construct the chain signature which is actually under test
+        chain_sig = chain(group_sig)
+        assert chain_sig.tasks[0].tasks[0] is child_sig
+
+        with patch.object(
+            # We want to get back the result of actually applying the task
+            child_sig, "apply_async",
+        ) as mock_apply, patch.object(
+            # The child signature may be clone by `chain.prepare_steps()`
+            child_sig, "clone", return_value=child_sig,
+        ):
+            res = chain_sig()
+        # `_prepare_chain_from_options()` sets this `chain` kwarg with the
+        # subsequent tasks which would be run - nothing in this case
+        mock_apply.assert_called_once_with(chain=[])
+        assert res is mock_apply.return_value
 
 
 class test_group(CanvasCase):


### PR DESCRIPTION
## Description

When chains are delayed, they are first frozen as part of preparation
which causes the sub-tasks to also be frozen. Afterward, the final (0th
since we reverse the tasks/result order when freezing) result object
from the freezing process would be passed back to the caller. This
caused problems in signaling completion of groups contained in chains
because the group relies on a promise which is fulfilled by a barrier
linked to each of its applied subtasks. By constructing two
`GroupResult` objects (one during freezing, one when the chain sub-tasks
are applied), this resulted in there being two promises; only one of
which would actually be fulfilled by the group subtasks.

This change ensures that in the special case where a chain has a single
task, we pass back the result object constructed when the task was
actually applied. When that single child is a group which does not get
unrolled (ie. contains more than one child itself), this ensures that we
pass back a `GroupResult` object which will actually be fulfilled. The
caller can then await the result confidently!
