### PR TITLE
fix: Preserve call/errbacks of replaced tasks

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -6,9 +6,9 @@ from kombu import serialization
 from kombu.exceptions import OperationalError
 from kombu.utils.uuid import uuid
 
-from celery import current_app, group, states
+from celery import current_app, states
 from celery._state import _task_stack
-from celery.canvas import _chain, signature
+from celery.canvas import _chain, group, signature
 from celery.exceptions import (Ignore, ImproperlyConfigured,
                                MaxRetriesExceededError, Reject, Retry)
 from celery.local import class_property
@@ -893,39 +893,40 @@ class Task:
             raise ImproperlyConfigured(
                 "A signature replacing a task must not be part of a chord"
             )
+        if isinstance(sig, _chain) and not getattr(sig, "tasks", True):
+            raise ImproperlyConfigured("Cannot replace with an empty chain")
 
+        # Ensure callbacks or errbacks from the replaced signature are retained
         if isinstance(sig, group):
-            sig |= self.app.tasks['celery.accumulate'].s(index=0).set(
-                link=self.request.callbacks,
-                link_error=self.request.errbacks,
-            )
-        elif isinstance(sig, _chain):
-            if not sig.tasks:
-                raise ImproperlyConfigured(
-                    "Cannot replace with an empty chain"
-                )
-
-        if self.request.chain:
-            if "link" in sig.options:
-                final_task_links = sig.tasks[-1].options.setdefault("link", [])
-                final_task_links.extend(maybe_list(sig.options["link"]))
-            # Construct the new remainder of the task by chaining the signature
-            # we're being replaced by with signatures constructed from the
-            # chain elements in the current request.
-            for t in reversed(self.request.chain):
-                sig |= signature(t, app=self.app)
-
+            # Groups get uplifted to a chord so that we can link onto the body
+            sig |= self.app.tasks['celery.accumulate'].s(index=0)
+        for callback in maybe_list(self.request.callbacks) or []:
+            sig.link(callback)
+        for errback in maybe_list(self.request.errbacks) or []:
+            sig.link_error(errback)
+        # If the replacement signature is a chain, we need to push callbacks
+        # down to the final task so they run at the right time even if we
+        # proceed to link further tasks from the original request below
+        if isinstance(sig, _chain) and "link" in sig.options:
+            final_task_links = sig.tasks[-1].options.setdefault("link", [])
+            final_task_links.extend(maybe_list(sig.options["link"]))
+        # We need to freeze the replacement signature with the current task's
+        # ID to ensure that we don't disassociate it from the existing task IDs
+        # which would break previously constructed results objects.
+        sig.freeze(self.request.id)
+        # Ensure the important options from the original signature are retained
         sig.set(
             chord=chord,
             group_id=self.request.group,
             group_index=self.request.group_index,
             root_id=self.request.root_id,
         )
-        # We need to freeze the new signature with the current task's ID to
-        # ensure that we don't disassociate the new signature from the existing
-        # task IDs which would break previously constructed results objects.
-        sig.freeze(self.request.id)
-
+        # If the task being replaced is part of a chain, we need to re-create
+        # it with the replacement signature - these subsequent tasks will
+        # retain their original task IDs as well
+        for t in reversed(self.request.chain or []):
+            sig |= signature(t, app=self.app)
+        # Finally, either apply or delay the new signature!
         if self.request.is_eager:
             return sig.apply().get()
         else:

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -906,11 +906,6 @@ class Task:
                 )
 
         if self.request.chain:
-            # We need to freeze the new signature with the current task's ID to
-            # ensure that we don't disassociate the new chain from the existing
-            # task IDs which would break previously constructed results
-            # objects.
-            sig.freeze(self.request.id)
             if "link" in sig.options:
                 final_task_links = sig.tasks[-1].options.setdefault("link", [])
                 final_task_links.extend(maybe_list(sig.options["link"]))
@@ -926,6 +921,9 @@ class Task:
             group_index=self.request.group_index,
             root_id=self.request.root_id,
         )
+        # We need to freeze the new signature with the current task's ID to
+        # ensure that we don't disassociate the new signature from the existing
+        # task IDs which would break previously constructed results objects.
         sig.freeze(self.request.id)
 
         if self.request.is_eager:

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -642,7 +642,8 @@ class _chain(Signature):
 
     def run(self, args=None, kwargs=None, group_id=None, chord=None,
             task_id=None, link=None, link_error=None, publisher=None,
-            producer=None, root_id=None, parent_id=None, app=None, **options):
+            producer=None, root_id=None, parent_id=None, app=None,
+            group_index=None, **options):
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         args = args if args else ()
@@ -656,7 +657,7 @@ class _chain(Signature):
 
         tasks, results_from_prepare = self.prepare_steps(
             args, kwargs, self.tasks, root_id, parent_id, link_error, app,
-            task_id, group_id, chord,
+            task_id, group_id, chord, group_index=group_index,
         )
 
         if results_from_prepare:

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -295,6 +295,12 @@ def fail(*args):
     raise ExpectedException(*args)
 
 
