### PR TITLE
Reintroduce docstrings in programmatic start

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -356,9 +356,16 @@ class Celery:
         _deregister_app(self)
 
     def start(self, argv=None):
+        """Run :program:`celery` using `argv`.
+
+        Uses :data:`sys.argv` if `argv` is not specified.
+        """
         from celery.bin.celery import celery
 
         celery.params[0].default = self
+
+        if argv is None:
+            argv = sys.argv
 
         try:
             celery.main(args=argv, standalone_mode=False)
@@ -368,6 +375,10 @@ class Celery:
             celery.params[0].default = None
 
     def worker_main(self, argv=None):
+        """Run :program:`celery worker` using `argv`.
+
+        Uses :data:`sys.argv` if `argv` is not specified.
+        """
         if argv is None:
             argv = sys.argv
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -579,20 +579,12 @@ class test_App:
         for key, value in changes.items():
             assert restored.conf[key] == value
 
-    # def test_worker_main(self):
-    #     from celery.bin import worker as worker_bin
-    #
-    #     class worker(worker_bin.worker):
-    #
-    #         def execute_from_commandline(self, argv):
-    #             return argv
-    #
-    #     prev, worker_bin.worker = worker_bin.worker, worker
-    #     try:
-    #         ret = self.app.worker_main(argv=['--version'])
-    #         assert ret == ['--version']
-    #     finally:
-    #         worker_bin.worker = prev
+    @patch('celery.bin.celery.celery')
+    def test_worker_main(self, mocked_celery):
+        self.app.worker_main(argv=['worker', '--help'])
+
+        mocked_celery.main.assert_called_with(
+            args=['worker', '--help'], standalone_mode=False)
 
     def test_config_from_envvar(self):
         os.environ['CELERYTEST_CONFIG_OBJECT'] = 't.unit.app.test_app'
@@ -774,6 +766,11 @@ class test_App:
         assert self.app.config_from_envvar(key, force=True)
         assert self.app.conf['FOO'] == 10
         assert self.app.conf['BAR'] == 20
+
+    @patch('celery.bin.celery.celery')
+    def test_start(self, mocked_celery):
+        self.app.start()
+        mocked_celery.main.assert_called()
 
     @pytest.mark.parametrize('url,expected_fields', [
         ('pyamqp://', {


### PR DESCRIPTION
## Description
 * reintroduce sys.argv default behaviour for "start" (as was
   commented for "worker_main" in https://github.com/celery/celery/pull/6481#discussion_r524048986
 * reintroduce docstrings for "start" and "worker_main" methods
 * reintroduce and adapt tests for "start" and "worker_main"

Programmatic start (code and unittests) was removed due to
01651d2f5d9ad20dfb9812d92831510147974b23 and reintroduced
in #6481.

Resolves: #6730
Relates: #6481 #6404