### PR TITLE
Provide builtin yaml reducer for Signature objects

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -481,6 +481,8 @@ class Signature(dict):
     def __json__(self):
         return dict(self)
 
+    __yaml__ = __json__
+
     def __repr__(self):
         return self.reprcall()
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -57,6 +57,15 @@ def task_name_from(task):
     return getattr(task, 'name', task)
 
 
+try:
+    from kombu.utils.yaml import register_yaml_decoder
+except ImportError:
+    # kombu < 5.2 or pyyaml not installed.
+    def register_yaml_decoder(klass):
+        return klass
+
+
+@register_yaml_decoder
 @abstract.CallableSignature.register
 class Signature(dict):
     """Task Signature.

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -84,6 +84,10 @@ class test_Signature(CanvasCase):
         x = Signature('TASK', link=Signature('B', app=self.app), app=self.app)
         assert x.__json__() == dict(x)
 
+    def test_yaml(self):
+        x = Signature('TASK', link=Signature('B', app=self.app), app=self.app)
+        assert x.__yaml__() == dict(x)
+
     @pytest.mark.usefixtures('depends_on_current_app')
     def test_reduce(self):
         x = Signature('TASK', (2, 4), app=self.app)


### PR DESCRIPTION
related to #6901
related to https://github.com/celery/kombu/pull/1373

I have one remaining question. Where should I register `celery.canvas.Signature` class to be serializable with yaml ? in `celery` or in `kombu` ? where it is recommended ?

```python
# canvas.py
from kombu.utils.yaml import register_yaml_decoders

@register_yaml_decoders
@abstract.CallableSignature.register
class Signature(dict):
  ...
```

