### PR TITLE
fnmatch.translate() already translates globs for us.

### DIFF
--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -2,8 +2,8 @@
 
 Contains utilities for working with task routers, (:setting:`task_routes`).
 """
+import fnmatch
 import re
-import string
 from collections import OrderedDict
 from collections.abc import Mapping
 
@@ -23,11 +23,6 @@ except AttributeError:  # pragma: no cover
 __all__ = ('MapRoute', 'Router', 'prepare')
 
 
-def glob_to_re(glob, quote=string.punctuation.replace('*', '')):
-    glob = ''.join('\\' + c if c in quote else c for c in glob)
-    return glob.replace('*', '.+?')
-
-
 class MapRoute:
     """Creates a router out of a :class:`dict`."""
 
@@ -39,7 +34,7 @@ class MapRoute:
             if isinstance(k, Pattern):
                 self.patterns[k] = v
             elif '*' in k:
-                self.patterns[re.compile(glob_to_re(k))] = v
+                self.patterns[re.compile(fnmatch.translate(k))] = v
             else:
                 self.map[k] = v
 
@@ -126,6 +121,7 @@ def expand_router_string(router):
 
 def prepare(routes):
     """Expand the :setting:`task_routes` setting."""
+
     def expand_route(route):
         if isinstance(route, (Mapping, list, tuple)):
             return MapRoute(route)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

There's no longer a need for our faulty implementation of glob_to_re since the functionality is provided in the fnmatch standard module.
This incidently, fixes #5646.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->