### PR TITLE
fix child task inherit parent priority

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -731,8 +731,7 @@ class Celery:
                     parent_id = parent.request.id
 
                 if conf.task_inherit_parent_priority:
-                    options.setdefault('priority',
-                                       parent.request.delivery_info.get('priority'))
+                    options.update({'priority': parent.request.delivery_info.get('priority')})
 
         message = amqp.create_task_message(
             task_id, name, args, kwargs, countdown, eta, group_id, group_index,


### PR DESCRIPTION
fix child tasks cannot inherit the priority of the parent task.

## Description
In addition to the other priority-related PR #5313. 
fix child tasks cannot inherit the priority of the parent task. 
It has been tested in production and seems to work as designed.

