### PR TITLE
Update getting started guide's step to install homebrew

### DIFF
--- a/docs/getting-started/brokers/rabbitmq.rst
+++ b/docs/getting-started/brokers/rabbitmq.rst
@@ -86,7 +86,7 @@ documentation`_:
 
 .. code-block:: console
 
-    ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 Finally, we can install RabbitMQ using :command:`brew`:
 


### PR DESCRIPTION
## Description

I was going through the [getting-started](https://docs.celeryproject.org/en/stable/getting-started/brokers/rabbitmq.html#starting-stopping-the-rabbitmq-server) guide and noticed the homebrew install command was working as intended. I replaced it with the correct command found on the [homebrew](https://brew.sh/) site 

