### PR TITLE
fix inspect --json output to return valid json without --quiet

### DIFF
--- a/celery/bin/control.py
+++ b/celery/bin/control.py
@@ -144,6 +144,8 @@ def inspect(ctx, action, timeout, destination, json, **kwargs):
 
     if json:
         ctx.obj.echo(dumps(replies))
+        return
+
     nodecount = len(replies)
     if not ctx.obj.quiet:
         ctx.obj.echo('\n{} {} online.'.format(


### PR DESCRIPTION
resolves #6857

before `--quiet` was needed in addtition to `--json` to generate parsable valid json output.
Now only `--json` is needed to generate valid json output (no `\n\n3 nodes online.` at the end) 

before:
```console
(venv) jonas@ububox:~/workspace/celery$ celery -A tasks inspect --json active | jq
{
  "celery@ububox": []
}
1
parse error: Invalid literal at line 3, column 7
```
after:
```console
(venv) jonas@ububox:~/workspace/celery$ celery -A tasks inspect --json active | jq
{
  "celery@ububox": []
}
```