### PR TITLE
Make `ResultSet.on_ready` promise hold a weakref to self

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -2,6 +2,7 @@
 
 import datetime
 import time
+from weakref import proxy
 from collections import deque
 from contextlib import contextmanager
 
@@ -535,7 +536,7 @@ class ResultSet(ResultBase):
     def __init__(self, results, app=None, ready_barrier=None, **kwargs):
         self._app = app
         self.results = results
-        self.on_ready = promise(args=(self,))
+        self.on_ready = promise(args=(proxy(self),))
         self._on_full = ready_barrier or barrier(results)
         if self._on_full:
             self._on_full.then(promise(self._on_ready, weak=True))


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This avoids a memory leak since the promise creates a reference cycle to `self`.
See https://github.com/celery/celery/issues/4843#issuecomment-847634277.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
