### PR TITLE
redis: Support Sentinel with SSL

### DIFF
--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -1126,3 +1126,34 @@ class test_SentinelBackend:
         )
         pool = x._get_pool(**x.connparams)
         assert pool
+
+    def test_backend_ssl(self):
+        pytest.importorskip('redis')
+
+        from celery.backends.redis import SentinelBackend
+        self.app.conf.redis_backend_use_ssl = {
+            'ssl_cert_reqs': "CERT_REQUIRED",
+            'ssl_ca_certs': '/path/to/ca.crt',
+            'ssl_certfile': '/path/to/client.crt',
+            'ssl_keyfile': '/path/to/client.key',
+        }
+        self.app.conf.redis_socket_timeout = 30.0
+        self.app.conf.redis_socket_connect_timeout = 100.0
+        x = SentinelBackend(
+            'sentinel://:bosco@vandelay.com:123//1', app=self.app,
+        )
+        assert x.connparams
+        assert len(x.connparams['hosts']) == 1
+        assert x.connparams['hosts'][0]['host'] == 'vandelay.com'
+        assert x.connparams['hosts'][0]['db'] == 1
+        assert x.connparams['hosts'][0]['port'] == 123
+        assert x.connparams['hosts'][0]['password'] == 'bosco'
+        assert x.connparams['socket_timeout'] == 30.0
+        assert x.connparams['socket_connect_timeout'] == 100.0
+        assert x.connparams['ssl_cert_reqs'] == ssl.CERT_REQUIRED
+        assert x.connparams['ssl_ca_certs'] == '/path/to/ca.crt'
+        assert x.connparams['ssl_certfile'] == '/path/to/client.crt'
+        assert x.connparams['ssl_keyfile'] == '/path/to/client.key'
+
+        from celery.backends.redis import SentinelManagedSSLConnection
+        assert x.connparams['connection_class'] is SentinelManagedSSLConnection


### PR DESCRIPTION
Use the SentinelManagedSSLConnection when SSL is enabled for the
transport.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
