### PR TITLE
Note on gevent time limit support

### DIFF
--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -434,7 +434,7 @@ Time Limits
 
 .. versionadded:: 2.0
 
-:pool support: *prefork/gevent*
+:pool support: *prefork/gevent (see note below)*
 
 .. sidebar:: Soft, or hard?
 
@@ -473,6 +473,11 @@ Time limits can also be set using the :setting:`task_time_limit` /
 
     Time limits don't currently work on platforms that don't support
     the :sig:`SIGUSR1` signal.
+
+.. note::
+
+    The gevent pool does not implement soft time limits. Additionally,
+    it will not enforce the hard time limit if the task is blocking.
 
 
 Changing time limits at run-time


### PR DESCRIPTION
## Description

I only learned about gevents limited support for time limits from https://github.com/celery/celery/issues/1958 and trying to debug my time limits.

It's an important point that is not clear from the existing pool support note in the doc.