### PR TITLE
Pytest worker shutdown timeout

### DIFF
--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -121,6 +121,7 @@ def _start_worker_thread(app,
         without_gossip=True,
         **kwargs)
 
+    # TODO: Shall we consider starting the thread with daemon=True
     t = threading.Thread(target=worker.start)
     t.start()
     worker.ensure_started()
@@ -128,9 +129,16 @@ def _start_worker_thread(app,
 
     yield worker
 
+    # TODO: Shall we check if the worker is still executing tasks, so that
+    # the timeout below is only applied to the shutdown operation?
+
     from celery.worker import state
     state.should_terminate = 0
     t.join(10)
+    if t.is_alive():
+        raise RuntimeError(
+            "Worker thread failed to exit within the allocated timeout. "
+        )
     state.should_terminate = None
 
 

--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -124,8 +124,7 @@ def _start_worker_thread(app,
         without_gossip=True,
         **kwargs)
 
-    # TODO: Shall we consider starting the thread with daemon=True
-    t = threading.Thread(target=worker.start)
+    t = threading.Thread(target=worker.start, daemon=True)
     t.start()
     worker.ensure_started()
     _set_task_join_will_block(False)

--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -131,9 +131,6 @@ def _start_worker_thread(app,
 
     yield worker
 
-    # TODO: Shall we check if the worker is still executing tasks, so that
-    # the timeout below is only applied to the shutdown operation?
-
     from celery.worker import state
     state.should_terminate = 0
     t.join(shutdown_timeout)

--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -59,6 +59,7 @@ def start_worker(
     logfile=None,  # type: str
     perform_ping_check=True,  # type: bool
     ping_task_timeout=10.0,  # type: float
+    shutdown_timeout=10.0,  # type: float
     **kwargs  # type: Any
 ):
     # type: (...) -> Iterable
@@ -75,6 +76,7 @@ def start_worker(
                               loglevel=loglevel,
                               logfile=logfile,
                               perform_ping_check=perform_ping_check,
+                              shutdown_timeout=shutdown_timeout,
                               **kwargs) as worker:
         if perform_ping_check:
             from .tasks import ping
@@ -93,6 +95,7 @@ def _start_worker_thread(app,
                          logfile=None,
                          WorkController=TestWorkController,
                          perform_ping_check=True,
+                         shutdown_timeout=10.0,
                          **kwargs):
     # type: (Celery, int, str, Union[str, int], str, Any, **Any) -> Iterable
     """Start Celery worker in a thread.
@@ -134,10 +137,12 @@ def _start_worker_thread(app,
 
     from celery.worker import state
     state.should_terminate = 0
-    t.join(10)
+    t.join(shutdown_timeout)
     if t.is_alive():
         raise RuntimeError(
             "Worker thread failed to exit within the allocated timeout. "
+            "Consider raising `shutdown_timeout` if your tasks take longer "
+            "to execute."
         )
     state.should_terminate = None
 

--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -167,6 +167,8 @@ This fixture starts a Celery worker instance that you can use
 for integration tests.  The worker will be started in a *separate thread*
 and will be shutdown as soon as the test returns.
 
+By default the fixture will wait up to 10 seconds for the worker to complete
+outstanding tasks and will raise an exception if the time limit is exceeded.
 Example:
 
 .. code-block:: python

--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -169,6 +169,9 @@ and will be shutdown as soon as the test returns.
 
 By default the fixture will wait up to 10 seconds for the worker to complete
 outstanding tasks and will raise an exception if the time limit is exceeded.
+The timeout can be customized by setting the ``shutdown_timeout`` key in the
+dictionary returned by the :func:`celery_worker_parameters` fixture.
+
 Example:
 
 .. code-block:: python


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fixes #6584.

This PR is an initial attempt to:
1. Raise an error when a worker thread started by the `celery_worker` fixture does not exit within the predefined timeout
2. Let the user customize the timeout

It is missing tests and there are still a couple TODOs in the code worth checking. I may consider bringing it into a fully mergeable state after an initial round of feedback and depending on time constraints.

