### PR TITLE
use same serializer as task seriazlier

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -30,11 +30,12 @@ from billiard.compat import buf_t, isblocking, setblocking
 from billiard.pool import ACK, NACK, RUN, TERMINATE, WorkersJoined
 from billiard.queues import _SimpleQueue
 from kombu.asynchronous import ERR, WRITE
-from kombu.serialization import pickle as _pickle
+from kombu.serialization import pickle as _pickle, registry as serializer_registry
 from kombu.utils.eventio import SELECT_BAD_FD
 from kombu.utils.functional import fxrange
 from vine import promise
 
+from celery import current_app
 from celery.utils.functional import noop
 from celery.utils.log import get_logger
 from celery.worker import state as worker_state
@@ -508,7 +509,7 @@ class AsynPool(_pool.Pool):
         self.handle_result_event = self._result_handler.handle_event
         self._create_timelimit_handlers(hub)
         self._create_process_handlers(hub)
-        self._create_write_handlers(hub)
+        self._create_write_handlers(hub, dumps=serializer_registry._encoders[current_app.conf.task_serializer][-1])
 
         # Add handler for when a process exits (calls maintain_pool)
         [self._track_child_process(w, hub) for w in self._pool]


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Make `asynpool` to use the same serializer as `task_seriazlier`
If one of the arguments isn't pickleable, and I'm using a different serializer that I registered (dill for example)
The task is being serialized great, but the `asynpool` isn't working since it is using pickle hardcodded
