### PR TITLE
Fix #6844 by allowing safe queries via app.inspect().active().

### DIFF
--- a/celery/app/control.py
+++ b/celery/app/control.py
@@ -135,6 +135,8 @@ class Inspect:
 
     def active(self, safe=None):
         """Return list of tasks currently executed by workers.
+        Arguments:
+            safe (Boolean): Set to True to disable deserialization.
 
         Returns:
             Dict: Dictionary ``{HOSTNAME: [TASK_INFO,...]}``.
@@ -142,11 +144,8 @@ class Inspect:
         See Also:
             For ``TASK_INFO`` details see :func:`query_task` return value.
 
-        Note:
-            ``safe`` is ignored since 4.0 as no objects will need
-            serialization now that we have argsrepr/kwargsrepr.
         """
-        return self._request('active')
+        return self._request('active', safe=safe)
 
     def scheduled(self, safe=None):
         """Return list of scheduled tasks with details.

--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -362,9 +362,9 @@ def reserved(state, **kwargs):
 
 
 @inspect_command(alias='dump_active')
-def active(state, **kwargs):
+def active(state, safe=False, **kwargs):
     """List of tasks currently being executed."""
-    return [request.info()
+    return [request.info(safe=safe)
             for request in state.tset(worker_state.active_requests)]
 
 

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -600,8 +600,8 @@ class Request:
         return {
             'id': self.id,
             'name': self.name,
-            'args': self._args,
-            'kwargs': self._kwargs,
+            'args': self._args if not safe else self._argsrepr,
+            'kwargs': self._kwargs if not safe else self._kwargsrepr,
             'type': self._type,
             'hostname': self._hostname,
             'time_start': self.time_start,

--- a/t/unit/app/test_control.py
+++ b/t/unit/app/test_control.py
@@ -97,6 +97,10 @@ class test_inspect:
         self.inspect.active()
         self.assert_broadcast_called('active')
 
+    def test_active_safe(self):
+        self.inspect.active(safe=True)
+        self.assert_broadcast_called('active', safe=True)
+
     def test_clock(self):
         self.inspect.clock()
         self.assert_broadcast_called('clock')

--- a/t/unit/app/test_control.py
+++ b/t/unit/app/test_control.py
@@ -95,7 +95,7 @@ class test_inspect:
 
     def test_active(self):
         self.inspect.active()
-        self.assert_broadcast_called('active')
+        self.assert_broadcast_called('active', safe=None)
 
     def test_active_safe(self):
         self.inspect.active(safe=True)

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -298,6 +298,20 @@ class test_ControlPanel:
         finally:
             worker_state.active_requests.discard(r)
 
+    def test_active_safe(self):
+        kwargsrepr = '<anything>'
+        r = Request(
+            self.TaskMessage(self.mytask.name, id='do re mi',
+                             kwargsrepr=kwargsrepr),
+            app=self.app,
+        )
+        worker_state.active_requests.add(r)
+        try:
+            active_resp = self.panel.handle('dump_active', {'safe': True})
+            assert active_resp[0]['kwargs'] == kwargsrepr
+        finally:
+            worker_state.active_requests.discard(r)
+
     def test_pool_grow(self):
 
         class MockPool:

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -232,7 +232,7 @@ class test_Request(RequestCase):
             kwargs[str(i)] = ''.join(
                 random.choice(string.ascii_lowercase) for i in range(1000))
         assert self.get_request(
-            self.add.s(**kwargs)).info(safe=True).get('kwargs') == kwargs
+            self.add.s(**kwargs)).info(safe=True).get('kwargs') == '' # mock message doesn't populate kwargsrepr
         assert self.get_request(
             self.add.s(**kwargs)).info(safe=False).get('kwargs') == kwargs
         args = []
@@ -240,7 +240,7 @@ class test_Request(RequestCase):
             args.append(''.join(
                 random.choice(string.ascii_lowercase) for i in range(1000)))
         assert list(self.get_request(
-            self.add.s(*args)).info(safe=True).get('args')) == args
+            self.add.s(*args)).info(safe=True).get('args')) == [] # mock message doesn't populate argsrepr
         assert list(self.get_request(
             self.add.s(*args)).info(safe=False).get('args')) == args
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Restores the `safe` option to `app.control.inspect.active`. This affords querying active tasks from context that might not be able to deserialize task arguments. See #6844  for details and when the breakage occurred.