### PR TITLE
Fix typo in mark_as_failure

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -190,7 +190,7 @@ class Backend:
                 # elements of the chain. This is only truly important so
                 # that the last chain element which controls completion of
                 # the chain itself is marked as completed to avoid stalls.
-                if self.store_result and state in states.PROPAGATE_STATES:
+                if store_result and state in states.PROPAGATE_STATES:
                     try:
                         chained_task_id = chain_elem_opts['task_id']
                     except KeyError:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

This is an obvious typo in `mark_as_failure`. We noticed the issue after upgrading from 5.0.5 to 5.1.2 and immediately seeing lots of results stored for tasks configured with `store_result=False`.