### PR TITLE
Added note about automatic killing all child processes of worker after its termination

### DIFF
--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -97,6 +97,11 @@ longer version:
 
     $ ps auxww | awk '/celery worker/ {print $2}' | xargs kill -9
 
+.. versionchanged:: 5.2
+    On Linux systems, Celery now supports sending :sig:`KILL` signal to all child processes
+    after worker termination. This is done via `PR_SET_PDEATHSIG` option of ``prctl(2)``.
+
+
 .. _worker-restarting:
 
 Restarting the worker


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
This PR documents that child processes are automatically killed after worker exits - see #6942

Fixes #6945

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
