### PR TITLE
Update docs to reflect default scheduling strategy

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -64,11 +64,12 @@ consider enabling the :setting:`task_reject_on_worker_lost` setting.
     the process by force so only use them to detect cases where you haven't
     used manual timeouts yet.
 
-    The default prefork pool scheduler is not friendly to long-running tasks,
-    so if you have tasks that run for minutes/hours make sure you enable
-    the :option:`-Ofair <celery worker -O>` command-line argument to
-    the :program:`celery worker`. See :ref:`optimizing-prefetch-limit` for more
-    information, and for the best performance route long-running and
+    In previous versions, the default prefork pool scheduler was not friendly
+    to long-running tasks, so if you had tasks that ran for minutes/hours, it
+    was advised to enable the :option:`-Ofair <celery worker -O>` command-line
+    argument to the :program:`celery worker`. However, as of version 4.0, 
+    -Ofair is now the default scheduling strategy. See :ref:`optimizing-prefetch-limit`
+    for more information, and for the best performance route long-running and
     short-running tasks to dedicated workers (:ref:`routing-automatic`).
 
     If your worker hangs then please investigate what tasks are running


### PR DESCRIPTION
-Ofair is now the default scheduling strategy as of v4.0: https://github.com/celery/celery/blob/8ebcce1523d79039f23da748f00bec465951de2a/docs/history/whatsnew-4.0.rst#ofair-is-now-the-default-scheduling-strategy

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
