### PR TITLE
Add sentinel_kwargs to Redis Sentinel docs

### DIFF
--- a/docs/getting-started/brokers/redis.rst
+++ b/docs/getting-started/brokers/redis.rst
@@ -58,6 +58,12 @@ It is also easy to connect directly to a list of Redis Sentinel:
     app.conf.broker_url = 'sentinel://localhost:26379;sentinel://localhost:26380;sentinel://localhost:26381'
     app.conf.broker_transport_options = { 'master_name': "cluster1" }
 
+Additional options can be passed to the Sentinel client using ``sentinel_kwargs``:
+
+.. code-block:: python
+
+    app.conf.broker_transport_options = { 'sentinel_kwargs': { 'password': "password" } }
+
 .. _redis-visibility_timeout:
 
 Visibility Timeout


### PR DESCRIPTION
If Sentinel has a password, it also has to be passed down via the `sentinel_kwargs` option. If it was not supplied I got an error: `No master found for 'mymaster'`.

Google did not do much for me trying to find this option, I found it in the source, so I think it should be documented.
