### PR TITLE
When using the MongoDB backend, don't cleanup if result_expires is 0 or None

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -248,6 +248,9 @@ class MongoBackend(BaseBackend):
 
     def cleanup(self):
         """Delete expired meta-data."""
+        if not self.expires:
+            return
+
         self.collection.delete_many(
             {'date_done': {'$lt': self.app.now() - self.expires_delta}},
         )

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -485,6 +485,12 @@ class test_MongoBackend:
         mock_get_database.assert_called_once_with()
         mock_collection.delete_many.assert_called()
 
+        self.backend.collections = mock_collection = Mock()
+        self.backend.expires = None
+
+        self.backend.cleanup()
+        mock_collection.delete_many.assert_not_called()
+
     def test_get_database_authfailure(self):
         x = MongoBackend(app=self.app)
         x._get_connection = Mock()


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fixes #6450.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->