### PR TITLE
Fixes build for PyPy3

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -48,18 +48,16 @@ jobs:
           ${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ matrix.python-version }}-v1-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements/dev.txt \
-            -r requirements/test.txt \
-            -r requirements/test-ci-default.txt \
-            -r requirements/docs.txt \
-            -r requirements/test-integration.txt \
-            -r requirements/pkgutils.txt
-    - name: Run Unit test with pytest
-      run: |
-        PYTHONPATH=. pytest -xv --cov=celery --cov-report=xml --cov-report term t/unit
+
+    - name: Install tox
+      run: python -m pip install tox
+    - name: >
+        Run tox for
+        "${{ matrix.python-version }}-unit"
+      timeout-minutes: 15
+      run: >
+        tox --verbose --verbose -e
+        "${{ matrix.python-version }}-unit"
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -59,13 +59,11 @@ jobs:
         tox --verbose --verbose -e
         "${{ matrix.python-version }}-unit"
 
-
-    -   uses: codecov/codecov-action@v1
-        with:
-            token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-            flags: unittests # optional
-            fail_ci_if_error: true # optional (default = false)
-            verbose: true # optional (default = false)
+    - uses: codecov/codecov-action@v1
+      with:
+        flags: unittests # optional
+        fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -59,15 +59,22 @@ jobs:
         tox --verbose --verbose -e
         "${{ matrix.python-version }}-unit"
 
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
     -   uses: codecov/codecov-action@v1
         with:
             token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
             flags: unittests # optional
             fail_ci_if_error: true # optional (default = false)
             verbose: true # optional (default = false)
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      # Must match the Python version in tox.ini for flake8
+      with: { python-version: 3.9 }
+    - name: Install tox
+      run: python -m pip install tox
+    - name: Lint with flake8
+      run: tox --verbose -e flake8

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,10 +51,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest case pytest-celery pytest-subtests pytest-timeout pytest-cov
-        python -m pip install moto boto3 msgpack PyYAML
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
+        python -m pip install -r requirements/dev.txt \
+            -r requirements/test.txt \
+            -r requirements/test-ci-default.txt \
+            -r requirements/docs.txt \
+            -r requirements/test-integration.txt \
+            -r requirements/pkgutils.txt
     - name: Run Unit test with pytest
       run: |
         PYTHONPATH=. pytest -xv --cov=celery --cov-report=xml --cov-report term t/unit

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -585,6 +585,7 @@ if getattr(redis, "sentinel", None):
 
 class SentinelBackend(RedisBackend):
     """Redis sentinel task result store."""
+
     # URL looks like `sentinel://0.0.0.0:26347/3;sentinel://0.0.0.0:26348/3`
     _SERVER_URI_SEPARATOR = ";"
 
@@ -598,9 +599,7 @@ class SentinelBackend(RedisBackend):
         super().__init__(*args, **kwargs)
 
     def as_uri(self, include_password=False):
