### PR TITLE
update docs/userguide - `@task` -> `@app.task`

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -153,7 +153,7 @@ be the task instance (``self``), just like Python bound methods:
 
     logger = get_task_logger(__name__)
 
-    @task(bind=True)
+    @app.task(bind=True)
     def add(self, x, y):
         logger.info(self.request.id)
 
@@ -175,7 +175,7 @@ The ``base`` argument to the task decorator specifies the base class of the task
         def on_failure(self, exc, task_id, args, kwargs, einfo):
             print('{0!r} failed: {1!r}'.format(task_id, exc))
 
-    @task(base=MyTask)
+    @app.task(base=MyTask)
     def add(x, y):
         raise KeyError()
 
@@ -318,7 +318,7 @@ on the automatic naming:
 
 .. code-block:: python
 
-    @task(name='proj.tasks.add')
+    @app.task(name='proj.tasks.add')
     def add(x, y):
         return x + y
 


### PR DESCRIPTION
## Description

Hi, thanks for maintaining this awesome project!

I think the documentation, here: https://docs.celeryproject.org/en/latest/userguide/tasks.html#task-inheritance is not correct/up to date. It says `@task` but I think it is supposed to say `@app.task`

one example here:

```py
import celery

class MyTask(celery.Task):

    def on_failure(self, exc, task_id, args, kwargs, einfo):
        print('{0!r} failed: {1!r}'.format(task_id, exc))

@task(base=MyTask)
def add(x, y):
    raise KeyError()
 ```
- I think the decorator to `add` should be `@app.task(base=MyTask)` right? I found two other places where this is imo not correct?

If I am mistaken here, I am sorry and would appreciate a quick explanation why `app` is not there.