### PR TITLE
Fix '--pool=threads' support in command line options parsing

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -142,7 +142,8 @@ def maybe_patch_concurrency(argv=None, short_opts=None,
 
         # set up eventlet/gevent environments ASAP
         from celery import concurrency
-        concurrency.get_implementation(pool)
+        if pool in concurrency.get_available_pool_names():
+            concurrency.get_implementation(pool)
 
 
 # this just creates a new module, that imports stuff on first attribute

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -40,7 +40,7 @@ class WorkersPool(click.Choice):
 
     def __init__(self):
         """Initialize the workers pool option with the relevant choices."""
-        super().__init__(('prefork', 'eventlet', 'gevent', 'solo'))
+        super().__init__(concurrency.get_available_pool_names())
 
     def convert(self, value, param, ctx):
         # Pools like eventlet/gevent needs to patch libs as early

--- a/celery/concurrency/__init__.py
+++ b/celery/concurrency/__init__.py
@@ -5,7 +5,7 @@
 # too much (e.g., for eventlet patching)
 from kombu.utils.imports import symbol_by_name
 
-__all__ = ('get_implementation',)
+__all__ = ('get_implementation', 'get_available_pool_names',)
 
 ALIASES = {
     'prefork': 'celery.concurrency.prefork:TaskPool',
@@ -26,3 +26,7 @@ else:
 def get_implementation(cls):
     """Return pool implementation by name."""
     return symbol_by_name(cls, ALIASES)
+
+
+def get_available_pool_names():
+    return tuple(ALIASES.keys())

--- a/t/unit/concurrency/test_concurrency.py
+++ b/t/unit/concurrency/test_concurrency.py
@@ -1,9 +1,12 @@
+import importlib
 import os
+import sys
 from itertools import count
 from unittest.mock import Mock, patch
 
 import pytest
 
+from celery import concurrency
 from celery.concurrency.base import BasePool, apply_target
 from celery.exceptions import WorkerShutdown, WorkerTerminate
 
@@ -152,3 +155,31 @@ class test_BasePool:
 
     def test_interface_no_close(self):
         assert BasePool(10).on_close() is None
+
+
+class test_get_available_pool_names:
+
+    def test_no_concurrent_futures__returns_no_threads_pool_name(self):
+        expected_pool_names = (
+            'prefork',
+            'eventlet',
+            'gevent',
+            'solo',
+            'processes',
+        )
+        with patch.dict(sys.modules, {'concurrent.futures': None}):
+            importlib.reload(concurrency)
+            assert concurrency.get_available_pool_names() == expected_pool_names
+
+    def test_concurrent_futures__returns_threads_pool_name(self):
+        expected_pool_names = (
+            'prefork',
+            'eventlet',
+            'gevent',
+            'solo',
+            'processes',
+            'threads',
+        )
+        with patch.dict(sys.modules, {'concurrent.futures': Mock()}):
+            importlib.reload(concurrency)
+            assert concurrency.get_available_pool_names() == expected_pool_names


### PR DESCRIPTION
## Description

This PR fixes ``celery worker`` behaviour when parsing ``--pool=threads`` argument, and a related issue in command line ``--pool`` argument parsing.

### First issue
The ``threads`` pool type is not recognised in command line args parsing. It's missing from the list of possible options, even though it's supported by Celery since 4.4.

**Minimal example of the issue:**
Run ``celery worker --pool=threads``
This is the output:
```
Usage: celery worker [OPTIONS]
Try 'celery worker --help' for help.

Error: Invalid value for '-P' / '--pool': invalid choice: threads. (choose from prefork, eventlet, gevent, solo)
```

### Second issue
When you specify any argument that is not specified in the ``ALIASES`` dict in ``celery/concurrency/__init__.py``, you get an error. It happens, because the function ``maybe_patch_concurrency`` tries to get pool implementation before actually validating the command line arguments.

**Minimal example:**
Run ``celery worker --pool=xxx``
This is the output:
```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/bin/celery", line 8, in <module>
    sys.exit(main())
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/celery/__main__.py", line 13, in main
    maybe_patch_concurrency()
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/celery/__init__.py", line 145, in maybe_patch_concurrency
    concurrency.get_implementation(pool)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/celery/concurrency/__init__.py", line 28, in get_implementation
    return symbol_by_name(cls, ALIASES)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/kombu/utils/imports.py", line 56, in symbol_by_name
    module = imp(module_name, package=package, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 965, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'xxx'
```

I fixed that issue and now it outputs the proper error message:
```
# celery worker --pool=xxx

Usage: celery worker [OPTIONS]
Try 'celery worker --help' for help.

Error: Invalid value for '-P' / '--pool': invalid choice: xxx. (choose from prefork, eventlet, gevent, solo, processes, threads)
```

