### PR TITLE
Use the dropseed/changerelease action to sync changelog to GitHub Releases

### DIFF
--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -14,7 +14,6 @@ jobs:
     - uses: docker://pandoc/core:2.14
       with:
         args: "Changelog.rst -f rst -t markdown -o CR_CHANGELOG.md"
-      
     - name: "Clean up markdown"
       run: |
         # https://stackoverflow.com/a/1252191/1110798

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: docker://pandoc/core:2.9
+    - uses: docker://pandoc/core:2.14
       with:
         args: "Changelog.rst -f rst -t markdown -o CR_CHANGELOG.md --markdown-headings=atx"
     - run: cat CR_CHANGELOG.md

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -13,9 +13,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker://pandoc/core:2.9
       with:
-        args: "Changelog.rst -f rst -t markdown -o /tmp/CR_CHANGELOG.md"
+        args: "Changelog.rst -f rst -t markdown -o CR_CHANGELOG.md"
     - uses: dropseed/changerelease@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        changelog: /tmp/CR_CHANGELOG.md
+        changelog: CR_CHANGELOG.md
         remote_changelog: false

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -18,3 +18,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         changelog: /tmp/CR_CHANGELOG.md
+        remote_changelog: false

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: docker://pandoc/core:2.9
-        with:
-          args: "Changelog.rst -f rst -t markdown -o /tmp/CR_CHANGELOG.md"
+      with:
+        args: "Changelog.rst -f rst -t markdown -o /tmp/CR_CHANGELOG.md"
     - uses: dropseed/changerelease@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -14,11 +14,13 @@ jobs:
     - uses: docker://pandoc/core:2.14
       with:
         args: "Changelog.rst -f rst -t markdown -o CR_CHANGELOG.md"
+      
     - name: "Clean up markdown"
       run: |
+        # https://stackoverflow.com/a/1252191/1110798
         cat CR_CHANGELOG.md
-        sed -e ':a' -e 'N' -e '$!ba' -e 's/release-date\n\n:  /release-date:/g' CR_CHANGELOG.md > CR_CHANGELOG.md
-        sed -e ':a' -e 'N' -e '$!ba' -e 's/release-by\n\n:  /release-by:/g' CR_CHANGELOG.md > CR_CHANGELOG.md
+        sed -i -e ':a' -e 'N' -e '$!ba' -e 's/release-date\n\n:   /Release date: /g' CR_CHANGELOG.md
+        sed -i -e ':a' -e 'N' -e '$!ba' -e 's/release-by\n\n:   /Release by: /g' CR_CHANGELOG.md
         cat CR_CHANGELOG.md
     - uses: dropseed/changerelease@v1
       with:

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -19,3 +19,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         changelog: CR_CHANGELOG.md
         remote_changelog: false
+        limit: -1

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -1,0 +1,20 @@
+name: changerelease
+on:
+  workflow_dispatch: {}
+  push:
+    paths: [Changelog.rst]
+    branches: [master]
+    tags: ["*"]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker://pandoc/core:2.9
+        with:
+          args: "Changelog.rst -f rst -t markdown -o /tmp/CR_CHANGELOG.md"
+    - uses: dropseed/changerelease@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        changelog: /tmp/CR_CHANGELOG.md

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker://pandoc/core:2.14
       with:
-        args: "Changelog.rst -f rst -t markdown -o CR_CHANGELOG.md --markdown-headings=atx"
+        args: "Changelog.rst -f rst -t markdown -o CR_CHANGELOG.md"
     - run: cat CR_CHANGELOG.md
     - uses: dropseed/changerelease@v1
       with:

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -14,7 +14,12 @@ jobs:
     - uses: docker://pandoc/core:2.14
       with:
         args: "Changelog.rst -f rst -t markdown -o CR_CHANGELOG.md"
-    - run: cat CR_CHANGELOG.md
+    - name: "Clean up markdown"
+      run: |
+        cat CR_CHANGELOG.md
+        sed -e ':a' -e 'N' -e '$!ba' -e 's/release-date\n\n:  /release-date:/g' CR_CHANGELOG.md > CR_CHANGELOG.md
+        sed -e ':a' -e 'N' -e '$!ba' -e 's/release-by\n\n:  /release-by:/g' CR_CHANGELOG.md > CR_CHANGELOG.md
+        cat CR_CHANGELOG.md
     - uses: dropseed/changerelease@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -6,6 +6,9 @@ on:
     branches: [master]
     tags: ["*"]
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -14,6 +14,7 @@ jobs:
     - uses: docker://pandoc/core:2.9
       with:
         args: "Changelog.rst -f rst -t markdown -o CR_CHANGELOG.md"
+    - run: cat CR_CHANGELOG.md
     - uses: dropseed/changerelease@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker://pandoc/core:2.9
       with:
-        args: "Changelog.rst -f rst -t markdown -o CR_CHANGELOG.md"
+        args: "Changelog.rst -f rst -t markdown -o CR_CHANGELOG.md --markdown-headings=atx"
     - run: cat CR_CHANGELOG.md
     - uses: dropseed/changerelease@v1
       with:


### PR DESCRIPTION
@thedrow here's a workflow file that I think will do what we talked about in https://github.com/dropseed/changerelease/issues/2. I did a little bit of extra fiddling with `sed` to tweak what happens with those release date/by directives (?) -- you're obviously welcome to make any changes.

You can look at the releases it created on my fork: https://github.com/davegaeddert/celery/releases

Hope that helps!