### PR TITLE
Handle Terminated exception (fixes #2727)

### DIFF
--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -254,7 +254,7 @@ class test_Request(RequestCase):
         req.on_retry(Mock())
         req.on_ack.assert_called_with(req_logger, req.connection_errors)
 
-    def test_on_failure_Terminated(self):
+    def test_on_failure_Terminated_acknowledges(self):
         einfo = None
         try:
             raise Terminated('9')
@@ -263,10 +263,7 @@ class test_Request(RequestCase):
         assert einfo is not None
         req = self.get_request(self.add.s(2, 2))
         req.on_failure(einfo)
-        req.eventer.send.assert_called_with(
-            'task-revoked',
-            uuid=req.id, terminated=True, signum='9', expired=False,
-        )
+        req.on_ack.assert_called_with(req_logger, req.connection_errors)
 
     def test_on_failure_propagates_MemoryError(self):
         einfo = None


### PR DESCRIPTION
## Description

I am opening this pull request to propose a fix for #2727.

The worker won't anymore raise a Terminated exception when `revoke(task_id, terminate=True)` is called, but instead will ack
the message and terminate the task successfully.

Is the desired behavior to not throw the `Terminated` exception and acknowledge the message?

If yes, I will fix the broken tests. Also, feel free to suggest if there are other tests that need to be written.