### PR TITLE
Fix for issue #5030 "Celery Result backend on Windows OS".

### DIFF
--- a/celery/backends/filesystem.py
+++ b/celery/backends/filesystem.py
@@ -38,6 +38,10 @@ class FilesystemBackend(KeyValueStoreBackend):
         self.url = url
         path = self._find_path(url)
 
+        # Remove forwarding "/" for Windows os
+        if os.name == "nt" and path.startswith("/"):
+            path = path[1:]
+
         # We need the path and separator as bytes objects
         self.path = path.encode(encoding)
         self.sep = sep.encode(encoding)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fix for issue #5030 "Celery Result backend on Windows OS".
Filesystem result backend didn't work on Windows.
