### PR TITLE
Fixes race condition deadlock.

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -99,6 +99,7 @@ class ResultConsumer(BaseResultConsumer):
         super().on_after_fork()
 
     def _reconnect_pubsub(self):
+        self._pubsub.close()
         self._pubsub = None
         self.backend.client.connection_pool.reset()
         # task state might have changed when the connection was down so we


### PR DESCRIPTION
## Description

We experience intermittent Celery lock-ups when using Redis backend (we specifically use Redis results backend). Debugging shows that deadlock happens during garbage collection when it coincides with losing connection to Redis.

Problem is that Redis PubSub class uses destructor `__del__` which grabs a threading.Lock. Also, other methods of Redis connections and connection pool use locks and queues.

In an unfortunate event when interpreter is running some disconnection/connection code guarded by lock, and PubSub is asynchronously garbage collected, it attempts to grab the same lock inside the destructor, causing a deadlock.

I suggest explicitly closing pubsub before setting it to `None`. When the PubSub destructor will be run, it won't attempt to grab a lock and exit immediately, thus eliminating possibility of deadlock.