### PR TITLE
Deduplicate successful tasks

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -299,6 +299,9 @@ NAMESPACES = Namespace(
         disable_rate_limits=Option(
             False, type='bool', old={'celery_disable_rate_limits'},
         ),
+        deduplicate_successful_tasks=Option(
+            False, type='bool'
+        ),
         enable_remote_control=Option(
             True, type='bool', old={'celery_enable_remote_control'},
         ),

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -48,6 +48,8 @@ __all__ = (
     'setup_worker_optimizations', 'reset_worker_optimizations',
 )
 
+from celery.worker.state import successful_requests
+
 logger = get_logger(__name__)
 
 #: Format string used to log task success.
@@ -402,6 +404,9 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
 
             if deduplicate_successful_tasks:
                 r = AsyncResult(task_request.id, app=app)
+                if task_request.id in successful_requests:
+                    return trace_ok_t(R, I, T, Rstr)
+
                 try:
                     state = r.state
                 except BackendGetMetaError:

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -20,7 +20,9 @@ from celery import current_app, group, signals, states
 from celery._state import _task_stack
 from celery.app.task import Context
 from celery.app.task import Task as BaseTask
-from celery.exceptions import Ignore, InvalidTaskError, Reject, Retry
+from celery.exceptions import (BackendGetMetaError, Ignore, InvalidTaskError,
+                               Reject, Retry)
+from celery.result import AsyncResult
 from celery.utils.log import get_logger
 from celery.utils.nodenames import gethostname
 from celery.utils.objects import mro_lookup
@@ -327,6 +329,9 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
     else:
         publish_result = not eager and not ignore_result
 
+    deduplicate_successful_tasks = ((app.conf.task_acks_late or task.acks_late)
+                                    and app.conf.worker_deduplicate_successful_tasks)
+
     hostname = hostname or gethostname()
     inherit_parent_priority = app.conf.task_inherit_parent_priority
 
@@ -394,6 +399,21 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
             push_task(task)
             task_request = Context(request or {}, args=args,
                                    called_directly=False, kwargs=kwargs)
+
+            if deduplicate_successful_tasks:
+                r = AsyncResult(task_request.id, app=app)
+                try:
+                    state = r.state
+                except BackendGetMetaError:
+                    pass
+                else:
+                    if state == SUCCESS:
+                        info(LOG_IGNORED, {
+                            'id': task_request.id,
+                            'name': get_task_name(task_request, name),
+                            'description': 'Task already completed successfully.'
+                        })
+                        return trace_ok_t(R, I, T, Rstr)
             root_id = task_request.root_id or uuid
             task_priority = task_request.delivery_info.get('priority') if \
                 inherit_parent_priority else None

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -402,10 +402,11 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
             task_request = Context(request or {}, args=args,
                                    called_directly=False, kwargs=kwargs)
 
-            if deduplicate_successful_tasks:
-                r = AsyncResult(task_request.id, app=app)
+            redelivered = task_request.delivery_info.get('redelivered', False)
+            if deduplicate_successful_tasks and redelivered:
                 if task_request.id in successful_requests:
                     return trace_ok_t(R, I, T, Rstr)
+                r = AsyncResult(task_request.id, app=app)
 
                 try:
                     state = r.state

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -399,11 +399,12 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
             except AttributeError:
                 raise InvalidTaskError(
                     'Task keyword arguments is not a mapping')
-            push_task(task)
+
             task_request = Context(request or {}, args=args,
                                    called_directly=False, kwargs=kwargs)
 
-            redelivered = task_request.delivery_info.get('redelivered', False)
+            redelivered = (task_request.delivery_info
+                           and task_request.delivery_info.get('redelivered', False))
             if deduplicate_successful_tasks and redelivered:
                 if task_request.id in successful_requests:
                     return trace_ok_t(R, I, T, Rstr)
@@ -421,6 +422,8 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                             'description': 'Task already completed successfully.'
                         })
                         return trace_ok_t(R, I, T, Rstr)
