### PR TITLE
Allow heartbeats to be sent in tests

### DIFF
--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -119,7 +119,7 @@ def _start_worker_thread(app,
         logfile=logfile,
         # not allowed to override TestWorkController.on_consumer_ready
         ready_callback=None,
-        without_heartbeat=True,
+        without_heartbeat=kwargs.pop("without_heartbeat", True),
         without_mingle=True,
         without_gossip=True,
         **kwargs)

--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -194,6 +194,20 @@ Example:
     def test_other(celery_worker):
         ...
 
+Heartbeats are disabled by default which means that the test worker doesn't
+send events for ``worker-online``, ``worker-offline`` and ``worker-heartbeat``.
+To enable heartbeats modify the :func:`celery_worker_parameters` fixture:
+
+.. code-block:: python
+
+    # Put this in your conftest.py
+    @pytest.fixture(scope="session")
+    def celery_worker_parameters():
+        return {"without_heartbeat": False}
+        ...
+
+
+
 Session scope
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
I'm writing a Prometheus exporter at
https://github.com/danihodovic/celery-exporter.

In order to test the worker events: worker-heartbeat, worker-online,
worker-offline I need to be able to enable heartbeats for the testing
worker.

The change allows for overriding the default value of heartbeat = False.
