### PR TITLE
Upgrade AzureBlockBlob storage backend to use Azure blob storage library v12

### DIFF
--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -8,13 +8,11 @@ from celery.utils.log import get_logger
 from .base import KeyValueStoreBackend
 
 try:
-    from azure import storage as azurestorage
-    from azure.common import AzureMissingResourceHttpError
-    from azure.storage.blob import BlockBlobService
-    from azure.storage.common.retry import ExponentialRetry
-except ImportError:  # pragma: no cover
-    azurestorage = BlockBlobService = ExponentialRetry = \
-        AzureMissingResourceHttpError = None  # noqa
+    import azure.storage.blob as azurestorage
+    from azure.storage.blob import BlobServiceClient, BlobClient
+    from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
+except ImportError:
+    azurestorage = None
 
 __all__ = ("AzureBlockBlobBackend",)
 
@@ -27,17 +25,14 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
     def __init__(self,
                  url=None,
                  container_name=None,
-                 retry_initial_backoff_sec=None,
-                 retry_increment_base=None,
-                 retry_max_attempts=None,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
 
-        if azurestorage is None:
+        if azurestorage is None or azurestorage.__version__ < '12':
             raise ImproperlyConfigured(
-                "You need to install the azure-storage library to use the "
-                "AzureBlockBlob backend")
+                "You need to install the azure-storage-blob v12 library to"
+                "use the AzureBlockBlob backend")
 
         conf = self.app.conf
 
@@ -46,18 +41,6 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
         self._container_name = (
             container_name or
             conf["azureblockblob_container_name"])
-
-        self._retry_initial_backoff_sec = (
-            retry_initial_backoff_sec or
-            conf["azureblockblob_retry_initial_backoff_sec"])
-
-        self._retry_increment_base = (
-            retry_increment_base or
-            conf["azureblockblob_retry_increment_base"])
-
-        self._retry_max_attempts = (
-            retry_max_attempts or
-            conf["azureblockblob_retry_max_attempts"])
 
     @classmethod
     def _parse_url(cls, url, prefix="azureblockblob://"):
@@ -68,26 +51,22 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
         return connection_string
 
     @cached_property
-    def _client(self):
-        """Return the Azure Storage Block Blob service.
+    def _blob_service_client(self):
+        """Return the Azure Storage Blob service client.
 
         If this is the first call to the property, the client is created and
         the container is created if it doesn't yet exist.
 
         """
-        client = BlockBlobService(connection_string=self._connection_string)
+        client = BlobServiceClient.from_connection_string(self._connection_string)
 
-        created = client.create_container(
-            container_name=self._container_name, fail_on_exist=False)
-
-        if created:
-            LOGGER.info("Created Azure Blob Storage container %s",
-                        self._container_name)
-
-        client.retry = ExponentialRetry(
-            initial_backoff=self._retry_initial_backoff_sec,
-            increment_base=self._retry_increment_base,
-            max_attempts=self._retry_max_attempts).retry
+        try:
+            client.create_container(name=self._container_name)
+            msg = f"Container created with name {self._container_name}."
+        except ResourceExistsError:
+            msg = f"Container with name {self._container_name} already." \
+                "exists. This will not be created."
+        LOGGER.info(msg)
 
         return client
 
@@ -96,16 +75,19 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
 
         Args:
               key: The key for which to read the value.
-
         """
+
         key = bytes_to_str(key)
-        LOGGER.debug("Getting Azure Block Blob %s/%s",
-                     self._container_name, key)
+        LOGGER.debug("Getting Azure Block Blob %s/%s", self._container_name, key)
+
+        blob_client = self._blob_service_client.get_blob_client(
+            container=self._container_name,
+            blob=key,
+        )
 
         try:
-            return self._client.get_blob_to_text(
-                self._container_name, key).content
-        except AzureMissingResourceHttpError:
+            return blob_client.download_blob().readall()
+        except ResourceNotFoundError:
             return None
 
     def set(self, key, value):
@@ -117,11 +99,14 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
 
         """
         key = bytes_to_str(key)
-        LOGGER.debug("Creating Azure Block Blob at %s/%s",
-                     self._container_name, key)
+        LOGGER.debug(f"Creating azure blob at {self._container_name}/{key}")
 
-        return self._client.create_blob_from_text(
-            self._container_name, key, value)
+        blob_client = self._blob_service_client.get_blob_client(
+            container=self._container_name,
+            blob=key,
+        )
+
+        blob_client.upload_blob(value)
 
     def mget(self, keys):
         """Read all the values for the provided keys.
