### PR TITLE
Fix: serialization error when gossip working

### DIFF
--- a/celery/worker/consumer/gossip.py
+++ b/celery/worker/consumer/gossip.py
@@ -176,6 +176,7 @@ class Gossip(bootsteps.ConsumerStep):
             channel,
             queues=[ev.queue],
             on_message=partial(self.on_message, ev.event_from_message),
+            accept=ev.accept,
             no_ack=True
         )]
 

--- a/t/integration/test_serialization.py
+++ b/t/integration/test_serialization.py
@@ -1,0 +1,54 @@
+import os
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+disabled_error_message = "Refusing to deserialize disabled content of type "
+
+
+class test_config_serialization:
+    def test_accept(self, celery_app):
+        app = celery_app
+        # Redefine env to use in subprocess
+        # broker_url and result backend are different for each integration test backend
+        passenv = {
+            **os.environ,
+            "CELERY_BROKER_URL": app.conf.broker_url,
+            "CELERY_RESULT_BACKEND": app.conf.result_backend,
+        }
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            f1 = executor.submit(get_worker_error_messages, "w1", passenv)
+            f2 = executor.submit(get_worker_error_messages, "w2", passenv)
+            time.sleep(3)
+            log1 = f1.result()
+            log2 = f2.result()
+
+        for log in [log1, log2]:
+            assert log.find(disabled_error_message) == -1, log
+
+
+def get_worker_error_messages(name, env):
+    """run a worker and return its stderr
+
+    :param name: the name of the worker
+    :param env: the environment to run the worker in
+
+    worker must be running in other process because of avoiding conflict."""
+    worker = subprocess.Popen(
+        [
+            "celery",
+            "--config",
+            "t.integration.test_serialization_config",
+            "worker",
+            "-c",
+            "2",
+            "-n",
+            f"{name}@%%h",
+        ],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        env=env,
+    )
+    worker.terminate()
+    err = worker.stderr.read().decode("utf-8")
+    return err

--- a/t/integration/test_serialization_config.py
+++ b/t/integration/test_serialization_config.py
@@ -1,0 +1,5 @@
+event_serializer = "pickle"
+result_serializer = "pickle"
+accept_content = ["pickle", "json"]
+worker_redirect_stdouts = False
+worker_log_color = False

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -696,6 +696,7 @@ class test_Gossip:
         c.app.connection = _amqp_connection()
         c.hostname = hostname
         c.pid = pid
+        c.app.events.Receiver.return_value = Mock(accept=[])
         return c
 
     def setup_election(self, g, c):


### PR DESCRIPTION
Fix of https://github.com/celery/celery/issues/5075

## Current problem

Currently, Gossip does not respect accept_content when generating a consumer.
If you have multiple Celery workers running and allow pickle with accept_content, you may get a `Refusing to deserialize disabled content of type pickle (application/x-python-serialize)` error.

This error does not occur when running a single worker, but it does occur when running multiple workers.

## What this PR does

- Make Gossip respect accept_content
  - To do this, Gossip needs to pass accept_content when generating a consumer
- Add tests to verify that multiple workers are running and no errors containing `Refusing to deserialize disabled content of type` are occurring

## Additional notes

- Some of the existing unit tests use `Mock()` to replace Gossip processing. This is the case with `t/unit/worker/test_consumer.py`.
  - The `Mock()` needs to be configured with additional settings to work as intended with this change.

- Some of the tests are unstable. I (@kitsuyui) have confirmed that these failures occur without my changes.
1. The update to Codecov reports sometimes fails with a 500 error
2. Integration tests sometimes fail due to timeouts


