### PR TITLE
Multithreaded backend

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -1181,10 +1181,11 @@ class Celery:
     @property
     def oid(self):
         """Universally unique identifier for this app."""
-
-        if not hasattr(tlocal, 'oid'):
-            tlocal.oid = oid_from(self, threads=True)
-        return tlocal.oid
+        try:
+            return tlocal.oid
+        except AttributeError:
+            tlocal.oid = new_oid = oid_from(self, threads=True)
+            return new_oid
 
     @cached_property
     def amqp(self):
@@ -1194,9 +1195,11 @@ class Celery:
     @property
     def backend(self):
         """Current backend instance."""
-        if not hasattr(tlocal, 'backend'):
-            tlocal.backend = self._get_backend()
-        return tlocal.backend
+        try:
+            return tlocal.backend
+        except AttributeError:
+            tlocal.backend = new_backend = self._get_backend()
+            return new_backend
 
     @property
     def conf(self):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -65,6 +65,8 @@ Example:
     {0}="proj.celeryconfig"
 """
 
+tlocal = threading.local()
+
 
 def app_has_custom(app, attr):
     """Return true if app has customized method `attr`.
@@ -1190,10 +1192,12 @@ class Celery:
         """AMQP related functionality: :class:`~@amqp`."""
         return instantiate(self.amqp_cls, app=self)
 
-    @cached_property
+    @property
     def backend(self):
         """Current backend instance."""
