### PR TITLE
fixes Github Action unit tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,7 +49,7 @@ jobs:
     
     - name: Run Unit test with pytest
       run: |
-        pytest -xv t/unit
+        PYTHONPATH=. pytest -xv t/unit
 
     - name: Lint with flake8
       run: |

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -796,7 +796,7 @@ class test_KeyValueStoreBackend:
 
             self.b.expire.assert_not_called()
             deps.delete.assert_called_with()
-            deps.join_native.assert_called_with(propagate=True, timeout=3.0)
+            deps.join_native.assert_called_with(propagate=True, timeout=4.0)
 
     def test_chord_part_return_propagate_set(self):
         with self._chord_part_context(self.b) as (task, deps, _):

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -1025,7 +1025,7 @@ class test_RedisBackend_chords_complex(basetest_RedisBackend):
             self.app.conf.result_chord_join_timeout -= 1.0
 
         join_func = complex_header_result.return_value.join_native
-        join_func.assert_called_once_with(timeout=3.0, propagate=True)
+        join_func.assert_called_once_with(timeout=4.0, propagate=True)
 
     @pytest.mark.parametrize("supports_native_join", (True, False))
     def test_on_chord_part_return(


### PR DESCRIPTION
Sets `PYTHONPATH` so tests will run against the code in this repo instead of against the celery installed by pip.

See https://github.com/celery/celery/pull/6576#pullrequestreview-574472666