### PR TITLE
remove unused property `autoregister` from the Task class

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -219,9 +219,6 @@ class Task:
     #: The result store backend used for this task.
     backend = None
 
-    #: If disabled this task won't be registered automatically.
-    autoregister = True
-
     #: If enabled the task will report its status as 'started' when the task
     #: is executed by a worker.  Disabled by default as the normal behavior
     #: is to not report that level of granularity.  Tasks are either pending,


### PR DESCRIPTION
Fixes #6623

issue: https://github.com/celery/celery/issues/6623
Seems to have been an remainder from 3.x/4.x times when class
based tasks have autoregistered.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
