### PR TITLE
test: Fix unexpected failure from bad mocking

### DIFF
--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1289,17 +1289,20 @@ class test_apply_task(TasksCase):
             f.get()
 
     def test_apply_simulates_delivery_info(self):
-        self.task_check_request_context.request_stack.push = Mock()
+        task_to_apply = self.task_check_request_context
+        with patch.object(
+            task_to_apply.request_stack, "push",
+            wraps=task_to_apply.request_stack.push,
+        ) as mock_push:
+            task_to_apply.apply(
+                priority=4,
+                routing_key='myroutingkey',
+                exchange='myexchange',
+            )
 
-        self.task_check_request_context.apply(
-            priority=4,
-            routing_key='myroutingkey',
-            exchange='myexchange',
-        )
+        mock_push.assert_called_once()
 
-        self.task_check_request_context.request_stack.push.assert_called_once()
-
-        request = self.task_check_request_context.request_stack.push.call_args[0][0]
+        request = mock_push.call_args[0][0]
 
         assert request.delivery_info == {
             'is_eager': True,


### PR DESCRIPTION
## Description

This test would attempt to mock the `request_stack` of a task so as to
confirm that it could confirm that the request object pushed onto it
contained simulated delivery information as expected. However, it did
not wrap the original call target which led to an unfortunate
interaction with the worker optimisations in `app/trace.py` which would
not find the request on the stack and therefore not end up calling the
task's `run()` method.

The worker optimisations can be enabled as a side effect of other tests
like `test_regression_worker_startup_info()` in the mongo and cache
backend suites. This led to a situation where the test changed in the
diff would fail if those tests happened to run before it! Luckily, the
side effect of the worker optimizations being enabled are not what cause
the unrelated failure, the test in this diff was a just a bit unaware of
the consequences of its mocking.