### PR TITLE
document time limit options of apply_async

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -454,6 +454,11 @@ class Task:
 
             retry_policy (Mapping): Override the retry policy used.
                 See the :setting:`task_publish_retry_policy` setting.
+                
+            time_limit (int): If set, overrides the default time limit.
+            
+            soft_time_limit (int): If set, overrides the default soft
+                time limit.
 
             queue (str, kombu.Queue): The queue to route the task to.
                 This must be a key present in :setting:`task_queues`, or


### PR DESCRIPTION
I have noticed that time_limit and soft_time_limit do actually work with apply_async. Since I would like to use these options in my project, it would give me some peace of mind if these options were explicitly documented.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
