### PR TITLE
Celery Mailbox accept and serializer parameters are initialized from configuration

### DIFF
--- a/celery/app/control.py
+++ b/celery/app/control.py
@@ -431,7 +431,8 @@ class Control:
         self.mailbox = self.Mailbox(
             app.conf.control_exchange,
             type='fanout',
-            accept=['json'],
+            accept=app.conf.accept_content,
+            serializer=app.conf.task_serializer,
             producer_pool=lazy(lambda: self.app.amqp.producer_pool),
             queue_ttl=app.conf.control_queue_ttl,
             reply_queue_ttl=app.conf.control_queue_ttl,

--- a/t/unit/app/test_control.py
+++ b/t/unit/app/test_control.py
@@ -241,6 +241,12 @@ class test_Control:
         self.app.control.broadcast.assert_called_with(
             name, destination=destination, arguments=args, **_options or {})
 
+    def test_serializer(self):
+        self.app.conf['task_serializer'] = 'test'
+        self.app.conf['accept_content'] = ['test']
+        assert control.Control(self.app).mailbox.serializer == 'test'
+        assert control.Control(self.app).mailbox.accept == ['test']
+
     def test_purge(self):
         self.app.amqp.TaskConsumer = Mock(name='TaskConsumer')
         self.app.control.purge()


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This PR is removing hardcoded serializers and accepted_serializers parameters in Pidbox mechanism used by Control/Inspect. From one on, Control/Inspect are using `task_serializer` and `accept_content` configuration parameters for defining underlying protocol. 

This PR is fixing this example:

```python
import time

from celery import Celery


app = Celery('example')
app.conf.update(
    backend_url='redis://localhost:6379',
    broker_url='redis://localhost:6379',
    result_backend='redis://localhost:6379',
    task_serializer='pickle',
    accept_content=['pickle', 'json'],
)


@app.task(name='task1')
def task1(*args, **kwargs):
    print('Start', args, kwargs)
    time.sleep(30)
    print('Finish', args, kwargs)


def main():
    task1.delay({1, 2, 3})     # Set is not JSON serializable
    # inspect queue items
    inspected = app.control.inspect()
    active_tasks = inspected.active()
    print(active_tasks)

if __name__ == '__main__':
    main()
```
**Before the fix**: `insepcted.active()` was creashing due trying to serialize set to JSON format
**After the fix**: `insepcted.active()` is using pickle for serializing control protocol.

Fixes  #6672
Fixes #5890