### PR TITLE
Kill all workers when main process exits in prefork model

### DIFF
--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -41,6 +41,8 @@ def process_initializer(app, hostname):
     Initialize the child pool process to ensure the correct
     app instance is used and things like logging works.
     """
+    # Each running worker gets SIGKILL by OS when main process exits.
+    platforms.set_pdeathsig('SIGKILL')
     _set_task_join_will_block(True)
     platforms.signals.reset(*WORKER_SIGRESET)
     platforms.signals.ignore(*WORKER_SIGIGNORE)

--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -17,6 +17,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 
 from billiard.compat import close_open_fds, get_fdmax
+from billiard.util import set_pdeathsig as _set_pdeathsig
 # fileno used to be in this module
 from kombu.utils.compat import maybe_fileno
 from kombu.utils.encoding import safe_str
@@ -707,6 +708,15 @@ def strargv(argv):
         return ' '.join(argv[arg_start:])
     return ''
 
+
+def set_pdeathsig(name):
+    """Sends signal ``name`` to process when parent process terminates."""
+    if signals.supported('SIGKILL'):
+        try:
+            _set_pdeathsig(signals.signum('SIGKILL'))
+        except OSError:
+            # We ignore when OS does not support set_pdeathsig
+            pass
 
 def set_process_title(progname, info=None):
     """Set the :command:`ps` name for the currently running process.

--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -718,6 +718,7 @@ def set_pdeathsig(name):
             # We ignore when OS does not support set_pdeathsig
             pass
 
