### PR TITLE
Fix warning in ``test_get_sync_subtask_option``

### DIFF
--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -59,6 +59,9 @@ class _MockBackend:
     def wait_for_pending(self, *args, **kwargs):
         return True
 
+    def remove_pending_result(self, *args, **kwargs):
+        return True
+
 
 class test_AsyncResult:
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

`test_get_sync_subtask_option` emits a warning since `remove_pending_result` was missing in `_MockBackend`.

See [build log](https://github.com/celery/celery/runs/2928417277?check_suite_focus=true#step:8:3119) for an example.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
