### PR TITLE
Explicitly require setuptools, bin/celery.py and utils/imports.py imports pkg_resources

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,3 +6,4 @@ click>=7.0,<8.0
 click-didyoumean>=0.0.3
 click-repl>=0.1.6
 click-plugins>=1.1.1
+setuptools


### PR DESCRIPTION


*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
Some files have runtime dependency on setuptools because of importing `pkg_resources` module. In Fedora, we build the package using setuptools, but we ship it to users potentially without it. I suggest explicitly list this requirement.
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
