### PR TITLE
 Support Redis Sentinel with SSL

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -186,6 +186,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
 
     #: :pypi:`redis` client module.
     redis = redis
+    connection_class_ssl = redis.SSLConnection if redis else None
 
     #: Maximum number of connections in the pool.
     max_connections = None
@@ -241,7 +242,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         ssl = _get('redis_backend_use_ssl')
         if ssl:
             self.connparams.update(ssl)
-            self.connparams['connection_class'] = redis.SSLConnection
+            self.connparams['connection_class'] = self.connection_class_ssl
 
         if url:
             self.connparams = self._params_from_url(url, self.connparams)
@@ -250,7 +251,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         # redis_backend_use_ssl dict, check ssl_cert_reqs is valid. If set
         # via query string ssl_cert_reqs will be a string so convert it here
         if ('connection_class' in self.connparams and
-                self.connparams['connection_class'] is redis.SSLConnection):
+                issubclass(self.connparams['connection_class'], redis.SSLConnection)):
             ssl_cert_reqs_missing = 'MISSING'
             ssl_string_to_constant = {'CERT_REQUIRED': CERT_REQUIRED,
                                       'CERT_OPTIONAL': CERT_OPTIONAL,
@@ -546,10 +547,25 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         )
 
 
+if getattr(redis, "sentinel", None):
+    class SentinelManagedSSLConnection(
+            redis.sentinel.SentinelManagedConnection,
+            redis.SSLConnection):
+        """Connect to a Redis server using Sentinel + TLS.
+
+        Use Sentinel to identify which Redis server is the current master
+        to connect to and when connecting to the Master server, use an
+        SSL Connection.
+        """
+
+        pass
+
+
 class SentinelBackend(RedisBackend):
     """Redis sentinel task result store."""
 
     sentinel = getattr(redis, "sentinel", None)
+    connection_class_ssl = SentinelManagedSSLConnection if sentinel else None
 
     def __init__(self, *args, **kwargs):
         if self.sentinel is None:

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -1146,3 +1146,34 @@ class test_SentinelBackend:
         )
         pool = x._get_pool(**x.connparams)
         assert pool
+
+    def test_backend_ssl(self):
+        pytest.importorskip('redis')
+
+        from celery.backends.redis import SentinelBackend
+        self.app.conf.redis_backend_use_ssl = {
+            'ssl_cert_reqs': "CERT_REQUIRED",
+            'ssl_ca_certs': '/path/to/ca.crt',
+            'ssl_certfile': '/path/to/client.crt',
+            'ssl_keyfile': '/path/to/client.key',
+        }
+        self.app.conf.redis_socket_timeout = 30.0
+        self.app.conf.redis_socket_connect_timeout = 100.0
+        x = SentinelBackend(
+            'sentinel://:bosco@vandelay.com:123//1', app=self.app,
+        )
+        assert x.connparams
+        assert len(x.connparams['hosts']) == 1
+        assert x.connparams['hosts'][0]['host'] == 'vandelay.com'
+        assert x.connparams['hosts'][0]['db'] == 1
+        assert x.connparams['hosts'][0]['port'] == 123
+        assert x.connparams['hosts'][0]['password'] == 'bosco'
+        assert x.connparams['socket_timeout'] == 30.0
+        assert x.connparams['socket_connect_timeout'] == 100.0
+        assert x.connparams['ssl_cert_reqs'] == ssl.CERT_REQUIRED
+        assert x.connparams['ssl_ca_certs'] == '/path/to/ca.crt'
+        assert x.connparams['ssl_certfile'] == '/path/to/client.crt'
+        assert x.connparams['ssl_keyfile'] == '/path/to/client.key'
+
+        from celery.backends.redis import SentinelManagedSSLConnection
+        assert x.connparams['connection_class'] is SentinelManagedSSLConnection


### PR DESCRIPTION
Reverts celery/celery#6518.

We were going to release 5.0.6 which was a bugfix version which doesn't contain new features.
We have decided to go along with 5.1.0 immidiately instead.

See #6490 for the original pull request.