### PR TITLE
Fix docstring for Signal.send to match code

### DIFF
--- a/celery/utils/dispatch/signal.py
+++ b/celery/utils/dispatch/signal.py
@@ -254,9 +254,9 @@ class Signal:  # pragma: no cover
     def send(self, sender, **named):
         """Send signal from sender to all connected receivers.
 
-        If any receiver raises an error, the error propagates back through
-        send, terminating the dispatch loop, so it is quite possible to not
-        have all receivers called if a raises an error.
+        If any receiver raises an error, the exception is returned as the
+        corresponding response. (This is different from the "send" in
+        Django signals. In Celery "send" and "send_robust" do the same thing.)
 
         Arguments:
             sender (Any): The sender of the signal.


### PR DESCRIPTION
## Description

The docstring for Signal.send doesn't seem to match the implementation.

It seems like this paragraph may have been taken from Django:

        If any receiver raises an error, the error propagates back through
        send, terminating the dispatch loop, so it is quite possible to not
        have all receivers called if a raises an error.

The implementation right below the docstring, however, seems to do the opposite -- like Django's send_robust, it catches any exception and returns it. This seems intentional, since Celery's send_robust is just an alias for send.

This creates a little bit of potential confusion about what the intended behaviour actually is -- whether Celery might in some future version "fix the bug" and make exceptions terminate the dispatch loop to make the implementation match the documented behaviour. I think fixing the docstring to match the code is much more sensible here, since code might already be dependent on the existing robust behaviour.