### PR TITLE
fix: Calling of errbacks when chords fail

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1123,18 +1123,17 @@ class group(Signature):
             task.set_immutable(immutable)
 
     def link(self, sig):
-        # Simply link to first task
+        # Simply link to first task. Doing this is slightly misleading because
+        # the callback may be executed before all children in the group are
+        # completed and also if any children other than the first one fail.
+        #
+        # The callback signature is cloned and made immutable since it the
+        # first task isn't actually capable of passing the return values of its
+        # siblings to the callback task.
         sig = sig.clone().set(immutable=True)
         return self.tasks[0].link(sig)
 
     def link_error(self, sig):
-        try:
-            sig = sig.clone().set(immutable=True)
-        except AttributeError:
-            # See issue #5265.  I don't use isinstance because current tests
-            # pass a Mock object as argument.
-            sig['immutable'] = True
-            sig = Signature.from_dict(sig)
         # Any child task might error so we need to ensure that they are all
         # capable of calling the linked error signature. This opens the
         # possibility that the task is called more than once but that's better

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -301,11 +301,6 @@ def fail_replaced(self, *args):
     raise self.replace(fail.si(*args))
 
 
-@shared_task
-def chord_error(*args):
-    return args
-
-
 @shared_task(bind=True)
 def return_priority(self, *_args):
     return "Priority: %s" % self.request.delivery_info['priority']
@@ -385,3 +380,15 @@ def rebuild_signature(sig_dict):
         if isinstance(sig, chord):
             _recurse(sig.body)
     _recurse(sig_obj)
+
+
+@shared_task
+def errback_old_style(request_id):
+    redis_count(request_id)
+    return request_id
+
+
+@shared_task
+def errback_new_style(request, exc, tb):
+    redis_count(request.id)
+    return request.id


### PR DESCRIPTION
## Description

We had a special case for calling errbacks when a chord failed which
assumed they were old style. This change ensures that we call the proper
errback dispatch method which understands new and old style errbacks,
and adds test to confirm that things behave as one might expect now.