### PR TITLE
Route chord_unlock task to the same queue as chord body

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -650,6 +650,12 @@ class Backend:
             body_type = None
 
         queue = body.options.get('queue', getattr(body_type, 'queue', None))
+
+        if queue is None:
+            # fallback to default routing if queue name was not
+            # explicitly passed to body callback
+            queue = self.app.amqp.router.route(kwargs, body.name)['queue'].name
+
         priority = body.options.get('priority', getattr(body_type, 'priority', 0))
         self.app.tasks['celery.chord_unlock'].apply_async(
             (header_result.id, body,), kwargs,

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -206,7 +206,7 @@ class test_BaseBackend_interface:
 
         self.b.apply_chord(header_result_args, body)
         called_kwargs = self.app.tasks[unlock].apply_async.call_args[1]
-        assert called_kwargs['queue'] is None
+        assert called_kwargs['queue'] == 'testcelery'
 
         self.b.apply_chord(header_result_args, body.set(queue='test_queue'))
         called_kwargs = self.app.tasks[unlock].apply_async.call_args[1]
@@ -228,7 +228,7 @@ class test_BaseBackend_interface:
             callback_different_app_signature = self.app.signature('callback_different_app')
             self.b.apply_chord(header_result_args, callback_different_app_signature)
             called_kwargs = self.app.tasks[unlock].apply_async.call_args[1]
-            assert called_kwargs['queue'] is None
+            assert called_kwargs['queue'] == 'testcelery'
 
             callback_different_app_signature.set(queue='test_queue_three')
             self.b.apply_chord(header_result_args, callback_different_app_signature)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fixes https://github.com/celery/celery/issues/6888