### PR TITLE
Fix checking expiration of X.509 certificates

### DIFF
--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -27,7 +27,7 @@ class Certificate:
 
     def has_expired(self):
         """Check if the certificate has expired."""
-        return datetime.datetime.now() > self._cert.not_valid_after
+        return datetime.datetime.utcnow() >= self._cert.not_valid_after
 
     def get_pubkey(self):
         """Get public key from certificate."""

--- a/t/unit/security/test_certificate.py
+++ b/t/unit/security/test_certificate.py
@@ -38,7 +38,7 @@ class test_Certificate(SecurityCase):
         x = Certificate(CERT1)
 
         x._cert = Mock(name='cert')
-        time_after = datetime.datetime.now() + datetime.timedelta(days=-1)
+        time_after = datetime.datetime.utcnow() + datetime.timedelta(days=-1)
         x._cert.not_valid_after = time_after
 
         assert x.has_expired() is True
@@ -47,7 +47,7 @@ class test_Certificate(SecurityCase):
         x = Certificate(CERT1)
 
         x._cert = Mock(name='cert')
-        time_after = datetime.datetime.now() + datetime.timedelta(days=1)
+        time_after = datetime.datetime.utcnow() + datetime.timedelta(days=1)
         x._cert.not_valid_after = time_after
 
         assert x.has_expired() is False


### PR DESCRIPTION
## Description

`not_valid_after` is a naïve datetime representing a moment in UTC. It should not be compared to a naïve datetime representing the current local date and time.

Also, the value is inclusive.

https://cryptography.io/en/3.4.6/x509/reference.html#cryptography.x509.Certificate.not_valid_after