### PR TITLE
Prevent worker to send expired revoked items upon hello command

### DIFF
--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -310,6 +310,8 @@ def hello(state, from_node, revoked=None, **kwargs):
         logger.info('sync with %s', from_node)
         if revoked:
             worker_state.revoked.update(revoked)
+        # Do not send expired items to the other worker.
+        worker_state.revoked.purge()
         return {
             'revoked': worker_state.revoked._data,
             'clock': state.app.clock.forward(),

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -17,9 +17,7 @@ from celery.worker import consumer, control
 from celery.worker import state as worker_state
 from celery.worker.pidbox import Pidbox, gPidbox
 from celery.worker.request import Request
-from celery.worker.state import REVOKE_EXPIRES
-from celery.worker.state import revoked
-
+from celery.worker.state import REVOKE_EXPIRES, revoked
 
 hostname = socket.gethostname()
 

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -1,5 +1,6 @@
 import socket
 import sys
+import time
 from collections import defaultdict
 from datetime import datetime, timedelta
 from queue import Queue as FastQueue
@@ -16,7 +17,9 @@ from celery.worker import consumer, control
 from celery.worker import state as worker_state
 from celery.worker.pidbox import Pidbox, gPidbox
 from celery.worker.request import Request
+from celery.worker.state import REVOKE_EXPIRES
 from celery.worker.state import revoked
+
 
 hostname = socket.gethostname()
 
@@ -191,6 +194,22 @@ class test_ControlPanel:
             assert x['clock'] == 315  # incremented
         finally:
             worker_state.revoked.discard('revoked1')
+
+    def test_hello_does_not_send_expired_revoked_items(self):
+        consumer = Consumer(self.app)
+        panel = self.create_panel(consumer=consumer)
+        panel.state.app.clock.value = 313
+        panel.state.hostname = 'elaine@vandelay.com'
+        # Add an expired revoked item to the revoked set.
+        worker_state.revoked.add(
+            'expired_in_past',
+            now=time.monotonic() - REVOKE_EXPIRES - 1
+        )
+        x = panel.handle('hello', {
+            'from_node': 'george@vandelay.com',
+            'revoked': {'1234', '4567', '891'}
+        })
+        assert 'expired_in_past' not in x['revoked']
 
     def test_conf(self):
         consumer = Consumer(self.app)


### PR DESCRIPTION
This PR solves the issue when a newly spawned worker receives a lot of old and expired revocations.
There is no reason to send old revocations that are already expired.

In bigger systems that rely on revocations and use a much larger `LimitedSet` this is a problem as the hello response may be hundreds of megabytes large. Receiving such a large message from other workers takes a lot of time and also stresses RabbitMQ (the broker we use). This is also a way to reclaim some memory back in case there are no longer active revocations.

Let me know what do you think about it.
