### PR TITLE
fix: `LoggingProxy.write()` return type

### DIFF
--- a/celery/utils/log.py
+++ b/celery/utils/log.py
@@ -223,7 +223,6 @@ class LoggingProxy:
         if getattr(self._thread, 'recurse_protection', False):
             # Logger is logging back to this file, so stop recursing.
             return 0
-        data = data.strip()
         if data and not self.closed:
             self._thread.recurse_protection = True
             try:

--- a/celery/utils/log.py
+++ b/celery/utils/log.py
@@ -214,19 +214,25 @@ class LoggingProxy:
         return [wrap_handler(h) for h in self.logger.handlers]
 
     def write(self, data):
+        # type: (AnyStr) -> int
         """Write message to logging object."""
         if _in_sighandler:
-            return print(safe_str(data), file=sys.__stderr__)
+            safe_data = safe_str(data)
+            print(safe_data, file=sys.__stderr__)
+            return len(safe_data)
         if getattr(self._thread, 'recurse_protection', False):
             # Logger is logging back to this file, so stop recursing.
-            return
+            return 0
         data = data.strip()
         if data and not self.closed:
             self._thread.recurse_protection = True
             try:
-                self.logger.log(self.loglevel, safe_str(data))
+                safe_data = safe_str(data)
+                self.logger.log(self.loglevel, safe_data)
+                return len(safe_data)
             finally:
                 self._thread.recurse_protection = False
+        return 0
 
     def writelines(self, sequence):
         # type: (Sequence[str]) -> None

--- a/t/unit/app/test_log.py
+++ b/t/unit/app/test_log.py
@@ -268,9 +268,9 @@ class test_default_logger:
             p.write('foo')
             assert 'foo' not in sio.getvalue()
             p.closed = False
-            write_res = p.write('foo')
-            assert 'foo' in sio.getvalue()
-            assert write_res == 3
+            write_res = p.write('foo ')
+            assert 'foo ' in sio.getvalue()
+            assert write_res == 4
             lines = ['baz', 'xuzzy']
             p.writelines(lines)
             for line in lines:

--- a/t/unit/app/test_log.py
+++ b/t/unit/app/test_log.py
@@ -268,8 +268,9 @@ class test_default_logger:
             p.write('foo')
             assert 'foo' not in sio.getvalue()
             p.closed = False
-            p.write('foo')
+            write_res = p.write('foo')
             assert 'foo' in sio.getvalue()
+            assert write_res == 3
             lines = ['baz', 'xuzzy']
             p.writelines(lines)
             for line in lines:
@@ -290,7 +291,7 @@ class test_default_logger:
         p = LoggingProxy(logger, loglevel=logging.ERROR)
         p._thread.recurse_protection = True
         try:
-            assert p.write('FOOFO') is None
+            assert p.write('FOOFO') == 0
         finally:
             p._thread.recurse_protection = False
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Updates the return type of `LoggingProxy.write()` such that it conforms to `IO.write()`.

Additionally, removes the mutation of written data such as stripping whitespace. That said, this is quite a subjective change and was clearly added for a reason in the first place... It just feels odd to me that if `LoggingProxy`'s only job is to forward streams that it would also mutate them along the way.

Fixes #6790
