### PR TITLE
Add note for Task.max_retries default in documentation

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -825,7 +825,7 @@ You can also set `autoretry_for`, `max_retries`, `retry_backoff`, `retry_backoff
 .. attribute:: Task.max_retries
 
     A number. Maximum number of retries before giving up. A value of ``None``
-    means task will retry forever.
+    means task will retry forever. By default, this option is set to ``3``.
 
 .. attribute:: Task.retry_backoff
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

The documentation lacks the mention of the default value for Task.max_retries. Since the last sentence talks about the behavior with a None value, it can be mistakenly assumed that this is the default value.
