### PR TITLE
Add `azureblockblob_base_path` config

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -280,3 +280,4 @@ Maksym Shalenyi, 2020/07/30
 Frazer McLean, 2020/09/29
 Henrik Bruåsdal, 2020/11/29
 Tom Wojcik, 2021/01/24
+Ruaridh Williamson, 2021/03/09

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -132,6 +132,7 @@ NAMESPACES = Namespace(
         retry_initial_backoff_sec=Option(2, type='int'),
         retry_increment_base=Option(2, type='int'),
         retry_max_attempts=Option(3, type='int'),
+        base_path=Option('', type='string'),
     ),
     control=Namespace(
         queue_ttl=Option(300.0, type='float'),

--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -43,6 +43,8 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
             container_name or
             conf["azureblockblob_container_name"])
 
+        self.base_path = conf.get('azureblockblob_base_path', '')
+
     @classmethod
     def _parse_url(cls, url, prefix="azureblockblob://"):
         connection_string = url[len(prefix):]
@@ -82,7 +84,7 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
 
         blob_client = self._blob_service_client.get_blob_client(
             container=self._container_name,
-            blob=key,
+            blob=self.base_path + key,
         )
 
         try:
@@ -103,7 +105,7 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
 
         blob_client = self._blob_service_client.get_blob_client(
             container=self._container_name,
-            blob=key,
+            blob=self.base_path + key,
         )
 
         blob_client.upload_blob(value, overwrite=True)
@@ -129,7 +131,7 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
 
         blob_client = self._blob_service_client.get_blob_client(
             container=self._container_name,
-            blob=key,
+            blob=self.base_path + key,
         )
 
         blob_client.delete_blob()

--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -105,7 +105,7 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
 
         blob_client = self._blob_service_client.get_blob_client(
             container=self._container_name,
-            blob=self.base_path + key,
+            blob=f'{self.base_path}{key}',
         )
 
         blob_client.upload_blob(value, overwrite=True)

--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -84,7 +84,7 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
 
         blob_client = self._blob_service_client.get_blob_client(
             container=self._container_name,
-            blob=self.base_path + key,
+            blob=f'{self.base_path}{key}',
         )
 
         try:

--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -131,7 +131,7 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
 
         blob_client = self._blob_service_client.get_blob_client(
             container=self._container_name,
-            blob=self.base_path + key,
+            blob=f'{self.base_path}{key}',
         )
 
         blob_client.delete_blob()

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1534,6 +1534,8 @@ The name for the storage container in which to store the results.
 ``azureblockblob_base_path``
 ~~~~~~~~~~~~~~~~
 
+.. versionadded:: 5.1
+
 Default: None.
 
 A base path in the storage container to use to store result keys. For example::

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1540,7 +1540,7 @@ Default: None.
 
 A base path in the storage container to use to store result keys. For example::
 
-    azureblockblob_base_path = '/prefix'
+    azureblockblob_base_path = 'prefix/'
 
 .. setting:: azureblockblob_retry_initial_backoff_sec
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1529,6 +1529,17 @@ Default: celery.
 
 The name for the storage container in which to store the results.
 
+.. setting:: azureblockblob_base_path
+
+``azureblockblob_base_path``
+~~~~~~~~~~~~~~~~
+
+Default: None.
+
+A base path in the storage container to use to store result keys. For example::
+
+    azureblockblob_base_path = '/prefix'
+
 .. setting:: azureblockblob_retry_initial_backoff_sec
 
 ``azureblockblob_retry_initial_backoff_sec``

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1532,7 +1532,7 @@ The name for the storage container in which to store the results.
 .. setting:: azureblockblob_base_path
 
 ``azureblockblob_base_path``
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 5.1
 

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -25,6 +25,10 @@ class test_AzureBlockBlobBackend:
             app=self.app,
             url=self.url)
 
+    @pytest.fixture(params=['', 'my_folder/'])
+    def base_path(self, request):
+        return request.param
+
     def test_missing_third_party_sdk(self):
         azurestorage = azureblockblob.azurestorage
         try:
@@ -57,11 +61,12 @@ class test_AzureBlockBlobBackend:
         assert mock_blob_service_client_instance.create_container.call_count == 1
 
     @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
-    def test_get(self, mock_client):
+    def test_get(self, mock_client, base_path):
+        self.backend.base_path = base_path
         self.backend.get(b"mykey")
 
         mock_client.get_blob_client \
-            .assert_called_once_with(blob="mykey", container="celery")
+            .assert_called_once_with(blob=base_path + "mykey", container="celery")
 
         mock_client.get_blob_client.return_value \
             .download_blob.return_value \
@@ -77,31 +82,34 @@ class test_AzureBlockBlobBackend:
         assert self.backend.get(b"mykey") is None
 
     @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
-    def test_set(self, mock_client):
+    def test_set(self, mock_client, base_path):
+        self.backend.base_path = base_path
         self.backend._set_with_state(b"mykey", "myvalue", states.SUCCESS)
 
         mock_client.get_blob_client.assert_called_once_with(
-            container="celery", blob="mykey")
+            container="celery", blob=base_path + "mykey")
 
         mock_client.get_blob_client.return_value \
             .upload_blob.assert_called_once_with("myvalue", overwrite=True)
 
     @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
-    def test_mget(self, mock_client):
+    def test_mget(self, mock_client, base_path):
         keys = [b"mykey1", b"mykey2"]
 
+        self.backend.base_path = base_path
         self.backend.mget(keys)
 
         mock_client.get_blob_client.assert_has_calls(
-            [call(blob=key.decode(), container='celery') for key in keys],
+            [call(blob=base_path + key.decode(), container='celery') for key in keys],
             any_order=True,)
 
     @patch(MODULE_TO_MOCK + ".AzureBlockBlobBackend._blob_service_client")
-    def test_delete(self, mock_client):
+    def test_delete(self, mock_client, base_path):
+        self.backend.base_path = base_path
         self.backend.delete(b"mykey")
 
         mock_client.get_blob_client.assert_called_once_with(
-            container="celery", blob="mykey")
+            container="celery", blob=base_path + "mykey")
 
         mock_client.get_blob_client.return_value \
             .delete_blob.assert_called_once()

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -113,3 +113,18 @@ class test_AzureBlockBlobBackend:
 
         mock_client.get_blob_client.return_value \
             .delete_blob.assert_called_once()
+
+    def test_base_path_conf(self, base_path):
+        self.app.conf.azureblockblob_base_path = base_path
+        backend = AzureBlockBlobBackend(
+            app=self.app,
+            url=self.url
+        )
+        assert backend.base_path == base_path
+
+    def test_base_path_conf_default(self):
+        backend = AzureBlockBlobBackend(
+            app=self.app,
+            url=self.url
+        )
+        assert backend.base_path == ''


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

- Allow for a basepath such as 'FolderName/' within the Azure container
- Port across the same pattern from `S3Backend`