@@ -130,6 +115,7 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
               keys: The list of keys to read.
 
         """
+
         return [self.get(key) for key in keys]
 
     def delete(self, key):
@@ -140,7 +126,11 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
 
         """
         key = bytes_to_str(key)
-        LOGGER.debug("Deleting Azure Block Blob at %s/%s",
-                     self._container_name, key)
+        LOGGER.debug(f"Deleting azure blob at {self._container_name}/{key}")
 
-        self._client.delete_blob(self._container_name, key)
+        blob_client = self._blob_service_client.get_blob_client(
+            container=self._container_name,
+            blob=key,
+        )
+
+        blob_client.delete_blob()

--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -9,7 +9,7 @@ from .base import KeyValueStoreBackend
 
 try:
     import azure.storage.blob as azurestorage
-    from azure.storage.blob import BlobServiceClient, BlobClient
+    from azure.storage.blob import BlobServiceClient
     from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 except ImportError:
     azurestorage = None
@@ -76,7 +76,6 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
         Args:
               key: The key for which to read the value.
         """
-
         key = bytes_to_str(key)
         LOGGER.debug("Getting Azure Block Blob %s/%s", self._container_name, key)
 
@@ -86,7 +85,7 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
         )
 
         try:
-            return blob_client.download_blob().readall()
+            return blob_client.download_blob().readall().decode()
         except ResourceNotFoundError:
             return None
 
@@ -106,7 +105,7 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
             blob=key,
         )
 
-        blob_client.upload_blob(value)
+        blob_client.upload_blob(value, overwrite=True)
 
     def mget(self, keys):
         """Read all the values for the provided keys.
