### PR TITLE
Allow using non-true values in app kwargs

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -323,7 +323,7 @@ class Celery:
         """Optional callback called at init."""
 
     def __autoset(self, key, value):
-        if value:
+        if value is not None:
             self._preconf[key] = value
             self._preconf_set_by_auto.add(key)
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -274,7 +274,11 @@ class test_App:
         with self.Celery(broker='foo://baribaz') as app:
             assert app.conf.broker_url == 'foo://baribaz'
 
-    def test_pending_confugration__kwargs(self):
+    def test_pending_configuration_non_true__kwargs(self):
+        with self.Celery(task_create_missing_queues=False) as app:
+            assert app.conf.task_create_missing_queues is False
+
+    def test_pending_configuration__kwargs(self):
         with self.Celery(foo='bar') as app:
             assert app.conf.foo == 'bar'
 


### PR DESCRIPTION
## Description

Trying to instantiate Celery app with *non-true kwargs* will not work
for those configs which have *True* as default, for example,
this will not have effect:

```
>>> app = Celery(task_create_missing_queues=False)
>>> app.conf['task_create_missing_queues']
True
```

This fix simply changes the filtering which from now on will discard
*None* values only.

Fixes: #6865