### PR TITLE
Raise proper error when replacing with an empty chain

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -8,7 +8,7 @@ from kombu.utils.uuid import uuid
 
 from celery import current_app, group, states
 from celery._state import _task_stack
-from celery.canvas import signature
+from celery.canvas import _chain, signature
 from celery.exceptions import (Ignore, ImproperlyConfigured,
                                MaxRetriesExceededError, Reject, Retry)
 from celery.local import class_property
@@ -880,6 +880,11 @@ class Task:
                 link=self.request.callbacks,
                 link_error=self.request.errbacks,
             )
+        elif isinstance(sig, _chain):
+            if not sig.tasks:
+                raise ImproperlyConfigured(
+                    "Cannot replace with an empty chain"
+                )
 
         if self.request.chain:
             # We need to freeze the new signature with the current task's ID to

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -101,6 +101,11 @@ def replace_with_chain_which_raises(self, *args, link_msg=None):
 
 
 @shared_task(bind=True)
+def replace_with_empty_chain(self, *_):
+    return self.replace(chain())
+
+
+@shared_task(bind=True)
 def add_to_all(self, nums, val):
     """Add the given value to all supplied numbers."""
     subtasks = [add.s(num, val) for num in nums]


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Previously, an `IndexError` was raised when providing an empty chain to `self.replace()`.
We now raise an `ImproperlyConfigured` exception which explains what is wrong and should help the user fix the problem.

Fixes #6451.
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->