### PR TITLE
Fix hardcoded join timeout

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -928,7 +928,9 @@ class BaseKeyValueStoreBackend(Backend):
             j = deps.join_native if deps.supports_native_join else deps.join
             try:
                 with allow_join_result():
-                    ret = j(timeout=3.0, propagate=True)
+                    ret = j(
+                        timeout=app.conf.result_chord_join_timeout,
+                        propagate=True)
             except Exception as exc:  # pylint: disable=broad-except
                 try:
                     culprit = next(deps._failed_join_report())

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -469,7 +469,10 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
                         else header_result.join
                     )
                     with allow_join_result():
-                        resl = join_func(timeout=3.0, propagate=True)
+                        resl = join_func(
+                            timeout=app.conf.result_chord_join_timeout,
+                            propagate=True
+                        )
                 else:
                     # Otherwise simply extract and decode the results we
                     # stashed along the way, which should be faster for large

--- a/requirements/test-ci-default.txt
+++ b/requirements/test-ci-default.txt
@@ -12,7 +12,7 @@
 -r extras/thread.txt
 -r extras/elasticsearch.txt
 -r extras/couchdb.txt
-#-r extras/couchbase.txt
+-r extras/couchbase.txt
 -r extras/arangodb.txt
 -r extras/consul.txt
 -r extras/cosmosdbsql.txt

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -786,6 +786,18 @@ class test_KeyValueStoreBackend:
             callback.backend.fail_from_current_stack = Mock()
             yield task, deps, cb
 
+    def test_chord_part_return_timeout(self):
+        with self._chord_part_context(self.b) as (task, deps, _):
+            try:
+                self.app.conf.result_chord_join_timeout += 1.0
+                self.b.on_chord_part_return(task.request, 'SUCCESS', 10)
+            finally:
+                self.app.conf.result_chord_join_timeout -= 1.0
+
+            self.b.expire.assert_not_called()
+            deps.delete.assert_called_with()
+            deps.join_native.assert_called_with(propagate=True, timeout=4.0)
+
     def test_chord_part_return_propagate_set(self):
         with self._chord_part_context(self.b) as (task, deps, _):
             self.b.on_chord_part_return(task.request, 'SUCCESS', 10)

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -1012,6 +1012,21 @@ class test_RedisBackend_chords_complex(basetest_RedisBackend):
         mock_header_result.save.assert_called_once_with(backend=self.b)
         mock_header_result.save.reset_mock()
 
+    def test_on_chord_part_return_timeout(self, complex_header_result):
+        tasks = [self.create_task(i) for i in range(10)]
+        random.shuffle(tasks)
+        try:
+            self.app.conf.result_chord_join_timeout += 1.0
+            for task, result_val in zip(tasks, itertools.cycle((42, ))):
+                self.b.on_chord_part_return(
+                    task.request, states.SUCCESS, result_val,
+                )
+        finally:
+            self.app.conf.result_chord_join_timeout -= 1.0
+
+        join_func = complex_header_result.return_value.join_native
+        join_func.assert_called_once_with(timeout=4.0, propagate=True)
+
     @pytest.mark.parametrize("supports_native_join", (True, False))
     def test_on_chord_part_return(
         self, complex_header_result, supports_native_join,


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fixes #6577 

This PR replaces hardcoded `3.0` timeout with `result_chord_join_timeout` value in `on_chord_part_return` methods for base and redis result backends.