### PR TITLE
Allow pycurl==7.43.0.6 to be used too

### DIFF
--- a/requirements/extras/sqs.txt
+++ b/requirements/extras/sqs.txt
@@ -1,2 +1,2 @@
 boto3>=1.9.125
-pycurl==7.43.0.5  # Latest version with wheel built (for appveyor)
+pycurl>=7.43.0.5,<7.44.0  # Latest version with wheel built (for appveyor)

--- a/requirements/test-ci-default.txt
+++ b/requirements/test-ci-default.txt
@@ -20,4 +20,4 @@
 -r extras/azureblockblob.txt
 
 # SQS dependencies other than boto
-pycurl==7.43.0.5  # Latest version with wheel built (for appveyor)
+pycurl==7.43.0.6  # Latest version with wheel built (for appveyor)


### PR DESCRIPTION


*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

The improved SSL backend detection released in pycurl 7.43.0.6 makes life a lot easier but you can't currently install `pycurl==7.43.0.6` and `celery[sqs]` at the same time because you end up with a ResolutionImpossible error.

```
The conflict is caused by:
    The user requested pycurl==7.43.0.6
    celery[sqs] 4.4.7 depends on pycurl==7.43.0.5; extra == "sqs"
```

Please ignore the 4.4.7, it's still the same on v5.0.4
