### PR TITLE
Post (and Crosspost) Release to Reddit

### DIFF
--- a/.github/workflows/post_release_to_reddit.yml
+++ b/.github/workflows/post_release_to_reddit.yml
@@ -1,0 +1,51 @@
+name: Post Release to Reddit
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: bluwy/release-for-reddit-action@v1.2.0
+      id: reddit
+      with:
+        username: ${{ secrets.REDDIT_USERNAME }}
+        password: ${{ secrets.REDDIT_PASSWORD }}
+        app-id: ${{ secrets.REDDIT_APP_ID }}
+        app-secret: ${{ secrets.REDDIT_APP_SECRET }}
+        subreddit: Python
+        title: Celery {{ github.event.release.tag_name }} Released!
+        comment: ${{ github.event.release.body }}
+        # This is the "News" flair.
+        flair-id: 0ad780a0-1c5e-11ea-978c-0ee7bacb2bff
+        notification: false
+    - uses: bluwy/release-for-reddit-action@v1.2.0
+      with:
+        username: ${{ secrets.REDDIT_USERNAME }}
+        password: ${{ secrets.REDDIT_PASSWORD }}
+        app-id: ${{ secrets.REDDIT_APP_ID }}
+        app-secret: ${{ secrets.REDDIT_APP_SECRET }}
+        subreddit: django
+        url: ${{ steps.reddit.outputs.postUrl }}
+        title: Celery {{ github.event.release.tag_name }} Released!
+    - uses: bluwy/release-for-reddit-action@v1.2.0
+      with:
+        username: ${{ secrets.REDDIT_USERNAME }}
+        password: ${{ secrets.REDDIT_PASSWORD }}
+        app-id: ${{ secrets.REDDIT_APP_ID }}
+        app-secret: ${{ secrets.REDDIT_APP_SECRET }}
+        subreddit: flask
+        url: ${{ steps.reddit.outputs.postUrl }}
+        title: Celery {{ github.event.release.tag_name }} Released!
+    - uses: bluwy/release-for-reddit-action@v1.2.0
+      with:
+        username: ${{ secrets.REDDIT_USERNAME }}
+        password: ${{ secrets.REDDIT_PASSWORD }}
+        app-id: ${{ secrets.REDDIT_APP_ID }}
+        app-secret: ${{ secrets.REDDIT_APP_SECRET }}
+        subreddit: FastAPI
+        url: ${{ steps.reddit.outputs.postUrl }}
+        title: Celery {{ github.event.release.tag_name }} Released!


### PR DESCRIPTION
Need the following secrets prepared (@thedrow and/or @auvipy):

```
REDDIT_USERNAME
REDDIT_PASSWORD
REDDIT_APP_ID
REDDIT_APP_SECRET
```

For getting those values see these two links:

- https://github.com/bluwy/release-for-reddit-action#get-into-action
- https://github.com/bluwy/release-for-reddit-action#setup-api

As for crossposting to other subreddits, here's what we currently have:

- The main post is to the `Python` subreddit with the `News` flair applied.
- Crossposts are to `django`, `flask`, and `FastAPI`. The rationale is that, especially with the first two, Celery is frequently paired with them so I bet folks would be happy to know about new Celery releases. `FastAPI` has a number of tutorials and articles online for usage with Celery, so I'm guessing it has a fair amount of paired usage with Celery in the wild. I'm less sure on that one for now though given it's newer and their Reddit isn't huge. I'll let you guys decide!