### PR TITLE
Allow to enable Events with app.conf mechanism

### DIFF
--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -206,6 +206,7 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
               '--task-events',
               '--events',
               is_flag=True,
+              default=None,
               cls=CeleryOption,
               help_group="Pool Options",
               help="Send task-related events that can be captured by monitors"


### PR DESCRIPTION
# Allow to enable Events with app.conf mechanism

### Description

`--task-events` is defined as a [Click Boolean Flag](https://click.palletsprojects.com/en/8.0.x/options/#boolean-flags), without an *off-switch* and `False` as the implicit default value, so when this parameter is omitted in CLI invocation, *Click* will set it to `False`. Because the aforementioned, *Events* only can be enabled via CLI (values in `app.conf.worker_send_task_events` will be ignored).

### Current behaviour

1. `click.option` decorator for `--task-events` sets `task_events` flag to `False`
https://github.com/celery/celery/blob/e2e3e95bf8ac9f85e1ee91753602c47bac878380/celery/bin/worker.py#L205

2. `either` function resolves to the first non-None value (in our case `False` from `task_events` argument ) ignoring values from `app.conf`
https://github.com/celery/celery/blob/e2e3e95bf8ac9f85e1ee91753602c47bac878380/celery/worker/worker.py#L377

### Proposed solution

This fix changes `--task-events` default value from *implicit `False`* to *explicit `None`*, allowing `either` method to correctly resolve in favor of `app.conf.worker_send_task_events` value when set.

Fixes: #6910