### PR TITLE
Terminate tasks with late acknoledgement on connection loss

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -290,6 +290,9 @@ NAMESPACES = Namespace(
         __old__=OLD_NS_WORKER,
         agent=Option(None, type='string'),
         autoscaler=Option('celery.worker.autoscale:Autoscaler'),
+        cancel_long_running_tasks_on_connection_loss=Option(
+            False, type='bool'
+        ),
         concurrency=Option(0, type='int'),
         consumer=Option('celery.worker.consumer:Consumer', type='string'),
         direct=Option(False, type='bool', old={'celery_worker_direct'}),

--- a/celery/bin/amqp.py
+++ b/celery/bin/amqp.py
@@ -25,7 +25,7 @@ class AMQPContext:
         self.connection = self.cli_context.app.connection()
         self.channel = None
         self.reconnect()
-    
+
     @property
     def app(self):
         return self.cli_context.app

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -345,7 +345,7 @@ class Consumer:
             if request.task.acks_late and not request.acknowledged:
                 warn(TERMINATING_TASK_ON_RESTART_AFTER_A_CONNECTION_LOSS,
                      request)
-                request.abort(self.pool)
+                request.cancel(self.pool)
 
     def register_with_event_loop(self, hub):
         self.blueprint.send_all(

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -345,7 +345,7 @@ class Consumer:
             if request.task.acks_late and not request.acknowledged:
                 warn(TERMINATING_TASK_ON_RESTART_AFTER_A_CONNECTION_LOSS,
                      request)
-                request.terminate(self.pool)
+                request.abort(self.pool)
 
     def register_with_event_loop(self, hub):
         self.blueprint.send_all(

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -510,7 +510,7 @@ class Request:
             # If the message no longer has a connection and the worker
             # is terminated, we aborted it.
             # Otherwise, it is revoked.
-            if self.message.channel.connection:
+            if self.message.channel.connection and not self._already_revoked:
                 # This is a special case where the process
                 # would not have had time to write the result.
                 self._announce_revoked(

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -399,7 +399,7 @@ class Request:
             if obj is not None:
                 obj.terminate(signal)
 
-    def abort(self, pool, signal=None):
+    def cancel(self, pool, signal=None):
         signal = _signals.signum(signal or TERM_SIGNAME)
         if self.time_start:
             pool.terminate_job(self.worker_pid, signal)

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -579,7 +579,7 @@ class Request:
             self.humaninfo(),
             f' ETA:[{self._eta}]' if self._eta else '',
             f' expires:[{self._expires}]' if self._expires else '',
-        ])
+        ]).strip()
 
     def __repr__(self):
         """``repr(self)``."""

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -404,7 +404,7 @@ class Request:
         if self.time_start:
             pool.terminate_job(self.worker_pid, signal)
             self.task.backend.mark_as_retry(self.id,
-                                            Retry,
+                                            Retry(message='aborted by Celery'),
                                             request=self._context)
 
         if self._apply_result is not None:

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2735,6 +2735,36 @@ Default: 4.0.
 
 The timeout in seconds (int/float) when waiting for a new worker process to start up.
 
+.. setting:: worker_cancel_long_running_tasks_on_connection_loss
+
+``worker_cancel_long_running_tasks_on_connection_loss``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.1
+
+Default: Disabled by default.
+
+Kill all long-running tasks with late acknowledgment enabled on connection loss.
+
+Tasks which have not been acknowledged before the connection loss cannot do so
+anymore since their channel is gone and the task is redelivered back to the queue.
+This is why tasks with late acknowledged enabled must be idempotent as they may be executed more than once.
+In this case, the task is being executed twice per connection loss (and sometimes in parallel in other workers).
+
+When turning this option on, those tasks which have not been completed are
+cancelled and their execution is terminated.
+Tasks which have completed in any way before the connection loss
+are recorded as such in the result backend as long as :setting:`task_ignore_result` is not enabled.
+
+.. warning::
+
+    This feature was introduced as a future breaking change.
+    If it is turned off, Celery will emit a warning message.
+
+    In Celery 6.0, the :setting:`worker_cancel_long_running_tasks_on_connection_loss`
+    will be set to ``True`` by default as the current behavior leads to more
+    problems than it solves.
+
 .. _conf-events:
 
 Events

--- a/examples/app/myapp.py
+++ b/examples/app/myapp.py
@@ -22,8 +22,6 @@ name using the fully qualified form::
     $ celery -A myapp:app worker -l INFO
 
 """
-from random import randint
-from time import sleep
 
 from celery import Celery
 
@@ -31,20 +29,13 @@ app = Celery(
     'myapp',
     broker='amqp://guest@localhost//',
     # ## add result backend here if needed.
-    backend='redis://'
+    # backend='rpc'
 )
-
-app.conf.task_acks_late = True
 
 
 @app.task
 def add(x, y):
     return x + y
-
-
-@app.task
-def s():
-    sleep(randint(30, 120))
 
 
 if __name__ == '__main__':

--- a/examples/app/myapp.py
+++ b/examples/app/myapp.py
@@ -22,6 +22,8 @@ name using the fully qualified form::
     $ celery -A myapp:app worker -l INFO
 
 """
