### PR TITLE
Ensure AMQPContext exposes an app attribute

### DIFF
--- a/celery/bin/amqp.py
+++ b/celery/bin/amqp.py
@@ -25,6 +25,10 @@ class AMQPContext:
         self.connection = self.cli_context.app.connection()
         self.channel = None
         self.reconnect()
+    
+    @property
+    def app(self):
+        return self.cli_context.app
 
     def respond(self, retval):
         if isinstance(retval, str):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fixes #6726 - `handle_preload_options` introduced in celery v5.0.3 expects the context object it receives to have an app attribute. In case of the `celery amqp` command the `CLIContext` object gets wrapped around by an `AMQPContext` which does not expose this attribute. This tiny modification fixes that by making `AMQPContext` expose an app by delegating to the underlying `CLIContext` object.