### PR TITLE
Fix for revoked tasks being moved to RETRY state

### DIFF
--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -523,11 +523,12 @@ class Request:
             # If the message no longer has a connection and the worker
             # is terminated, we aborted it.
             # Otherwise, it is revoked.
-            if self.message.channel.connection and not self._already_revoked:
+            if self.message.channel.connection:
                 # This is a special case where the process
                 # would not have had time to write the result.
-                self._announce_revoked(
-                    'terminated', True, str(exc), False)
+                if not self._already_revoked:
+                    self._announce_revoked(
+                        'terminated', True, str(exc), False)
             elif not self._already_cancelled:
                 self._announce_cancelled()
             return


### PR DESCRIPTION
https://github.com/celery/celery/issues/6793

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fixes 6793. (I assume the intention here was to do nothing if we do have a connection but self._already_revoked, not to _anounce_cancelled in that case as in the orginal code, which would wrongly move the state to RETRY.)