### PR TITLE
fix: Have evcam accept kwargs

### DIFF
--- a/celery/events/snapshot.py
+++ b/celery/events/snapshot.py
@@ -84,7 +84,8 @@ class Polaroid:
 
 
 def evcam(camera, freq=1.0, maxrate=None, loglevel=0,
-          logfile=None, pidfile=None, timer=None, app=None):
+          logfile=None, pidfile=None, timer=None, app=None,
+          **kwargs):
     """Start snapshot recorder."""
     app = app_or_default(app)
 


### PR DESCRIPTION
The `events` command forwards all command-line flags to evcam. This includes the `--executable` flag which was not handled by the `evcam` function. Accepting `**kwargs` allows `evcam` to accept this and other flags in the future without explicit support.

Fixes #6771.