### PR TITLE
improv: Make regen consume items more reliably

### DIFF
--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -978,11 +978,15 @@ class test_chord(CanvasCase):
             yield self.add.s(1, 1)
             self.second_item_returned = True
             yield self.add.s(2, 2)
+            raise pytest.fail("This should never be reached")
 
         self.second_item_returned = False
         c = chord(build_generator(), self.add.s(3))
         c.app
-        assert not self.second_item_returned
+        # The second task gets returned due to lookahead in `regen()`
+        assert self.second_item_returned
+        # Access it again to make sure the generator is not further evaluated
+        c.app
 
     def test_reverse(self):
         x = chord([self.add.s(2, 2), self.add.s(4, 4)], body=self.mul.s(4))


### PR DESCRIPTION
## Description

This is a follow up to #6789 with some more significant changes to the `regen`
implementation to:
  * avoid re-iterating previously consumed elements in `__getitem__()`
  * mark the instance as done when a single lookahead stops iterating
  ** this fixes an edge case where a repeating underlying iterator could be duplicated if regen is not fully iterated
  ** element duplication from repeatable underlying iterables is not generally fixed since we still store the iterable not its iterator (IIUC)
