### PR TITLE
Fix type error in S3 backend

### DIFF
--- a/celery/backends/s3.py
+++ b/celery/backends/s3.py
@@ -72,6 +72,7 @@ class S3Backend(KeyValueStoreBackend):
         s3_object.put(Body=value)
 
     def delete(self, key):
+        key = bytes_to_str(key)
         s3_object = self._get_s3_object(key)
         s3_object.delete()
 

--- a/t/unit/backends/test_s3.py
+++ b/t/unit/backends/test_s3.py
@@ -140,8 +140,9 @@ class test_S3Backend:
         with pytest.raises(ClientError):
             s3_backend.get('uuidddd')
 
+    @pytest.mark.parametrize("key", ['uuid', b'uuid'])
     @mock_s3
-    def test_delete_a_key(self):
+    def test_delete_a_key(self, key):
         self._mock_s3_resource()
 
         self.app.conf.s3_access_key_id = 'somekeyid'
@@ -149,12 +150,12 @@ class test_S3Backend:
         self.app.conf.s3_bucket = 'bucket'
 
         s3_backend = S3Backend(app=self.app)
-        s3_backend._set_with_state('uuid', 'another_status', states.SUCCESS)
-        assert s3_backend.get('uuid') == 'another_status'
+        s3_backend._set_with_state(key, 'another_status', states.SUCCESS)
+        assert s3_backend.get(key) == 'another_status'
 
-        s3_backend.delete('uuid')
+        s3_backend.delete(key)
 
-        assert s3_backend.get('uuid') is None
+        assert s3_backend.get(key) is None
 
     @mock_s3
     def test_with_a_non_existing_bucket(self):


### PR DESCRIPTION
Fixes a `TypeError` when deleting a task result with S3 backend. This links to #5721, which already solved this problem for `.get()` and `.set()`, but not for `.delete()`