### PR TITLE
doc: Amend IRC network link to Libera

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -424,7 +424,7 @@ IRC
 Come chat with us on IRC. The **#celery** channel is located at the
 `Libera Chat`_ network.
 
-.. _`Libera Chat`: https:/libera.chat/
+.. _`Libera Chat`: https://libera.chat/
 
 .. _bug-tracker:
 

--- a/README.rst
+++ b/README.rst
@@ -421,10 +421,10 @@ please join the `celery-users`_ mailing list.
 IRC
 ---
 
-Come chat with us on IRC. The **#celery** channel is located at the `Freenode`_
-network.
+Come chat with us on IRC. The **#celery** channel is located at the
+`Libera Chat`_ network.
 
-.. _`Freenode`: https://freenode.net
+.. _`Libera Chat`: https:/libera.chat/
 
 .. _bug-tracker:
 


### PR DESCRIPTION
## Description

For the moment, it seems best to have the IRC link in the README pointing at a location where the community is congregating. Further discussion on #6811 or a follow on issue can track other platforms and bridging.

Ref #6811