### PR TITLE
Prepared Hacker News Post on Release Action

### DIFF
--- a/.github/workflows/post_release_to_hacker_news.yml
+++ b/.github/workflows/post_release_to_hacker_news.yml
@@ -1,0 +1,17 @@
+on:
+  release:
+    types: [released]
+
+jobs:
+  post_release_to_hacker_news:
+    runs-on: ubuntu-latest
+    name: Post Release to Hacker News
+    steps:
+      - name: Post the Release
+        uses: MicahLyle/github-action-post-to-hacker-news@v1
+        env:
+          HN_USERNAME: ${{ secrets.HN_USERNAME }}
+          HN_PASSWORD: ${{ secrets.HN_PASSWORD }}
+          HN_TITLE_FORMAT_SPECIFIER:  Celery v%s Released!
+          HN_URL_FORMAT_SPECIFIER: https://docs.celeryproject.org/en/v%s/changelog.html
+          HN_TEST_MODE: true


### PR DESCRIPTION
@thedrow and/or @auvipy 

`HN_USERNAME` and `HN_PASSWORD` should be provided in the secrets. I've tested this live and was able to verify that it works. However, if you'd like to do one test run first,  you can keep `HN_TEST_MODE` as `true`. Otherwise, if you're fully ready to go once the secrets are in, they feel free to set `HN_TEST_MODE` and maybe we can use this for the first time on the 5.1.0 release!