+
 def set_process_title(progname, info=None):
     """Set the :command:`ps` name for the currently running process.
 

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -1,12 +1,10 @@
 import errno
 import os
-import signal
 import socket
 from itertools import cycle
 from unittest.mock import Mock, patch
 
 import pytest
-from billiard.util import set_pdeathsig
 from case import mock
 
 import t.skip

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -1,9 +1,11 @@
 import errno
 import os
 import socket
+import signal
 from itertools import cycle
 from unittest.mock import Mock, patch
 
+from billiard.util import set_pdeathsig
 import pytest
 from case import mock
 
@@ -53,11 +55,18 @@ class MockResult:
         return self.value
 
 
+@patch('celery.platforms.set_mp_process_title')
 class test_process_initializer:
 
+    @staticmethod
+    def Loader(*args, **kwargs):
+        loader = Mock(*args, **kwargs)
+        loader.conf = {}
+        loader.override_backends = {}
+        return loader
+
     @patch('celery.platforms.signals')
-    @patch('celery.platforms.set_mp_process_title')
-    def test_process_initializer(self, set_mp_process_title, _signals):
+    def test_process_initializer(self, _signals, set_mp_process_title):
         with mock.restore_logging():
             from celery import signals
             from celery._state import _tls
@@ -67,13 +76,7 @@ class test_process_initializer:
             on_worker_process_init = Mock()
             signals.worker_process_init.connect(on_worker_process_init)
 
-            def Loader(*args, **kwargs):
-                loader = Mock(*args, **kwargs)
-                loader.conf = {}
-                loader.override_backends = {}
-                return loader
-
-            with self.Celery(loader=Loader) as app:
+            with self.Celery(loader=self.Loader) as app:
                 app.conf = AttributeDict(DEFAULTS)
                 process_initializer(app, 'awesome.worker.com')
                 _signals.ignore.assert_any_call(*WORKER_SIGIGNORE)
@@ -99,6 +102,19 @@ class test_process_initializer:
                     process_initializer(app, 'luke.worker.com')
                 finally:
                     os.environ.pop('CELERY_LOG_FILE', None)
+
+    @patch('celery.platforms.set_pdeathsig')
+    def test_pdeath_sig(self, _set_pdeathsig, set_mp_process_title):
+        with mock.restore_logging():
+            from celery import signals
+            on_worker_process_init = Mock()
+            signals.worker_process_init.connect(on_worker_process_init)
+            from celery.concurrency.prefork import process_initializer
+
+            with self.Celery(loader=self.Loader) as app:
+                app.conf = AttributeDict(DEFAULTS)
+                process_initializer(app, 'awesome.worker.com')
+            _set_pdeathsig.assert_called_once_with('SIGKILL')
 
 
 class test_process_destructor:

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -1,12 +1,12 @@
 import errno
 import os
-import socket
 import signal
+import socket
 from itertools import cycle
 from unittest.mock import Mock, patch
 
-from billiard.util import set_pdeathsig
 import pytest
+from billiard.util import set_pdeathsig
 from case import mock
 
 import t.skip

--- a/t/unit/utils/test_platforms.py
+++ b/t/unit/utils/test_platforms.py
@@ -18,9 +18,9 @@ from celery.platforms import (ASSUMING_ROOT, ROOT_DISALLOWED,
                               close_open_fds, create_pidlock, detached,
                               fd_by_path, get_fdmax, ignore_errno, initgroups,
                               isatty, maybe_drop_privileges, parse_gid,
-                              parse_uid, set_mp_process_title,
+                              parse_uid, set_mp_process_title, set_pdeathsig,
                               set_process_title, setgid, setgroups, setuid,
-                              signals, set_pdeathsig)
+                              signals)
 from celery.utils.text import WhateverIO
 
 try:

--- a/t/unit/utils/test_platforms.py
+++ b/t/unit/utils/test_platforms.py
@@ -20,7 +20,7 @@ from celery.platforms import (ASSUMING_ROOT, ROOT_DISALLOWED,
                               isatty, maybe_drop_privileges, parse_gid,
                               parse_uid, set_mp_process_title,
                               set_process_title, setgid, setgroups, setuid,
-                              signals)
+                              signals, set_pdeathsig)
 from celery.utils.text import WhateverIO
 
 try:
@@ -168,6 +168,18 @@ class test_Signals:
     def test_setitem_raises(self, set):
         set.side_effect = ValueError()
         signals['INT'] = lambda *a: a
+
+
+class test_set_pdeathsig:
+
+    def test_call(self):
+        set_pdeathsig('SIGKILL')
+
+    @t.skip.if_win32
+    def test_call_with_correct_parameter(self):
+        with patch('celery.platforms._set_pdeathsig') as _set_pdeathsig:
+            set_pdeathsig('SIGKILL')
+            _set_pdeathsig.assert_called_once_with(signal.SIGKILL)
 
 
 @t.skip.if_win32


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This PR ensures that OS will kill all remaining workers in prefork model when main process terminates. This is applicable only for linux platform. Other OS won't handle/kill orphaned workers. This PR should help also with memory leaks caused by orphained workers - see [1]. This PR needs billiard with version >= 3.6.0.0. Fixes #102.

Example:

master branch:

```bash
# Start Celery in different terminal: matus@matus-debian:~/dev/celery$ celery -A tasks worker --loglevel=INFO
matus@matus-debian:~$ ps aux | grep celery
matus       6611  9.4  1.1  57484 43796 pts/0    S+   22:58   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6613  0.0  0.8  56232 35172 pts/0    S+   22:58   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6614  0.0  0.8  56236 35052 pts/0    S+   22:58   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6615  0.0  0.8  56240 35052 pts/0    S+   22:58   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6616  0.0  0.8  56244 35056 pts/0    S+   22:58   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6618  0.0  0.0   6148   720 pts/1    S+   22:58   0:00 grep --color=auto celery
matus@matus-debian:~$ kill -KILL 6611
matus@matus-debian:~$ ps aux | grep celery
matus       6613  0.0  0.8  56232 35172 pts/0    S    22:58   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6614  0.0  0.8  56236 35052 pts/0    S    22:58   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6615  0.0  0.8  56240 35052 pts/0    S    22:58   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6616  0.0  0.8  56244 35056 pts/0    S    22:58   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6620  0.0  0.0   6148   656 pts/1    S+   22:58   0:00 grep --color=auto celery
```

PR branch:

```bash
# Start Celery in different terminal: matus@matus-debian:~/dev/celery$ celery -A tasks worker --loglevel=INFO
matus@matus-debian:~$ ps aux | grep celery
matus       6561  2.0  1.1  57760 44324 pts/0    S+   22:56   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6563  0.0  0.9  62772 39248 pts/0    S+   22:56   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6564  0.1  0.9  62780 39252 pts/0    S+   22:56   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6565  0.1  0.9  62784 39252 pts/0    S+   22:56   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6566  0.0  0.9  62788 39256 pts/0    S+   22:56   0:00 /home/matus/dev/celery39/bin/python /home/matus/dev/celery39/bin/celery -A tasks worker --loglevel=INFO
matus       6572  0.0  0.0   6148   720 pts/1    S+   22:56   0:00 grep --color=auto celery
matus@matus-debian:~$ kill -KILL 6561
matus@matus-debian:~$ ps aux | grep celery
matus       6575  0.0  0.0   6148   660 pts/1    S+   22:57   0:00 grep --color=auto celery
```

[1] https://medium.com/squad-engineering/two-years-with-celery-in-production-bug-fix-edition-22238669601d
