### PR TITLE
Allow configuration of RedisBackend's health_check_interval

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -213,6 +213,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         socket_connect_timeout = _get('redis_socket_connect_timeout')
         retry_on_timeout = _get('redis_retry_on_timeout')
         socket_keepalive = _get('redis_socket_keepalive')
+        health_check_interval = _get('redis_backend_health_check_interval')
 
         self.connparams = {
             'host': _get('redis_host') or 'localhost',
@@ -224,6 +225,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             'retry_on_timeout': retry_on_timeout or False,
             'socket_connect_timeout':
                 socket_connect_timeout and float(socket_connect_timeout),
+            'health_check_interval': health_check_interval,
         }
 
         # absent in redis.connection.UnixDomainSocketConnection

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -225,8 +225,10 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             'retry_on_timeout': retry_on_timeout or False,
             'socket_connect_timeout':
                 socket_connect_timeout and float(socket_connect_timeout),
-            'health_check_interval': health_check_interval,
         }
+
+        if health_check_interval:
+            self.connparams["health_check_interval"] = health_check_interval
 
         # absent in redis.connection.UnixDomainSocketConnection
         if socket_keepalive:

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1167,6 +1167,22 @@ Note that the ``ssl_cert_reqs`` string should be one of ``required``,
 ``optional``, or ``none`` (though, for backwards compatibility, the string
 may also be one of ``CERT_REQUIRED``, ``CERT_OPTIONAL``, ``CERT_NONE``).
 
+
+.. setting:: redis_backend_health_check_interval
+
+.. versionadded:: 5.1.0
+
+``redis_backend_health_check_interval``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: Not configured
+
+The Redis backend supports health checks.  This value must be
+set as an integer whose value is the number of seconds between
+health checks.  If a ConnectionError or a TimeoutError is
+encountered during the health check, the connection will be
+re-established and the command retried exactly once.
+
 .. setting:: redis_backend_use_ssl
 
 ``redis_backend_use_ssl``

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -415,6 +415,42 @@ class test_RedisBackend(basetest_RedisBackend):
         from redis.connection import SSLConnection
         assert x.connparams['connection_class'] is SSLConnection
 
+    def test_backend_health_check_interval_ssl(self):
+        pytest.importorskip('redis')
+
+        self.app.conf.redis_backend_use_ssl = {
+            'ssl_cert_reqs': ssl.CERT_REQUIRED,
+            'ssl_ca_certs': '/path/to/ca.crt',
+            'ssl_certfile': '/path/to/client.crt',
+            'ssl_keyfile': '/path/to/client.key',
+        }
+        self.app.conf.redis_backend_health_check_interval = 10
+        x = self.Backend(
+            'rediss://:bosco@vandelay.com:123//1', app=self.app,
+        )
+        assert x.connparams
+        assert x.connparams['host'] == 'vandelay.com'
+        assert x.connparams['db'] == 1
+        assert x.connparams['port'] == 123
+        assert x.connparams['password'] == 'bosco'
+        assert x.connparams['health_check_interval'] == 10
+
+        from redis.connection import SSLConnection
+        assert x.connparams['connection_class'] is SSLConnection
+
+    def test_backend_health_check_interval(self):
+        pytest.importorskip('redis')
+
+        self.app.conf.redis_backend_health_check_interval = 10
+        x = self.Backend(
+            'redis://vandelay.com:123//1', app=self.app,
+        )
+        assert x.connparams
+        assert x.connparams['host'] == 'vandelay.com'
+        assert x.connparams['db'] == 1
+        assert x.connparams['port'] == 123
+        assert x.connparams['health_check_interval'] == 10
+
     @pytest.mark.parametrize('cert_str', [
         "required",
         "CERT_REQUIRED",

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -451,6 +451,18 @@ class test_RedisBackend(basetest_RedisBackend):
         assert x.connparams['port'] == 123
         assert x.connparams['health_check_interval'] == 10
 
+    def test_backend_health_check_interval_not_set(self):
+        pytest.importorskip('redis')
+
+        x = self.Backend(
+            'redis://vandelay.com:123//1', app=self.app,
+        )
+        assert x.connparams
+        assert x.connparams['host'] == 'vandelay.com'
+        assert x.connparams['db'] == 1
+        assert x.connparams['port'] == 123
+        assert "health_check_interval" not in x.connparams
+
     @pytest.mark.parametrize('cert_str', [
         "required",
         "CERT_REQUIRED",


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

👋 Hey folks,

Was working through a reliability issue on our end with our Redis connections and came across the need to update the `health_check_interval` for the underlying Redis connection.  The goal here is a simple implementation that allows reading this value via environment variable (`redis_backend_health_check_interval`) and passing this through as a `kwarg` to the underlying `redis-py` module.

This is my proposed solution to https://github.com/celery/celery/issues/6665.  Please let me know what you think and thank you for the great library.

Cheers,
Chris