### PR TITLE
Ensure regen utility class gets marked as done when concretised

### DIFF
--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -249,6 +249,13 @@ class _regen(UserList, list):
             pass
         return self.__consumed
 
+    def __repr__(self):
+        return "<{}: [{}{}]>".format(
+            self.__class__.__name__,
+            ", ".join(repr(e) for e in self.__consumed),
+            "..." if not self.__done else "",
+        )
+
 
 def _argsfromspec(spec, replace_defaults=True):
     if spec.defaults:

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -241,12 +241,9 @@ class _regen(UserList, list):
 
     @property
     def data(self):
-        try:
-            if not self.__done:
-                self.__consumed.extend(list(self.__it))
+        if not self.__done:
+            self.__consumed.extend(self.__it)
             self.__done = True
-        except StopIteration:
-            pass
         return self.__consumed
 
     def __repr__(self):

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -242,7 +242,9 @@ class _regen(UserList, list):
     @property
     def data(self):
         try:
-            self.__consumed.extend(list(self.__it))
+            if not self.__done:
+                self.__consumed.extend(list(self.__it))
+            self.__done = True
         except StopIteration:
             pass
         return self.__consumed

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -170,6 +170,42 @@ class test_regen:
         g = regen(die())
         assert "..." in repr(g)
 
+    def test_partial_reconcretisation(self):
+        class WeirdIterator():
+            def __init__(self, iter_):
+                self.iter_ = iter_
+                self._errored = False
+
+            def __iter__(self):
+                yield from self.iter_
+                if not self._errored:
+                    try:
+                        # This should stop the regen instance from marking
+                        # itself as being done
+                        raise AssertionError("Iterator errored")
+                    finally:
+                        self._errored = True
+
+        original_list = list(range(42))
+        g = regen(WeirdIterator(original_list))
+        iter_g = iter(g)
+        for e in original_list:
+            assert e == next(iter_g)
+        with pytest.raises(AssertionError, match="Iterator errored"):
+            next(iter_g)
+        # The following checks are for the known "misbehaviour"
+        assert getattr(g, "_regen__done") is False
+        # If the `regen()` instance doesn't think it's done then it'll dupe the
+        # elements from the underlying iterator if it can be re-used
+        iter_g = iter(g)
+        for e in original_list * 2:
+            assert next(iter_g) == e
+        with pytest.raises(StopIteration):
+            next(iter_g)
+        assert getattr(g, "_regen__done") is True
+        # Finally we xfail this test to keep track of it
+        raise pytest.xfail(reason="#6794")
+
 
 class test_head_from_fun:
 

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -161,6 +161,15 @@ class test_regen:
         assert g == original_list
         assert g == original_list
 
+    def test_repr(self):
+        def die():
+            raise AssertionError("Generator died")
+            yield None
+
+        # Confirm that `regen()` instances are not concretised when represented
+        g = regen(die())
+        assert "..." in repr(g)
+
 
 class test_head_from_fun:
 

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -1,3 +1,5 @@
+import collections
+
 import pytest
 from kombu.utils.functional import lazy
 
@@ -149,6 +151,15 @@ class test_regen:
 
     def test_nonzero__empty_iter(self):
         assert not regen(iter([]))
+
+    def test_deque(self):
+        original_list = [42]
+        d = collections.deque(original_list)
+        # Confirm that concretising a `regen()` instance repeatedly for an
+        # equality check always returns the original list
+        g = regen(d)
+        assert g == original_list
+        assert g == original_list
 
 
 class test_head_from_fun:


### PR DESCRIPTION
## Description

Ensure `regen()` instances get marked as done when concretised via the
`UserList.data` property implementation. We also improve laziness of
`regen.__repr__()` so it reflects the fact that it's lazy.

Fixes: #6786