### PR TITLE
Restore CLI plugins

### DIFF
--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -7,6 +7,8 @@ import click
 import click.exceptions
 from click.types import ParamType
 from click_didyoumean import DYMGroup
+from click_plugins import with_plugins
+from pkg_resources import iter_entry_points
 
 from celery import VERSION_BANNER
 from celery.app.utils import find_app
@@ -69,6 +71,7 @@ class App(ParamType):
 APP = App()
 
 
+@with_plugins(iter_entry_points('celery.commands'))
 @click.group(cls=DYMGroup, invoke_without_command=True)
 @click.option('-A',
               '--app',

--- a/docs/userguide/extending.rst
+++ b/docs/userguide/extending.rst
@@ -816,12 +816,10 @@ Entry-points is special meta-data that can be added to your packages ``setup.py`
 and then after installation, read from the system using the :mod:`pkg_resources` module.
 
 Celery recognizes ``celery.commands`` entry-points to install additional
-sub-commands, where the value of the entry-point must point to a valid subclass
-of :class:`celery.bin.base.Command`. There's limited documentation,
-unfortunately, but you can find inspiration from the various commands in the
-:mod:`celery.bin` package.
+sub-commands, where the value of the entry-point must point to a valid click
+command.
 
-This is how the :pypi:`Flower` monitoring extension adds the :program:`celery flower` command,
+This is how the :pypi:`Flower` monitoring extension may add the :program:`celery flower` command,
 by adding an entry-point in :file:`setup.py`:
 
 .. code-block:: python
@@ -830,44 +828,35 @@ by adding an entry-point in :file:`setup.py`:
         name='flower',
         entry_points={
             'celery.commands': [
-               'flower = flower.command:FlowerCommand',
+               'flower = flower.command:flower',
             ],
         }
     )
 
 The command definition is in two parts separated by the equal sign, where the
 first part is the name of the sub-command (flower), then the second part is
-the fully qualified symbol path to the class that implements the command:
+the fully qualified symbol path to the function that implements the command:
 
 .. code-block:: text
 
-    flower.command:FlowerCommand
+    flower.command:flower
 
 The module path and the name of the attribute should be separated by colon
 as above.
 
 
-In the module :file:`flower/command.py`, the command class is defined
-something like this:
+In the module :file:`flower/command.py`, the command function may be defined
+as the following:
 
 .. code-block:: python
 
-    from celery.bin.base import Command
+    import click
 
-
-    class FlowerCommand(Command):
-
-        def add_arguments(self, parser):
-            parser.add_argument(
-                '--port', default=8888, type='int',
-                help='Webserver port',
-            ),
-            parser.add_argument(
-                '--debug', action='store_true',
-            )
-
-        def run(self, port=None, debug=False, **kwargs):
-            print('Running our command')
+    @click.command()
+    @click.option('--port', default=8888, type=int, help='Webserver port')
+    @click.option('--debug', is_flag=True)
+    def flower(port, debug):
+        print('Running our command')
 
 
 Worker API

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,3 +5,4 @@ vine>=5.0.0,<6.0
 click>=7.0
 click-didyoumean>=0.0.3
 click-repl>=0.1.6
+click-plugins>=1.1.1


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This PR fixes a regression in #5718 which overlooked the fact that we allow the CLI to be extended with new sub-command plugins.

I have also updated the documentation accordingly which fixes #6439.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->