+
+            push_task(task)
             root_id = task_request.root_id or uuid
             task_priority = task_request.delivery_info.get('priority') if \
                 inherit_parent_priority else None

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -332,7 +332,8 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
         publish_result = not eager and not ignore_result
 
     deduplicate_successful_tasks = ((app.conf.task_acks_late or task.acks_late)
-                                    and app.conf.worker_deduplicate_successful_tasks)
+                                    and app.conf.worker_deduplicate_successful_tasks
+                                    and app.backend.persistent)
 
     hostname = hostname or gethostname()
     inherit_parent_priority = app.conf.task_inherit_parent_priority

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -497,7 +497,7 @@ class Request:
             if isinstance(retval.exception, (SystemExit, KeyboardInterrupt)):
                 raise retval.exception
             return self.on_failure(retval, return_ok=True)
-        task_ready(self)
+        task_ready(self, successful=True)
 
         if self.task.acks_late:
             self.acknowledge()

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2601,6 +2601,33 @@ to have different import categories.
 The modules in this setting are imported after the modules in
 :setting:`imports`.
 
+.. setting:: worker_deduplicate_successful_tasks
+
+``worker_deduplicate_successful_tasks``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.1
+
+Default: False
+
+Before each task execution, instruct the worker to check if this task is
+a duplicate message.
+
+Deduplication occurs only with tasks that have the same identifier,
+enabled late acknowledgment, were redelivered by the message broker
+and their state is ``SUCCESS`` in the result backend.
+
+To avoid overflowing the result backend with queries, a local cache of
+successfully executed tasks is checked before querying the result backend
+in case the task was already successfully executed by the same worker that
+received the task.
+
+This cache can be made persistent by setting the :setting:`worker_state_db`
+setting.
+
+If the result backend is not persistent (the RPC backend, for example),
+this setting is ignored.
+
 .. _conf-concurrency:
 
 .. setting:: worker_concurrency

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, Mock, patch, PropertyMock
 from uuid import uuid4
 
 import pytest
@@ -529,7 +529,8 @@ class test_trace(TraceCase):
 
         with patch('celery.app.trace.AsyncResult') as async_result_mock:
             assert trace(self.app, add, (1, 1), task_id=task_id, request=request) == (2, None)
-            async_result_mock().state.side_effect = BackendGetMetaError
+            state_property = PropertyMock(side_effect=BackendGetMetaError)
+            type(async_result_mock()).state = state_property
             assert trace(self.app, add, (1, 1), task_id=task_id, request=request) == (2, None)
 
         self.app.conf.worker_deduplicate_successful_tasks = False

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -484,7 +484,7 @@ class test_trace(TraceCase):
 
         self.app.conf.worker_deduplicate_successful_tasks = True
         task_id = str(uuid4())
-        request = {'id': task_id}
+        request = {'id': task_id, 'delivery_info': {'redelivered': True}}
 
         assert trace(self.app, add, (1, 1), task_id=task_id, request=request) == (2, None)
         assert trace(self.app, add, (1, 1), task_id=task_id, request=request) == (None, None)
@@ -504,7 +504,7 @@ class test_trace(TraceCase):
 
         self.app.conf.worker_deduplicate_successful_tasks = True
         task_id = str(uuid4())
-        request = {'id': task_id}
+        request = {'id': task_id, 'delivery_info': {'redelivered': True}}
 
         with patch('celery.app.trace.AsyncResult') as async_result_mock:
             async_result_mock().state.return_value = PENDING
@@ -526,7 +526,7 @@ class test_trace(TraceCase):
 
         self.app.conf.worker_deduplicate_successful_tasks = True
         task_id = str(uuid4())
-        request = {'id': task_id}
+        request = {'id': task_id, 'delivery_info': {'redelivered': True}}
 
         with patch('celery.app.trace.AsyncResult') as async_result_mock:
             assert trace(self.app, add, (1, 1), task_id=task_id, request=request) == (2, None)
@@ -550,7 +550,7 @@ class test_trace(TraceCase):
         self.app.conf.worker_deduplicate_successful_tasks = True
 
         task_id = str(uuid4())
-        request = {'id': task_id}
+        request = {'id': task_id, 'delivery_info': {'redelivered': True}}
 
         successful_requests.add(task_id)
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This feature allows the user to deduplicate successful tasks that acks late.

The trace function fetches the metadata from the backend each time it receives a task and compares its state.
If the state is `SUCCESS` we log and bail instead of executing the task.
The task is acknowledged and everything proceeds normally.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
