### PR TITLE
events.py: Remove duplicate decorator in wrong place

### DIFF
--- a/celery/bin/events.py
+++ b/celery/bin/events.py
@@ -48,7 +48,6 @@ def _run_evtop(app):
             raise click.UsageError("The curses module is required for this command.")
 
 
-@handle_preload_options
 @click.command(cls=CeleryDaemonCommand)
 @click.option('-d',
               '--dump',


### PR DESCRIPTION
`@handle_preload_options` was specified twice as a decorator of `events`, once at the top (wrong) and once at the bottom (right).
This fixes the `celery events` commands and also `celery --help` which crash with a traceback in celery 5.0.4.