### PR TITLE
start chord header tasks as soon as possible

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -590,6 +590,9 @@ class Backend:
     def on_chord_part_return(self, request, state, result, **kwargs):
         pass
 
+    def set_chord_size(self, group_id, chord_size):
+        pass
+
     def fallback_chord_unlock(self, header_result, body, countdown=1,
                               **kwargs):
         kwargs['result'] = [r.as_tuple() for r in header_result]
@@ -605,8 +608,9 @@ class Backend:
     def ensure_chords_allowed(self):
         pass
 
-    def apply_chord(self, header_result, body, **kwargs):
+    def apply_chord(self, header_result_args, body, **kwargs):
         self.ensure_chords_allowed()
+        header_result = self.app.GroupResult(*header_result_args)
         self.fallback_chord_unlock(header_result, body, **kwargs)
 
     def current_task_children(self, request=None):
@@ -887,8 +891,9 @@ class BaseKeyValueStoreBackend(Backend):
             meta['result'] = result_from_tuple(result, self.app)
             return meta
 
-    def _apply_chord_incr(self, header_result, body, **kwargs):
+    def _apply_chord_incr(self, header_result_args, body, **kwargs):
         self.ensure_chords_allowed()
+        header_result = self.app.GroupResult(*header_result_args)
         header_result.save(backend=self)
 
     def on_chord_part_return(self, request, state, result, **kwargs):

--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -128,11 +128,11 @@ class CacheBackend(KeyValueStoreBackend):
     def delete(self, key):
         return self.client.delete(key)
 
-    def _apply_chord_incr(self, header_result, body, **kwargs):
-        chord_key = self.get_key_for_chord(header_result.id)
+    def _apply_chord_incr(self, header_result_args, body, **kwargs):
+        chord_key = self.get_key_for_chord(header_result_args[0])
         self.client.set(chord_key, 0, time=self.expires)
         return super()._apply_chord_incr(
-            header_result, body, **kwargs)
+            header_result_args, body, **kwargs)
 
     def incr(self, key):
         return self.client.incr(key)

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -15,7 +15,7 @@ from celery.canvas import maybe_signature
 from celery.exceptions import (BackendStoreError, ChordError,
                                ImproperlyConfigured)
 from celery.result import GroupResult, allow_join_result
-from celery.utils.functional import dictfilter
+from celery.utils.functional import dictfilter, _regen
 from celery.utils.log import get_logger
 from celery.utils.time import humanize_seconds
 
@@ -410,15 +410,20 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             raise ChordError(f'Dependency {tid} raised {retval!r}')
         return retval
 
-    def apply_chord(self, header_result, body, **kwargs):
+    def set_chord_size(self, group_id, chord_size):
+        self.set(self.get_key_for_group(group_id, '.s'), chord_size)
+
+    def apply_chord(self, header_result_args, body, **kwargs):
         # If any of the child results of this chord are complex (ie. group
         # results themselves), we need to save `header_result` to ensure that
         # the expected structure is retained when we finish the chord and pass
         # the results onward to the body in `on_chord_part_return()`. We don't
         # do this is all cases to retain an optimisation in the common case
         # where a chord header is comprised of simple result objects.
-        if any(isinstance(nr, GroupResult) for nr in header_result.results):
-            header_result.save(backend=self)
+        if not isinstance(header_result_args[1], _regen):
+            header_result = self.app.GroupResult(*header_result_args)
+            if any(isinstance(nr, GroupResult) for nr in header_result.results):
+                header_result.save(backend=self)
 
     @cached_property
     def _chord_zset(self):
@@ -440,6 +445,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         client = self.client
         jkey = self.get_key_for_group(gid, '.j')
         tkey = self.get_key_for_group(gid, '.t')
+        skey = self.get_key_for_group(gid, '.s')
         result = self.encode_result(result, state)
         encoded = self.encode([1, tid, state, result])
         with client.pipeline() as pipe:
@@ -447,77 +453,80 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
                 pipe.zadd(jkey, {encoded: group_index}).zcount(jkey, "-inf", "+inf")
                 if self._chord_zset
                 else pipe.rpush(jkey, encoded).llen(jkey)
-            ).get(tkey)
+            ).get(tkey).get(skey)
             if self.expires:
                 pipeline = pipeline \
                     .expire(jkey, self.expires) \
-                    .expire(tkey, self.expires)
+                    .expire(tkey, self.expires) \
+                    .expire(skey, self.expires)
 
-            _, readycount, totaldiff = pipeline.execute()[:3]
+            _, readycount, totaldiff, chord_size_bytes = pipeline.execute()[:4]
 
         totaldiff = int(totaldiff or 0)
 