@@ -115,7 +114,6 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
               keys: The list of keys to read.
 
         """
-
         return [self.get(key) for key in keys]
 
     def delete(self, key):

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,4 +36,4 @@ services:
     image: dwmkerr/dynamodb:38
 
   azurite:
-    image: arafato/azurite:2.6.5
+    image: mcr.microsoft.com/azure-storage/azurite:3.10.0

--- a/requirements/extras/azureblockblob.txt
+++ b/requirements/extras/azureblockblob.txt
@@ -1,3 +1,1 @@
-azure-storage==0.36.0
-azure-common==1.1.5
-azure-storage-common==1.1.0
+azure-storage-blob==12.6.0

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -11,7 +11,6 @@ MODULE_TO_MOCK = "celery.backends.azureblockblob"
 
 pytest.importorskip('azure.storage.blob')
 
-
 class test_AzureBlockBlobBackend:
     def setup(self):
         self.url = (
@@ -41,55 +40,66 @@ class test_AzureBlockBlobBackend:
         with pytest.raises(ImproperlyConfigured):
             AzureBlockBlobBackend._parse_url("")
 
-    @patch(MODULE_TO_MOCK + ".BlockBlobService")
+    @patch(MODULE_TO_MOCK + ".BlobServiceClient")
     def test_create_client(self, mock_blob_service_factory):
         mock_blob_service_instance = Mock()
         mock_blob_service_factory.return_value = mock_blob_service_instance
         backend = AzureBlockBlobBackend(app=self.app, url=self.url)
 
         # ensure container gets created on client access...
-        assert mock_blob_service_instance.create_container.call_count == 0
-        assert backend._client is not None
-        assert mock_blob_service_instance.create_container.call_count == 1
+        assert mock_blob_service_instance.from_connection_string.return_value.create_container.call_count == 0
+        assert backend._blob_service_client is not None
+        assert mock_blob_service_instance.from_connection_string.return_value.create_container.call_count == 1
 
         # ...but only once per backend instance
-        assert backend._client is not None
+        assert backend._blob_service_client is not None
         assert mock_blob_service_instance.create_container.call_count == 1
 
-    @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._client")
+    @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
     def test_get(self, mock_client):
         self.backend.get(b"mykey")
 
-        mock_client.get_blob_to_text.assert_called_once_with(
-            "celery", "mykey")
+        mock_client.get_blob_client \
+            .assert_called_once_with(blob="mykey", container="celery")
 
-    @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._client")
+        mock_client.get_blob_client.return_value \
+            .download_blob.return_value \
+            .readall.assert_called_once()
+
+    @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
     def test_get_missing(self, mock_client):
-        mock_client.get_blob_to_text.side_effect = \
-            azureblockblob.AzureMissingResourceHttpError("Missing", 404)
+        mock_client.get_blob_client.return_value \
+            .download_blob.return_value \
+            .readall.side_effect = azureblockblob.ResourceNotFoundError
 
-        assert self.backend.get(b"mykey") is None
+        print(self.backend.get(b"mykey"))
 
-    @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._client")
+    @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
     def test_set(self, mock_client):
         self.backend._set_with_state(b"mykey", "myvalue", states.SUCCESS)
 
-        mock_client.create_blob_from_text.assert_called_once_with(
-            "celery", "mykey", "myvalue")
+        mock_client.get_blob_client.assert_called_once_with(
+            container="celery", blob="mykey")
 
-    @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._client")
+        mock_client.get_blob_client.return_value \
+            .upload_blob.assert_called_once_with("myvalue")
+
+    @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
     def test_mget(self, mock_client):
         keys = [b"mykey1", b"mykey2"]
 
         self.backend.mget(keys)
 
-        mock_client.get_blob_to_text.assert_has_calls(
-            [call("celery", "mykey1"),
-             call("celery", "mykey2")])
+        mock_client.get_blob_client.assert_has_calls(
+            [call(blob=key.decode(), container='celery') for key in keys],
+            any_order=True,)
 
-    @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._client")
+    @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
     def test_delete(self, mock_client):
         self.backend.delete(b"mykey")
 
-        mock_client.delete_blob.assert_called_once_with(
-            "celery", "mykey")
+        mock_client.get_blob_client.assert_called_once_with(
+            container="celery", blob="mykey")
+
+        mock_client.get_blob_client.return_value \
+            .delete_blob.assert_called_once()

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -42,18 +42,18 @@ class test_AzureBlockBlobBackend:
 
     @patch(MODULE_TO_MOCK + ".BlobServiceClient")
     def test_create_client(self, mock_blob_service_factory):
-        mock_blob_service_instance = Mock()
-        mock_blob_service_factory.return_value = mock_blob_service_instance
+        mock_blob_service_client_instance = Mock()
+        mock_blob_service_factory.from_connection_string.return_value = mock_blob_service_client_instance
         backend = AzureBlockBlobBackend(app=self.app, url=self.url)
 
         # ensure container gets created on client access...
-        assert mock_blob_service_instance.from_connection_string.return_value.create_container.call_count == 0
+        assert mock_blob_service_client_instance.create_container.call_count == 0
         assert backend._blob_service_client is not None
-        assert mock_blob_service_instance.from_connection_string.return_value.create_container.call_count == 1
+        assert mock_blob_service_client_instance.create_container.call_count == 1
 
         # ...but only once per backend instance
         assert backend._blob_service_client is not None
-        assert mock_blob_service_instance.create_container.call_count == 1
+        assert mock_blob_service_client_instance.create_container.call_count == 1
 
     @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
     def test_get(self, mock_client):

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -11,6 +11,7 @@ MODULE_TO_MOCK = "celery.backends.azureblockblob"
 
 pytest.importorskip('azure.storage.blob')
 
+
 class test_AzureBlockBlobBackend:
     def setup(self):
         self.url = (
@@ -64,7 +65,8 @@ class test_AzureBlockBlobBackend:
 
         mock_client.get_blob_client.return_value \
             .download_blob.return_value \
-            .readall.assert_called_once()
+            .readall.return_value \
+            .decode.assert_called_once()
 
     @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
     def test_get_missing(self, mock_client):
@@ -72,7 +74,7 @@ class test_AzureBlockBlobBackend:
             .download_blob.return_value \
             .readall.side_effect = azureblockblob.ResourceNotFoundError
 
-        print(self.backend.get(b"mykey"))
+        assert self.backend.get(b"mykey") is None
 
     @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
     def test_set(self, mock_client):
@@ -82,7 +84,7 @@ class test_AzureBlockBlobBackend:
             container="celery", blob="mykey")
 
         mock_client.get_blob_client.return_value \
-            .upload_blob.assert_called_once_with("myvalue")
+            .upload_blob.assert_called_once_with("myvalue", overwrite=True)
 
     @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
     def test_mget(self, mock_client):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
This PR upgrades the AzureBlockBlob storage backend to use Azure blob storage library v12. This replaces the currently used SDK (Azure blob storage library v2.1) which is considered a legacy version by Microsoft.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
