### PR TITLE
fix AttributeError regression in #6619

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -208,7 +208,7 @@ def _evaluate_entry_args(entry_args):
         return []
     return [
         v() if isinstance(v, BeatLazyFunc) else v
-        for v in entry_args.args
+        for v in entry_args
     ]
 
 

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -212,6 +212,23 @@ class test_Scheduler:
         scheduler.apply_async(entry, advance=False)
         foo.apply_async.assert_called()
 
+    def test_apply_async_without_null_args(self):
+
+        @self.app.task(shared=False)
+        def foo(moo: int):
+            return moo
+        foo.apply_async = Mock(name='foo.apply_async')
+
+        scheduler = mScheduler(app=self.app)
+        entry = scheduler.Entry(task=foo.name, app=self.app, args=None,
+                                kwargs=None)
+        entry.args = (101,)
+        entry.kwargs = None
+
+        scheduler.apply_async(entry, advance=False)
+        foo.apply_async.assert_called()
+        assert foo.apply_async.call_args[0][0] == [101]
+
     def test_should_sync(self):
 
         @self.app.task(shared=False)


### PR DESCRIPTION
## Description

Fixes regression in #6619 

Please see the relevant stacktrace below:

```python
    def _evaluate_entry_args(entry_args):
        if not entry_args:
            return []                              
        return [
            v() if isinstance(v, BeatLazyFunc) else v
>           for v in entry_args.args                                                                                                                                                                         
        ]                         
E       AttributeError: 'tuple' object has no attribute 'args'
                                    
celery/beat.py:211: AttributeError
```
