### PR TITLE
ci: Move Python 3.9 test base from dev to release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - '3.6'
   - '3.7'
   - '3.8'
-  - '3.9-dev'
+  - '3.9'
 os:
     - linux
 stages:
@@ -25,9 +25,9 @@ env:
 jobs:
   fast_finish: true
   allow_failures:
-  - python: '3.9-dev'
+  - python: '3.9'
   include:
-  - python: '3.9-dev'
+  - python: '3.9'
     env: MATRIX_TOXENV=integration-rabbitmq
     stage: integration
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {3.6,3.7,3.8,3.9-dev,pypy3}-unit
-    {3.6,3.7,3.8,3.9-dev,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
+    {3.6,3.7,3.8,3.9,pypy3}-unit
+    {3.6,3.7,3.8,3.9,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
 
     flake8
     apicheck
@@ -14,9 +14,9 @@ deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/pkgutils.txt
 
-    3.6,3.7,3.8,3.9-dev: -r{toxinidir}/requirements/test-ci-default.txt
-    3.5,3.6,3.7,3.8,3.9-dev: -r{toxinidir}/requirements/docs.txt
-    3.6,3.7,3.8,3.9-dev: -r{toxinidir}/requirements/docs.txt
+    3.6,3.7,3.8,3.9: -r{toxinidir}/requirements/test-ci-default.txt
+    3.5,3.6,3.7,3.8,3.9: -r{toxinidir}/requirements/docs.txt
+    3.6,3.7,3.8,3.9: -r{toxinidir}/requirements/docs.txt
     pypy3: -r{toxinidir}/requirements/test-ci-base.txt
 
     integration: -r{toxinidir}/requirements/test-integration.txt
@@ -63,7 +63,7 @@ basepython =
     3.6: python3.6
     3.7: python3.7
     3.8: python3.8
-    3.9-dev: python3.9
+    3.9: python3.9
     pypy3: pypy3
     flake8,apicheck,linkcheck,configcheck,bandit: python3.8
     flakeplus: python2.7


### PR DESCRIPTION
Python 3.9 landed on 5 October. This changeset bumps tox and travis to use it.