### PR TITLE
#6748 Fix Retry.__reduce__ method

### DIFF
--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -180,7 +180,7 @@ class Retry(TaskPredicate):
         return f'Retry {self.humanize()}'
 
     def __reduce__(self):
-        return self.__class__, (self.message, self.excs, self.when)
+        return self.__class__, (self.message, self.exc, self.when)
 
 
 RetryTaskError = Retry  # noqa: E305 XXX compat

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -97,8 +97,6 @@ __all__ = (
     'CeleryCommandException',
 )
 
-from celery.utils.serialization import get_pickleable_exception
-
 UNREGISTERED_FMT = """\
 Task of kind {0} never registered, please make sure it's imported.\
 """
@@ -182,8 +180,7 @@ class Retry(TaskPredicate):
         return f'Retry {self.humanize()}'
 
     def __reduce__(self):
-        exc = get_pickleable_exception(self.exc)
-        return self.__class__, (self.message, exc, self.when)
+        return self.__class__, (self.message, self.exc, self.when)
 
 
 RetryTaskError = Retry  # noqa: E305 XXX compat

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -97,6 +97,8 @@ __all__ = (
     'CeleryCommandException',
 )
 
+from celery.utils.serialization import get_pickleable_exception
+
 UNREGISTERED_FMT = """\
 Task of kind {0} never registered, please make sure it's imported.\
 """
@@ -180,7 +182,8 @@ class Retry(TaskPredicate):
         return f'Retry {self.humanize()}'
 
     def __reduce__(self):
-        return self.__class__, (self.message, self.exc, self.when)
+        exc = get_pickleable_exception(self.exc)
+        return self.__class__, (self.message, exc, self.when)
 
 
 RetryTaskError = Retry  # noqa: E305 XXX compat

--- a/t/unit/app/test_exceptions.py
+++ b/t/unit/app/test_exceptions.py
@@ -12,8 +12,7 @@ class test_Retry:
         assert x.humanize()
 
     def test_pickleable(self):
-        x = Retry('foo', KeyError(), when=datetime.utcnow(), is_eager=True,
-                  sig=Signature())
+        x = Retry('foo', KeyError(), when=datetime.utcnow())
         y = pickle.loads(pickle.dumps(x))
         assert x.message == y.message
         assert repr(x.exc) == repr(y.exc)

--- a/t/unit/app/test_exceptions.py
+++ b/t/unit/app/test_exceptions.py
@@ -1,7 +1,6 @@
 import pickle
 from datetime import datetime
 
-from celery.canvas import Signature
 from celery.exceptions import Reject, Retry
 
 

--- a/t/unit/app/test_exceptions.py
+++ b/t/unit/app/test_exceptions.py
@@ -12,7 +12,8 @@ class test_Retry:
 
     def test_pickleable(self):
         x = Retry('foo', KeyError(), when=datetime.utcnow())
-        assert pickle.loads(pickle.dumps(x))
+        y = pickle.loads(pickle.dumps(x))
+        assert repr(x) == repr(y)
 
 
 class test_Reject:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

This PR fixes invalid pickle protocol support for `celery.exceptions.Retry` (closes #6748)