### PR TITLE
Copy __annotations__ when creating tasks

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -452,6 +452,7 @@ class Celery(object):
                 '_decorated': True,
                 '__doc__': fun.__doc__,
                 '__module__': fun.__module__,
+                '__annotations__': fun.__annotations__,
                 '__header__': staticmethod(head_from_fun(fun, bound=bind)),
                 '__wrapped__': run}, **options))()
             # for some reason __qualname__ cannot be set in type()

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -414,7 +414,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         transport_options = self.app.conf.get(
             'result_backend_transport_options', {}
         )
-        return transport_options.get('result_chord_ordered', False)
+        return transport_options.get('result_chord_ordered', True)
 
     def on_chord_part_return(self, request, state, result,
                              propagate=None, **kwargs):

--- a/docs/getting-started/brokers/redis.rst
+++ b/docs/getting-started/brokers/redis.rst
@@ -151,17 +151,26 @@ Group result ordering
 Versions of Celery up to and including 4.4.6 used an unsorted list to store
 result objects for groups in the Redis backend. This can cause those results to
 be be returned in a different order to their associated tasks in the original
-group instantiation.
-
-Celery 4.4.7 and up introduce an opt-in behaviour which fixes this issue and
-ensures that group results are returned in the same order the tasks were
-defined, matching the behaviour of other backends. This change is incompatible
-with workers running versions of Celery without this feature, so the feature
-must be turned on using the boolean `result_chord_ordered` option of the
-:setting:`result_backend_transport_options` setting, like so:
+group instantiation. Celery 4.4.7 introduced an opt-in behaviour which fixes
+this issue and ensures that group results are returned in the same order the
+tasks were defined, matching the behaviour of other backends. In Celery 5.0
+this behaviour was changed to be opt-out. The behaviour is controlled by the
+`result_chord_ordered` configuration option which may be set like so:
 
 .. code-block:: python
 
+    # Specifying this for workers running Celery 4.4.6 or earlier has no effect
     app.conf.result_backend_transport_options = {
-        'result_chord_ordered': True
+        'result_chord_ordered': True    # or False
     }
+
+This is an incompatible change in the runtime behaviour of workers sharing the
+same Redis backend for result storage, so all workers must follow either the
+new or old behaviour to avoid breakage. For clusters with some workers running
+Celery 4.4.6 or earlier, this means that workers running 4.4.7 need no special
+configuration and workers running 5.0 or later must have `result_chord_ordered`
+set to `False`. For clusters with no workers running 4.4.6 or earlier but some
+workers running 4.4.7, it is recommended that `result_chord_ordered` be set to
+`True` for all workers to ease future migration. Migration between behaviours
+will disrupt results currently held in the Redis backend and cause breakage if
+downstream tasks are run by migrated workers - plan accordingly.

--- a/docs/history/changelog-4.3.rst
+++ b/docs/history/changelog-4.3.rst
@@ -8,6 +8,16 @@ This document contains change notes for bugfix releases in
 the 4.3.x series, please see :ref:`whatsnew-4.3` for
 an overview of what's new in Celery 4.3.
 
+4.3.1
+=====
+
+:release-date: 2020-09-10 1:00 P.M UTC+3:00
+:release-by: Omer Katz
+
+- Limit vine version to be below 5.0.0.
+
+  Contributed by **Omer Katz**
+
 4.3.0
 =====
 :release-date: 2019-03-31 7:00 P.M UTC+3:00

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -866,7 +866,7 @@ class test_chord:
         redis_connection = get_redis_connection()
         # The redis key is either a list or zset depending on configuration
         if manager.app.conf.result_backend_transport_options.get(
-            'result_chord_ordered', False
+            'result_chord_ordered', True
         ):
             job_results = redis_connection.zrange(j_key, 0, 3)
         else:

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -496,6 +496,16 @@ class test_App:
         finally:
             _imports.MP_MAIN_FILE = None
 
+    def test_can_get_type_hints_for_tasks(self):
+        import typing
+
+        with self.Celery() as app:
+            @app.task
+            def foo(parameter: int) -> None:
+                pass
+
+            assert typing.get_type_hints(foo) == {'parameter': int, 'return': type(None)}
+
     def test_annotate_decorator(self):
         from celery.app.task import Task
 

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -625,9 +625,9 @@ class test_RedisBackend:
 
         for i in range(10):
             self.b.on_chord_part_return(tasks[i].request, states.SUCCESS, i)
-            assert self.b.client.rpush.call_count
-            self.b.client.rpush.reset_mock()
-        assert self.b.client.lrange.call_count
+            assert self.b.client.zadd.call_count
+            self.b.client.zadd.reset_mock()
+        assert self.b.client.zrangebyscore.call_count
         jkey = self.b.get_key_for_group('group_id', '.j')
         tkey = self.b.get_key_for_group('group_id', '.t')
         self.b.client.delete.assert_has_calls([call(jkey), call(tkey)])
@@ -685,9 +685,9 @@ class test_RedisBackend:
 
         for i in range(10):
             self.b.on_chord_part_return(tasks[i].request, states.SUCCESS, i)
-            assert self.b.client.rpush.call_count
-            self.b.client.rpush.reset_mock()
-        assert self.b.client.lrange.call_count
+            assert self.b.client.zadd.call_count
+            self.b.client.zadd.reset_mock()
+        assert self.b.client.zrangebyscore.call_count
         jkey = self.b.get_key_for_group('group_id', '.j')
         tkey = self.b.get_key_for_group('group_id', '.t')
         self.b.client.delete.assert_has_calls([call(jkey), call(tkey)])
@@ -807,7 +807,7 @@ class test_RedisBackend:
         with self.chord_context(1) as (_, request, callback):
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, ChordError())
-            self.b.client.pipeline.return_value.rpush().llen().get().expire(
+            self.b.client.pipeline.return_value.zadd().zcount().get().expire(
             ).expire().execute.return_value = (1, 1, 0, 4, 5)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
@@ -851,7 +851,7 @@ class test_RedisBackend:
         with self.chord_context(1) as (_, request, callback):
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, RuntimeError())
-            self.b.client.pipeline.return_value.rpush().llen().get().expire(
+            self.b.client.pipeline.return_value.zadd().zcount().get().expire(
             ).expire().execute.return_value = (1, 1, 0, 4, 5)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)


### PR DESCRIPTION
This will allow getting type hints.

Fixes #6186 for `v4.5`.