### PR TITLE
fix: configuration variables names

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -146,8 +146,9 @@ have been moved into a new  ``task_`` prefix.
 ``CELERY_SEND_SENT_EVENT``                 :setting:`task_send_sent_event`
 ``CELERY_SERIALIZER``                      :setting:`task_serializer`
 ``CELERYD_SOFT_TIME_LIMIT``                :setting:`task_soft_time_limit`
+``CELERY_TASK_TRACK_STARTED``              :setting:`task_track_started`
+``CELERY_TASK_REJECT_ON_WORKER_LOST``      :setting:`task_reject_on_worker_lost`
 ``CELERYD_TIME_LIMIT``                     :setting:`task_time_limit`
-``CELERY_TRACK_STARTED``                   :setting:`task_track_started`
 ``CELERYD_AGENT``                          :setting:`worker_agent`
 ``CELERYD_AUTOSCALER``                     :setting:`worker_autoscaler`
 ``CELERYD_CONCURRENCY``                    :setting:`worker_concurrency`


### PR DESCRIPTION
## Description

This PR fixes the documentation's incorrect and missing variables names:
- [`CELERY_TRACK_STARTED` should be `CELERY_TASK_TRACK_STARTED`](https://stackoverflow.com/a/49240216)
- `CELERY_TASK_REJECT_ON_WORKER_LOST` is missing
