### PR TITLE
Drop Python 3.6 support.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-rc.1', 'pypy-3.6', 'pypy-3.7']
+        python-version: ['3.7', '3.8', '3.9', '3.10.0-rc.1', 'pypy-3.7']
         os: ["ubuntu-20.04", "windows-2019"]
         exclude:
           - os: windows-2019

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 requires =
     tox-gh-actions
 envlist =
-    {3.6,3.7,3.8,3.9,3.10,pypy3}-unit
-    {3.6,3.7,3.8,3.9,3.10,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
+    {3.7,3.8,3.9,3.10,pypy3}-unit
+    {3.7,3.8,3.9,3.10,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
 
     flake8
     apicheck
@@ -13,7 +13,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.6: 3.6-unit
     3.7: 3.7-unit
     3.8: 3.8-unit
     3.9: 3.9-unit
@@ -31,8 +30,8 @@ deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/pkgutils.txt
 
-    3.6,3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/test-ci-default.txt
-    3.6,3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/docs.txt
+    3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/test-ci-default.txt
+    3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/docs.txt
     pypy3: -r{toxinidir}/requirements/test-ci-default.txt
 
     integration: -r{toxinidir}/requirements/test-integration.txt
@@ -74,7 +73,6 @@ setenv =
     azureblockblob: TEST_BACKEND=azureblockblob://DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
 
 basepython =
-    3.6: python3.6
     3.7: python3.7
     3.8: python3.8
     3.9: python3.9


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Python 3.6 is EOL in a few days and 5.2 will not support it.
Therefore, we will not need to test Celery with Python 3.6 anymore.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->