### PR TITLE
Simulate more exhaustive delivery info in apply()

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -764,7 +764,12 @@ class Task:
             'callbacks': maybe_list(link),
             'errbacks': maybe_list(link_error),
             'headers': headers,
-            'delivery_info': {'is_eager': True},
+            'delivery_info': {
+                'is_eager': True,
+                'exchange': options.get('exchange'),
+                'routing_key': options.get('routing_key'),
+                'priority': options.get('priority'),
+            },
         }
         tb = None
         tracer = build_tracer(

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1282,6 +1282,26 @@ class test_apply_task(TasksCase):
         with pytest.raises(KeyError):
             f.get()
 
+    def test_apply_simulates_delivery_info(self):
+        self.task_check_request_context.request_stack.push = Mock()
+
+        self.task_check_request_context.apply(
+            priority=4,
+            routing_key='myroutingkey',
+            exchange='myexchange',
+        )
+
+        self.task_check_request_context.request_stack.push.assert_called_once()
+
+        request = self.task_check_request_context.request_stack.push.call_args[0][0]
+
+        assert request.delivery_info == {
+            'is_eager': True,
+            'exchange': 'myexchange',
+            'routing_key': 'myroutingkey',
+            'priority': 4,
+        }
+
 
 class test_apply_async(TasksCase):
     def common_send_task_arguments(self):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

When calling tasks directly, all options such as priority, exchange
and routing_key are accepted, but ignored.

All though these options take no effect when calling tasks
eagerly, it is useful to keep the data around. An application
might take action based on the priority, exchange or the
routing key.

It is especially useful when writing unit tests. This allows
tasks to be run eagerly, yet test that the application behaves
correctly when these options are passed.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
