### PR TITLE
Single line drift warning

### DIFF
--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -51,10 +51,10 @@ HEARTBEAT_EXPIRE_WINDOW = 200
 #: before we alert that clocks may be unsynchronized.
 HEARTBEAT_DRIFT_MAX = 16
 
-DRIFT_WARNING = """\
-Substantial drift from %s may mean clocks are out of sync.  Current drift is
-%s seconds.  [orig: %s recv: %s]
-"""
+DRIFT_WARNING = (
+    "Substantial drift from %s may mean clocks are out of sync.  Current drift is "
+    "%s seconds.  [orig: %s recv: %s]"
+)
 
 logger = get_logger(__name__)
 warn = logger.warning


### PR DESCRIPTION

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

The drift warning currently spans multiple lines, which causes issues
in some logging systems. Make it a single line message instead.
