### PR TITLE
Add new setting: 'task_args_repr_function'.

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -241,6 +241,9 @@ NAMESPACES = Namespace(
         acks_on_failure_or_timeout=Option(True, type='bool'),
         always_eager=Option(False, type='bool'),
         annotations=Option(type='any'),
+        args_repr_function=Option(
+            'celery.utils.saferepr.saferepr', type='any',
+        ),
         compression=Option(type='string', old={'celery_message_compression'}),
         create_missing_queues=Option(True, type='bool'),
         inherit_parent_priority=Option(False, type='bool'),

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -367,6 +367,25 @@ methods that have been registered with :mod:`kombu.serialization.registry`.
 
     :ref:`calling-serializers`.
 
+.. setting:: task_args_repr_function
+
+``task_args_repr_function``
+~~~~~~~~~~~~~~~~~
+
+.. versionadded: 5.?
+
+Default: ``"celery.utils.saferepr.saferepr"``.
+
+Function used to get a string representation of the task args and kwargs used
+for logging purposes.
+
+It can be specified as either:
+
+    A function with the signature (o, **kwargs)
+
+    A string providing the path to a function with the signature (o, **kwargs).
+
+
 .. setting:: task_publish_retry
 
 ``task_publish_retry``


### PR DESCRIPTION
## Description
Add new setting: `task_args_repr_function` (perhaps there is a more appropriate name).
This setting allows you to choose which function do you want to use to generate `argsrepr` and `kwargsrepr` (the string representation of the task args and kwargs used for logging purposes).

Default is `"celery.utils.saferepr.saferepr"` which is the currently used function.

## Examples
```python3
def task_args_repr_function(o, **kwargs):
    return json.dumps(o)
```

so it will be easier to parse them later on in some backends like the one of `django-celery-results`.

or

```python3
def task_args_repr_function(o, **kwargs):
    if isinstance(o, dict):
        o = o.copy()
        if 'card_number' in o:
            o['card_number'] = '***'
        if 'phone_number' in o:
            o['phone_number'] = o['phone_number'][:3]
        if 'email' in o:
            o.pop('email')
    return repr(o)
```

so we don't have to specify `kwargsrepr` param at each task call.

## Tests
Tests not done yet. Please let me know if you agree with this approach, and I will add some tests.