+from random import randint
+from time import sleep
 
 from celery import Celery
 
@@ -29,13 +31,20 @@ app = Celery(
     'myapp',
     broker='amqp://guest@localhost//',
     # ## add result backend here if needed.
-    # backend='rpc'
+    backend='redis://'
 )
+
+app.conf.task_acks_late = True
 
 
 @app.task
 def add(x, y):
     return x + y
+
+
+@app.task
+def s():
+    sleep(randint(30, 120))
 
 
 if __name__ == '__main__':

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -9,8 +9,8 @@ from case import ContextMock
 
 from celery.utils.collections import LimitedSet
 from celery.worker.consumer.agent import Agent
-from celery.worker.consumer.consumer import CLOSE, TERMINATE, Consumer, \
-    CANCEL_TASKS_BY_DEFAULT
+from celery.worker.consumer.consumer import (CANCEL_TASKS_BY_DEFAULT, CLOSE,
+                                             TERMINATE, Consumer)
 from celery.worker.consumer.gossip import Gossip
 from celery.worker.consumer.heart import Heart
 from celery.worker.consumer.mingle import Mingle

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -9,11 +9,13 @@ from case import ContextMock
 
 from celery.utils.collections import LimitedSet
 from celery.worker.consumer.agent import Agent
-from celery.worker.consumer.consumer import CLOSE, TERMINATE, Consumer
+from celery.worker.consumer.consumer import CLOSE, TERMINATE, Consumer, \
+    CANCEL_TASKS_BY_DEFAULT
 from celery.worker.consumer.gossip import Gossip
 from celery.worker.consumer.heart import Heart
 from celery.worker.consumer.mingle import Mingle
 from celery.worker.consumer.tasks import Tasks
+from celery.worker.state import active_requests
 
 
 class test_Consumer:
@@ -271,6 +273,39 @@ class test_Consumer:
         assert error.call_args[0][3] == 'Trying again in 4.00 seconds... (2/3)'
         errback(Mock(), 6)
         assert error.call_args[0][3] == 'Trying again in 6.00 seconds... (3/3)'
+
+    def test_cancel_long_running_tasks_on_connection_loss(self):
+        c = self.get_consumer()
+        c.app.conf.worker_cancel_long_running_tasks_on_connection_loss = True
+
+        mock_request_acks_late_not_acknowledged = Mock()
+        mock_request_acks_late_not_acknowledged.task.acks_late = True
+        mock_request_acks_late_not_acknowledged.acknowledged = False
+        mock_request_acks_late_acknowledged = Mock()
+        mock_request_acks_late_acknowledged.task.acks_late = True
+        mock_request_acks_late_acknowledged.acknowledged = True
+        mock_request_acks_early = Mock()
+        mock_request_acks_early.task.acks_late = False
+        mock_request_acks_early.acknowledged = False
+
+        active_requests.add(mock_request_acks_late_not_acknowledged)
+        active_requests.add(mock_request_acks_late_acknowledged)
+        active_requests.add(mock_request_acks_early)
+
+        c.on_connection_error_after_connected(Mock())
+
+        mock_request_acks_late_not_acknowledged.cancel.assert_called_once_with(c.pool)
+        mock_request_acks_late_acknowledged.cancel.assert_not_called()
+        mock_request_acks_early.cancel.assert_not_called()
+
+        active_requests.clear()
+
+    def test_cancel_long_running_tasks_on_connection_loss__warning(self):
+        c = self.get_consumer()
+        c.app.conf.worker_cancel_long_running_tasks_on_connection_loss = False
+
+        with pytest.deprecated_call(match=CANCEL_TASKS_BY_DEFAULT):
+            c.on_connection_error_after_connected(Mock())
 
 
 class test_Heart:

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -754,6 +754,7 @@ class test_Request(RequestCase):
 
     def test_on_failure_task_cancelled(self):
         job = self.xRequest()
+        job.eventer = Mock()
         job.time_start = 1
         job.message.channel.connection = None
 
@@ -761,9 +762,14 @@ class test_Request(RequestCase):
             raise Terminated()
         except Terminated:
             exc_info = ExceptionInfo()
+
             job.on_failure(exc_info)
 
         assert job._already_cancelled
+
+        job.on_failure(exc_info)
+        job.eventer.send.assert_called_once_with('task-cancelled',
+                                                 uuid=job.id)
 
     def test_from_message_invalid_kwargs(self):
         m = self.TaskMessage(self.mytask.name, args=(), kwargs='foo')

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -735,6 +735,19 @@ class test_Request(RequestCase):
             job.on_failure(exc_info)
         assert job.acknowledged is True
 