-        """
-        Return the server addresses as URIs, sanitizing the password or not.
-        """
+        """Return the server addresses as URIs, sanitizing the password or not."""
         # Allow superclass to do work if we don't need to force sanitization
         if include_password:
             return super(SentinelBackend, self).as_uri(

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -116,6 +116,7 @@ class CLIContext:
 
 
 def handle_preload_options(f):
+    """Extract preload options and return a wrapped callable."""
     def caller(ctx, *args, **kwargs):
         app = ctx.obj.app
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1253,8 +1253,10 @@ class group(Signature):
 
     def freeze(self, _id=None, group_id=None, chord=None,
                root_id=None, parent_id=None, group_index=None):
-        return self.app.GroupResult(*self._freeze_group_tasks(_id=_id, group_id=group_id,
-                                                              chord=chord, root_id=root_id, parent_id=parent_id, group_index=group_index))
+        return self.app.GroupResult(*self._freeze_group_tasks(
+            _id=_id, group_id=group_id,
+            chord=chord, root_id=root_id, parent_id=parent_id, group_index=group_index
+        ))
 
     _freeze = freeze
 

--- a/celery/concurrency/__init__.py
+++ b/celery/concurrency/__init__.py
@@ -29,4 +29,5 @@ def get_implementation(cls):
 
 
 def get_available_pool_names():
+    """Return all available pool type names."""
     return tuple(ALIASES.keys())

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -304,6 +304,7 @@ class BackendStoreError(BackendError):
 
 
 class CeleryCommandException(ClickException):
+    """A general command exception which stores an exit code."""
 
     def __init__(self, message, exit_code):
         super().__init__(message=message)

--- a/celery/utils/threads.py
+++ b/celery/utils/threads.py
@@ -46,8 +46,8 @@ class bgThread(threading.Thread):
 
     def __init__(self, name=None, **kwargs):
         super().__init__()
-        self._is_shutdown = threading.Event()
-        self._is_stopped = threading.Event()
+        self.__is_shutdown = threading.Event()
+        self.__is_stopped = threading.Event()
         self.daemon = True
         self.name = name or self.__class__.__name__
 
@@ -60,7 +60,7 @@ class bgThread(threading.Thread):
 
     def run(self):
         body = self.body
-        shutdown_set = self._is_shutdown.is_set
+        shutdown_set = self.__is_shutdown.is_set
         try:
             while not shutdown_set():
                 try:
@@ -77,7 +77,7 @@ class bgThread(threading.Thread):
 
     def _set_stopped(self):
         try:
-            self._is_stopped.set()
+            self.__is_stopped.set()
         except TypeError:  # pragma: no cover
             # we lost the race at interpreter shutdown,
             # so gc collected built-in modules.
@@ -85,8 +85,8 @@ class bgThread(threading.Thread):
 
     def stop(self):
         """Graceful shutdown."""
-        self._is_shutdown.set()
-        self._is_stopped.wait()
+        self.__is_shutdown.set()
+        self.__is_stopped.wait()
         if self.is_alive():
             self.join(THREAD_TIMEOUT_MAX)
 

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -119,7 +119,7 @@ on connection loss cancels all currently executed tasks with late acknowledgemen
 These tasks cannot be acknowledged as the connection is gone, and the tasks are automatically redelivered back to the queue.
 You can enable this behavior using the worker_cancel_long_running_tasks_on_connection_loss setting.
 In Celery 5.1 it is set to False by default. The setting will be set to True by default in Celery 6.0.
-"""
+"""  # noqa: E501
 
 
 def dump_body(m, body):

--- a/requirements/extras/couchbase.txt
+++ b/requirements/extras/couchbase.txt
@@ -1,1 +1,1 @@
-couchbase>=3.0.0
+couchbase>=3.0.0; platform_python_implementation!='PyPy'

--- a/requirements/extras/solar.txt
+++ b/requirements/extras/solar.txt
@@ -1,1 +1,1 @@
-ephem
+ephem; platform_python_implementation!="PyPy"

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -45,7 +45,6 @@ class test_MongoBackend:
         self.patching('celery.backends.mongodb.MongoBackend.encode')
         self.patching('celery.backends.mongodb.MongoBackend.decode')
         self.patching('celery.backends.mongodb.Binary')
-        self.patching('datetime.datetime')
         self.backend = MongoBackend(app=self.app, url=self.default_url)
 
     def test_init_no_mongodb(self, patching):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -854,7 +854,7 @@ class test_group(CanvasCase):
         # This is an invalid setup because we can't complete a chord header if
         # there are no actual tasks which will run in it. However, the current
         # behaviour of an `IndexError` isn't particularly helpful to a user.
-        res_obj = group_sig.apply_async()
+        group_sig.apply_async()
 
     def test_apply_contains_chords_containing_chain_with_empty_tail(self):
         ggchild_count = 42

--- a/t/unit/utils/test_timer2.py
+++ b/t/unit/utils/test_timer2.py
@@ -44,14 +44,15 @@ class test_Timer:
         t.start.assert_called_with()
 
     @patch('celery.utils.timer2.sleep')
-    def test_on_tick(self, sleep):
+    @patch('os._exit')  # To ensure the test fails gracefully
+    def test_on_tick(self, _exit, sleep):
         def next_entry_side_effect():
             # side effect simulating following scenario:
             # 3.33, 3.33, 3.33, <shutdown event set>
             for _ in range(3):
                 yield 3.33
             while True:
-                yield t._is_shutdown.set()
+                yield getattr(t, "_Timer__is_shutdown").set()
 
         on_tick = Mock(name='on_tick')
         t = timer2.Timer(on_tick=on_tick)
@@ -61,6 +62,7 @@ class test_Timer:
         t.run()
         sleep.assert_called_with(3.33)
         on_tick.assert_has_calls([call(3.33), call(3.33), call(3.33)])
+        _exit.assert_not_called()
 
     @patch('os._exit')
     def test_thread_crash(self, _exit):
@@ -72,12 +74,16 @@ class test_Timer:
 
     def test_gc_race_lost(self):
         t = timer2.Timer()
-        t._is_stopped.set = Mock()
-        t._is_stopped.set.side_effect = TypeError()
-
-        t._is_shutdown.set()
-        t.run()
-        t._is_stopped.set.assert_called_with()
+        with patch.object(t, "_Timer__is_stopped") as mock_stop_event:
+            # Mark the timer as shutting down so we escape the run loop,
+            # mocking the running state so we don't block!
+            with patch.object(t, "running", new=False):
+                t.stop()
+            # Pretend like the interpreter has shutdown and GCed built-in
+            # modules, causing an exception
+            mock_stop_event.set.side_effect = TypeError()
+            t.run()
+        mock_stop_event.set.assert_called_with()
 
     def test_test_enter(self):
         t = timer2.Timer()

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps=
     3.6,3.7,3.8,3.9: -r{toxinidir}/requirements/test-ci-default.txt
     3.5,3.6,3.7,3.8,3.9: -r{toxinidir}/requirements/docs.txt
     3.6,3.7,3.8,3.9: -r{toxinidir}/requirements/docs.txt
-    pypy3: -r{toxinidir}/requirements/test-ci-base.txt
+    pypy3: -r{toxinidir}/requirements/test-ci-default.txt
 
     integration: -r{toxinidir}/requirements/test-integration.txt
 


### PR DESCRIPTION
@auvipy, I took at stab at fixing the PyPy failures.  My first step is to try to install all the requirements and recreate the unit test failure in the docker environment.  I ran into issues installing the python requirements and am wondering if more work needs to be done before we can expect celery to run with PyPy.  Looks like at least a couple of the dependencies do not work with PyPy since they rely on a C backend.

couchbase: https://docs.couchbase.com/python-sdk/current/hello-world/start-using-sdk.html#pypy-support
ephem: https://github.com/celery/django-celery-beat/issues/69#issue-247235755 (Note we may be able to replace this with skyfield.  See [here](https://rhodesmill.org/pyephem/) for more.)

This PR illustrates the same error I'm getting in the docker environment: https://github.com/celery/celery/runs/1930241932?check_suite_focus=true

How should I move forward?