### PR TITLE
Update systemd tmpfiles path

### DIFF
--- a/docs/userguide/daemonizing.rst
+++ b/docs/userguide/daemonizing.rst
@@ -432,7 +432,7 @@ You can also use systemd-tmpfiles in order to create working directories (for lo
 
 .. code-block:: bash
 
-  d /var/run/celery 0755 celery celery -
+  d /run/celery 0755 celery celery -
   d /var/log/celery 0755 celery celery -
 
 


### PR DESCRIPTION
To fix the systemd warning message: `/etc/tmpfiles.d/celery.conf:1: Line references path below legacy directory /var/run/, updating /var/run/celery → /run/celery; please update the tmpfiles.d/ drop-in file accordingly`
Change the path to `/run` as is now preferred by systemd.