### PR TITLE
Fix multithreaded backend usage

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -282,3 +282,4 @@ Henrik Bruåsdal, 2020/11/29
 Tom Wojcik, 2021/01/24
 Ruaridh Williamson, 2021/03/09
 Patrick Zhang, 2017/08/19
+Konstantin Kochin, 2021/07/11

--- a/celery/app/control.py
+++ b/celery/app/control.py
@@ -135,6 +135,7 @@ class Inspect:
 
     def active(self, safe=None):
         """Return list of tasks currently executed by workers.
+
         Arguments:
             safe (Boolean): Set to True to disable deserialization.
 

--- a/t/unit/app/test_backends.py
+++ b/t/unit/app/test_backends.py
@@ -1,10 +1,87 @@
+import threading
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
 
+import celery.contrib.testing.worker as contrib_embed_worker
 from celery.app import backends
 from celery.backends.cache import CacheBackend
 from celery.exceptions import ImproperlyConfigured
+from celery.utils.nodenames import anon_nodename
+
+
+class CachedBackendWithTreadTrucking(CacheBackend):
+    test_instance_count = 0
+    test_call_stats = {}
+
+    def _track_attribute_access(self, method_name):
+        cls = type(self)
+
+        instance_no = getattr(self, '_instance_no', None)
+        if instance_no is None:
+            instance_no = self._instance_no = cls.test_instance_count
+            cls.test_instance_count += 1
+            cls.test_call_stats[instance_no] = []
+
+        cls.test_call_stats[instance_no].append({
+            'thread_id': threading.get_ident(),
+            'method_name': method_name
+        })
+
+    def __getattribute__(self, name):
+        if name == '_instance_no' or name == '_track_attribute_access':
+            return super().__getattribute__(name)
+
+        if name.startswith('__') and name != '__init__':
+            return super().__getattribute__(name)
+
+        self._track_attribute_access(name)
+        return super().__getattribute__(name)
+
+
+@contextmanager
+def embed_worker(app,
+                 concurrency=1,
+                 pool='threading', **kwargs):
+    """
+    Helper embedded worker for testing.
+
+    It's based on a :func:`celery.contrib.testing.worker.start_worker`,
+    but doesn't modifies logging settings and additionally shutdown
+    worker pool.
+    """
+    # prepare application for worker
+    app.finalize()
+    app.set_current()
+
+    worker = contrib_embed_worker.TestWorkController(
+        app=app,
+        concurrency=concurrency,
+        hostname=anon_nodename(),
+        pool=pool,
+        # not allowed to override TestWorkController.on_consumer_ready
+        ready_callback=None,
+        without_heartbeat=kwargs.pop("without_heartbeat", True),
+        without_mingle=True,
+        without_gossip=True,
+        **kwargs
+    )
+
+    t = threading.Thread(target=worker.start, daemon=True)
+    t.start()
+    worker.ensure_started()
+
+    yield worker
+
+    worker.stop()
+    t.join(10.0)
+    if t.is_alive():
+        raise RuntimeError(
+            "Worker thread failed to exit within the allocated timeout. "
+            "Consider raising `shutdown_timeout` if your tasks take longer "
+            "to execute."
+        )
 
 
 class test_backends:
@@ -35,3 +112,25 @@ class test_backends:
     def test_backend_can_not_be_module(self, app):
         with pytest.raises(ImproperlyConfigured):
             backends.by_name(pytest, app.loader)
+
+    @pytest.mark.celery(
+        result_backend=f'{CachedBackendWithTreadTrucking.__module__}.'
+                       f'{CachedBackendWithTreadTrucking.__qualname__}'
+                       f'+memory://')
+    def test_backend_thread_safety(self):
+        @self.app.task
+        def dummy_add_task(x, y):
+            return x + y
+
+        with embed_worker(app=self.app, pool='threads'):
+            result = dummy_add_task.delay(6, 9)
+            assert result.get(timeout=10) == 15
+
+        call_stats = CachedBackendWithTreadTrucking.test_call_stats
+        # check that backend instance is used without same thread
+        for backend_call_stats in call_stats.values():
+            thread_ids = set()
+            for call_stat in backend_call_stats:
+                thread_ids.add(call_stat['thread_id'])
+            assert len(thread_ids) <= 1, \
+                "The same celery backend instance is used by multiple threads"

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -232,7 +232,7 @@ class test_Request(RequestCase):
             kwargs[str(i)] = ''.join(
                 random.choice(string.ascii_lowercase) for i in range(1000))
         assert self.get_request(
-            self.add.s(**kwargs)).info(safe=True).get('kwargs') == '' # mock message doesn't populate kwargsrepr
+            self.add.s(**kwargs)).info(safe=True).get('kwargs') == ''  # mock message doesn't populate kwargsrepr
         assert self.get_request(
             self.add.s(**kwargs)).info(safe=False).get('kwargs') == kwargs
         args = []
@@ -240,7 +240,7 @@ class test_Request(RequestCase):
             args.append(''.join(
                 random.choice(string.ascii_lowercase) for i in range(1000)))
         assert list(self.get_request(
-            self.add.s(*args)).info(safe=True).get('args')) == [] # mock message doesn't populate argsrepr
+            self.add.s(*args)).info(safe=True).get('args')) == []  # mock message doesn't populate argsrepr
         assert list(self.get_request(
             self.add.s(*args)).info(safe=False).get('args')) == args
 


### PR DESCRIPTION
## Description

This PR adds the following fix for changes from PR #6416:

- Fix `celery/app/trace.py::build_tracer` function to prevent *backend* capturing into closure during Celery task creation. It prevents backend instance usage by multiple threads, as task creation and usage may be done by different threads.
 
