### PR TITLE
Pass DAEMON_OPTS to stopwait in generic celeryd

### DIFF
--- a/extra/generic-init.d/celeryd
+++ b/extra/generic-init.d/celeryd
@@ -269,7 +269,7 @@ dryrun () {
 
 
 stop_workers () {
-    _chuid stopwait $CELERYD_NODES --pidfile="$CELERYD_PID_FILE"
+    _chuid stopwait $CELERYD_NODES $DAEMON_OPTS --pidfile="$CELERYD_PID_FILE"
 }
 
 


### PR DESCRIPTION
The stop_workers function in this template file is missing the $DAEMON_OPTS parameters.


