### PR TITLE
Copy __annotations__ when creating tasks

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -452,6 +452,7 @@ class Celery(object):
                 '_decorated': True,
                 '__doc__': fun.__doc__,
                 '__module__': fun.__module__,
+                '__annotations__': fun.__annotations__,
                 '__header__': staticmethod(head_from_fun(fun, bound=bind)),
                 '__wrapped__': run}, **options))()
             # for some reason __qualname__ cannot be set in type()

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -496,6 +496,16 @@ class test_App:
         finally:
             _imports.MP_MAIN_FILE = None
 
+    def test_can_get_type_hints_for_tasks(self):
+        import typing
+
+        with self.Celery() as app:
+            @app.task
+            def foo(parameter: int) -> None:
+                pass
+
+            assert typing.get_type_hints(foo) == {'parameter': int, 'return': type(None)}
+
     def test_annotate_decorator(self):
         from celery.app.task import Task
 


### PR DESCRIPTION
This will allow getting type hints.

Fixes #6186 for `v4.5`
