### PR TITLE
Fix inconsistency in documentation for `link_error`

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -278,3 +278,4 @@ Dipankar Achinta, 2019/10/24
 Sardorbek Imomaliev, 2020/01/24
 Maksym Shalenyi, 2020/07/30
 Frazer McLean, 2020/09/29
+Henrik Bruåsdal, 2020/11/29

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -135,23 +135,18 @@ task that adds 16 to the previous result, forming the expression
 
 
 You can also cause a callback to be applied if task raises an exception
-(*errback*), but this behaves differently from a regular callback
-in that it will be passed the id of the parent task, not the result.
-This is because it may not always be possible to serialize
-the exception raised, and so this way the error callback requires
-a result backend to be enabled, and the task must retrieve the result
-of the task instead.
+(*errback*). The worker won't actually call the errback as a task, but will
+instead call the errback function directly so that the raw request, exception
+and traceback objects can be passed to it.
 
 This is an example error callback:
 
 .. code-block:: python
 
     @app.task
-    def error_handler(uuid):
-        result = AsyncResult(uuid)
-        exc = result.get(propagate=False)
+    def error_handler(request, exc, traceback):
         print('Task {0} raised exception: {1!r}\n{2!r}'.format(
-              uuid, exc, result.traceback))
+              request.id, exc, traceback))
 
 it can be added to the task using the ``link_error`` execution
 option:

--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -569,7 +569,7 @@ Here's an example errback:
     def log_error(request, exc, traceback):
         with open(os.path.join('/var/errors', request.id), 'a') as fh:
             print('--\n\n{0} {1} {2}'.format(
-                task_id, exc, traceback), file=fh)
+                request.id, exc, traceback), file=fh)
 
 To make it even easier to link tasks together there's
 a special signature called :class:`~celery.chain` that lets


### PR DESCRIPTION
## Description

- Makes the documentation for `link_error` consistent between the canvas and calling pages. I've just copied over the text from the canvas page, but let me know if it should be adjusted to better fit the context of the calling page. Fixes #4099
- Fix an undefined variable in the existing new-style errback example
