### PR TITLE
Prefer more specific glob routing patterns

### DIFF
--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -29,20 +29,19 @@ class MapRoute:
     def __init__(self, map):
         map = map.items() if isinstance(map, Mapping) else map
         self.map = {}
-        self.patterns = {}
+        patterns = {}
         for k, v in map:
             if isinstance(k, Pattern):
-                self.patterns[k] = v
+                patterns[k] = v
             elif '*' in k:
-                self.patterns[re.compile(fnmatch.translate(k))] = v
+                patterns[re.compile(fnmatch.translate(k))] = v
             else:
                 self.map[k] = v
 
         # We sort by the regex pattern's length since longer regex patterns
         # are likely to be more specific.
-        self.patterns = tuple(reversed(sorted(tuple(self.patterns.items()),
-                                              key=lambda pattern: len(
-                                                  pattern[0].pattern))))
+        self.patterns = tuple(reversed(sorted(patterns.items(),
+                                              key=lambda item: len(item[0].pattern))))
 
     def __call__(self, name, *args, **kwargs):
         try:

--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -21,8 +21,8 @@ except AttributeError:  # pragma: no cover
 
 __all__ = ('MapRoute', 'Router', 'prepare')
 
-
 GLOB_PATTERNS = ('*', '?', '[', ']', '!')
+
 
 class MapRoute:
     """Creates a router out of a :class:`dict`."""
@@ -56,12 +56,16 @@ class MapRoute:
         except KeyError:
             pass
         except ValueError:
+            # if self.map[name] is a string we consider it to be the queue's
+            # name.
             return {'queue': self.map[name]}
         for regex, route in self.patterns:
             if regex.match(name):
                 try:
                     return dict(route)
                 except ValueError:
+                    # if route is a string we consider it to be the queue's
+                    # name.
                     return {'queue': route}
 
 

--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -29,7 +29,7 @@ class MapRoute:
     def __init__(self, map):
         map = map.items() if isinstance(map, Mapping) else map
         self.map = {}
-        self.patterns = OrderedDict()
+        self.patterns = {}
         for k, v in map:
             if isinstance(k, Pattern):
                 self.patterns[k] = v
@@ -38,6 +38,12 @@ class MapRoute:
             else:
                 self.map[k] = v
 
+        # We sort by the regex pattern's length since longer regex patterns
+        # are likely to be more specific.
+        self.patterns = tuple(reversed(sorted(tuple(self.patterns.items()),
+                                              key=lambda pattern: len(
+                                                  pattern[0].pattern))))
+
     def __call__(self, name, *args, **kwargs):
         try:
             return dict(self.map[name])
@@ -45,7 +51,7 @@ class MapRoute:
             pass
         except ValueError:
             return {'queue': self.map[name]}
-        for regex, route in self.patterns.items():
+        for regex, route in self.patterns:
             if regex.match(name):
                 try:
                     return dict(route)

--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -24,10 +24,10 @@ __all__ = ('MapRoute', 'Router', 'prepare')
 
 GLOB_PATTERNS = ('*', '?', '[', ']', '!')
 
-MAP_ROUTES_MUST_BE_A_DICTIONARY = """\
-Starting from Celery 5.1 the task_routes configuration must be a dictionary.
-Support for providing a list of router objects will be removed in 6.0.
-""".strip()
+MAP_ROUTES_MUST_BE_A_DICTIONARY = (
+    "Starting from Celery 5.1 the task_routes configuration must be a dictionary. "
+    "Support for providing a list of router objects will be removed in 6.0."
+)
 
 
 class MapRoute:

--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -48,22 +48,43 @@ to match all tasks in the ``feed.tasks`` name-space:
 
     app.conf.task_routes = {'feed.tasks.*': {'queue': 'feeds'}}
 
-If the order of matching patterns is important you should
-specify the router in *items* format instead:
+.. versionadded:: 5.1
+
+Previously, the order of the matching patterns mattered.
+
+This configuration would route all of the tasks in the feed module to the
+``feeds`` queue.
 
 .. code-block:: python
 
     task_routes = ([
-        ('feed.tasks.*', {'queue': 'feeds'}),
-        ('web.tasks.*', {'queue': 'web'}),
-        (re.compile(r'(video|image)\.tasks\..*'), {'queue': 'media'}),
-    ],)
+        ('feed.*', {'queue': 'feeds'}),
+        ('feed.notifications.*', {'queue': 'notifications'})
+    ])
+
+This was both surprising to the user who hasn't read the documentation
+throughoutly and inconvenient as you had to ensure the order of the routes
+is correct, or else there will be a production issue.
+
+In version 5.1 we now sort the task routes by their regex pattern's length.
+This results in the more specific glob, in our example: ``feed.notifications.*``,
+to be always picked as it is matched first.
+
+This is both predicable and easy to use.
 
 .. note::
 
     The :setting:`task_routes` setting can either be a dictionary, or a
     list of router objects, so in this case we need to specify the setting
     as a tuple containing a list.
+
+.. warning::
+
+    Since 5.1, the order of the routes does not matter.
+    Therefore, using the form of a list of router objects
+    as a value for :setting:`task_routes` is deprecated.
+
+    In 6.0, support for this form will be removed.
 
 After installing the router, you can start server `z` to only process the feeds
 queue like this:


### PR DESCRIPTION
_Note_: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
The order of specification for task routes no longer matter as we now sort by pattern length.
If two overlapping patterns will match a route, we now prefer the longer one as it is more specific.

Fixes #6670.

