### PR TITLE
Fire task failure signal on final reject

### DIFF
--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -579,6 +579,12 @@ class Request:
                 store_result=self.store_errors,
             )
 
+            signals.task_failure.send(sender=self.task, task_id=self.id,
+                                      exception=exc, args=self.args,
+                                      kwargs=self.kwargs,
+                                      traceback=exc_info.traceback,
+                                      einfo=exc_info)
+
         if send_failed_event:
             self.send_event(
                 'task-failed',


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

When a task is rejected but not re-queued, it is marked as failed.
However, the `task_failure` signal isn't sent in this case, although it should have been fired.

This PR fixes that and slightly improves our test quality.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
