### PR TITLE
Fix for issue #5030 "Celery Result backend on Windows OS"

### DIFF
--- a/celery/backends/filesystem.py
+++ b/celery/backends/filesystem.py
@@ -47,6 +47,8 @@ class FilesystemBackend(KeyValueStoreBackend):
         super(FilesystemBackend, self).__init__(*args, **kwargs)
         self.url = url
         path = self._find_path(url)
+        if os.name == "nt" and path.startswith("/"):
+            path = path[1:]
 
         # We need the path and separator as bytes objects
         self.path = path.encode(encoding)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fix for issue #5030 "Celery Result backend on Windows OS".
Filesystem result backend didn't work on Windows.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
