### PR TITLE
Give indication whether the task is replacing another

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -88,6 +88,7 @@ class Context:
     properties = None
     retries = 0
     reply_to = None
+    replaced_task_nesting = 0
     root_id = None
     shadow = None
     taskset = None   # compat alias to group
@@ -128,6 +129,7 @@ class Context:
             'headers': self.headers,
             'retries': self.retries,
             'reply_to': self.reply_to,
+            'replaced_task_nesting': self.replaced_task_nesting,
             'origin': self.origin,
         }
 
@@ -916,11 +918,13 @@ class Task:
         # which would break previously constructed results objects.
         sig.freeze(self.request.id)
         # Ensure the important options from the original signature are retained
+        replaced_task_nesting = self.request.get('replaced_task_nesting', 0) + 1
         sig.set(
             chord=chord,
             group_id=self.request.group,
             group_index=self.request.group_index,
             root_id=self.request.root_id,
+            replaced_task_nesting=replaced_task_nesting
         )
         # If the task being replaced is part of a chain, we need to re-create
         # it with the replacement signature - these subsequent tasks will

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -312,6 +312,10 @@ class Request:
         return self._request_dict['reply_to']
 
     @property
+    def replaced_task_nesting(self):
+        return self._request_dict.get('replaced_task_nesting', 0)
+
+    @property
     def correlation_id(self):
         # used similarly to reply_to
         return self._request_dict['correlation_id']

--- a/docs/internals/protocol.rst
+++ b/docs/internals/protocol.rst
@@ -49,6 +49,7 @@ Definition
         'argsrepr': str repr(args),
         'kwargsrepr': str repr(kwargs),
         'origin': str nodename,
+        'replaced_task_nesting': int
     }
 
     body = (

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -67,7 +67,7 @@ consider enabling the :setting:`task_reject_on_worker_lost` setting.
     In previous versions, the default prefork pool scheduler was not friendly
     to long-running tasks, so if you had tasks that ran for minutes/hours, it
     was advised to enable the :option:`-Ofair <celery worker -O>` command-line
-    argument to the :program:`celery worker`. However, as of version 4.0, 
+    argument to the :program:`celery worker`. However, as of version 4.0,
     -Ofair is now the default scheduling strategy. See :ref:`optimizing-prefetch-limit`
     for more information, and for the best performance route long-running and
     short-running tasks to dedicated workers (:ref:`routing-automatic`).
@@ -376,6 +376,9 @@ The request defines the following attributes:
 
 :properties: Mapping of message properties received with this task message
              (may be :const:`None` or :const:`{}`)
+
+:replaced_task_nesting: How many times the task was replaced, if at all.
+                        (may be :const:`0`)
 
 Example
 -------

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -91,7 +91,7 @@ class test_Signature(CanvasCase):
         assert fun(*args) == x
 
     def test_replace(self):
-        x = Signature('TASK', ('A'), {})
+        x = Signature('TASK', ('A',), {})
         assert x.replace(args=('B',)).args == ('B',)
         assert x.replace(kwargs={'FOO': 'BAR'}).kwargs == {
             'FOO': 'BAR',

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1020,6 +1020,11 @@ class test_tasks(TasksCase):
         with pytest.raises(Ignore):
             self.mytask.replace(sig1)
         sig1.freeze.assert_called_once_with(self.mytask.request.id)
+        sig1.set.assert_called_once_with(replaced_task_nesting=1,
+                                         chord=ANY,
+                                         group_id=ANY,
+                                         group_index=ANY,
+                                         root_id=ANY)
 
     def test_replace_with_chord(self):
         sig1 = Mock(name='sig1')


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

We now increase the `replaced_task_nesting` option each time we replace a task.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
