### PR TITLE
fix: Chord counting of group children

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1424,8 +1424,15 @@ class _chord(Signature):
             subtasks = getattr(sig_obj.tasks, "tasks", sig_obj.tasks)
             return sum(cls._descend(task) for task in subtasks)
         elif isinstance(sig_obj, _chain):
-            # The last element in a chain counts toward this chord
-            return cls._descend(sig_obj.tasks[-1])
+            # The last non-empty element in a chain counts toward this chord
+            for child_sig in sig_obj.tasks[-1::-1]:
+                child_size = cls._descend(child_sig)
+                if child_size > 0:
+                    return child_size
+            else:
+                # We have to just hope this chain is part of some encapsulating
+                # signature which is valid and can fire the chord body
+                return 0
         elif isinstance(sig_obj, chord):
             # The child chord's body counts toward this chord
             return cls._descend(sig_obj.body)

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1415,20 +1415,20 @@ class _chord(Signature):
         )
 
     @classmethod
-    def __descend(cls, sig_obj):
+    def _descend(cls, sig_obj):
         # Sometimes serialized signatures might make their way here
         if not isinstance(sig_obj, Signature) and isinstance(sig_obj, dict):
             sig_obj = Signature.from_dict(sig_obj)
         if isinstance(sig_obj, group):
             # Each task in a group counts toward this chord
             subtasks = getattr(sig_obj.tasks, "tasks", sig_obj.tasks)
-            return sum(cls.__descend(task) for task in subtasks)
+            return sum(cls._descend(task) for task in subtasks)
         elif isinstance(sig_obj, _chain):
             # The last element in a chain counts toward this chord
-            return cls.__descend(sig_obj.tasks[-1])
+            return cls._descend(sig_obj.tasks[-1])
         elif isinstance(sig_obj, chord):
             # The child chord's body counts toward this chord
-            return cls.__descend(sig_obj.body)
+            return cls._descend(sig_obj.body)
         elif isinstance(sig_obj, Signature):
             # Each simple signature counts as 1 completion for this chord
             return 1
@@ -1437,7 +1437,7 @@ class _chord(Signature):
 
     def __length_hint__(self):
         tasks = getattr(self.tasks, "tasks", self.tasks)
-        return sum(self.__descend(task) for task in tasks)
+        return sum(self._descend(task) for task in tasks)
 
     def run(self, header, body, partial_args, app=None, interval=None,
             countdown=1, max_retries=None, eager=False,

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1296,8 +1296,8 @@ class group(Signature):
         return app if app is not None else current_app
 
 
-@Signature.register_type()
-class chord(Signature):
+@Signature.register_type(name="chord")
+class _chord(Signature):
     r"""Barrier synchronization primitive.
 
     A chord consists of a header and a body.
@@ -1535,6 +1535,11 @@ class chord(Signature):
 
     tasks = getitem_property('kwargs.header', 'Tasks in chord header.')
     body = getitem_property('kwargs.body', 'Body task of chord.')
+
+
+# Add a back-compat alias for the previous `chord` class name which conflicts
+# with keyword arguments elsewhere in this file
+chord = _chord
 
 
 def signature(varies, *args, **kwargs):


### PR DESCRIPTION
## Description

Fixes #6721

This PR fixes the faulty chord counting reported in #6721, as well as an edge case where the tail task of a chain being counted for chord size could be an empty group (or other zero sized thing).