### PR TITLE
Add LOG_RECEIVED to customize logging

### DIFF
--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -52,6 +52,11 @@ from celery.worker.state import successful_requests
 
 logger = get_logger(__name__)
 
+#: Format string used to log task receipt.
+LOG_RECEIVED = """\
+Task %(name)s[%(id)s] received\
+"""
+
 #: Format string used to log task success.
 LOG_SUCCESS = """\
 Task %(name)s[%(id)s] succeeded in %(runtime)ss: %(return_value)s\

--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -4,6 +4,7 @@ import logging
 from kombu.asynchronous.timer import to_timestamp
 
 from celery import signals
+from celery.app import trace as _app_trace
 from celery.exceptions import InvalidTaskError
 from celery.utils.imports import symbol_by_name
 from celery.utils.log import get_logger
@@ -148,7 +149,10 @@ def default(task, app, consumer,
             body=body, headers=headers, decoded=decoded, utc=utc,
         )
         if _does_info:
-            info('Received task: %s', req)
+            # Similar to `app.trace.info()`, we pass the formatting args as the
+            # `extra` kwarg for custom log handlers
+            context = {'id': req.id, 'name': req.name}
+            info(_app_trace.LOG_RECEIVED, context, extra={'data': context})
         if (req.expires or req.id in revoked_tasks) and req.revoked():
             return
 

--- a/docs/userguide/extending.rst
+++ b/docs/userguide/extending.rst
@@ -301,6 +301,32 @@ Another example could use the timer to wake up at regular intervals:
                 if req.time_start and time() - req.time_start > self.timeout:
                     raise SystemExit()
 
+Customizing Task Handling Logs
+------------------------------
+
+The Celery worker emits messages to the Python logging subsystem for various
+events throughout the lifecycle of a task.
+These messages can be customized by overriding the ``LOG_<TYPE>`` format
+strings which are defined in :file:`celery/app/trace.py`.
+For example:
+
+.. code-block:: python
+
+    import celery.app.trace
+
+    celery.app.trace.LOG_SUCCESS = "This is a custom message"
+
+The various format strings are all provided with the task name and ID for
+``%`` formatting, and some of them receive extra fields like the return value
+or the exception which caused a task to fail.
+These fields can be used in custom format strings like so:
+
+.. code-block:: python
+
+    import celery.app.trace
+
+    celery.app.trace.LOG_REJECTED = "%(name)r is cursed and I won't run it: %(exc)s"
+
 .. _extending-consumer_blueprint:
 
 Consumer

--- a/t/unit/worker/test_strategy.py
+++ b/t/unit/worker/test_strategy.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from contextlib import contextmanager
 from unittest.mock import ANY, Mock, patch
@@ -6,6 +7,7 @@ import pytest
 from kombu.utils.limits import TokenBucket
 
 from celery import Task, signals
+from celery.app.trace import LOG_RECEIVED
 from celery.exceptions import InvalidTaskError
 from celery.utils.time import rate
 from celery.worker import state
@@ -164,6 +166,33 @@ class test_default_strategy_proto2:
             req = C.get_request()
             for callback in callbacks:
                 callback.assert_called_with(req)
+
+    def test_log_task_received(self, caplog):
+        caplog.set_level(logging.INFO, logger="celery.worker.strategy")
+        with self._context(self.add.s(2, 2)) as C:
+            C()
+        for record in caplog.records:
+            if record.msg == LOG_RECEIVED:
+                assert record.levelno == logging.INFO
+                break
+        else:
+            raise ValueError("Expected message not in captured log records")
+
+    def test_log_task_received_custom(self, caplog):
+        caplog.set_level(logging.INFO, logger="celery.worker.strategy")
+        custom_fmt = "CUSTOM MESSAGE"
+        with self._context(
+            self.add.s(2, 2)
+        ) as C, patch(
+            "celery.app.trace.LOG_RECEIVED", new=custom_fmt,
+        ):
+            C()
+        for record in caplog.records:
+            if record.msg == custom_fmt:
+                assert set(record.args) == {"id", "name"}
+                break
+        else:
+            raise ValueError("Expected message not in captured log records")
 
     def test_signal_task_received(self):
         callback = Mock()

--- a/t/unit/worker/test_strategy.py
+++ b/t/unit/worker/test_strategy.py
@@ -144,12 +144,14 @@ class test_default_strategy_proto2:
         message = self.prepare_message(message)
         yield self.Context(sig, s, reserved, consumer, message)
 
-    def test_when_logging_disabled(self):
+    def test_when_logging_disabled(self, caplog):
+        # Capture logs at any level above `NOTSET`
+        caplog.set_level(logging.NOTSET + 1, logger="celery.worker.strategy")
         with patch('celery.worker.strategy.logger') as logger:
             logger.isEnabledFor.return_value = False
             with self._context(self.add.s(2, 2)) as C:
                 C()
-                logger.info.assert_not_called()
+        assert not caplog.records
 
     def test_task_strategy(self):
         with self._context(self.add.s(2, 2)) as C:


### PR DESCRIPTION
## Description

Add `LOG_RECEIVED` so `Received task` logging can be customized like `LOG_SUCCESS` and friends.

Fixes #6756 