### PR TITLE
Backport gevent import fix into 3.1 branch

### DIFF
--- a/celery/concurrency/gevent.py
+++ b/celery/concurrency/gevent.py
@@ -38,7 +38,7 @@ def apply_timeout(target, args=(), kwargs={}, callback=None,
 class Schedule(timer2.Schedule):
 
     def __init__(self, *args, **kwargs):
-        from gevent.greenlet import Greenlet, GreenletExit
+        from gevent import Greenlet, GreenletExit
 
         class _Greenlet(Greenlet):
             cancel = Greenlet.kill


### PR DESCRIPTION
cherry-picked 022f447dd into 3.1 branch so the gevent import is fixed. See #4737, #4754