### PR TITLE
Fix JSON decoding errors when using MongoDB as backend

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -202,8 +202,8 @@ class MongoBackend(BaseBackend):
                 'status': obj['status'],
                 'result': self.decode(obj['result']),
                 'date_done': obj['date_done'],
-                'traceback': self.decode(obj['traceback']),
-                'children': self.decode(obj['children']),
+                'traceback': obj['traceback'],
+                'children': obj['children'],
             })
         return {'status': states.PENDING, 'result': None}
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Below is a sample data of the meta-data for a task stored in MongoDB.
```json
{
    "_id": "50b5a2aa-e0a4-4c85-abb2-b62dd81de0a1",
    "status": "FAILURE",
    "result": "{\"exc_type\": \"Exception\", \"exc_message\": [\"error\"], \"exc_module\": \"builtins\"}",
    "traceback": "Traceback (most recent call last):\n  File \"c:\\code\\.venv\\lib\\site-packages\\celery\\app\\trace.py\", line 405, in trace_task\n    R = retval = fun(*args, **kwargs)\n  File \"c:\\code\\.venv\\lib\\site-packages\\celery\\app\\trace.py\", line 697, in __protected_call__\n    return self.run(*args, **kwargs)\n  File \"c:\\Code\\nwcd\\worker\\tasks\\run.py\", line 94, in parent\n    raise Exception('error')\nException: error\n",
    "children": [
        [
            ["7cb0ccf3-fe70-4c44-a110-56e87fabdd95", null], null
        ]
    ],
    "date_done": "2021-03-12T04:09:11.885766",
    "group_id": "8359b4f9-3a5f-4b4d-b480-7e49a2f1fe8e"
}
```
You can find that 'traceback' is a string and 'children' is a list. Both of them cannot be decoded by JSON. So I removed the code for decoding.
```python
# celery\backends\mongodb.py
    def _get_task_meta_for(self, task_id):
        """Get task meta-data for a task by id."""
        obj = self.collection.find_one({'_id': task_id})
        if obj:
            return self.meta_from_decoded({
                'task_id': obj['_id'],
                'status': obj['status'],
                'result': self.decode(obj['result']),
                'date_done': obj['date_done'],
                'traceback': obj['traceback'],  # Was self.decode(obj['traceback'])
                'children': obj['children'],  # Was self.decode(obj['children'])
            })
        return {'status': states.PENDING, 'result': None}
```
`self.decode` for decoding 'traceback' and 'children' will result in Python errors. Please see below for the sample code to reproduce the errors.
```python
# Task definitions
@app.task()
def parent(raise_error=False):
    child.delay()
    if raise_error:
        raise Exception('error')
    return {'raise_error': raise_error}


@app.task()
def child():
    return {'result': 123}
```
```python
parent.delay().get()  # kombu.exceptions.DecodeError occurred here due to 'children' cannot be decoded
```
```python
from celery import chord
task_chord = chord([parent.si(True)], parent.si())
task_chord.delay()  # json.decoder.JSONDecodeError occurred on worker side due to 'traceback' cannot be decoded
```