-        return self._get_backend()
+        if not hasattr(tlocal, 'backend'):
+            tlocal.backend = self._get_backend()
+        return tlocal.backend
 
     @property
     def conf(self):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -1178,14 +1178,13 @@ class Celery:
         """
         return get_current_worker_task()
 
-    @cached_property
+    @property
     def oid(self):
         """Universally unique identifier for this app."""
-        # since 4.0: thread.get_ident() is not included when
-        # generating the process id.  This is due to how the RPC
-        # backend now dedicates a single thread to receive results,
-        # which would not work if each thread has a separate id.
-        return oid_from(self, threads=False)
+
+        if not hasattr(tlocal, 'oid'):
+            tlocal.oid = oid_from(self, threads=True)
+        return tlocal.oid
 
     @cached_property
     def amqp(self):

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -338,5 +338,5 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
 
     @cached_property
     def oid(self):
-        # cached here is the app OID: name of queue we receive results on.
-        return self.app.oid
+        # cached here is the app thread OID: name of queue we receive results on.
+        return self.app.thread_oid

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -296,7 +296,7 @@ class Signature(dict):
         if parent_id:
             opts['parent_id'] = parent_id
         if 'reply_to' not in opts:
-            opts['reply_to'] = self.app.oid
+            opts['reply_to'] = self.app.thread_oid
         if group_id and "group_id" not in opts:
             opts['group_id'] = group_id
         if chord:

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from unittest.mock import Mock, patch, sentinel
+from unittest.mock import Mock, patch, sentinel, PropertyMock
 
 import pytest
 
@@ -294,9 +294,8 @@ class test_add_to_chord:
             return self.add_to_chord(sig, lazy)
         self.adds = adds
 
+    @patch('celery.Celery.backend', new=PropertyMock(name='backend'))
     def test_add_to_chord(self):
-        self.app.backend = Mock(name='backend')
-
         sig = self.add.s(2, 2)
         sig.delay = Mock(name='sig.delay')
         self.adds.request.group = uuid()
@@ -333,8 +332,8 @@ class test_add_to_chord:
 
 class test_Chord_task(ChordCase):
 
+    @patch('celery.Celery.backend', new=PropertyMock(name='backend'))
     def test_run(self):
-        self.app.backend = Mock()
         self.app.backend.cleanup = Mock()
         self.app.backend.cleanup.__name__ = 'cleanup'
         Chord = self.app.tasks['celery.chord']

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -708,19 +708,19 @@ class test_GroupResult:
                 ]),
             ]),
         ])
-        ts.app.backend = backend
 
-        vals = ts.get()
-        assert vals == [
-            '1.1',
-            [
-                '2.1',
+        with patch('celery.Celery.backend', new=backend):
+            vals = ts.get()
+            assert vals == [
+                '1.1',
                 [
-                    '3.1',
-                    '3.2',
-                ]
-            ],
-        ]
+                    '2.1',
+                    [
+                        '3.1',
+                        '3.2',
+                    ]
+                ],
+            ]
 
     def test_getitem(self):
         subs = [MockAsyncResultSuccess(uuid(), app=self.app),
@@ -771,15 +771,16 @@ class test_GroupResult:
         results = [self.app.AsyncResult(uuid(), backend=backend)
                    for i in range(10)]
         ts = self.app.GroupResult(uuid(), results)
-        ts.app.backend = backend
-        backend.ids = [result.id for result in results]
-        res = ts.join_native()
-        assert res == list(range(10))
-        callback = Mock(name='callback')
-        assert not ts.join_native(callback=callback)
-        callback.assert_has_calls([
-            call(r.id, i) for i, r in enumerate(ts.results)
-        ])
+
+        with patch('celery.Celery.backend', new=backend):
+            backend.ids = [result.id for result in results]
+            res = ts.join_native()
+            assert res == list(range(10))
+            callback = Mock(name='callback')
+            assert not ts.join_native(callback=callback)
+            callback.assert_has_calls([
+                call(r.id, i) for i, r in enumerate(ts.results)
+            ])
 
     def test_join_native_raises(self):
         ts = self.app.GroupResult(uuid(), [self.app.AsyncResult(uuid())])
@@ -813,9 +814,9 @@ class test_GroupResult:
         results = [self.app.AsyncResult(uuid(), backend=backend)
                    for i in range(10)]
         ts = self.app.GroupResult(uuid(), results)
-        ts.app.backend = backend
-        backend.ids = [result.id for result in results]
-        assert len(list(ts.iter_native())) == 10
+        with patch('celery.Celery.backend', new=backend):
+            backend.ids = [result.id for result in results]
+            assert len(list(ts.iter_native())) == 10
 
     def test_join_timeout(self):
         ar = MockAsyncResultSuccess(uuid(), app=self.app)

--- a/t/unit/test_canvas.py
+++ b/t/unit/test_canvas.py
@@ -1,0 +1,33 @@
+import uuid
+
+
+class test_Canvas:
+
+    def test_freeze_reply_to(self):
+        # Tests that Canvas.freeze() correctly
+        # creates reply_to option
+
+        @self.app.task
+        def test_task(a, b):
+            return
+
+        s = test_task.s(2, 2)
+        s.freeze()
+
+        from concurrent.futures import ThreadPoolExecutor
+
+        def foo():
+            s = test_task.s(2, 2)
+            s.freeze()
+            return self.app.thread_oid, s.options['reply_to']
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(foo)
+        t_reply_to_app, t_reply_to_opt = future.result()
+
+        assert uuid.UUID(s.options['reply_to'])
+        assert uuid.UUID(t_reply_to_opt)
+        # reply_to must be equal to thread_oid of Application
+        assert self.app.thread_oid == s.options['reply_to']
+        assert t_reply_to_app == t_reply_to_opt
+        # reply_to must be thread-relative.
+        assert t_reply_to_opt != s.options['reply_to']


### PR DESCRIPTION
## Description

This PR contains two changes:
1. Storing backend to separate thread local variable to avoid sharing underlying Connection object between threads. This means that now each thread has it's own Backend object.
2. Change `oid` (Universally unique identifier) to be thread-based. Moreover, the `oid` is now different for each thread. This is causing that each thread has it's own reply-to queue (Before all threads shares one reply-to queue which was causing missing responses)

This PR fixes #6414 and probably also issues linked to it.