### PR TITLE
 original dict subclass replaced with a plain dict after sanity checking the keys

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -316,13 +316,6 @@ class AMQP:
         if kwargsrepr is None:
             kwargsrepr = saferepr(kwargs, self.kwargsrepr_maxsize)
 
-        if callbacks:
-            callbacks = [utf8dict(callback) for callback in callbacks]
-        if errbacks:
-            errbacks = [utf8dict(errback) for errback in errbacks]
-        if chord:
-            chord = utf8dict(chord)
-
         if not root_id:  # empty root_id defaults to task_id
             root_id = task_id
 
@@ -394,13 +387,6 @@ class AMQP:
             expires = now + timedelta(seconds=expires)
         eta = eta and eta.isoformat()
         expires = expires and expires.isoformat()
-
-        if callbacks:
-            callbacks = [utf8dict(callback) for callback in callbacks]
-        if errbacks:
-            errbacks = [utf8dict(errback) for errback in errbacks]
-        if chord:
-            chord = utf8dict(chord)
 
         return task_message(
             headers={},


### PR DESCRIPTION
Today I found a bug while updating my codebase from v4.4.7 to v5.0.4 on python3.8

https://github.com/celery/celery/pull/5954/files#diff-07a65448b2db3252a9711766beec23372715cd7597c3e309bf53859eabc0107fL416-R416

Behavior that used to be called only in Python 2.7 environments without the simplejson package installed is now always used, and it replaces the original dict subclass with a plain dict after sanity checking the keys. I think this is a mistake, those code blocks should have been removed when dropping Python 2.7 support rather than making them the default behavior.

[Issue](https://github.com/celery/celery/issues/6560) reported 


In following PR cleanup work done.
https://github.com/celery/celery/pull/5954/files#diff-07a65448b2db3252a9711766beec23372715cd7597c3e309bf53859eabc0107fL337
