### PR TITLE
ci: Fix pypy3 CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,9 @@ jobs:
       - TOXENV=flake8,apicheck,configcheck,bandit
       - CELERY_TOX_PARALLEL='--parallel --parallel-live'
     stage: lint
+
   - python: pypy3.6-7.3.1
-    env: TOXENV=pypy3
+    env: TOXENV=pypy3-unit
     stage: test
 
 before_install:


### PR DESCRIPTION
This changeset fixes the TOXENV for pypy3 unit tests in travis and adds
rabbitmq integration tests against pypy3 as well like we do for Python 3.9.
