### PR TITLE
Forward shadow option for retried tasks

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -74,6 +74,7 @@ class Context:
     headers = None
     delivery_info = None
     reply_to = None
+    shadow = None
     root_id = None
     parent_id = None
     correlation_id = None
@@ -114,6 +115,7 @@ class Context:
             'parent_id': self.parent_id,
             'group_id': self.group,
             'group_index': self.group_index,
+            'shadow': self.shadow,
             'chord': self.chord,
             'chain': self.chain,
             'link': self.callbacks,

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -422,6 +422,12 @@ class test_task_retries(TasksCase):
         assert sig.options['exchange'] == 'testex'
         assert sig.options['routing_key'] == 'testrk'
 
+    def test_signature_from_request__shadow_name(self):
+        self.retry_task.push_request()
+        self.retry_task.request.shadow = 'test'
+        sig = self.retry_task.signature_from_request()
+        assert sig.options['shadow'] == 'test'
+
     def test_retry_kwargs_can_be_empty(self):
         self.retry_task_mockapply.push_request()
         try:


### PR DESCRIPTION
## Description

A retried task get logged with the `task.name` event if `shadow` is set.
This change sets the task shadow name also for retried tasks.

Current output
> [INFO/MainProcess] Received task: MyTask[59e5c65f-544c-4cd4-8403-3975a802d0d5]  
> [INFO/MainProcess] Received task: **tasks.add**[59e5c65f-544c-4cd4-8403-3975a802d0d5] ETA:[2021-03-02 19:23:21.343560+00:00] 
> [INFO/ForkPoolWorker-8] Task MyTask[59e5c65f-544c-4cd4-8403-3975a802d0d5] retry: Retry in 10s
> [INFO/ForkPoolWorker-8] Task **tasks.add**[59e5c65f-544c-4cd4-8403-3975a802d0d5] retry: Retry in 10s
> [INFO/MainProcess] Received task: **tasks.add**[59e5c65f-544c-4cd4-8403-3975a802d0d5] ETA:[2021-03-02 19:23:33.023274+00:00] 
> [INFO/ForkPoolWorker-8] Task **tasks.add**[59e5c65f-544c-4cd4-8403-3975a802d0d5] retry: Retry in 10s
> [INFO/MainProcess] Received task: **tasks.add**[59e5c65f-544c-4cd4-8403-3975a802d0d5] ETA:[2021-03-02 19:23:43.035171+00:00] 

With this PR
> [INFO/MainProcess] Received task: MyTask[9c1ecfea-d4a6-4cf6-ba21-073db73c0152]  
> [INFO/ForkPoolWorker-8] Task MyTask[9c1ecfea-d4a6-4cf6-ba21-073db73c0152] retry: Retry in 10s
> [INFO/MainProcess] Received task: MyTask[9c1ecfea-d4a6-4cf6-ba21-073db73c0152] ETA:[2021-03-02 19:22:18.579569+00:00] 
> [INFO/ForkPoolWorker-8] Task MyTask[9c1ecfea-d4a6-4cf6-ba21-073db73c0152] retry: Retry in 10s
> [INFO/MainProcess] Received task: MyTask[9c1ecfea-d4a6-4cf6-ba21-073db73c0152] ETA:[2021-03-02 19:22:29.610700+00:00]
> [INFO/ForkPoolWorker-8] Task MyTask[9c1ecfea-d4a6-4cf6-ba21-073db73c0152] retry: Retry in 10s
> [INFO/MainProcess] Received task: MyTask[9c1ecfea-d4a6-4cf6-ba21-073db73c0152]  ETA:[2021-03-02 19:22:39.625028+00:00] 
