### PR TITLE
Make `setup_default_app` actually set the default app

### DIFF
--- a/celery/contrib/testing/app.py
+++ b/celery/contrib/testing/app.py
@@ -2,6 +2,7 @@
 import weakref
 from contextlib import contextmanager
 from copy import deepcopy
+from types import SimpleNamespace
 
 from kombu.utils.imports import symbol_by_name
 
@@ -66,44 +67,53 @@ def TestApp(name=None, config=None, enable_logging=False, set_as_current=False,
 
 
 @contextmanager
-def set_trap(app):
+def _set_app(app: Celery):
+    """Setup an app for testing.
+
+    Ensures state is clean after the test returns.
+    """
+
+    prev_default_app = _state.default_app
+    prev_finalizers = set(_state._on_app_finalizers)
+    prev_apps = weakref.WeakSet(_state._apps)
+    prev_tls = _state._tls
+
+    _state.set_default_app(app)
+    _state._tls = SimpleNamespace(current_app=app)
+    yield
+
+    _state._tls = prev_tls
+    _state.set_default_app(prev_default_app)
+    _state._on_app_finalizers = prev_finalizers
+    _state._apps = prev_apps
+
+
+@contextmanager
+def set_trap():
     """Contextmanager that installs the trap app.
 
     The trap means that anything trying to use the current or default app
     will raise an exception.
     """
-    trap = Trap()
-    prev_tls = _state._tls
-    _state.set_default_app(trap)
-
-    class NonTLS:
-        current_app = trap
-    _state._tls = NonTLS()
-
-    yield
-    _state._tls = prev_tls
+    with _set_app(Trap()):
+        yield
 
 
 @contextmanager
 def setup_default_app(app, use_trap=False):
-    """Setup default app for testing.
+    """Setup default app (or the trap app) for testing.
 
     Ensures state is clean after the test returns.
     """
+
     prev_current_app = _state.get_current_app()
-    prev_default_app = _state.default_app
-    prev_finalizers = set(_state._on_app_finalizers)
-    prev_apps = weakref.WeakSet(_state._apps)
 
     if use_trap:
-        with set_trap(app):
+        with set_trap():
             yield
     else:
-        yield
+        with _set_app(app):
+            yield
 
-    _state.set_default_app(prev_default_app)
-    _state._tls.current_app = prev_current_app
     if app is not prev_current_app:
         app.close()
-    _state._on_app_finalizers = prev_finalizers
-    _state._apps = prev_apps


### PR DESCRIPTION
Fixes #6525
Refs #6007

## Description
This PR:

* refactors the `set_trap()` context manager into a more reusable internal `_set_app()` context manager
* has `setup_default_app()` actually use that context manager when not using a trap app

This seems like the correct thing to do (after all, otherwise `setup_default_app()` doesn't really use `app`), but I'm afraid people who have assumed `celery_app` _doesn't_ set the app as the default app could be upset by the change.

