### PR TITLE
add store_eager_result setting so eager tasks can store result on the backend

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -279,3 +279,4 @@ Sardorbek Imomaliev, 2020/01/24
 Maksym Shalenyi, 2020/07/30
 Frazer McLean, 2020/09/29
 Henrik Bruåsdal, 2020/11/29
+Tom Wojcik, 2021/01/24

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -255,6 +255,7 @@ NAMESPACES = Namespace(
             False, type='bool', old={'celery_eager_propagates_exceptions'},
         ),
         ignore_result=Option(False, type='bool'),
+        store_eager_result=Option(False, type='bool'),
         protocol=Option(2, type='int', old={'celery_task_protocol'}),
         publish_retry=Option(
             True, type='bool', old={'celery_task_publish_retry'},

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -309,6 +309,7 @@ class Task:
         ('acks_on_failure_or_timeout', 'task_acks_on_failure_or_timeout'),
         ('reject_on_worker_lost', 'task_reject_on_worker_lost'),
         ('ignore_result', 'task_ignore_result'),
+        ('store_eager_result', 'task_store_eager_result'),
         ('store_errors_even_if_ignored', 'task_store_errors_even_if_ignored'),
     )
 

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -159,9 +159,13 @@ class TraceInfo:
 
     def handle_error_state(self, task, req,
                            eager=False, call_errbacks=True):
-        store_errors = not eager
         if task.ignore_result:
             store_errors = task.store_errors_even_if_ignored
+        elif eager and task.store_eager_result:
+            store_errors = True
+        else:
+            store_errors = not eager
+
         return {
             RETRY: self.handle_retry,
             FAILURE: self.handle_failure,

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -316,7 +316,13 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
     ignore_result = task.ignore_result
     track_started = task.track_started
     track_started = not eager and (task.track_started and not ignore_result)
-    publish_result = not eager and not ignore_result
+
+    # #6476
+    if eager and not ignore_result and task.store_eager_result:
+        publish_result = True
+    else:
+        publish_result = not eager and not ignore_result
+
     hostname = hostname or gethostname()
     inherit_parent_priority = app.conf.task_inherit_parent_priority
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -429,7 +429,7 @@ It's the same as always running ``apply()`` with ``throw=True``.
 .. setting:: task_store_eager_result
 
 ``task_store_eager_result``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Default: Disabled.
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -426,6 +426,21 @@ propagate exceptions.
 
 It's the same as always running ``apply()`` with ``throw=True``.
 
+.. setting:: task_store_eager_result
+
+``task_store_eager_result``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: Disabled.
+
+If this is :const:`True`
+and :setting:`task_always_eager` is :const:`True`
+and :setting:`task_ignore_result` is :const:`False`,
+the results of eagerly executed tasks will be saved to the backend.
+
+By default, even with :setting:`task_always_eager` set to :const:`True`
+and :setting:`task_ignore_result` is :const:`False`, the result will not be saved.
+
 .. setting:: task_remote_tracebacks
 
 ``task_remote_tracebacks``

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -433,13 +433,13 @@ It's the same as always running ``apply()`` with ``throw=True``.
 
 Default: Disabled.
 
-If this is :const:`True`
-and :setting:`task_always_eager` is :const:`True`
+If this is :const:`True` and :setting:`task_always_eager` is :const:`True`
 and :setting:`task_ignore_result` is :const:`False`,
 the results of eagerly executed tasks will be saved to the backend.
 
 By default, even with :setting:`task_always_eager` set to :const:`True`
-and :setting:`task_ignore_result` is :const:`False`, the result will not be saved.
+and :setting:`task_ignore_result` set to :const:`False`,
+the result will not be saved.
 
 .. setting:: task_remote_tracebacks
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -431,6 +431,8 @@ It's the same as always running ``apply()`` with ``throw=True``.
 ``task_store_eager_result``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 5.1
+
 Default: Disabled.
 
 If this is :const:`True` and :setting:`task_always_eager` is :const:`True`

--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -18,6 +18,9 @@ To test task behavior in unit tests the preferred method is mocking.
     of what happens in a worker, and there are many discrepancies
     between the emulation and what happens in reality.
 
+    Note that eagerly executed tasks don't write results to backend by default.
+    If you want to enable this functionality, have a look at :setting:`task_store_eager_result`.
+
 A Celery task is much like a web view, in that it should only
 define how to perform the action in the context of being called as a task.
 

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -159,10 +159,10 @@ class test_trace(TraceCase):
         self.trace(add, (2, 2), {}, eager=True)
 
         add.backend.mark_as_done.assert_called_once_with(
-            'id-1', # task_id
-            4,      # result
-            ANY,    # request
-            False   # store_result
+            'id-1',     # task_id
+            4,          # result
+            ANY,        # request
+            False       # store_result
         )
 
     def test_eager_task_does_not_call_store_result(self):
@@ -191,10 +191,10 @@ class test_trace(TraceCase):
         self.trace(add, (2, 2), {}, eager=True)
 
         add.backend.mark_as_done.assert_called_once_with(
-            'id-1', # task_id
-            4,      # result
-            ANY,    # request
-            True    # store_result
+            'id-1',     # task_id
+            4,          # result
+            ANY,        # request
+            True        # store_result
         )
 
     def test_eager_task_with_setting_will_call_store_result(self):

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -482,6 +482,32 @@ class test_TraceInfo(TraceCase):
             call_errbacks=True,
         )
 
+    def test_handle_error_state_for_eager_task(self):
+        x = self.TI(states.FAILURE)
+        x.handle_failure = Mock()
+
+        x.handle_error_state(self.add, self.add.request, eager=True)
+        x.handle_failure.assert_called_once_with(
+            self.add,
+            self.add.request,
+            store_errors=False,
+            call_errbacks=True,
+        )
+
+    def test_handle_error_for_eager_saved_to_backend(self):
+        x = self.TI(states.FAILURE)
+        x.handle_failure = Mock()
+
+        self.add.store_eager_result = True
+
+        x.handle_error_state(self.add, self.add.request, eager=True)
+        x.handle_failure.assert_called_with(
+            self.add,
+            self.add.request,
+            store_errors=True,
+            call_errbacks=True,
+        )
+
     @patch('celery.app.trace.ExceptionInfo')
     def test_handle_reject(self, ExceptionInfo):
         x = self.TI(states.FAILURE)


### PR DESCRIPTION
Currently, if you use **eager** tasks and set that you **do not want to ignore the result**, it won't be saved on the backend.
There's literally no possible way to do that. 

This PR adds a setting that will allow doing just that.

Imo that's a bug. Fixing it by allowing the task result to be saved when ignore result is false might break a lot of already existing projects so adding a new setting is the safest option.

Fixes #6476
