### PR TITLE
Add args to LOG_RECEIVED (fixes #6885)

### DIFF
--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -527,6 +527,8 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                                 'name': get_task_name(task_request, name),
                                 'return_value': Rstr,
                                 'runtime': T,
+                                'args': safe_repr(args),
+                                'kwargs': safe_repr(kwargs),
                             })
 
                 # -* POST *-

--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -2,6 +2,7 @@
 import logging
 
 from kombu.asynchronous.timer import to_timestamp
+from kombu.utils.encoding import safe_repr
 
 from celery import signals
 from celery.app import trace as _app_trace
@@ -151,7 +152,12 @@ def default(task, app, consumer,
         if _does_info:
             # Similar to `app.trace.info()`, we pass the formatting args as the
             # `extra` kwarg for custom log handlers
-            context = {'id': req.id, 'name': req.name}
+            context = {
+                'id': req.id,
+                'name': req.name,
+                'args': safe_repr(req.args),
+                'kwargs': safe_repr(req.kwargs),
+            }
             info(_app_trace.LOG_RECEIVED, context, extra={'data': context})
         if (req.expires or req.id in revoked_tasks) and req.revoked():
             return

--- a/t/unit/worker/test_strategy.py
+++ b/t/unit/worker/test_strategy.py
@@ -191,7 +191,7 @@ class test_default_strategy_proto2:
             C()
         for record in caplog.records:
             if record.msg == custom_fmt:
-                assert set(record.args) == {"id", "name"}
+                assert set(record.args) == {"id", "name", "kwargs", "args"}
                 break
         else:
             raise ValueError("Expected message not in captured log records")


### PR DESCRIPTION
## Description
Add `args` to the `context` that's logged with `LOG_RECEIVED` (like `LOG_REJECTED`)

Fixed #6885 
