### PR TITLE
`some_task.apply_async(ignore_result=True)` now avoids persisting the result

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -284,7 +284,7 @@ class AMQP:
                    time_limit=None, soft_time_limit=None,
                    create_sent_event=False, root_id=None, parent_id=None,
                    shadow=None, chain=None, now=None, timezone=None,
-                   origin=None, argsrepr=None, kwargsrepr=None):
+                   origin=None, ignore_result=False, argsrepr=None, kwargsrepr=None):
         args = args or ()
         kwargs = kwargs or {}
         if not isinstance(args, (list, tuple)):
@@ -335,7 +335,8 @@ class AMQP:
                 'parent_id': parent_id,
                 'argsrepr': argsrepr,
                 'kwargsrepr': kwargsrepr,
-                'origin': origin or anon_nodename()
+                'origin': origin or anon_nodename(),
+                'ignore_result': ignore_result,
             },
             properties={
                 'correlation_id': task_id,

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -774,6 +774,7 @@ class Task:
             'callbacks': maybe_list(link),
             'errbacks': maybe_list(link_error),
             'headers': headers,
+            'ignore_result': options.get('ignore_result', False),
             'delivery_info': {
                 'is_eager': True,
                 'exchange': options.get('exchange'),

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -61,36 +61,37 @@ def _reprtask(task, fmt=None, flags=None):
 class Context:
     """Task request variables (Task.request)."""
 
-    logfile = None
-    loglevel = None
-    hostname = None
-    id = None
-    args = None
-    kwargs = None
-    retries = 0
-    eta = None
-    expires = None
-    is_eager = False
-    headers = None
-    delivery_info = None
-    reply_to = None
-    shadow = None
-    root_id = None
-    parent_id = None
-    correlation_id = None
-    taskset = None   # compat alias to group
-    group = None
-    group_index = None
-    chord = None
-    chain = None
-    utc = None
-    called_directly = True
-    callbacks = None
-    errbacks = None
-    timelimit = None
-    origin = None
     _children = None   # see property
     _protected = 0
+    args = None
+    callbacks = None
+    called_directly = True
+    chain = None
+    chord = None
+    correlation_id = None
+    delivery_info = None
+    errbacks = None
+    eta = None
+    expires = None
+    group = None
+    group_index = None
+    headers = None
+    hostname = None
+    id = None
+    ignore_result = False
+    is_eager = False
+    kwargs = None
+    logfile = None
+    loglevel = None
+    origin = None
+    parent_id = None
+    retries = 0
+    reply_to = None
+    root_id = None
+    shadow = None
+    taskset = None   # compat alias to group
+    timelimit = None
+    utc = None
 
     def __init__(self, *args, **kwargs):
         self.update(*args, **kwargs)

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -505,6 +505,11 @@ class Task:
                 attribute.  Trailing can also be disabled by default using the
                 :attr:`trail` attribute
 
+            ignore_result (bool): If set to `False` (default) the result
+                of a task will be stored in the backend. If set to `True`
+                the result will not be stored. This can also be set
+                using the :attr:`ignore_result` in the `app.task` decorator.
+
             publisher (kombu.Producer): Deprecated alias to ``producer``.
 
             headers (Dict): Message headers to be included in the message.

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -150,7 +150,7 @@ class Backend:
     def mark_as_done(self, task_id, result,
                      request=None, store_result=True, state=states.SUCCESS):
         """Mark task as successfully executed."""
-        if store_result:
+        if not request.ignore_result and store_result:
             self.store_result(task_id, result, state, request=request)
         if request and request.chord:
             self.on_chord_part_return(request, state, result)

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -76,6 +76,12 @@ class _nulldict(dict):
     __setitem__ = update = setdefault = ignore
 
 
+def _is_request_ignore_result(request):
+    if request is None:
+        return False
+    return request.ignore_result
+
+
 class Backend:
     READY_STATES = states.READY_STATES
     UNREADY_STATES = states.UNREADY_STATES
@@ -150,7 +156,7 @@ class Backend:
     def mark_as_done(self, task_id, result,
                      request=None, store_result=True, state=states.SUCCESS):
         """Mark task as successfully executed."""
-        if not request.ignore_result and store_result:
+        if (store_result and not _is_request_ignore_result(request)):
             self.store_result(task_id, result, state, request=request)
         if request and request.chord:
             self.on_chord_part_return(request, state, result)

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -120,6 +120,7 @@ class Request:
         self._eventer = eventer
         self._connection_errors = connection_errors or ()
         self._task = task or self._app.tasks[self._type]
+        self._ignore_result = self._request_dict.get('ignore_result', False)
 
         # timezone means the message is timezone-aware, and the only timezone
         # supported at this point is UTC.
@@ -239,6 +240,10 @@ class Request:
     @property
     def hostname(self):
         return self._hostname
+
+    @property
+    def ignore_result(self):
+        return self._ignore_result
 
     @property
     def eventer(self):

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -96,10 +96,15 @@ class test_tasks:
         assert list(ret) == list(range(120))
 
     @flaky
+    @pytest.mark.xfail(reason="Issue #5398")
     def test_ignore_result(self, manager):
         """Testing calling task with ignoring results."""
         result = add.apply_async((1, 2), ignore_result=True)
         assert result.get() is None
+        # We wait since it takes a bit of time for the result to be
+        # persisted in the result backend.
+        sleep(1)
+        assert result.result is None
 
     @flaky
     def test_timeout(self, manager):

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -96,7 +96,6 @@ class test_tasks:
         assert list(ret) == list(range(120))
 
     @flaky
-    @pytest.mark.xfail(reason="Issue #5398")
     def test_ignore_result(self, manager):
         """Testing calling task with ignoring results."""
         result = add.apply_async((1, 2), ignore_result=True)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fixes #5398.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
