### PR TITLE
Fixes #6047: fix a typo in django-celery-result doc and add cache_backend doc for django celery backend.

### DIFF
--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -210,7 +210,7 @@ To use this with your project you need to follow these steps:
 
     .. code-block:: python
 
-        CELERY_CACHE_BACKEND = 'django-cache'
+        CELERY_RESULT_BACKEND = 'django-cache'
 
     We can also use the cache defined in the CACHES setting in django.
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1028,8 +1028,12 @@ setting:
 ``cache_backend``
 ~~~~~~~~~~~~~~~~~
 
-This setting is no longer used as it's now possible to specify
+This setting is no longer used in celery's builtin backends as it's now possible to specify
 the cache backend directly in the :setting:`result_backend` setting.
+
+.. note::
+
+    The :ref:`django-celery-results` library uses ``cache_backend`` for choosing django caches.
 
 .. _conf-mongodb-result-backend:
 


### PR DESCRIPTION
## Description

Fixes #6047