-        try:
-            callback = maybe_signature(request.chord, app=app)
-            total = callback['chord_size'] + totaldiff
-            if readycount == total:
-                header_result = GroupResult.restore(gid)
-                if header_result is not None:
-                    # If we manage to restore a `GroupResult`, then it must
-                    # have been complex and saved by `apply_chord()` earlier.
-                    #
-                    # Before we can join the `GroupResult`, it needs to be
-                    # manually marked as ready to avoid blocking
-                    header_result.on_ready()
-                    # We'll `join()` it to get the results and ensure they are
-                    # structured as intended rather than the flattened version
-                    # we'd construct without any other information.
-                    join_func = (
-                        header_result.join_native
-                        if header_result.supports_native_join
-                        else header_result.join
-                    )
-                    with allow_join_result():
-                        resl = join_func(
-                            timeout=app.conf.result_chord_join_timeout,
-                            propagate=True
+        if chord_size_bytes:
+            try:
+                callback = maybe_signature(request.chord, app=app)
+                total = int(chord_size_bytes) + totaldiff
+                if readycount == total:
+                    header_result = GroupResult.restore(gid)
+                    if header_result is not None:
+                        # If we manage to restore a `GroupResult`, then it must
+                        # have been complex and saved by `apply_chord()` earlier.
+                        #
+                        # Before we can join the `GroupResult`, it needs to be
+                        # manually marked as ready to avoid blocking
+                        header_result.on_ready()
+                        # We'll `join()` it to get the results and ensure they are
+                        # structured as intended rather than the flattened version
+                        # we'd construct without any other information.
+                        join_func = (
+                            header_result.join_native
+                            if header_result.supports_native_join
+                            else header_result.join
                         )
-                else:
-                    # Otherwise simply extract and decode the results we
-                    # stashed along the way, which should be faster for large
-                    # numbers of simple results in the chord header.
-                    decode, unpack = self.decode, self._unpack_chord_result
-                    with client.pipeline() as pipe:
-                        if self._chord_zset:
-                            pipeline = pipe.zrange(jkey, 0, -1)
-                        else:
-                            pipeline = pipe.lrange(jkey, 0, total)
-                        resl, = pipeline.execute()
-                    resl = [unpack(tup, decode) for tup in resl]
-                try:
-                    callback.delay(resl)
-                except Exception as exc:  # pylint: disable=broad-except
-                    logger.exception(
-                        'Chord callback for %r raised: %r', request.group, exc)
-                    return self.chord_error_from_stack(
-                        callback,
-                        ChordError(f'Callback error: {exc!r}'),
-                    )
-                finally:
-                    with client.pipeline() as pipe:
-                        _, _ = pipe \
-                            .delete(jkey) \
-                            .delete(tkey) \
-                            .execute()
-        except ChordError as exc:
-            logger.exception('Chord %r raised: %r', request.group, exc)
-            return self.chord_error_from_stack(callback, exc)
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.exception('Chord %r raised: %r', request.group, exc)
-            return self.chord_error_from_stack(
-                callback,
-                ChordError(f'Join error: {exc!r}'),
-            )
+                        with allow_join_result():
+                            resl = join_func(
+                                timeout=app.conf.result_chord_join_timeout,
+                                propagate=True
+                            )
+                    else:
+                        # Otherwise simply extract and decode the results we
+                        # stashed along the way, which should be faster for large
+                        # numbers of simple results in the chord header.
+                        decode, unpack = self.decode, self._unpack_chord_result
+                        with client.pipeline() as pipe:
+                            if self._chord_zset:
+                                pipeline = pipe.zrange(jkey, 0, -1)
+                            else:
+                                pipeline = pipe.lrange(jkey, 0, total)
+                            resl, = pipeline.execute()
+                        resl = [unpack(tup, decode) for tup in resl]
+                    try:
+                        callback.delay(resl)
+                    except Exception as exc:  # pylint: disable=broad-except
+                        logger.exception(
+                            'Chord callback for %r raised: %r', request.group, exc)
+                        return self.chord_error_from_stack(
+                            callback,
+                            ChordError(f'Callback error: {exc!r}'),
+                        )
+                    finally:
+                        with client.pipeline() as pipe:
+                            pipe \
+                                .delete(jkey) \
+                                .delete(tkey) \
+                                .delete(skey) \
+                                .execute()
+            except ChordError as exc:
+                logger.exception('Chord %r raised: %r', request.group, exc)
+                return self.chord_error_from_stack(callback, exc)
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.exception('Chord %r raised: %r', request.group, exc)
+                return self.chord_error_from_stack(
+                    callback,
+                    ChordError(f'Join error: {exc!r}'),
+                )
 
     def _create_client(self, **params):
         return self._get_client()(

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -370,7 +370,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         return tts
 
     def set(self, key, value, **retry_policy):
-        if len(value) > self._MAX_STR_VALUE_SIZE:
+        if isinstance(value, str) and len(value) > self._MAX_STR_VALUE_SIZE:
             raise BackendStoreError('value too large for Redis backend')
 
         return self.ensure(self._set, (key, value), **retry_policy)

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -15,7 +15,7 @@ from celery.canvas import maybe_signature
 from celery.exceptions import (BackendStoreError, ChordError,
                                ImproperlyConfigured)
 from celery.result import GroupResult, allow_join_result
-from celery.utils.functional import dictfilter, _regen
+from celery.utils.functional import _regen, dictfilter
 from celery.utils.log import get_logger
 from celery.utils.time import humanize_seconds
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1172,13 +1172,13 @@ class group(Signature):
                 sig, res, group_id = current_task
                 _chord = sig.options.get("chord") or chord
                 if _chord is not None and next_task is None:
-                    chord_length = task_index + 1
+                    chord_size = task_index + 1
                     if isinstance(sig, _chain):
                         if sig.tasks[-1].subtask_type == 'chord':
-                            chord_length = sig.tasks[-1].__length_hint__()
+                            chord_size = sig.tasks[-1].__length_hint__()
                         else:
-                            chord_length = task_index + len(sig.tasks[-1])
-                    app.backend.set_chord_size(group_id, chord_length)
+                            chord_size = task_index + len(sig.tasks[-1])
+                    app.backend.set_chord_size(group_id, chord_size)
                 sig.apply_async(producer=producer, add_to_parent=False,
                                 chord=_chord, args=args, kwargs=kwargs,
                                 **options)

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from functools import partial as _partial
 from functools import reduce
 from operator import itemgetter
+from types import GeneratorType
 
 from kombu.utils.functional import fxrange, reprcall
 from kombu.utils.objects import cached_property
@@ -25,7 +26,7 @@ from celery.utils import abstract
 from celery.utils.collections import ChainMap
 from celery.utils.functional import _regen
 from celery.utils.functional import chunks as _chunks
-from celery.utils.functional import (is_list, maybe_list, regen,
+from celery.utils.functional import (is_list, maybe_list, lookahead, regen,
                                      seq_concat_item, seq_concat_seq)
 from celery.utils.objects import getitem_property
 from celery.utils.text import remove_repeating_from_task, truncate
@@ -54,12 +55,6 @@ def maybe_unroll_group(group):
 
 def task_name_from(task):
     return getattr(task, 'name', task)
-
-
-def _upgrade(fields, sig):
-    """Used by custom signatures in .from_dict, to keep common fields."""
-    sig.update(chord_size=fields.get('chord_size'))
-    return sig
 
 
 @abstract.CallableSignature.register
@@ -165,7 +160,6 @@ class Signature(dict):
                 options=dict(options or {}, **ex),
                 subtask_type=subtask_type,
                 immutable=immutable,
-                chord_size=None,
             )
 
     def __call__(self, *partial_args, **partial_kwargs):
@@ -265,7 +259,6 @@ class Signature(dict):
                                          'kwargs': kwargs,
                                          'options': deepcopy(opts),
                                          'subtask_type': self.subtask_type,
-                                         'chord_size': self.chord_size,
                                          'immutable': self.immutable},
                                         app=self._app)
         signature._type = self._type
