### PR TITLE
added https verification check functionality in arangodb backend

### DIFF
--- a/celery/backends/arangodb.py
+++ b/celery/backends/arangodb.py
@@ -48,6 +48,7 @@ class ArangoDbBackend(KeyValueStoreBackend):
     password = None
     # protocol is not supported in backend url (http is taken as default)
     http_protocol = 'http'
+    verify = False
 
     # Use str as arangodb key not bytes
     key_t = str
@@ -88,6 +89,7 @@ class ArangoDbBackend(KeyValueStoreBackend):
         self.host = host or config.get('host', self.host)
         self.port = int(port or config.get('port', self.port))
         self.http_protocol = config.get('http_protocol', self.http_protocol)
+        self.verify = config.get('verify', self.verify)
         self.database = database or config.get('database', self.database)
         self.collection = \
             collection or config.get('collection', self.collection)
@@ -104,7 +106,7 @@ class ArangoDbBackend(KeyValueStoreBackend):
         if self._connection is None:
             self._connection = py_arango_connection.Connection(
                 arangoURL=self.arangodb_url, username=self.username,
-                password=self.password
+                password=self.password, verify=self.verify
             )
         return self._connection
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1884,6 +1884,16 @@ This is a dict supporting the following keys:
 
     Password to authenticate to the ArangoDB server (optional).
 
+* ``http_protocol``
+
+    HTTP Protocol in ArangoDB server connection.
+    Defaults to ``http``.
+
+* ``verify``
+
+    HTTPS Verification check while creating the ArangoDB connection.
+    Defaults to ``False``.
+
 .. _conf-cosmosdbsql-result-backend:
 
 CosmosDB backend settings (experimental)

--- a/t/unit/backends/test_arangodb.py
+++ b/t/unit/backends/test_arangodb.py
@@ -71,7 +71,8 @@ class test_ArangoDbBackend:
             'password': 'mysecret',
             'database': 'celery_database',
             'collection': 'celery_collection',
-            'http_protocol': 'https'
+            'http_protocol': 'https',
+            'verify': True
         }
         x = ArangoDbBackend(app=self.app)
         assert x.host == 'test.arangodb.com'
@@ -82,6 +83,7 @@ class test_ArangoDbBackend:
         assert x.collection == 'celery_collection'
         assert x.http_protocol == 'https'
         assert x.arangodb_url == 'https://test.arangodb.com:8529'
+        assert x.verify == True
 
     def test_backend_by_url(
         self, url="arangodb://username:password@host:port/database/collection"
@@ -106,6 +108,7 @@ class test_ArangoDbBackend:
             assert x.collection == 'celery_collection'
             assert x.http_protocol == 'http'
             assert x.arangodb_url == 'http://test.arangodb.com:8529'
+            assert x.verify == False
 
     def test_backend_cleanup(self):
         now = datetime.datetime.utcnow()


### PR DESCRIPTION
The backend throws an error if its an unverified https backend.
Verification will be bypassed as default.