### PR TITLE
predefined_queues_urls -> predefined_queues

### DIFF
--- a/docs/getting-started/brokers/sqs.rst
+++ b/docs/getting-started/brokers/sqs.rst
@@ -137,7 +137,7 @@ Predefined Queues
 
 If you want Celery to use a set of predefined queues in AWS, and to
 never attempt to list SQS queues, nor attempt to create or delete them,
-pass a map of queue names to URLs using the :setting:`predefined_queue_urls`
+pass a map of queue names to URLs using the :setting:`predefined_queues`
 setting::
 
     broker_transport_options = {


### PR DESCRIPTION
I find the current documentation a bit confusing. It states that we should use the "`predefined_queues_urls` setting", but the setting is actually `predefined_queues`.  Reading https://github.com/celery/kombu/pull/1156, I can see that it was formerly called `predefined_queues_urls` when in development, which is from where I assume this term came.