@@ -530,8 +523,6 @@ class Signature(dict):
     kwargs = getitem_property('kwargs', 'Keyword arguments to task.')
     options = getitem_property('options', 'Task execution options.')
     subtask_type = getitem_property('subtask_type', 'Type of signature')
-    chord_size = getitem_property(
-        'chord_size', 'Size of chord (if applicable)')
     immutable = getitem_property(
         'immutable', 'Flag set if no longer accepts new arguments')
 
@@ -604,7 +595,7 @@ class _chain(Signature):
             if isinstance(tasks, tuple):  # aaaargh
                 tasks = d['kwargs']['tasks'] = list(tasks)
             tasks = [maybe_signature(task, app=app) for task in tasks]
-        return _upgrade(d, _chain(tasks, app=app, **d['options']))
+        return _chain(tasks, app=app, **d['options'])
 
     def __init__(self, *tasks, **options):
         tasks = (regen(tasks[0]) if len(tasks) == 1 and is_list(tasks[0])
@@ -908,9 +899,7 @@ class _basemap(Signature):
 
     @classmethod
     def from_dict(cls, d, app=None):
-        return _upgrade(
-            d, cls(*cls._unpack_args(d['kwargs']), app=app, **d['options']),
-        )
+        return cls(*cls._unpack_args(d['kwargs']), app=app, **d['options'])
 
     def __init__(self, task, it, **options):
         Signature.__init__(
@@ -964,10 +953,7 @@ class chunks(Signature):
 
     @classmethod
     def from_dict(cls, d, app=None):
-        return _upgrade(
-            d, chunks(*cls._unpack_args(
-                d['kwargs']), app=app, **d['options']),
-        )
+        return chunks(*cls._unpack_args(d['kwargs']), app=app, **d['options'])
 
     def __init__(self, task, it, n, **options):
         Signature.__init__(
@@ -1008,7 +994,10 @@ def _maybe_group(tasks, app):
     elif isinstance(tasks, abstract.CallableSignature):
         tasks = [tasks]
     else:
-        tasks = [signature(t, app=app) for t in tasks]
+        if isinstance(tasks, GeneratorType):
+            tasks = regen(signature(t, app=app) for t in tasks)
+        else:
+            tasks = [signature(t, app=app) for t in tasks]
     return tasks
 
 
@@ -1055,9 +1044,7 @@ class group(Signature):
         d["kwargs"]["tasks"] = rebuilt_tasks = type(orig_tasks)((
             maybe_signature(task, app=app) for task in orig_tasks
         ))
-        return _upgrade(
-            d, group(rebuilt_tasks, app=app, **d['options']),
-        )
+        return group(rebuilt_tasks, app=app, **d['options'])
 
     def __init__(self, *tasks, **options):
         if len(tasks) == 1:
@@ -1127,7 +1114,7 @@ class group(Signature):
         options, group_id, root_id = self._freeze_gid(options)
         tasks = self._prepared(self.tasks, [], group_id, root_id, app)
         return app.GroupResult(group_id, [
-            sig.apply(args=args, kwargs=kwargs, **options) for sig, _ in tasks
+            sig.apply(args=args, kwargs=kwargs, **options) for sig, _, _ in tasks
         ])
 
     def set_immutable(self, immutable):
@@ -1170,7 +1157,7 @@ class group(Signature):
             else:
                 if partial_args and not task.immutable:
                     task.args = tuple(partial_args) + tuple(task.args)
-                yield task, task.freeze(group_id=group_id, root_id=root_id)
+                yield task, task.freeze(group_id=group_id, root_id=root_id), group_id
 
     def _apply_tasks(self, tasks, producer=None, app=None, p=None,
                      add_to_parent=None, chord=None,
@@ -1179,12 +1166,22 @@ class group(Signature):
         #   XXX chord is also a class in outer scope.
         app = app or self.app
         with app.producer_or_acquire(producer) as producer:
-            for sig, res in tasks:
+            for task_index, (current_task, next_task) in enumerate(
+                lookahead(tasks)
+            ):
+                sig, res, group_id = current_task
+                _chord = sig.options.get("chord") or chord
+                if _chord is not None and next_task is None:
+                    chord_length = task_index + 1
+                    if isinstance(sig, _chain):
+                        if sig.tasks[-1].subtask_type == 'chord':
+                            chord_length = sig.tasks[-1].__length_hint__()
+                        else:
+                            chord_length = task_index + len(sig.tasks[-1])
+                    app.backend.set_chord_size(group_id, chord_length)
                 sig.apply_async(producer=producer, add_to_parent=False,
-                                chord=sig.options.get('chord') or chord,
-                                args=args, kwargs=kwargs,
+                                chord=_chord, args=args, kwargs=kwargs,
                                 **options)
-
                 # adding callback to result, such that it will gradually
                 # fulfill the barrier.
                 #
@@ -1204,10 +1201,10 @@ class group(Signature):
             options.pop('task_id', uuid()))
         return options, group_id, options.get('root_id')
 
-    def freeze(self, _id=None, group_id=None, chord=None,
-               root_id=None, parent_id=None, group_index=None):
+    def _freeze_group_tasks(self, _id=None, group_id=None, chord=None,
+                            root_id=None, parent_id=None, group_index=None):
         # pylint: disable=redefined-outer-name
-        #   XXX chord is also a class in outer scope.
+        #  XXX chord is also a class in outer scope.
         opts = self.options
         try:
             gid = opts['task_id']
@@ -1221,19 +1218,44 @@ class group(Signature):
             opts['group_index'] = group_index
         root_id = opts.setdefault('root_id', root_id)
         parent_id = opts.setdefault('parent_id', parent_id)
-        new_tasks = []
-        # Need to unroll subgroups early so that chord gets the
-        # right result instance for chord_unlock etc.
-        results = list(self._freeze_unroll(
-            new_tasks, group_id, chord, root_id, parent_id,
-        ))
-        if isinstance(self.tasks, MutableSequence):
-            self.tasks[:] = new_tasks
+        if isinstance(self.tasks, _regen):
+            tasks1, tasks2 = itertools.tee(self._unroll_tasks(self.tasks))
+            results = regen(self._freeze_tasks(tasks1, group_id, chord, root_id, parent_id))
+            self.tasks = regen(x[0] for x in zip(tasks2, results))
         else:
-            self.tasks = new_tasks
-        return self.app.GroupResult(gid, results)
+            new_tasks = []
+            # Need to unroll subgroups early so that chord gets the
+            # right result instance for chord_unlock etc.
+            results = list(self._freeze_unroll(
+                new_tasks, group_id, chord, root_id, parent_id,
+            ))
+            if isinstance(self.tasks, MutableSequence):
+                self.tasks[:] = new_tasks
+            else:
+                self.tasks = new_tasks
+        return gid, results
+
+    def freeze(self, _id=None, group_id=None, chord=None,
+               root_id=None, parent_id=None, group_index=None):
+        return self.app.GroupResult(*self._freeze_group_tasks(_id=_id, group_id=group_id,
+                                    chord=chord, root_id=root_id, parent_id=parent_id, group_index=group_index))
 
     _freeze = freeze
+
+    def _freeze_tasks(self, tasks, group_id, chord, root_id, parent_id):
+        group_index = 0
+        for task in tasks:
+            yield task.freeze(group_id=group_id,
+                              chord=chord,
+                              root_id=root_id,
+                              parent_id=parent_id,
+                              group_index=group_index)
+            group_index += 1
+
+    def _unroll_tasks(self, tasks):
+        for task in tasks:
+            task = maybe_signature(task, app=self._app).clone()
+            yield task
 
     def _freeze_unroll(self, new_tasks, group_id, chord, root_id, parent_id):
         # pylint: disable=redefined-outer-name
@@ -1305,7 +1327,7 @@ class chord(Signature):
     def from_dict(cls, d, app=None):
         options = d.copy()
         args, options['kwargs'] = cls._unpack_args(**options['kwargs'])
-        return _upgrade(d, cls(*args, app=app, **options))
+        return cls(*args, app=app, **options)
 
     @staticmethod
     def _unpack_args(header=None, body=None, **kwargs):
@@ -1422,7 +1444,6 @@ class chord(Signature):
         app = app or self._get_app(body)
         group_id = header.options.get('task_id') or uuid()
         root_id = body.options.get('root_id')
-        body.chord_size = self.__length_hint__()
         options = dict(self.options, **options) if options else self.options
         if options:
             options.pop('task_id', None)
@@ -1436,11 +1457,11 @@ class chord(Signature):
         options.pop('chord', None)
         options.pop('task_id', None)
 
-        header_result = header.freeze(group_id=group_id, chord=body, root_id=root_id)
+        header_result_args = header._freeze_group_tasks(group_id=group_id, chord=body, root_id=root_id)
 
-        if len(header_result) > 0:
+        if header.tasks:
             app.backend.apply_chord(
-                header_result,
+                header_result_args,
                 body,
                 interval=interval,
                 countdown=countdown,
@@ -1452,6 +1473,7 @@ class chord(Signature):
         # we execute the body manually here.
         else:
             body.delay([])
+            header_result = self.app.GroupResult(*header_result_args)
 
         bodyres.parent = header_result
         return bodyres
@@ -1504,7 +1526,7 @@ class chord(Signature):
                 tasks = self.tasks.tasks  # is a group
             except AttributeError:
                 tasks = self.tasks
-            if len(tasks):
+            if tasks:
                 app = tasks[0]._app
             if app is None and body is not None:
                 app = body._app

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1243,14 +1243,12 @@ class group(Signature):
     _freeze = freeze
 
     def _freeze_tasks(self, tasks, group_id, chord, root_id, parent_id):
-        group_index = 0
-        for task in tasks:
+        for group_index, task in enumerate(tasks):
             yield task.freeze(group_id=group_id,
                               chord=chord,
                               root_id=root_id,
                               parent_id=parent_id,
                               group_index=group_index)
-            group_index += 1
 
     def _unroll_tasks(self, tasks):
         for task in tasks:

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -26,7 +26,7 @@ from celery.utils import abstract
 from celery.utils.collections import ChainMap
 from celery.utils.functional import _regen
 from celery.utils.functional import chunks as _chunks
-from celery.utils.functional import (is_list, maybe_list, lookahead, regen,
+from celery.utils.functional import (is_list, lookahead, maybe_list, regen,
                                      seq_concat_item, seq_concat_seq)
 from celery.utils.objects import getitem_property
 from celery.utils.text import remove_repeating_from_task, truncate
@@ -1238,20 +1238,20 @@ class group(Signature):
     def freeze(self, _id=None, group_id=None, chord=None,
                root_id=None, parent_id=None, group_index=None):
         return self.app.GroupResult(*self._freeze_group_tasks(_id=_id, group_id=group_id,
-                                    chord=chord, root_id=root_id, parent_id=parent_id, group_index=group_index))
+                                                              chord=chord, root_id=root_id, parent_id=parent_id, group_index=group_index))
 
     _freeze = freeze
 
     def _freeze_tasks(self, tasks, group_id, chord, root_id, parent_id):
-            yield from (task.freeze(group_id=group_id,
-                              chord=chord,
-                              root_id=root_id,
-                              parent_id=parent_id,
-                              group_index=group_index)
-                              for group_index, task in enumerate(tasks))
+        yield from (task.freeze(group_id=group_id,
+                                chord=chord,
+                                root_id=root_id,
+                                parent_id=parent_id,
+                                group_index=group_index)
+                    for group_index, task in enumerate(tasks))
 
     def _unroll_tasks(self, tasks):
-       yield from (maybe_signature(task, app=self._app).clone() for task in tasks)
+        yield from (maybe_signature(task, app=self._app).clone() for task in tasks)
 
     def _freeze_unroll(self, new_tasks, group_id, chord, root_id, parent_id):
         # pylint: disable=redefined-outer-name

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1243,12 +1243,12 @@ class group(Signature):
     _freeze = freeze
 
     def _freeze_tasks(self, tasks, group_id, chord, root_id, parent_id):
-        for group_index, task in enumerate(tasks):
-            yield task.freeze(group_id=group_id,
+            yield from (task.freeze(group_id=group_id,
                               chord=chord,
                               root_id=root_id,
                               parent_id=parent_id,
                               group_index=group_index)
+                              for group_index, task in enumerate(tasks))
 
     def _unroll_tasks(self, tasks):
         for task in tasks:

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1251,9 +1251,7 @@ class group(Signature):
                               for group_index, task in enumerate(tasks))
 
     def _unroll_tasks(self, tasks):
-        for task in tasks:
-            task = maybe_signature(task, app=self._app).clone()
-            yield task
+       yield from (maybe_signature(task, app=self._app).clone() for task in tasks)
 
     def _freeze_unroll(self, new_tasks, group_id, chord, root_id, parent_id):
         # pylint: disable=redefined-outer-name

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -3,7 +3,7 @@ import inspect
 import sys
 from collections import UserList
 from functools import partial
-from itertools import islice
+from itertools import islice, tee, zip_longest
 
 from kombu.utils.functional import (LRUCache, dictfilter, is_list, lazy,
                                     maybe_evaluate, maybe_list, memoize)
@@ -158,6 +158,19 @@ def uniq(it):
     """Return all unique elements in ``it``, preserving order."""
     seen = set()
     return (seen.add(obj) or obj for obj in it if obj not in seen)
+
+
+def lookahead(it):
+    """Yield pairs of (current, next) items in `it`.
+
+    `next` is None if `current` is the last item.
+    Example:
+        >>> list(lookahead(x for x in range(6)))
+        [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, None)]
+    """
+    a, b = tee(it)
+    next(b, None)
+    return zip_longest(a, b)
 
 
 def regen(it):

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -24,6 +24,14 @@ def add(x, y, z=None):
         return x + y
 
 
+@shared_task
+def write_to_file_and_return_int(file_name, i):
+    with open(file_name, mode='a', buffering=1) as file_handle:
+        file_handle.write(str(i)+'\n')
+
+    return i
+
+
 @shared_task(typing=False)
 def add_not_typed(x, y):
     """Add two numbers, but don't check arguments"""

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -19,7 +19,8 @@ from .tasks import (ExpectedException, add, add_chord_to_chord, add_replaced,
                     print_unicode, raise_error, redis_echo,
                     replace_with_chain, replace_with_chain_which_raises,
                     replace_with_empty_chain, retry_once, return_exception,
-                    return_priority, second_order_replace1, tsum, write_to_file_and_return_int)
+                    return_priority, second_order_replace1, tsum,
+                    write_to_file_and_return_int)
 
 RETRYABLE_EXCEPTIONS = (OSError, ConnectionError, TimeoutError)
 

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1,4 +1,5 @@
 import re
+import tempfile
 from datetime import datetime, timedelta
 from time import sleep
 
@@ -18,7 +19,7 @@ from .tasks import (ExpectedException, add, add_chord_to_chord, add_replaced,
                     print_unicode, raise_error, redis_echo,
                     replace_with_chain, replace_with_chain_which_raises,
                     replace_with_empty_chain, retry_once, return_exception,
-                    return_priority, second_order_replace1, tsum)
+                    return_priority, second_order_replace1, tsum, write_to_file_and_return_int)
 
 RETRYABLE_EXCEPTIONS = (OSError, ConnectionError, TimeoutError)
 
@@ -1067,6 +1068,22 @@ class test_chord:
 
         assert len([cr for cr in chord_results if cr[2] != states.SUCCESS]
                    ) == 1
+
+    @flaky
+    def test_generator(self, manager):
+        def assert_generator(file_name):
+            for i in range(3):
+                sleep(1)
+                if i == 2:
+                    with open(file_name) as file_handle:
+                        # ensures chord header generators tasks are processed incrementally #3021
+                        assert file_handle.readline() == '0\n', "Chord header was unrolled too early"
+                yield write_to_file_and_return_int.s(file_name, i)
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
+            file_name = tmp_file.name
+            c = chord(assert_generator(file_name), tsum.s())
+            assert c().get(timeout=TIMEOUT) == 3
 
     @flaky
     def test_parallel_chords(self, manager):

--- a/t/unit/backends/test_cache.py
+++ b/t/unit/backends/test_cache.py
@@ -71,12 +71,12 @@ class test_CacheBackend:
 
     def test_apply_chord(self):
         tb = CacheBackend(backend='memory://', app=self.app)
-        result = self.app.GroupResult(
+        result_args = (
             uuid(),
             [self.app.AsyncResult(uuid()) for _ in range(3)],
         )
-        tb.apply_chord(result, None)
-        assert self.app.GroupResult.restore(result.id, backend=tb) == result
+        tb.apply_chord(result_args, None)
+        assert self.app.GroupResult.restore(result_args[0], backend=tb) == self.app.GroupResult(*result_args)
 
     @patch('celery.result.GroupResult.restore')
     def test_on_chord_part_return(self, restore):
@@ -91,12 +91,12 @@ class test_CacheBackend:
         self.app.tasks['foobarbaz'] = task
         task.request.chord = signature(task)
 
-        result = self.app.GroupResult(
+        result_args = (
             uuid(),
             [self.app.AsyncResult(uuid()) for _ in range(3)],
         )
-        task.request.group = result.id
-        tb.apply_chord(result, None)
+        task.request.group = result_args[0]
+        tb.apply_chord(result_args, None)
 
         deps.join_native.assert_not_called()
         tb.on_chord_part_return(task.request, 'SUCCESS', 10)

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -11,10 +11,10 @@ import pytest
 from case import ContextMock, mock
 
 from celery import signature, states, uuid
-from celery.result import AsyncResult, GroupResult
 from celery.canvas import Signature
 from celery.exceptions import (BackendStoreError, ChordError,
                                ImproperlyConfigured)
+from celery.result import AsyncResult, GroupResult
 from celery.utils.collections import AttributeDict
 
 
@@ -1007,7 +1007,7 @@ class test_RedisBackend_chords_complex(basetest_RedisBackend):
                 AsyncResult("foo"), GroupResult("foo"),
             )), 42,
         ), True),
