### PR TITLE
Fix passing queues into purge command

### DIFF
--- a/celery/bin/purge.py
+++ b/celery/bin/purge.py
@@ -32,10 +32,10 @@ def purge(ctx, force, queues, exclude_queues):
 
         There's no undo operation for this command.
     """
-    queues = queues or set()
-    exclude_queues = exclude_queues or set()
     app = ctx.obj.app
-    names = (queues or set(app.amqp.queues.keys())) - exclude_queues
+    queues = set(queues or app.amqp.queues.keys())
+    exclude_queues = set(exclude_queues or [])
+    names = queues - exclude_queues
     qnum = len(names)
 
     if names:


### PR DESCRIPTION
In current wersion calling `celery --app my.celery_app purge -Q queue_name` is failing with following trace:

```
    names = (queues or set(app.amqp.queues.keys())) - exclude_queues
TypeError: unsupported operand type(s) for -: 'list' and 'list'
```

Becouse code is expecting set and `queues` is actually a list.

Here is a fix.