### PR TITLE
Fix _autodiscover_tasks_from_fixups function

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -649,8 +649,8 @@ class Celery:
     def _autodiscover_tasks_from_fixups(self, related_name):
         return self._autodiscover_tasks_from_names([
             pkg for fixup in self._fixups
-            for pkg in fixup.autodiscover_tasks()
             if hasattr(fixup, 'autodiscover_tasks')
+            for pkg in fixup.autodiscover_tasks()
         ], related_name=related_name)
 
     def send_task(self, name, args=None, kwargs=None, countdown=None,

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -218,6 +218,13 @@ class test_App:
         self.app._using_v1_reduce = True
         assert loads(dumps(self.app))
 
+    def test_autodiscover_tasks_force_fixup_fallback(self):
+        self.app.loader.autodiscover_tasks = Mock()
+        self.app.autodiscover_tasks([], force=True)
+        self.app.loader.autodiscover_tasks.assert_called_with(
+            [], 'tasks',
+        )
+
     def test_autodiscover_tasks_force(self):
         self.app.loader.autodiscover_tasks = Mock()
         self.app.autodiscover_tasks(['proj.A', 'proj.B'], force=True)


### PR DESCRIPTION
## Description

Fixes function `_autodiscover_tasks_from_fixups`. In my production env an exception was raised, when I called `celery <something>`. 
```
...
  File "/opt/virtualenvs/celus/lib/python3.8/site-packages/celery/app/base.py", line 673, in _autodiscover_tasks_from_fixups
    return self._autodiscover_tasks_from_names([
  File "/opt/virtualenvs/celus/lib/python3.8/site-packages/celery/app/base.py", line 675, in <listcomp>
    for pkg in fixup.autodiscover_tasks()
AttributeError: 'NoneType' object has no attribute 'autodiscover_tasks'
```
I dig a bit deeper and I found out the related generator expression is not correct.
```
>>> [pkg for fixup in ['ab', 1, 3] for pkg in fixup.lower() if hasattr(fixup, 'lower')]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 1, in <listcomp>
AttributeError: 'int' object has no attribute 'lower'
```
The correct way how to express it is to move the `if` part before the second `for`.
```
>>> [pkg for fixup in ['ab', 1, 3] if hasattr(fixup, 'lower') for pkg in fixup.lower() if hasattr(fixup, 'lower')]
['a', 'b']
```