-        ])
+    ])
     def test_apply_chord_complex_header(self, results, assert_save_called):
         mock_group_result = Mock()
         mock_group_result.return_value.results = results

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -11,6 +11,7 @@ import pytest
 from case import ContextMock, mock
 
 from celery import signature, states, uuid
+from celery.result import AsyncResult, GroupResult
 from celery.canvas import Signature
 from celery.exceptions import (BackendStoreError, ChordError,
                                ImproperlyConfigured)
@@ -296,7 +297,7 @@ class basetest_RedisBackend:
         self.app.tasks['foobarbaz'] = task
         task.request.chord = signature(task)
         task.request.id = tid
-        task.request.chord['chord_size'] = 10
+        self.b.set_chord_size(group_id, 10)
         task.request.group = group_id
         task.request.group_index = i
         return task
@@ -306,7 +307,8 @@ class basetest_RedisBackend:
         with patch('celery.backends.redis.maybe_signature') as ms:
             request = Mock(name='request')
             request.id = 'id1'
-            request.group = 'gid1'
+            group_id = 'gid1'
+            request.group = group_id
             request.group_index = None
             tasks = [
                 self.create_task(i, group_id=request.group)
@@ -314,7 +316,7 @@ class basetest_RedisBackend:
             ]
             callback = ms.return_value = Signature('add')
             callback.id = 'id1'
