### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-beta.2', 'pypy3']
 
     steps:
     - name: Install apt packages

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-beta.2', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-beta.3', 'pypy3']
 
     steps:
     - name: Install apt packages

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
 
     steps:
     - name: Install apt packages

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,14 +50,13 @@ jobs:
           ${{ matrix.python-version }}-v1-
 
     - name: Install tox
-      run: python -m pip install tox
+      run: python -m pip install tox tox-gh-actions
     - name: >
         Run tox for
         "${{ matrix.python-version }}-unit"
       timeout-minutes: 15
       run: >
-        tox --verbose --verbose -e
-        "${{ matrix.python-version }}-unit"
+        tox --verbose --verbose
 
     - uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-beta.3', 'pypy3']
+    continue-on-error: ${{ matrix.python-version == '3.10.0-beta.3' }}
 
     steps:
     - name: Install apt packages

--- a/requirements/extras/eventlet.txt
+++ b/requirements/extras/eventlet.txt
@@ -1,1 +1,1 @@
-eventlet>=0.26.1
+eventlet>=0.26.1; python_version<"3.10"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@ pytest-celery
 pytest-subtests
 pytest-timeout~=1.4.2
 boto3>=1.9.178
-moto==1.3.7
+moto==2.0.10
 pre-commit
 -r extras/yaml.txt
 -r extras/msgpack.txt

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -12,6 +12,7 @@ from celery.backends.base import Backend
 from celery.utils import cached_property
 
 pytest.importorskip('gevent')
+pytest.importorskip('eventlet')
 
 
 @pytest.fixture(autouse=True)

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ python =
     3.7: 3.7-unit
     3.8: 3.8-unit
     3.9: 3.9-unit
-    3.10-beta.3: 3.10-unit
+    3.10: 3.10-unit
     pypy3: pypy3-unit
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,8 @@ deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/pkgutils.txt
 
-    3.6,3.7,3.8,3.9: -r{toxinidir}/requirements/test-ci-default.txt
-    3.5,3.6,3.7,3.8,3.9: -r{toxinidir}/requirements/docs.txt
-    3.6,3.7,3.8,3.9: -r{toxinidir}/requirements/docs.txt
+    3.6,3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/test-ci-default.txt
+    3.6,3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/docs.txt
     pypy3: -r{toxinidir}/requirements/test-ci-default.txt
 
     integration: -r{toxinidir}/requirements/test-integration.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {3.6,3.7,3.8,3.9,pypy3}-unit
-    {3.6,3.7,3.8,3.9,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
+    {3.6,3.7,3.8,3.9,3.10,pypy3}-unit
+    {3.6,3.7,3.8,3.9,3.10,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
 
     flake8
     apicheck
@@ -15,6 +15,7 @@ python =
     3.7: 3.7
     3.8: 3.8
     3.9: 3.9
+    3.10: 3.10-beta.3
     pypy3: pypy3
 
 [testenv]
@@ -75,6 +76,7 @@ basepython =
     3.7: python3.7
     3.8: python3.8
     3.9: python3.9
+    3.10: python3.10
     pypy3: pypy3
     flake8,apicheck,linkcheck,configcheck,bandit: python3.9
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,12 @@ envlist =
 
 [gh-actions]
 python =
-    3.6: 3.6
-    3.7: 3.7
-    3.8: 3.8
-    3.9: 3.9
-    3.10-beta.3: 3.10
-    pypy3: pypy3
+    3.6: 3.6-unit
+    3.7: 3.7-unit
+    3.8: 3.8-unit
+    3.9: 3.9-unit
+    3.10-beta.3: 3.10-unit
+    pypy3: pypy3-unit
 
 [testenv]
 sitepackages = False

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,6 @@
 [tox]
+requires =
+    tox-gh-actions
 envlist =
     {3.6,3.7,3.8,3.9,3.10,pypy3}-unit
     {3.6,3.7,3.8,3.9,3.10,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
@@ -15,7 +17,7 @@ python =
     3.7: 3.7
     3.8: 3.8
     3.9: 3.9
-    3.10: 3.10-beta.3
+    3.10-beta.3: 3.10
     pypy3: pypy3
 
 [testenv]


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

We will support Python 3.10 starting from Celery 5.2.
We should start testing with it now to figure out what kind of problems we may have.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