+    def test_on_failure_task_cancelled(self):
+        job = self.xRequest()
+        job.time_start = 1
+        job.message.channel.connection = None
+
+        try:
+            raise Terminated()
+        except Terminated:
+            exc_info = ExceptionInfo()
+            job.on_failure(exc_info)
+
+        assert job._already_cancelled
+
     def test_from_message_invalid_kwargs(self):
         m = self.TaskMessage(self.mytask.name, args=(), kwargs='foo')
         req = Request(m, app=self.app)

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -19,7 +19,7 @@ from celery.app.trace import (TraceInfo, build_tracer, fast_trace_task,
 from celery.backends.base import BaseDictBackend
 from celery.exceptions import (Ignore, InvalidTaskError, Reject, Retry,
                                TaskRevokedError, Terminated, WorkerLostError)
-from celery.signals import task_revoked, task_retry
+from celery.signals import task_retry, task_revoked
 from celery.worker import request as module
 from celery.worker import strategy
 from celery.worker.request import Request, create_request_cls
@@ -430,8 +430,8 @@ class test_Request(RequestCase):
         job = self.get_request(self.mytask.s(1, f='x'))
         job._apply_result = Mock(name='_apply_result')
         with self.assert_signal_called(
-            task_revoked, sender=job.task, request=job._context,
-            terminated=True, expired=False, signum=signum):
+                task_revoked, sender=job.task, request=job._context,
+                terminated=True, expired=False, signum=signum):
             job.time_start = monotonic()
             job.worker_pid = 314
             job.terminate(pool, signal='TERM')
@@ -446,8 +446,8 @@ class test_Request(RequestCase):
         signum = signal.SIGTERM
         job = self.get_request(self.mytask.s(1, f='x'))
         with self.assert_signal_called(
-            task_revoked, sender=job.task, request=job._context,
-            terminated=True, expired=False, signum=signum):
+                task_revoked, sender=job.task, request=job._context,
+                terminated=True, expired=False, signum=signum):
             job.time_start = monotonic()
             job.worker_pid = 313
             job.terminate(pool, signal='TERM')
@@ -468,8 +468,8 @@ class test_Request(RequestCase):
         job = self.get_request(self.mytask.s(1, f='x'))
         job._apply_result = Mock(name='_apply_result')
         with self.assert_signal_called(
-            task_retry, sender=job.task, request=job._context,
-            einfo=None):
+                task_retry, sender=job.task, request=job._context,
+                einfo=None):
             job.time_start = monotonic()
             job.worker_pid = 314
             job.cancel(pool, signal='TERM')
@@ -488,8 +488,8 @@ class test_Request(RequestCase):
             expires=datetime.utcnow() - timedelta(days=1)
         ))
         with self.assert_signal_called(
-            task_revoked, sender=job.task, request=job._context,
-            terminated=False, expired=True, signum=None):
+                task_revoked, sender=job.task, request=job._context,
+                terminated=False, expired=True, signum=None):
             job.revoked()
             assert job.id in revoked
             self.app.set_current()
@@ -520,8 +520,8 @@ class test_Request(RequestCase):
     def test_revoked(self):
         job = self.xRequest()
         with self.assert_signal_called(
-            task_revoked, sender=job.task, request=job._context,
-            terminated=False, expired=False, signum=None):
+                task_revoked, sender=job.task, request=job._context,
+                terminated=False, expired=False, signum=None):
             revoked.add(job.id)
             assert job.revoked()
             assert job._already_revoked
@@ -569,8 +569,8 @@ class test_Request(RequestCase):
         pool = Mock()
         job = self.xRequest()
         with self.assert_signal_called(
-            task_revoked, sender=job.task, request=job._context,
-            terminated=True, expired=False, signum=signum):
+                task_revoked, sender=job.task, request=job._context,
+                terminated=True, expired=False, signum=signum):
             job.terminate(pool, signal='TERM')
             assert not pool.terminate_job.call_count
             job.on_accepted(pid=314, time_accepted=monotonic())


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Tasks with late acknowledgement keep running after restart although the connection is lost and they cannot be acked anymore (to the best of my knowledge).

This results in log errors such as these:
```
[2021-03-02 18:29:58,355: CRITICAL/MainProcess] Couldn't ack 5, reason:RecoverableConnectionError(None, 'connection already closed', None, '')
Traceback (most recent call last):
  File "/home/thedrow/.virtualenvs/celery/lib/python3.9/site-packages/kombu/message.py", line 128, in ack_log_error
    self.ack(multiple=multiple)
  File "/home/thedrow/.virtualenvs/celery/lib/python3.9/site-packages/kombu/message.py", line 123, in ack
    self.channel.basic_ack(self.delivery_tag, multiple=multiple)
  File "/home/thedrow/.virtualenvs/celery/lib/python3.9/site-packages/amqp/channel.py", line 1391, in basic_ack
    return self.send_method(
  File "/home/thedrow/.virtualenvs/celery/lib/python3.9/site-packages/amqp/abstract_channel.py", line 54, in send_method
    raise RecoverableConnectionError('connection already closed')
amqp.exceptions.RecoverableConnectionError: connection already closed
[2021-03-02 18:29:58,356: CRITICAL/MainProcess] Couldn't ack 12, reason:RecoverableConnectionError(None, 'connection already closed', None, '')
```
If we cannot recover from this situation, we must terminate all tasks with late acknowledgement.
Any other suggestion, would be useful.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
