### PR TITLE
Fix Exception throw by Retry(exc parameter)

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -612,7 +612,7 @@ class Task:
     subtask_from_request = signature_from_request  # XXX compat
 
     def retry(self, args=None, kwargs=None, exc=None, throw=True,
-              eta=None, countdown=None, max_retries=None, **options):
+              eta=None, countdown=None, max_retries=-1, **options):
         """Retry the task, adding it to the back of the queue.
 
         Example:
@@ -675,7 +675,8 @@ class Task:
         """
         request = self.request
         retries = request.retries + 1
-        max_retries = self.max_retries if max_retries is None else max_retries
+        if max_retries is None or max_retries >= 0:
+            self.max_retries = max_retries
 
         # Not in worker or emulated by (apply/always_eager),
         # so just raise the original exception.
@@ -694,7 +695,7 @@ class Task:
             **options
         )
 
-        if max_retries is not None and retries > max_retries:
+        if self.max_retries is not None and retries > self.max_retries:
             if exc:
                 # On Py3: will augment any current exception with
                 # the exc' argument provided (raise exc from orig)


### PR DESCRIPTION
## Description
When Retry has paramater "max_retries" set, that value is valid only for "Retry Exception" and not for exc launched from "Retry Exception".
So using Retry with max_retries = 0, exc exception still uses the "task max_retries" making use of "max_retries" useless.
An override is an override. 
max_retries init value to -1 is for not preventing "None" as value for "infinite retry".

Actually i changed the behaviour you wanted to apply. You wanted to use max_retries as an additional check outside the normal "max_retries". But there is a double exception begin executed and the second one dosn't follow the caller(Retry) parameters.
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
