### PR TITLE
Discard jobs on flush if synack isn't enabled

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -978,10 +978,14 @@ class AsynPool(_pool.Pool):
     def flush(self):
         if self._state == TERMINATE:
             return
-        # cancel all tasks that haven't been accepted so that NACK is sent.
-        for job in self._cache.values():
+        # cancel all tasks that haven't been accepted so that NACK is sent
+        # if synack is enabled.
+        for job in tuple(self._cache.values()):
             if not job._accepted:
-                job._cancel()
+                if self.synack:
+                    job._cancel()
+                else:
+                    job.discard()
 
         # clear the outgoing buffer as the tasks will be redelivered by
         # the broker anyway.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fixes #6855.

A connection loss flushes the asynpool (See https://github.com/celery/celery/blob/117cd9ca410e8879f71bd84be27b8e69e462c56a/celery/worker/consumer/consumer.py#L414).
This is expected as these jobs cannot be completed anymore.
However, jobs that have not been accepted yet (that is, they are not running yet) are canceled. This only works if the synack keyword argument is set to True.
In our case, it isn't and therefore the jobs remain in the pool's cache forever.

This is a memory leak which we have now resolved by discarding the job (which clears it from the cache) as they will never be cancelled.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
