### PR TITLE
Fix setting worker concurrency option after signal

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -294,7 +294,7 @@ NAMESPACES = Namespace(
         cancel_long_running_tasks_on_connection_loss=Option(
             False, type='bool'
         ),
-        concurrency=Option(0, type='int'),
+        concurrency=Option(None, type='int'),
         consumer=Option('celery.worker.consumer:Consumer', type='string'),
         direct=Option(False, type='bool', old={'celery_worker_direct'}),
         disable_rate_limits=Option(


### PR DESCRIPTION
## Allow to set `worker_concurrency` option through `user_preload_options` signal mechanism.

### Current behaviour

1. `click.option` decorator for `--concurrency` option is executed, its callback returns `0` when evaluating https://github.com/celery/celery/blob/5fd182417d9a6cb1b5aebe29916814d7a725e62a/celery/bin/worker.py#L188 with the values `None or 0`; this default `0` comes from: https://github.com/celery/celery/blob/5fd182417d9a6cb1b5aebe29916814d7a725e62a/celery/app/defaults.py#L297

2. Celery `user_preload_options` signal is processed, then    `app.conf.worker_concurrency` value is correctly updated through `Settings.update`.

3. Celery `worker.worker.WorkController.setup_defaults` kicks off and `concurrency` attribute is resolved with https://github.com/celery/celery/blob/5fd182417d9a6cb1b5aebe29916814d7a725e62a/celery/worker/worker.py#L376

4. `either` method chains calls to `first` function with `None` as predicate (returns the first item that's not `None`): https://github.com/celery/celery/blob/5fd182417d9a6cb1b5aebe29916814d7a725e62a/celery/app/base.py#L925 in our case `first(None, defaults)` (defaults is `(0,)`) will take precedence and `0` will be returned, whatever value is in `app.conf.worker_concurrency`.

### Proposed solution

This fix changes `worker_concurrency` default from `0` to `None` allowing `either` method to correctly resolve in favor of `app.conf.worker_concurrency` value.

The final value used as _concurrency_ is resolved in https://github.com/celery/celery/blob/5fd182417d9a6cb1b5aebe29916814d7a725e62a/celery/worker/worker.py#L109 thus having `None` as default value for `self.concurrency` doesn't break things.

Fixes: #6836