### PR TITLE
Fix max_retries override on self.retry

### DIFF
--- a/celery/app/autoretry.py
+++ b/celery/app/autoretry.py
@@ -1,7 +1,7 @@
 """Tasks auto-retry functionality."""
 from vine.utils import wraps
 
-from celery.exceptions import Ignore, Retry
+from celery.exceptions import Ignore, Retry, ProtectedException
 from celery.utils.time import get_exponential_backoff_interval
 
 
@@ -38,6 +38,8 @@ def add_autoretry_behaviour(task, **options):
                 raise
             except Retry:
                 raise
+            except ProtectedException as exc:
+                raise exc.incapsulated
             except autoretry_for as exc:
                 if retry_backoff:
                     retry_kwargs['countdown'] = \

--- a/celery/app/autoretry.py
+++ b/celery/app/autoretry.py
@@ -48,6 +48,11 @@ def add_autoretry_behaviour(task, **options):
                             retries=task.request.retries,
                             maximum=retry_backoff_max,
                             full_jitter=retry_jitter)
-                raise task.retry(exc=exc, **retry_kwargs)
+                try:
+                    task.retry(exc=exc, **retry_kwargs)
+                except ProtectedException as exc:
+                    raise exc.encapsulated
+                except Exception as exc:
+                    raise exc
 
         task._orig_run, task.run = task.run, run

--- a/celery/app/autoretry.py
+++ b/celery/app/autoretry.py
@@ -39,7 +39,7 @@ def add_autoretry_behaviour(task, **options):
             except Retry:
                 raise
             except ProtectedException as exc:
-                raise exc.incapsulated
+                raise exc.encapsulated
             except autoretry_for as exc:
                 if retry_backoff:
                     retry_kwargs['countdown'] = \

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -675,6 +675,8 @@ class Task:
         """
         request = self.request
         retries = request.retries + 1
+        if max_retries is not None:
+            self.override_max_retries = max_retries
         max_retries = self.max_retries if max_retries is None else max_retries
 
         # Not in worker or emulated by (apply/always_eager),

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -10,7 +10,7 @@ from celery import current_app, group, states
 from celery._state import _task_stack
 from celery.canvas import signature
 from celery.exceptions import (Ignore, ImproperlyConfigured,
-                               MaxRetriesExceededError, Reject, Retry)
+                               MaxRetriesExceededError, Reject, Retry, ProtectedException)
 from celery.local import class_property
 from celery.result import EagerResult, denied_join_result
 from celery.utils import abstract
@@ -698,12 +698,12 @@ class Task:
             if exc:
                 # On Py3: will augment any current exception with
                 # the exc' argument provided (raise exc from orig)
-                raise_with_context(exc)
-            raise self.MaxRetriesExceededError(
+                raise_with_context(ProtectedException(exc))
+            raise ProtectedException(self.MaxRetriesExceededError(
                 "Can't retry {}[{}] args:{} kwargs:{}".format(
                     self.name, request.id, S.args, S.kwargs
                 ), task_args=S.args, task_kwargs=S.kwargs
-            )
+            ))
 
         ret = Retry(exc=exc, when=eta or countdown, is_eager=is_eager, sig=S)
 

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -297,5 +297,5 @@ class BackendStoreError(BackendError):
 
 class ProtectedException(Exception):
     def __init__(self, exc, *args, **kwargs):
-        self.incapsuled = exc
+        self.encapsulated = exc
         super().__init__(*args, **kwargs)

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -293,3 +293,9 @@ class BackendStoreError(BackendError):
 
     def __repr__(self):
         return super().__repr__() + " state:" + self.state + " task_id:" + self.task_id
+
+
+class ProtectedException(Exception):
+    def __init__(self, exc, *args, **kwargs):
+        self.incapsuled = exc
+        super().__init__(*args, **kwargs)

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -294,8 +294,3 @@ class BackendStoreError(BackendError):
     def __repr__(self):
         return super().__repr__() + " state:" + self.state + " task_id:" + self.task_id
 
-
-class ProtectedException(Exception):
-    def __init__(self, exc, *args, **kwargs):
-        self.encapsulated = exc
-        super().__init__(*args, **kwargs)

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -155,7 +155,7 @@ class TasksCase:
             self.retry(exc=MyCustomException)
 
         self.retry_task_max_retries_override = retry_task_max_retries_override
-        
+
         @self.app.task(bind=True, max_retries=0, iterations=0, shared=False,
                        autoretry_for=(Exception,))
         def retry_task_explicit_exception(self, **kwargs):
@@ -164,7 +164,7 @@ class TasksCase:
             raise MyCustomException()
 
         self.retry_task_explicit_exception = retry_task_explicit_exception
-        
+
         @self.app.task(bind=True, max_retries=3, iterations=0, shared=False)
         def retry_task_raise_without_throw(self, **kwargs):
             self.iterations += 1

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -144,6 +144,18 @@ class TasksCase:
 
         self.retry_task_auto_retry_exception_with_new_args = retry_task_auto_retry_exception_with_new_args
 
+        @self.app.task(bind=True, max_retries=10, iterations=0, shared=False,
+                       autoretry_for=(Exception,))
+        def retry_task_max_retries_override(self, **kwargs):
+            # Test for #6436
+            self.iterations += 1
+            if self.iterations == 3:
+                # I wanna force fail here cause i have enough
+                self.retry(exc=MyCustomException, max_retries=0)
+            self.retry(exc=MyCustomException)
+
+        self.retry_task_max_retries_override = retry_task_max_retries_override
+        
         @self.app.task(bind=True, max_retries=3, iterations=0, shared=False)
         def retry_task_raise_without_throw(self, **kwargs):
             self.iterations += 1
@@ -431,6 +443,14 @@ class test_task_retries(TasksCase):
 
     def test_eager_retry_with_autoretry_for_exception(self):
         assert self.retry_task_auto_retry_exception_with_new_args.si(place_holder="test").apply().get() == "test"
+
+    def test_retry_task_max_retries_override(self):
+        self.retry_task_max_retries_override.max_retries = 10
+        self.retry_task_max_retries_override.iterations = 0
+        result = self.retry_task_max_retries_override.apply()
+        with pytest.raises(MyCustomException):
+            result.get()
+        assert self.retry_task_max_retries_override.iterations == 3
 
     def test_retry_eager_should_return_value(self):
         self.retry_task.max_retries = 3


### PR DESCRIPTION
## Description
This seems a better patch for #6433 

This one FIX base idea from max_retries on self.retry and lets exception from self.retry escape from autoretry_for.
ProtectedException can be used even alone in a task to make it fail on spot.
`        raise ProtectedException(exc=Exception('You failed'))`
Doing this makes the task fail bypassing all. (This BUG raised cause i wanted to make a task fail on purpose from a trigger)
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
