### PR TITLE
canvas: fix kwargs argument to prevent recursion (#6810)

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1352,10 +1352,10 @@ class _chord(Signature):
     def __init__(self, header, body=None, task='celery.chord',
                  args=None, kwargs=None, app=None, **options):
         args = args if args else ()
-        kwargs = kwargs if kwargs else {}
+        kwargs = kwargs if kwargs else {'kwargs': {}}
         Signature.__init__(
             self, task, args,
-            {'kwargs': kwargs, 'header': _maybe_group(header, app),
+            {**kwargs, 'header': _maybe_group(header, app),
              'body': maybe_signature(body, app=app)}, app=app, **options
         )
         self.subtask_type = 'chord'

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -279,6 +279,24 @@ class test_chord(ChordCase):
         finally:
             chord.run = prev
 
+    def test_init(self):
+        from celery import chord
+        from celery.utils.serialization import pickle
+
+        @self.app.task(shared=False)
+        def addX(x, y):
+            return x + y
+
+        @self.app.task(shared=False)
+        def sumX(n):
+            return sum(n)
+
+        x = chord(addX.s(i, i) for i in range(10))
+        # kwargs used to nest and recurse in serialization/deserialization
+        # (#6810)
+        assert x.kwargs['kwargs'] == {}
+        assert pickle.loads(pickle.dumps(x)).kwargs == x.kwargs
+
 
 class test_add_to_chord:
 


### PR DESCRIPTION
## Description

When using a beat schedule running a task taking a chord as argument, celery crashed with max recursion depth reached. After debugging, kwargs were discovered to be nested every time \_\_init\_\_ is called. This PR fixes that.