### PR TITLE
DummyClient of cache+memory:// backend now shares state between threads

### DIFF
--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -20,6 +20,10 @@ The cache backend {0!r} is unknown,
 Please use one of the following backends instead: {1}\
 """
 
+# Global shared in-memory cache for in-memory cache client
+# This is to share cache between threads
+_DUMMY_CLIENT_CACHE = LRUCache(limit=5000)
+
 
 def import_best_memcache():
     if _imp[0] is None:
@@ -53,7 +57,7 @@ def get_best_memcache(*args, **kwargs):
 class DummyClient:
 
     def __init__(self, *args, **kwargs):
-        self.cache = LRUCache(limit=5000)
+        self.cache = _DUMMY_CLIENT_CACHE
 
     def get(self, key, *args, **kwargs):
         return self.cache.get(key)

--- a/t/unit/backends/test_cache.py
+++ b/t/unit/backends/test_cache.py
@@ -35,6 +35,16 @@ class test_CacheBackend:
         with pytest.raises(ImproperlyConfigured):
             CacheBackend(backend=None, app=self.app)
 
+    def test_memory_client_is_shared(self):
+        """This test verifies that memory:// backend state is shared over multiple threads"""
+        from threading import Thread
+        t = Thread(
+            target=lambda: CacheBackend(backend='memory://', app=self.app).set('test', 12345)
+        )
+        t.start()
+        t.join()
+        assert self.tb.client.get('test') == 12345
+
     def test_mark_as_done(self):
         assert self.tb.get_state(self.tid) == states.PENDING
         assert self.tb.get_result(self.tid) is None


### PR DESCRIPTION
## Description
This PR makes DummyClient state between multiple threads. Fixes #6521
