### PR TITLE
Drop the lzma extra

### DIFF
--- a/requirements/extras/lzma.txt
+++ b/requirements/extras/lzma.txt
@@ -1,1 +1,0 @@
-backports.lzma;python_version<"3.3"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ EXTENSIONS = {
     'eventlet',
     'gevent',
     'librabbitmq',
-    'lzma',
     'memcache',
     'mongodb',
     'msgpack',


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

The lzma backport is no longer needed since we don't support Python<3.3 anymore.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->