### PR TITLE
Warn when expiration date is in the past

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -739,6 +739,17 @@ class Celery:
                 expires_s = expires
 
             if expires_s < 0:
+                logger.warning(
+                    f"{task_id} has an expiration date in the past ({-expires_s}s ago).\n"
+                    "We assume this is intended and so we have set the "
+                    "expiration date to 0 instead.\n"
+                    "According to RabbitMQ's documentation:\n"
+                    "\"Setting the TTL to 0 causes messages to be expired upon "
+                    "reaching a queue unless they can be delivered to a "
+                    "consumer immediately.\"\n"
+                    "If this was unintended, please check the code which "
+                    "published this task."
+                )
                 expires_s = 0
 
             options["expiration"] = expires_s


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This is a followup on #6957.
When we do non-obvious things we should let the user know, loudly.
The least surprising default would be to ignore the expiration date, I think.
But since we did it this way, we should warn the users that what is going to happen is that we set the expiration date to 0 and what it means.

@nicolaerosia Would you mind reviewing this as well, please?

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
