### PR TITLE
Chords, get body_type independently to handle cases where body.type does not exist ...

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -644,7 +644,11 @@ class Backend:
     def fallback_chord_unlock(self, header_result, body, countdown=1,
                               **kwargs):
         kwargs['result'] = [r.as_tuple() for r in header_result]
-        body_type = body.get('type', None)
+        try:
+            body_type = getattr(body, 'type', None)
+        except NotRegistered:
+            body_type = None
+
         queue = body.options.get('queue', getattr(body_type, 'queue', None))
         priority = body.options.get('priority', getattr(body_type, 'priority', 0))
         self.app.tasks['celery.chord_unlock'].apply_async(

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -644,8 +644,9 @@ class Backend:
     def fallback_chord_unlock(self, header_result, body, countdown=1,
                               **kwargs):
         kwargs['result'] = [r.as_tuple() for r in header_result]
-        queue = body.options.get('queue', getattr(body.type, 'queue', None))
-        priority = body.options.get('priority', getattr(body.type, 'priority', 0))
+        body_type = body.get('type', None)
+        queue = body.options.get('queue', getattr(body_type, 'queue', None))
+        priority = body.options.get('priority', getattr(body_type, 'priority', 0))
         self.app.tasks['celery.chord_unlock'].apply_async(
             (header_result.id, body,), kwargs,
             countdown=countdown,

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -220,6 +220,22 @@ class test_BaseBackend_interface:
         called_kwargs = self.app.tasks[unlock].apply_async.call_args[1]
         assert called_kwargs['queue'] == 'test_queue_two'
 
+        with self.Celery() as app2:
+            @app2.task(name='callback_different_app', shared=False)
+            def callback_different_app(result):
+                pass
+
+            callback_different_app_signature = self.app.signature('callback_different_app')
+            self.b.apply_chord(header_result_args, callback_different_app_signature)
+            called_kwargs = self.app.tasks[unlock].apply_async.call_args[1]
+            assert called_kwargs['queue'] is None
+
+            callback_different_app_signature.set(queue='test_queue_three')
+            self.b.apply_chord(header_result_args, callback_different_app_signature)
+            called_kwargs = self.app.tasks[unlock].apply_async.call_args[1]
+            assert called_kwargs['queue'] == 'test_queue_three'
+
+
 
 class test_exception_pickle:
     def test_BaseException(self):

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -236,7 +236,6 @@ class test_BaseBackend_interface:
             assert called_kwargs['queue'] == 'test_queue_three'
 
 
-
 class test_exception_pickle:
     def test_BaseException(self):
         assert fnpe(Exception()) is None


### PR DESCRIPTION
… due to tasks being created via Signatures

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

When celery Chords are created by Signatures where the workflow is Task_1+Group+Task_2, when the Task_1 gets executed and moves to start the Chain, if the callback Chord Task_2 does not belong to the same queue as Task_1, body.type does not exist and ends up throwing error as the Task_2 does not belong to Task_1's task list and we end up with a NotRegistered error.

Fixes https://github.com/celery/celery/issues/6846