### PR TITLE
Minor changes to the django/proj/celery.py example

### DIFF
--- a/examples/django/proj/celery.py
+++ b/examples/django/proj/celery.py
@@ -2,7 +2,7 @@ import os
 
 from celery import Celery
 
-# set the default Django settings module for the 'celery' program.
+# Set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings')
 
 app = Celery('proj')
@@ -13,7 +13,7 @@ app = Celery('proj')
 #   should have a `CELERY_` prefix.
 app.config_from_object('django.conf:settings', namespace='CELERY')
 
-# Load task modules from all registered Django app configs.
+# Load task modules from all registered Django apps.
 app.autodiscover_tasks()
 
 


### PR DESCRIPTION
See #6738 for an explanation why it’s better to say “registered apps”.