### PR TITLE
Raise BackendStoreError when trying to insert Redis str value larger than 512MB

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -853,7 +853,11 @@ class BaseKeyValueStoreBackend(Backend):
         if current_meta['status'] == states.SUCCESS:
             return result
 
-        self._set_with_state(self.get_key_for_task(task_id), self.encode(meta), state)
+        try:
+            self._set_with_state(self.get_key_for_task(task_id), self.encode(meta), state)
+        except BackendStoreError as ex:
+            raise BackendStoreError(str(ex), state=state, task_id=task_id) from ex
+
         return result
 
     def _save_group(self, group_id, result):

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -288,7 +288,7 @@ class BackendGetMetaError(BackendError):
 
 
 class BackendStoreError(BackendError):
-    """An issue writing from the backend."""
+    """An issue writing to the backend."""
 
     def __init__(self, *args, **kwargs):
         self.state = kwargs.get('state', "")

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -12,7 +12,7 @@ from case import ContextMock, mock
 
 from celery import signature, states, uuid
 from celery.canvas import Signature
-from celery.exceptions import ChordError, ImproperlyConfigured
+from celery.exceptions import BackendStoreError, ChordError, ImproperlyConfigured
 from celery.utils.collections import AttributeDict
 
 
@@ -674,6 +674,10 @@ class test_RedisBackend(basetest_RedisBackend):
         self.b.client.expire.assert_called_with(
             key, 512,
         )
+
+    def test_set_raises_error_on_large_value(self):
+        with pytest.raises(BackendStoreError):
+            self.b.set('key', 'x' * (self.b._MAX_STR_VALUE_SIZE + 1))
 
 
 class test_RedisBackend_chords_simple(basetest_RedisBackend):


### PR DESCRIPTION
## Description

Fixes #6533
TL;DR; - raise error, instead of retry reconnect to Redis when inserting value larger than max Redis string size (512MB) - retry won't help in this case.