+@shared_task(bind=True)
+def fail_replaced(self, *args):
+    """Replace this task with one which raises ExpectedException."""
+    raise self.replace(fail.si(*args))
+
+
 @shared_task
 def chord_error(*args):
     return args

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -217,17 +217,17 @@ def retry_once_priority(self, *args, expires=60.0, max_retries=1,
 
 
 @shared_task
-def redis_echo(message):
+def redis_echo(message, redis_key="redis-echo"):
     """Task that appends the message to a redis list."""
     redis_connection = get_redis_connection()
-    redis_connection.rpush('redis-echo', message)
+    redis_connection.rpush(redis_key, message)
 
 
 @shared_task
-def redis_count():
-    """Task that increments a well-known redis key."""
+def redis_count(redis_key="redis-count"):
+    """Task that increments a specified or well-known redis key."""
     redis_connection = get_redis_connection()
-    redis_connection.incr('redis-count')
+    redis_connection.incr(redis_key)
 
 
 @shared_task(bind=True)

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -854,7 +854,7 @@ class test_group(CanvasCase):
         # This is an invalid setup because we can't complete a chord header if
         # there are no actual tasks which will run in it. However, the current
         # behaviour of an `IndexError` isn't particularly helpful to a user.
-        res_obj = group_sig.apply_async()
+        group_sig.apply_async()
 
     def test_apply_contains_chords_containing_chain_with_empty_tail(self):
         ggchild_count = 42

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1,7 +1,7 @@
 import socket
 import tempfile
 from datetime import datetime, timedelta
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch, sentinel
 
 import pytest
 from case import ContextMock
@@ -992,10 +992,12 @@ class test_tasks(TasksCase):
             retry=True, retry_policy=self.app.conf.task_publish_retry_policy)
 
     def test_replace(self):
-        sig1 = Mock(name='sig1')
+        sig1 = MagicMock(name='sig1')
         sig1.options = {}
+        self.mytask.request.id = sentinel.request_id
         with pytest.raises(Ignore):
             self.mytask.replace(sig1)
+        sig1.freeze.assert_called_once_with(self.mytask.request.id)
 
     def test_replace_with_chord(self):
         sig1 = Mock(name='sig1')

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1,7 +1,7 @@
 import socket
 import tempfile
 from datetime import datetime, timedelta
-from unittest.mock import ANY, MagicMock, Mock, patch, sentinel
+from unittest.mock import ANY, MagicMock, Mock, call, patch, sentinel
 
 import pytest
 from case import ContextMock
@@ -1005,7 +1005,6 @@ class test_tasks(TasksCase):
         with pytest.raises(ImproperlyConfigured):
             self.mytask.replace(sig1)
 
-    @pytest.mark.usefixtures('depends_on_current_app')
     def test_replace_callback(self):
         c = group([self.mytask.s()], app=self.app)
         c.freeze = Mock(name='freeze')
@@ -1013,29 +1012,23 @@ class test_tasks(TasksCase):
         self.mytask.request.id = 'id'
         self.mytask.request.group = 'group'
         self.mytask.request.root_id = 'root_id'
-        self.mytask.request.callbacks = 'callbacks'
-        self.mytask.request.errbacks = 'errbacks'
+        self.mytask.request.callbacks = callbacks = 'callbacks'
+        self.mytask.request.errbacks = errbacks = 'errbacks'
 
-        class JsonMagicMock(MagicMock):
-            parent = None
-
-            def __json__(self):
-                return 'whatever'
-
-            def reprcall(self, *args, **kwargs):
-                return 'whatever2'
-
-        mocked_signature = JsonMagicMock(name='s')
-        accumulate_mock = JsonMagicMock(name='accumulate', s=mocked_signature)
-        self.mytask.app.tasks['celery.accumulate'] = accumulate_mock
-
-        try:
-            self.mytask.replace(c)
-        except Ignore:
-            mocked_signature.return_value.set.assert_called_with(
-                link='callbacks',
-                link_error='errbacks',
-            )
+        # Replacement groups get uplifted to chords so that we can accumulate
+        # the results and link call/errbacks - patch the appropriate `chord`
+        # methods so we can validate this behaviour
+        with patch(
+            "celery.canvas.chord.link"
+        ) as mock_chord_link, patch(
+            "celery.canvas.chord.link_error"
+        ) as mock_chord_link_error:
+            with pytest.raises(Ignore):
+                self.mytask.replace(c)
+        # Confirm that the call/errbacks on the original signature are linked
+        # to the replacement signature as expected
+        mock_chord_link.assert_called_once_with(callbacks)
+        mock_chord_link_error.assert_called_once_with(errbacks)
 
     def test_replace_group(self):
         c = group([self.mytask.s()], app=self.app)


### PR DESCRIPTION
## Description

This change fixes the handling of callbacks and errbacks on tasks which get replaced to
ensure they get called as expected if the replacement signature succeeds or fails.

Fixes #6441