### PR TITLE
grp is no longer imported unconditionally

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -6,7 +6,6 @@ users, groups, and so on.
 
 import atexit
 import errno
-import grp
 import math
 import numbers
 import os
@@ -780,6 +779,8 @@ def ignore_errno(*errnos, **kwargs):
 
 
 def check_privileges(accept_content):
+    if grp is None or pwd is None:
+        return
     pickle_or_serialize = ('pickle' in accept_content
                            or 'application/group-python-serialize' in accept_content)
 

--- a/t/unit/utils/test_platforms.py
+++ b/t/unit/utils/test_platforms.py
@@ -1012,8 +1012,14 @@ def test_check_privileges_with_c_force_root_and_no_group_entry(accept_content,
 
 
 def test_skip_checking_privileges_when_grp_is_unavailable(recwarn):
-    with patch('celery.platforms.try_import',
-               return_value=None):
+    with patch("celery.platforms.grp", new=None):
+        check_privileges({'pickle'})
+
+    assert len(recwarn) == 0
+
+
+def test_skip_checking_privileges_when_pwd_is_unavailable(recwarn):
+    with patch("celery.platforms.pwd", new=None):
         check_privileges({'pickle'})
 
     assert len(recwarn) == 0

--- a/t/unit/utils/test_platforms.py
+++ b/t/unit/utils/test_platforms.py
@@ -911,8 +911,10 @@ def test_check_privileges_with_c_force_root(accept_content):
     ({'application/group-python-serialize'}, 'wheel'),
     ({'pickle', 'application/group-python-serialize'}, 'wheel'),
 ])
-def test_check_privileges_with_c_force_root_and_with_suspicious_group(accept_content, group_name):
-    with patch('celery.platforms.os') as os_module, patch('celery.platforms.grp') as grp_module:
+def test_check_privileges_with_c_force_root_and_with_suspicious_group(
+    accept_content, group_name):
+    with patch('celery.platforms.os') as os_module, patch(
+        'celery.platforms.grp') as grp_module:
         os_module.environ = {'C_FORCE_ROOT': 'true'}
         os_module.getuid.return_value = 60
         os_module.getgid.return_value = 60
@@ -936,8 +938,10 @@ def test_check_privileges_with_c_force_root_and_with_suspicious_group(accept_con
     ({'application/group-python-serialize'}, 'wheel'),
     ({'pickle', 'application/group-python-serialize'}, 'wheel'),
 ])
-def test_check_privileges_without_c_force_root_and_with_suspicious_group(accept_content, group_name):
-    with patch('celery.platforms.os') as os_module, patch('celery.platforms.grp') as grp_module:
+def test_check_privileges_without_c_force_root_and_with_suspicious_group(
+    accept_content, group_name):
+    with patch('celery.platforms.os') as os_module, patch(
+        'celery.platforms.grp') as grp_module:
         os_module.environ = {}
         os_module.getuid.return_value = 60
         os_module.getgid.return_value = 60
@@ -959,8 +963,10 @@ def test_check_privileges_without_c_force_root_and_with_suspicious_group(accept_
     {'application/group-python-serialize'},
     {'pickle', 'application/group-python-serialize'}
 ])
-def test_check_privileges_with_c_force_root_and_no_group_entry(accept_content, recwarn):
-    with patch('celery.platforms.os') as os_module, patch('celery.platforms.grp') as grp_module:
+def test_check_privileges_with_c_force_root_and_no_group_entry(accept_content,
+                                                               recwarn):
+    with patch('celery.platforms.os') as os_module, patch(
+        'celery.platforms.grp') as grp_module:
         os_module.environ = {'C_FORCE_ROOT': 'true'}
         os_module.getuid.return_value = 60
         os_module.getgid.return_value = 60
@@ -984,8 +990,10 @@ def test_check_privileges_with_c_force_root_and_no_group_entry(accept_content, r
     {'application/group-python-serialize'},
     {'pickle', 'application/group-python-serialize'}
 ])
-def test_check_privileges_with_c_force_root_and_no_group_entry(accept_content, recwarn):
-    with patch('celery.platforms.os') as os_module, patch('celery.platforms.grp') as grp_module:
+def test_check_privileges_with_c_force_root_and_no_group_entry(accept_content,
+                                                               recwarn):
+    with patch('celery.platforms.os') as os_module, patch(
+        'celery.platforms.grp') as grp_module:
         os_module.environ = {}
         os_module.getuid.return_value = 60
         os_module.getgid.return_value = 60
@@ -1001,3 +1009,11 @@ def test_check_privileges_with_c_force_root_and_no_group_entry(accept_content, r
             check_privileges(accept_content)
 
         assert recwarn[0].message.args[0] == ASSUMING_ROOT
+
+
+def test_skip_checking_privileges_when_grp_is_unavailable(recwarn):
+    with patch('celery.platforms.try_import',
+               return_value=None):
+        check_privileges({'pickle'})
+
+    assert len(recwarn) == 0


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This fixes a regression introduced in #6600 which caused an import error on non-Unix platforms.

Fixes #6797.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
