### PR TITLE
docs: clarify the 'keeping results' section

### DIFF
--- a/docs/getting-started/first-steps-with-celery.rst
+++ b/docs/getting-started/first-steps-with-celery.rst
@@ -229,7 +229,8 @@ and -- or you can define your own.
 For this example we use the `rpc` result backend, that sends states
 back as transient messages. The backend is specified via the ``backend`` argument to
 :class:`@Celery`, (or via the :setting:`result_backend` setting if
-you choose to use a configuration module):
+you choose to use a configuration module). So, you can modify this line in the `tasks.py`
+file to enable the `rpc://` backend:
 
 .. code-block:: python
 

--- a/docs/getting-started/first-steps-with-celery.rst
+++ b/docs/getting-started/first-steps-with-celery.rst
@@ -245,12 +245,13 @@ the message broker (a popular combination):
 
 To read more about result backends please see :ref:`task-result-backends`.
 
-Now with the result backend configured, let's call the task again.
-This time you'll hold on to the :class:`~@AsyncResult` instance returned
-when you call a task:
+Now with the result backend configured, close the current python session and `import` the
+`app` from `tasks` again to put the changes into effect. This time you'll hold on to the
+:class:`~@AsyncResult` instance returned when you call a task:
 
 .. code-block:: pycon
 
+    >>> from tasks import add    # close and reopen to get updated 'app'
     >>> result = add.delay(4, 4)
 
 The :meth:`~@AsyncResult.ready` method returns whether the task

--- a/docs/getting-started/first-steps-with-celery.rst
+++ b/docs/getting-started/first-steps-with-celery.rst
@@ -245,8 +245,8 @@ the message broker (a popular combination):
 
 To read more about result backends please see :ref:`task-result-backends`.
 
-Now with the result backend configured, close the current python session and `import` the
-`app` from `tasks` again to put the changes into effect. This time you'll hold on to the
+Now with the result backend configured, close the current python session and import the
+``tasks`` module again to put the changes into effect. This time you'll hold on to the
 :class:`~@AsyncResult` instance returned when you call a task:
 
 .. code-block:: pycon


### PR DESCRIPTION
## Description

It might seem obvious for experienced users, but new users could get
confused with where to add the 'backend' argument. Should it be passed
as an argument when invoking celery? In a seperate configuration file?
This leads to opening up many tabs and looking for a clue which in
turn, might frustrate a newbie.

So, the manual could simply save a lot of headache with explicitly
stating: you could modify this line in the very first 'tasks.py' file
you are trying to work with!

This commit fixes that.