### PR TITLE
Make Python 3.9 support official

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Operating System :: OS Independent"


### PR DESCRIPTION
Since https://github.com/celery/celery/pull/6418, the tests seem to pass on Python 3.9.
Let's make this official!