### PR TITLE
worker_pool setting is now respected correctly

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -274,9 +274,10 @@ class Celery:
         self.__autoset('broker_url', broker)
         self.__autoset('result_backend', backend)
         self.__autoset('include', include)
-        self.__autoset('broker_use_ssl', kwargs.get('broker_use_ssl'))
-        self.__autoset('redis_backend_use_ssl',
-                       kwargs.get('redis_backend_use_ssl'))
+
+        for key, value in kwargs.items():
+            self.__autoset(key, value)
+
         self._conf = Settings(
             PendingConfiguration(
                 self._preconf, self._finalize_pending_conf),

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -274,6 +274,10 @@ class test_App:
         with self.Celery(broker='foo://baribaz') as app:
             assert app.conf.broker_url == 'foo://baribaz'
 
+    def test_pending_confugration__kwargs(self):
+        with self.Celery(foo='bar') as app:
+            assert app.conf.foo == 'bar'
+
     def test_pending_configuration__setattr(self):
         with self.Celery(broker='foo://bar') as app:
             app.conf.task_default_delivery_mode = 44


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

#6701 tried to set the `worker_pool` using the `Celery` class' constructor. This wasn't supported for some reason.
I've included a fix for it in this PR as this behavior is surprising for our users, UX-wise.

Also, we now prefer the `worker_pool` setting if available over the default CLI value for the pool argument.

If we get the default value through the CLI, we should first check if the worker_pool setting was set.
If it was, we should prefer it over the default CLI value.

Fixes #6701.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
