### PR TITLE
Change deprecated from collections import Mapping/MutableMapping to from collections.abc import ...

### DIFF
--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -1,5 +1,5 @@
 import pickle
-from collections import Mapping
+from collections.abc import Mapping
 from itertools import count
 from time import monotonic
 
@@ -129,11 +129,11 @@ class test_ConfigurationView:
         assert len(self.view) == 2
 
     def test_isa_mapping(self):
-        from collections import Mapping
+        from collections.abc import Mapping
         assert issubclass(ConfigurationView, Mapping)
 
     def test_isa_mutable_mapping(self):
-        from collections import MutableMapping
+        from collections.abc import MutableMapping
         assert issubclass(ConfigurationView, MutableMapping)
 
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

'from collections import Mapping' is deprecated since Python 3.3 and will be removed in Python 3.10 .

Since celery supports only Python >= 3.6 according to tox.ini and this form of import should work since Python 3.3, I think it's okay to make the change without try/except ImportError .