### PR TITLE
pass_context for handle_preload_options decorator

### DIFF
--- a/celery/bin/graph.py
+++ b/celery/bin/graph.py
@@ -9,8 +9,9 @@ from celery.utils.graph import DependencyGraph, GraphFormatter
 
 
 @click.group()
+@click.pass_context
 @handle_preload_options
-def graph():
+def graph(ctx):
     """The ``celery graph`` command."""
 
 

--- a/celery/bin/list.py
+++ b/celery/bin/list.py
@@ -5,8 +5,9 @@ from celery.bin.base import CeleryCommand, handle_preload_options
 
 
 @click.group(name="list")
+@click.pass_context
 @handle_preload_options
-def list_():
+def list_(ctx):
     """Get info from broker.
 
     Note:

--- a/celery/bin/logtool.py
+++ b/celery/bin/logtool.py
@@ -111,8 +111,9 @@ class Audit:
 
 
 @click.group()
+@click.pass_context
 @handle_preload_options
-def logtool():
+def logtool(ctx):
     """The ``celery logtool`` command."""
 
 

--- a/celery/bin/upgrade.py
+++ b/celery/bin/upgrade.py
@@ -11,8 +11,9 @@ from celery.utils.functional import pass1
 
 
 @click.group()
+@click.pass_context
 @handle_preload_options
-def upgrade():
+def upgrade(ctx):
     """Perform upgrade between versions."""
 
 


### PR DESCRIPTION
handle_reload_options requires the ctx argument.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Several sub-commands throw an error:
TypeError: caller() missing 1 required positional argument: 'ctx'

Seems to be caused by a change in #6516
The @handle_preload_options decorator requires ctx argument, so they need @click.pass_context

Fixes #6582
