### PR TITLE
exit celery with non zero exit value if failing

### DIFF
--- a/celery/bin/control.py
+++ b/celery/bin/control.py
@@ -6,6 +6,7 @@ from kombu.utils.json import dumps
 
 from celery.bin.base import (COMMA_SEPARATED_LIST, CeleryCommand,
                              CeleryOption, handle_preload_options)
+from celery.exceptions import CeleryCommandException
 from celery.platforms import EX_UNAVAILABLE
 from celery.utils import text
 from celery.worker.control import Panel
@@ -81,8 +82,10 @@ def status(ctx, timeout, destination, json, **kwargs):
                                           callback=callback).ping()
 
     if not replies:
-        ctx.obj.echo('No nodes replied within time constraint')
-        return EX_UNAVAILABLE
+        raise CeleryCommandException(
+            message='No nodes replied within time constraint',
+            exit_code=EX_UNAVAILABLE
+        )
 
     if json:
         ctx.obj.echo(dumps(replies))
@@ -130,8 +133,10 @@ def inspect(ctx, action, timeout, destination, json, **kwargs):
                                           callback=callback)._request(action)
 
     if not replies:
-        ctx.obj.echo('No nodes replied within time constraint')
-        return EX_UNAVAILABLE
+        raise CeleryCommandException(
+            message='No nodes replied within time constraint',
+            exit_code=EX_UNAVAILABLE
+        )
 
     if json:
         ctx.obj.echo(dumps(replies))
@@ -184,8 +189,10 @@ def control(ctx, action, timeout, destination, json):
                                             arguments=arguments)
 
     if not replies:
-        ctx.obj.echo('No nodes replied within time constraint')
-        return EX_UNAVAILABLE
+        raise CeleryCommandException(
+            message='No nodes replied within time constraint',
+            exit_code=EX_UNAVAILABLE
+        )
 
     if json:
         ctx.obj.echo(dumps(replies))

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -54,6 +54,7 @@ import numbers
 
 from billiard.exceptions import (SoftTimeLimitExceeded, Terminated,
                                  TimeLimitExceeded, WorkerLostError)
+from click import ClickException
 from kombu.exceptions import OperationalError
 
 __all__ = (
@@ -91,6 +92,8 @@ __all__ = (
 
     # Worker shutdown semi-predicates (inherits from SystemExit).
     'WorkerShutdown', 'WorkerTerminate',
+
+    'CeleryCommandException',
 )
 
 UNREGISTERED_FMT = """\
@@ -293,3 +296,10 @@ class BackendStoreError(BackendError):
 
     def __repr__(self):
         return super().__repr__() + " state:" + self.state + " task_id:" + self.task_id
+
+
+class CeleryCommandException(ClickException):
+
+    def __init__(self, message, exit_code):
+        super().__init__(message=message)
+        self.exit_code = exit_code


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

There is an issue with version 5.x for the celery command. If the command is failing, the exit value is still 0. This PR will fix this and exits with the intended exit value.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes https://github.com/celery/celery/issues/6601) for example.
-->
