### PR TITLE
Fix Open Collective donate button

### DIFF
--- a/docs/_templates/sidebardonations.html
+++ b/docs/_templates/sidebardonations.html
@@ -1,8 +1,7 @@
 <iframe src="https://ghbtns.com/github-btn.html?user=celery&repo=celery&type=watch&count=true&size=large"
   allowtransparency="true" frameborder="0" scrolling="0" width="200px" height="35px"></iframe>
-</p>
 <div id="donate">
     <h3>Donations</h3>
     <p>Please help support this community project with a donation.</p>
-    <script src="https://opencollective.com/celery/donate/button.js" color="[white|green]"></script>
+    <script src="https://opencollective.com/celery/donate/button.js" color="blue"></script>
 </div>

--- a/docs/_templates/sidebardonations.html
+++ b/docs/_templates/sidebardonations.html
@@ -3,5 +3,7 @@
 <div id="donate">
     <h3>Donations</h3>
     <p>Please help support this community project with a donation.</p>
-    <script src="https://opencollective.com/celery/donate/button.js" color="blue"></script>
+    <a href="https://opencollective.com/celery/donate" target="_blank">
+      <img src="https://opencollective.com/celery/donate/button@2x.png?color=blue"/>
+    </a>
 </div>


### PR DESCRIPTION

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
Fixes #6828

The Donate button is not visible anywhere on the [https://docs.celeryproject.org/en/stable/](https://docs.celeryproject.org/en/stable/) site.

## The Problem
- The [Open Collective button.js script](https://opencollective.com/celery/donate/button.js) uses the color attribute to form `donate-button-<color>.svg` filenames.
- This filename is used to form a URL e.g. https://opencollective.com/static/images/buttons/donate-button-blue.svg.
- The URL is then used as the background image to the donate button.

When `color="[white|green]"` was used, the resulting filename, `donate-button-[white|green].svg`, could not be found (HTTP 404).

## Solution
[It appears that Open Collective only has static assets for "blue" and "white" donate buttons](https://github.com/opencollective/opencollective-frontend/tree/main/public/static/images/buttons).

This PR has currently set that color value to "blue" which looks like this.

<img src="https://opencollective.com/static/images/buttons/donate-button-blue.svg" />

The "white" alternative looks like this.

<img src="https://opencollective.com/static/images/buttons/donate-button-white.svg" />

Please let me know which one works better.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
