### PR TITLE
Update elasticsearch.py for support ipv

### DIFF
--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -232,14 +232,24 @@ class ElasticsearchBackend(KeyValueStoreBackend):
         http_auth = None
         if self.username and self.password:
             http_auth = (self.username, self.password)
-        return elasticsearch.Elasticsearch(
-            f'{self.host}:{self.port}',
-            retry_on_timeout=self.es_retry_on_timeout,
-            max_retries=self.es_max_retries,
-            timeout=self.es_timeout,
-            scheme=self.scheme,
-            http_auth=http_auth,
-        )
+        if ":" in self.host:
+            return elasticsearch.Elasticsearch(
+                f'[{self.host}]:{self.port}',
+                retry_on_timeout=self.es_retry_on_timeout,
+                max_retries=self.es_max_retries,
+                timeout=self.es_timeout,
+                scheme=self.scheme,
+                http_auth=http_auth,
+            )
+        else:
+            return elasticsearch.Elasticsearch(
+                f'{self.host}:{self.port}',
+                retry_on_timeout=self.es_retry_on_timeout,
+                max_retries=self.es_max_retries,
+                timeout=self.es_timeout,
+                scheme=self.scheme,
+                http_auth=http_auth,
+            )
 
     @property
     def server(self):


### PR DESCRIPTION
backend elasticsearch support IPv6.

eg:
ipv6 url is:    [fe80:xxx::97]:9200

_Note_: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