-            callback['chord_size'] = size
+            self.b.set_chord_size(group_id, size)
             callback.delay = Mock(name='callback.delay')
             yield tasks, request, callback
 
@@ -591,11 +593,11 @@ class test_RedisBackend(basetest_RedisBackend):
 
     def test_apply_chord(self, unlock='celery.chord_unlock'):
         self.app.tasks[unlock] = Mock()
-        header_result = self.app.GroupResult(
+        header_result_args = (
             uuid(),
             [self.app.AsyncResult(x) for x in range(3)],
         )
-        self.b.apply_chord(header_result, None)
+        self.b.apply_chord(header_result_args, None)
         assert self.app.tasks[unlock].apply_async.call_count == 0
 
     def test_unpack_chord_result(self):
@@ -639,6 +641,12 @@ class test_RedisBackend(basetest_RedisBackend):
         gid = uuid()
         b.add_to_chord(gid, 'sig')
         b.client.incr.assert_called_with(b.get_key_for_group(gid, '.t'), 1)
+
+    def test_set_chord_size(self):
+        b = self.Backend('redis://', app=self.app)
+        gid = uuid()
+        b.set_chord_size(gid, 10)
+        b.client.set.assert_called_with(b.get_key_for_group(gid, '.s'), 10)
 
     def test_expires_is_None(self):
         b = self.Backend(expires=None, app=self.app)
@@ -700,9 +708,10 @@ class test_RedisBackend_chords_simple(basetest_RedisBackend):
         assert self.b.client.zrangebyscore.call_count
         jkey = self.b.get_key_for_group('group_id', '.j')
         tkey = self.b.get_key_for_group('group_id', '.t')
-        self.b.client.delete.assert_has_calls([call(jkey), call(tkey)])
+        skey = self.b.get_key_for_group('group_id', '.s')
+        self.b.client.delete.assert_has_calls([call(jkey), call(tkey), call(skey)])
         self.b.client.expire.assert_has_calls([
-            call(jkey, 86400), call(tkey, 86400),
+            call(jkey, 86400), call(tkey, 86400), call(skey, 86400),
         ])
 
     def test_on_chord_part_return__unordered(self):
@@ -749,6 +758,7 @@ class test_RedisBackend_chords_simple(basetest_RedisBackend):
         old_expires = self.b.expires
         self.b.expires = None
         tasks = [self.create_task(i) for i in range(10)]
+        self.b.set_chord_size('group_id', 10)
 
         for i in range(10):
             self.b.on_chord_part_return(tasks[i].request, states.SUCCESS, i)
@@ -889,8 +899,8 @@ class test_RedisBackend_chords_simple(basetest_RedisBackend):
         with self.chord_context(1) as (_, request, callback):
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, ChordError())
-            self.b.client.pipeline.return_value.zadd().zcount().get().expire(
-            ).expire().execute.return_value = (1, 1, 0, 4, 5)
+            self.b.client.pipeline.return_value.zadd().zcount().get().get().expire(
+            ).expire().expire().execute.return_value = (1, 1, 0, b'1', 4, 5, 6)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
             task.backend.fail_from_current_stack.assert_called_with(
@@ -905,8 +915,8 @@ class test_RedisBackend_chords_simple(basetest_RedisBackend):
         with self.chord_context(1) as (_, request, callback):
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, ChordError())
-            self.b.client.pipeline.return_value.rpush().llen().get().expire(
-            ).expire().execute.return_value = (1, 1, 0, 4, 5)
+            self.b.client.pipeline.return_value.rpush().llen().get().get().expire(
+            ).expire().expire().execute.return_value = (1, 1, 0, b'1', 4, 5, 6)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
             task.backend.fail_from_current_stack.assert_called_with(
@@ -921,8 +931,8 @@ class test_RedisBackend_chords_simple(basetest_RedisBackend):
         with self.chord_context(1) as (_, request, callback):
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, ChordError())
-            self.b.client.pipeline.return_value.zadd().zcount().get().expire(
-            ).expire().execute.return_value = (1, 1, 0, 4, 5)
+            self.b.client.pipeline.return_value.zadd().zcount().get().get().expire(
+            ).expire().expire().execute.return_value = (1, 1, 0, b'1', 4, 5, 6)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
             task.backend.fail_from_current_stack.assert_called_with(
@@ -933,8 +943,8 @@ class test_RedisBackend_chords_simple(basetest_RedisBackend):
         with self.chord_context(1) as (_, request, callback):
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, RuntimeError())
-            self.b.client.pipeline.return_value.zadd().zcount().get().expire(
-            ).expire().execute.return_value = (1, 1, 0, 4, 5)
+            self.b.client.pipeline.return_value.zadd().zcount().get().get().expire(
+            ).expire().expire().execute.return_value = (1, 1, 0, b'1', 4, 5, 6)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
             task.backend.fail_from_current_stack.assert_called_with(
@@ -949,8 +959,8 @@ class test_RedisBackend_chords_simple(basetest_RedisBackend):
         with self.chord_context(1) as (_, request, callback):
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, RuntimeError())
-            self.b.client.pipeline.return_value.rpush().llen().get().expire(
-            ).expire().execute.return_value = (1, 1, 0, 4, 5)
+            self.b.client.pipeline.return_value.rpush().llen().get().get().expire(
+            ).expire().expire().execute.return_value = (1, 1, 0, b'1', 4, 5, 6)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
             task.backend.fail_from_current_stack.assert_called_with(
@@ -965,8 +975,8 @@ class test_RedisBackend_chords_simple(basetest_RedisBackend):
         with self.chord_context(1) as (_, request, callback):
             self.b.client.pipeline = ContextMock()
             raise_on_second_call(self.b.client.pipeline, RuntimeError())
-            self.b.client.pipeline.return_value.zadd().zcount().get().expire(
-            ).expire().execute.return_value = (1, 1, 0, 4, 5)
+            self.b.client.pipeline.return_value.zadd().zcount().get().get().expire(
+            ).expire().expire().execute.return_value = (1, 1, 0, b'1', 4, 5, 6)
             task = self.app._tasks['add'] = Mock(name='add_task')
             self.b.on_chord_part_return(request, states.SUCCESS, 10)
             task.backend.fail_from_current_stack.assert_called_with(
@@ -980,42 +990,34 @@ class test_RedisBackend_chords_complex(basetest_RedisBackend):
         with patch("celery.result.GroupResult.restore") as p:
             yield p
 
-    def test_apply_chord_complex_header(self):
-        mock_header_result = Mock()
+    @pytest.mark.parametrize(['results', 'assert_save_called'], [
         # No results in the header at all - won't call `save()`
-        mock_header_result.results = tuple()
-        self.b.apply_chord(mock_header_result, None)
-        mock_header_result.save.assert_not_called()
-        mock_header_result.save.reset_mock()
-        # A single simple result in the header - won't call `save()`
-        mock_header_result.results = (self.app.AsyncResult("foo"), )
-        self.b.apply_chord(mock_header_result, None)
-        mock_header_result.save.assert_not_called()
-        mock_header_result.save.reset_mock()
+        (tuple(), False),
+        # Simple results in the header - won't call `save()`
+        ((AsyncResult("foo"), ), False),
         # Many simple results in the header - won't call `save()`
-        mock_header_result.results = (self.app.AsyncResult("foo"), ) * 42
-        self.b.apply_chord(mock_header_result, None)
-        mock_header_result.save.assert_not_called()
-        mock_header_result.save.reset_mock()
+        ((AsyncResult("foo"), ) * 42, False),
         # A single complex result in the header - will call `save()`
-        mock_header_result.results = (self.app.GroupResult("foo"), )
-        self.b.apply_chord(mock_header_result, None)
-        mock_header_result.save.assert_called_once_with(backend=self.b)
-        mock_header_result.save.reset_mock()
+        ((GroupResult("foo", []),), True),
         # Many complex results in the header - will call `save()`
-        mock_header_result.results = (self.app.GroupResult("foo"), ) * 42
-        self.b.apply_chord(mock_header_result, None)
-        mock_header_result.save.assert_called_once_with(backend=self.b)
-        mock_header_result.save.reset_mock()
+        ((GroupResult("foo"), ) * 42, True),
         # Mixed simple and complex results in the header - will call `save()`
-        mock_header_result.results = itertools.islice(
+        (itertools.islice(
             itertools.cycle((
-                self.app.AsyncResult("foo"), self.app.GroupResult("foo"),
+                AsyncResult("foo"), GroupResult("foo"),
             )), 42,
-        )
-        self.b.apply_chord(mock_header_result, None)
-        mock_header_result.save.assert_called_once_with(backend=self.b)
-        mock_header_result.save.reset_mock()
+        ), True),
+        ])
+    def test_apply_chord_complex_header(self, results, assert_save_called):
+        mock_group_result = Mock()
+        mock_group_result.return_value.results = results
+        self.app.GroupResult = mock_group_result
+        header_result_args = ("gid11", results)
+        self.b.apply_chord(header_result_args, None)
+        if assert_save_called:
+            mock_group_result.return_value.save.assert_called_once_with(backend=self.b)
+        else:
+            mock_group_result.return_value.save.assert_not_called()
 
     def test_on_chord_part_return_timeout(self, complex_header_result):
         tasks = [self.create_task(i) for i in range(10)]

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -785,6 +785,17 @@ class test_group(CanvasCase):
 
 class test_chord(CanvasCase):
 
+    def test__get_app_does_not_exhaust_generator(self):
+        def build_generator():
+            yield self.add.s(1, 1)
+            self.second_item_returned = True
+            yield self.add.s(2, 2)
+
+        self.second_item_returned = False
+        c = chord(build_generator(), self.add.s(3))
+        c.app
+        assert not self.second_item_returned
+
     def test_reverse(self):
         x = chord([self.add.s(2, 2), self.add.s(4, 4)], body=self.mul.s(4))
         assert isinstance(signature(x), chord)

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -342,3 +342,13 @@ class test_Chord_task(ChordCase):
         Chord(group(self.add.signature((i, i)) for i in range(5)), body)
         Chord([self.add.signature((j, j)) for j in range(5)], body)
         assert self.app.backend.apply_chord.call_count == 2
+
+    @patch('celery.Celery.backend', new=PropertyMock(name='backend'))
+    def test_run__chord_size_set(self):
+        Chord = self.app.tasks['celery.chord']
+        body = self.add.signature()
+        group_size = 4
+        group1 = group(self.add.signature((i, i)) for i in range(group_size))
+        result = Chord(group1, body)
+
+        self.app.backend.set_chord_size.assert_called_once_with(result.parent.id, group_size)

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -140,14 +140,12 @@ class test_regen:
     def test_nonzero__does_not_consume_more_than_first_item(self):
         def build_generator():
             yield 1
-            self.consumed_second_item = True
+            pytest.fail("generator should not consume past first item")
             yield 2
 
-        self.consumed_second_item = False
         g = regen(build_generator())
         assert bool(g)
         assert g[0] == 1
-        assert not self.consumed_second_item
 
     def test_nonzero__empty_iter(self):
         assert not regen(iter([]))

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -3,8 +3,8 @@ from kombu.utils.functional import lazy
 
 from celery.utils.functional import (DummyContext, first, firstmethod,
                                      fun_accepts_kwargs, fun_takes_argument,
-                                     head_from_fun, maybe_list, mlazy,
-                                     padlist, regen, seq_concat_item,
+                                     head_from_fun, lookahead, maybe_list,
+                                     mlazy, padlist, regen, seq_concat_item,
                                      seq_concat_seq)
 
 
@@ -64,6 +64,10 @@ def test_first():
     iterations[0] = 0
     assert first(predicate, range(10, 20)) is None
     assert iterations[0] == 10
+
+
+def test_lookahead():
+    assert list(lookahead(x for x in range(6))) == [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, None)]
 
 
 def test_maybe_list():


### PR DESCRIPTION
Fixes #3021 . Previously, header tasks were not submitted to the broker for
execution until the entire generator was consumed.

Continuation of https://github.com/celery/celery/pull/6112 and much of this was originally pulled from https://github.com/celery/celery/pull/3043.

Update: this was split into 2 PRs per below review: https://github.com/celery/celery/pull/6589 should be merged first.  This has been rebased on top of that branch.