### PR TITLE
Update Changelog link in documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -297,7 +297,7 @@ Current active version branches:
 
 You can see the state of any branch by looking at the Changelog:
 
-    https://github.com/celery/celery/blob/master/Changelog
+    https://github.com/celery/celery/blob/master/Changelog.rst
 
 If the branch is in active development the topmost version info should
 contain meta-data like:


### PR DESCRIPTION
## Description
Changelog file was renamed from "Changelog" to "Changelog.rst"
in fd023ec174bedc2dc65c63a0dc7c85e425ac00c6.