### PR TITLE
Terminate job implementation for eventlet concurrency backend

### DIFF
--- a/celery/concurrency/eventlet.py
+++ b/celery/concurrency/eventlet.py
@@ -2,9 +2,10 @@
 import sys
 from time import monotonic
 
-from celery import signals
 from greenlet import GreenletExit
 from kombu.asynchronous import timer as _timer
+
+from celery import signals
 
 from . import base
 

--- a/celery/concurrency/eventlet.py
+++ b/celery/concurrency/eventlet.py
@@ -109,7 +109,7 @@ class TaskPool(base.BasePool):
 
     def on_start(self):
         self._pool = self.Pool(self.limit)
-        self._pool_map = dict()
+        self._pool_map = {}
         signals.eventlet_pool_started.send(sender=self)
         self._quick_put = self._pool.spawn
         self._quick_apply_sig = signals.eventlet_pool_apply.send

--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -324,7 +324,7 @@ Commands
 
 ``revoke``: Revoking tasks
 --------------------------
-:pool support: all, terminate only supported by prefork
+:pool support: all, terminate only supported by prefork and eventlet
 :broker support: *amqp, redis*
 :command: :program:`celery -A proj control revoke <task_id>`
 

--- a/t/unit/concurrency/test_eventlet.py
+++ b/t/unit/concurrency/test_eventlet.py
@@ -141,11 +141,11 @@ class test_TaskPool(EventletCase):
 
         assert len(pool._pool_map.keys()) == 1
         pid = list(pool._pool_map.keys())[0]
-        task = pool._pool_map[pid]
+        greenlet = pool._pool_map[pid]
 
         pool.terminate_job(pid)
-        task.link.assert_called_once()
-        task.kill.assert_called_once()
+        greenlet.link.assert_called_once()
+        greenlet.kill.assert_called_once()
 
     def test_make_killable_target(self):
         def valid_target():
@@ -154,13 +154,8 @@ class test_TaskPool(EventletCase):
         def terminating_target():
             raise GreenletExit()
 
-        def failing_target():
-            raise RuntimeError("some error")
-
         assert TaskPool._make_killable_target(valid_target)() == "some result..."
         assert TaskPool._make_killable_target(terminating_target)() == (False, None, None)
-        with pytest.raises(RuntimeError):
-            TaskPool._make_killable_target(failing_target)()
 
     def test_cleanup_after_job_finish(self):
         testMap = {'1': None}

--- a/t/unit/concurrency/test_eventlet.py
+++ b/t/unit/concurrency/test_eventlet.py
@@ -2,10 +2,10 @@ import sys
 from unittest.mock import Mock, patch
 
 import pytest
-from celery.concurrency.eventlet import TaskPool, Timer, apply_target
 from greenlet import GreenletExit
 
 import t.skip
+from celery.concurrency.eventlet import TaskPool, Timer, apply_target
 
 eventlet_modules = (
     'eventlet',


### PR DESCRIPTION
 # Terminate job implementation for eventlet concurrency backend

## Description

Current implementation of **TaskPool** which is based on **eventlet** library does not support terminating jobs. 
Revoking with `terminate=True` or terminating task raises `NotImplementedError: <class 'celery.concurrency.eventlet.TaskPool'> does not implement kill_job` exception while task continues to run. 

Fixes #5209 #3429 
Fixes only eventlet backend for this issue #4019 
