### PR TITLE
Fix default visibility timeout note in sqs documentation

### DIFF
--- a/docs/getting-started/backends-and-brokers/sqs.rst
+++ b/docs/getting-started/backends-and-brokers/sqs.rst
@@ -82,7 +82,7 @@ This option is set via the :setting:`broker_transport_options` setting::
 
     broker_transport_options = {'visibility_timeout': 3600}  # 1 hour.
 
-The default visibility timeout is 30 seconds.
+The default visibility timeout is 30 minutes.
 
 Polling Interval
 ----------------


### PR DESCRIPTION
This is a small fix for the documented default visibility timeout in sqs. The relevant code is in [kombu](https://github.com/celery/kombu/blob/0db1bdb6abeacd80e5a2e4190ffcb86599ab1a64/kombu/transport/SQS.py#L128).
Related to #3270