### PR TITLE
Add message properties to app.tasks.Context (#6777)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -281,4 +281,5 @@ Frazer McLean, 2020/09/29
 Henrik Bruåsdal, 2020/11/29
 Tom Wojcik, 2021/01/24
 Ruaridh Williamson, 2021/03/09
+Garry Lawrence, 2021/06/19
 Patrick Zhang, 2017/08/19

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -85,6 +85,7 @@ class Context:
     loglevel = None
     origin = None
     parent_id = None
+    properties = None
     retries = 0
     reply_to = None
     root_id = None

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -93,7 +93,8 @@ class Request:
                  maybe_make_aware=maybe_make_aware,
                  maybe_iso8601=maybe_iso8601, **opts):
         self._message = message
-        self._request_dict = message.headers if headers is None else headers
+        self._request_dict = (message.headers.copy() if headers is None
+                              else headers.copy())
         self._body = message.body if body is None else body
         self._app = app
         self._utc = utc
@@ -157,6 +158,7 @@ class Request:
             'redelivered': delivery_info.get('redelivered'),
         }
         self._request_dict.update({
+            'properties': properties,
             'reply_to': properties.get('reply_to'),
             'correlation_id': properties.get('correlation_id'),
             'hostname': self._hostname,

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -457,6 +457,11 @@ The request defines the following attributes:
         current task.  If using version one of the task protocol the chain
         tasks will be in ``request.callbacks`` instead.
 
+.. versionadded:: 5.2
+
+:properties: Mapping of message properties received with this task message
+             (may be :const:`None` or :const:`{}`)
+
 Example
 -------
 

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -305,6 +305,11 @@ def return_priority(self, *_args):
     return "Priority: %s" % self.request.delivery_info['priority']
 
 
+@shared_task(bind=True)
+def return_properties(self):
+    return self.request.properties
+
+
 class ClassBasedAutoRetryTask(Task):
     name = 'auto_retry_class_task'
     autoretry_for = (ValueError,)

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -9,7 +9,8 @@ from celery import group
 from .conftest import get_active_redis_channels
 from .tasks import (ClassBasedAutoRetryTask, ExpectedException, add,
                     add_ignore_result, add_not_typed, fail, print_unicode,
-                    retry, retry_once, retry_once_priority, sleeping)
+                    retry, retry_once, retry_once_priority, return_properties,
+                    sleeping)
 
 TIMEOUT = 10
 
@@ -269,6 +270,11 @@ class test_tasks:
             group(print_unicode.s() for _ in range(5))(),
             timeout=TIMEOUT, propagate=True,
         )
+
+    @flaky
+    def test_properties(self, celery_session_worker):
+        res = return_properties.apply_async(app_id="1234")
+        assert res.get(timeout=TIMEOUT)["app_id"] == "1234"
 
 
 class tests_task_redis_result_backend:


### PR DESCRIPTION
## Description

Fixes #6777 by exposing message properties in `app.task.Context` objects.

Includes a basic integration test. When I tried to run the full test suite, I encountered many failures on `master`, so I'm not too confident this hasn't broken anything. That being said, it is a fairly simple change.