### PR TITLE
Add cleanup implementation to filesystem backend

### DIFF
--- a/celery/backends/filesystem.py
+++ b/celery/backends/filesystem.py
@@ -103,10 +103,11 @@ class FilesystemBackend(KeyValueStoreBackend):
         epoch = datetime(1970, 1, 1, tzinfo=self.app.timezone)
         now_ts = (self.app.now() - epoch).total_seconds()
         cutoff_ts = now_ts - self.expires
-        for dir_entry in os.scandir(self.path):
+        for filename in os.listdir(self.path):
             for prefix in (self.task_keyprefix, self.group_keyprefix,
                            self.chord_keyprefix):
-                if dir_entry.name.startswith(prefix):
-                    if dir_entry.stat().st_mtime < cutoff_ts:
-                        self.unlink(dir_entry.path)
+                if filename.startswith(prefix):
+                    path = os.path.join(self.path, filename)
+                    if os.stat(path).st_mtime < cutoff_ts:
+                        self.unlink(path)
                     break

--- a/t/unit/backends/test_filesystem.py
+++ b/t/unit/backends/test_filesystem.py
@@ -108,6 +108,15 @@ class test_FilesystemBackend:
         time.sleep(day_length)  # let FS mark some difference in mtimes
         for tid in today_task_ids:
             tb.mark_as_done(tid, 42)
+        with patch.object(tb, 'expires', 0):
+            tb.cleanup()
+        # test that zero expiration time prevents any cleanup
+        filenames = set(os.listdir(tb.path))
+        assert all(
+            tb.get_key_for_task(tid) in filenames
+            for tid in yesterday_task_ids + today_task_ids
+        )
+        # test that non-zero expiration time enables cleanup by file mtime
         with patch.object(tb, 'expires', day_length):
             tb.cleanup()
         filenames = set(os.listdir(tb.path))

--- a/t/unit/backends/test_filesystem.py
+++ b/t/unit/backends/test_filesystem.py
@@ -1,6 +1,9 @@
 import os
 import pickle
+import sys
 import tempfile
+import time
+from unittest.mock import patch
 
 import pytest
 
@@ -92,3 +95,27 @@ class test_FilesystemBackend:
     def test_pickleable(self):
         tb = FilesystemBackend(app=self.app, url=self.url, serializer='pickle')
         assert pickle.loads(pickle.dumps(tb))
+
+    @pytest.mark.skipif(sys.platform == 'win32', reason='Test can fail on '
+                        'Windows/FAT due to low granularity of st_mtime')
+    def test_cleanup(self):
+        tb = FilesystemBackend(app=self.app, url=self.url)
+        yesterday_task_ids = [uuid() for i in range(10)]
+        today_task_ids = [uuid() for i in range(10)]
+        for tid in yesterday_task_ids:
+            tb.mark_as_done(tid, 42)
+        day_length = 0.2
+        time.sleep(day_length)  # let FS mark some difference in mtimes
+        for tid in today_task_ids:
+            tb.mark_as_done(tid, 42)
+        with patch.object(tb, 'expires', day_length):
+            tb.cleanup()
+        filenames = set(os.listdir(tb.path))
+        assert not any(
+            tb.get_key_for_task(tid) in filenames
+            for tid in yesterday_task_ids
+        )
+        assert all(
+            tb.get_key_for_task(tid) in filenames
+            for tid in today_task_ids
+        )


### PR DESCRIPTION
## Description

Filesystem back-end stores task results in files and currently has no `cleanup()` method. Without other ways of maintenance (e.g. `logrotate` or `systemd-tmpfiles`) that will eventually overflow file system. This PR adds `cleanup()` implementation, which we use in our production.