### PR TITLE
Tasks can now have required kwargs at any order

### DIFF
--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -259,11 +259,11 @@ def _argsfromspec(spec, replace_defaults=True):
     varargs = spec.varargs
     varkw = spec.varkw
     if spec.kwonlydefaults:
-        split = len(spec.kwonlydefaults)
-        kwonlyargs = spec.kwonlyargs[:-split]
+        kwonlyargs = set(spec.kwonlyargs) - set(spec.kwonlydefaults.keys())
         if replace_defaults:
             kwonlyargs_optional = [
-                (kw, i) for i, kw in enumerate(spec.kwonlyargs[-split:])]
+                (kw, i) for i, kw in enumerate(spec.kwonlydefaults.keys())
+            ]
         else:
             kwonlyargs_optional = list(spec.kwonlydefaults.items())
     else:

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -225,7 +225,6 @@ class test_head_from_fun:
         fun = head_from_fun(A.f, bound=True)
         assert fun(1) == 1
 
-    @pytest.mark.xfail(reason="Issue #5469")
     def test_kwonly_required_args(self):
         local = {}
         fun = ('def f_kwargs_required(*, a="a", b, c=None):'


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fixes #5469.
Thanks to @dimavitvickiy for the initial research in #5485.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
