### PR TITLE
Avoid using the isSet deprecated alias

### DIFF
--- a/celery/utils/timer2.py
+++ b/celery/utils/timer2.py
@@ -75,7 +75,7 @@ class Timer(threading.Thread):
             self.running = True
             self.scheduler = iter(self.schedule)
 
-            while not self.__is_shutdown.isSet():
+            while not self.__is_shutdown.is_set():
                 delay = self._next_entry()
                 if delay:
                     if self.on_tick:

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -739,12 +739,12 @@ class test_Service:
         s.sync()
         assert sh.closed
         assert sh.synced
-        assert s._is_stopped.isSet()
+        assert s._is_stopped.is_set()
         s.sync()
         s.stop(wait=False)
-        assert s._is_shutdown.isSet()
+        assert s._is_shutdown.is_set()
         s.stop(wait=True)
-        assert s._is_shutdown.isSet()
+        assert s._is_shutdown.is_set()
 
         p = s.scheduler._store
         s.scheduler._store = None
@@ -767,13 +767,13 @@ class test_Service:
         s, sh = self.get_service()
         s.scheduler.tick_raises_exit = True
         s.start()
-        assert s._is_shutdown.isSet()
+        assert s._is_shutdown.is_set()
 
     def test_start_manages_one_tick_before_shutdown(self):
         s, sh = self.get_service()
         s.scheduler.shutdown_service = s
         s.start()
-        assert s._is_shutdown.isSet()
+        assert s._is_shutdown.is_set()
 
 
 class test_EmbeddedService:

--- a/t/unit/worker/test_autoscale.py
+++ b/t/unit/worker/test_autoscale.py
@@ -130,8 +130,8 @@ class test_Autoscaler:
         worker = Mock(name='worker')
         x = Scaler(self.pool, 10, 3, worker=worker)
         x.run()
-        assert getattr(x, "_bgThread__is_shutdown").isSet()
-        assert getattr(x, "_bgThread__is_stopped").isSet()
+        assert getattr(x, "_bgThread__is_shutdown").is_set()
+        assert getattr(x, "_bgThread__is_stopped").is_set()
         assert x.scale_called
 
     def test_shrink_raises_exception(self):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

`Event.isSet` is a depreacted alias of `Event.is_set` which is PEP 8 compliant.
We shouldn't use the old alias in tests and definitely not in our production code.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
