### PR TITLE
Allow custom args to pass to cluster start

### DIFF
--- a/celery/bin/multi.py
+++ b/celery/bin/multi.py
@@ -288,7 +288,7 @@ class MultiTool(TermLogger):
 
     @splash
     @using_cluster
-    def start(self, cluster, **kwargs):
+    def start(self, cluster):
         self.note('> Starting nodes...')
         return int(any(cluster.start()))
 
@@ -469,7 +469,7 @@ class MultiTool(TermLogger):
 )
 @click.pass_context
 @handle_preload_options
-def multi(ctx):
+def multi(ctx, **kwargs):
     """Start multiple worker instances."""
     cmd = MultiTool(quiet=ctx.obj.quiet, no_color=ctx.obj.no_color)
     # In 4.x, celery multi ignores the global --app option.

--- a/celery/bin/multi.py
+++ b/celery/bin/multi.py
@@ -288,7 +288,7 @@ class MultiTool(TermLogger):
 
     @splash
     @using_cluster
-    def start(self, cluster):
+    def start(self, cluster, **kwargs):
         self.note('> Starting nodes...')
         return int(any(cluster.start()))
 


### PR DESCRIPTION
Though preload options were fixed by https://github.com/celery/celery/issues/6307, `multi` start will not accept the custom arguments as expected.

## Description

The `multi` command will not accept custom preload args on start -- if used, the following traceback is given:

example call

```bash
celery --app=celery_app --workdir=/path/to/project multi start worker_1 worker_2 --pidfile='/var/run/celery/%n.pid' --logfile='/var/log/celery/%n.log' --loglevel='INFO' -P solo -c 1 -Q:main 'collect' -P:main solo -c:main 1  -Q:worker_2 'q_1' -P:worker_2 solo -c:worker_2 1 -Z '<custom_arg_string>' -l debug
```
where `-Z` is the custom argument

```bash
Traceback (most recent call last):
  File "/home/pi/aero/bin/celery", line 10, in <module>
    sys.exit(main())
  File "/home/pi/aero/lib/python3.7/site-packages/celery/__main__.py", line 15, in main
    sys.exit(_main())
  File "/home/pi/aero/lib/python3.7/site-packages/celery/bin/celery.py", line 213, in main
    return celery(auto_envvar_prefix="CELERY")
  File "/home/pi/aero/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/pi/aero/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/pi/aero/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/pi/aero/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/pi/aero/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/pi/aero/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/pi/aero/lib/python3.7/site-packages/celery/bin/base.py", line 132, in caller
    return f(ctx, *args, **kwargs)
TypeError: multi() got an unexpected keyword argument '<some_preload_arg>'
```

By allowing **kwargs in the function definition (from the MR), the app will then started as expected.

NOTE: I'm new-ish to celery and my proposed change should be looked over carefully. Also, I would have expected to have to pass **kwargs into `cluster.start(**kwargs)` as well, but even without the workers start as expected with the correct options (as far as I can tell).

Happy to raise this as an issue instead if easier. Thanks