### PR TITLE
fix: no blank line in log output

### DIFF
--- a/celery/utils/log.py
+++ b/celery/utils/log.py
@@ -223,6 +223,7 @@ class LoggingProxy:
         if getattr(self._thread, 'recurse_protection', False):
             # Logger is logging back to this file, so stop recursing.
             return 0
+        data = data.rstrip('\n')
         if data and not self.closed:
             self._thread.recurse_protection = True
             try:

--- a/t/unit/app/test_log.py
+++ b/t/unit/app/test_log.py
@@ -268,8 +268,10 @@ class test_default_logger:
             p.write('foo')
             assert 'foo' not in sio.getvalue()
             p.closed = False
+            p.write('\n')
+            assert sio.getvalue() == ''
             write_res = p.write('foo ')
-            assert 'foo ' in sio.getvalue()
+            assert sio.getvalue() == 'foo \n'
             assert write_res == 4
             lines = ['baz', 'xuzzy']
             p.writelines(lines)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
resolves #6834

This fixes empty lines being printed in the log like this:
```console
[2021-06-30 19:28:02,606: WARNING/ForkPoolWorker-4] hello hello world
[2021-06-30 19:28:02,607: WARNING/ForkPoolWorker-4] 
```
This is I guess a compromise between the approach in #6834 to not mutate the string in this function and the unwanted behavior of empty lines in the log. It now only strips newlines but would leave normal leading and trailing whitespace (not sure why this  might be useful to have?) maybe `.strip()` would still be better but completely against the OP's approach.

I added a test case for this and also modifed another case to be stricter because previously it was not able to catch the newline issue the way it was written.

Please let me know what you think.