### PR TITLE
Add support for SQLAlchemy 1.4

### DIFF
--- a/celery/backends/database/session.py
+++ b/celery/backends/database/session.py
@@ -4,11 +4,16 @@ import time
 from kombu.utils.compat import register_after_fork
 from sqlalchemy import create_engine
 from sqlalchemy.exc import DatabaseError
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 
 from celery.utils.time import get_exponential_backoff_interval
+
+try:
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    # TODO: Remove this once we drop support for SQLAlchemy < 1.4.
+    from sqlalchemy.ext.declarative import declarative_base
 
 ResultModelBase = declarative_base()
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Following the changes in SQLAlchemy 1.4, the declarative base is no longer an extension.
Importing it from `sqlalchemy.ext.declarative` is deprecated and will be removed in SQLAlchemy 2.0.
This PR adds support for the newer versions of SQLAlchemy while maintaining backwards compatibility for previous versions.

Superceeds #6709.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
