### PR TITLE
Fix `celery shell` command

### DIFF
--- a/celery/bin/shell.py
+++ b/celery/bin/shell.py
@@ -130,7 +130,7 @@ def shell(ctx, ipython=False, bpython=False,
         import_module('celery.concurrency.eventlet')
     if gevent:
         import_module('celery.concurrency.gevent')
-    import celery.task.base
+    import celery
     app = ctx.obj.app
     app.loader.import_default_modules()
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
- Running the `celery shell` command on Celery version `5.0.0 (singularity)` produces the following error.

```
    .
    .
    .
File "/Users/..../Envs/tmp-9e2644dd148eaee/lib/python3.7/site-packages/celery/bin/shell.py", line 133, in shell
    import celery.task.base
ModuleNotFoundError: No module named 'celery.task'
```
- This PR removes the reference to `celery.task` and adds `import celery` to fix the shell command.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
