### PR TITLE
Added pytest to extras.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ EXTENSIONS = {
     'msgpack',
     'pymemcache',
     'pyro',
+    'pytest',
     'redis',
     's3',
     'slmq',


### PR DESCRIPTION
Missed in 9a6c2923e859b6993227605610255bd632c1ae68.

Without this we cannot `pip install celery[pytest]` as highlighted in the [documentation](https://docs.celeryproject.org/en/stable/userguide/testing.html#enabling):

```
  WARNING: celery 5.0.2 does not provide the extra 'pytest'
```