### PR TITLE
Update deprecated task module removal in 5.0 documentation

### DIFF
--- a/docs/history/whatsnew-5.0.rst
+++ b/docs/history/whatsnew-5.0.rst
@@ -262,6 +262,9 @@ you should import `kombu.utils.encoding` instead.
 If you were using the `celery.task` module before, you should import directly
 from the `celery` module instead.
 
+If you were using the `celery.task` decorator you should use 
+`celery.shared_task` instead.
+
 .. _new_command_line_interface:
 
 New Command Line Interface

--- a/docs/history/whatsnew-5.0.rst
+++ b/docs/history/whatsnew-5.0.rst
@@ -262,6 +262,9 @@ you should import `kombu.utils.encoding` instead.
 If you were using the `celery.task` module before, you should import directly
 from the `celery` module instead.
 
+If you were using `from celery.task import Task` you should use 
+`from celery import Task` instead.
+
 If you were using the `celery.task` decorator you should use 
 `celery.shared_task` instead.
 

--- a/docs/internals/deprecation.rst
+++ b/docs/internals/deprecation.rst
@@ -34,7 +34,7 @@ Compat Task Modules
 
         from celery import task
 
-- Module ``celery.task`` *may* be removed (not decided)
+- Module ``celery.task`` will be removed 
 
     This means you should change:
 
@@ -46,7 +46,18 @@ Compat Task Modules
 
     .. code-block:: python
 
+        from celery import shared_task
+
+    -- and:
+    .. code-block:: python
+
         from celery import task
+
+    into:
+
+    .. code-block:: python
+
+        from celery import shared_task
 
     -- and:
 

--- a/docs/whatsnew-5.1.rst
+++ b/docs/whatsnew-5.1.rst
@@ -290,6 +290,10 @@ you should import `kombu.utils.encoding` instead.
 If you were using the `celery.task` module before, you should import directly
 from the `celery` module instead.
 
+If you were using the `celery.task` decorator you should use 
+`celery.shared_task` instead.
+
+
 `azure-servicebus` 7.0.0 is now required
 ----------------------------------------
 

--- a/docs/whatsnew-5.1.rst
+++ b/docs/whatsnew-5.1.rst
@@ -290,6 +290,9 @@ you should import `kombu.utils.encoding` instead.
 If you were using the `celery.task` module before, you should import directly
 from the `celery` module instead.
 
+If you were using `from celery.task import Task` you should use 
+`from celery import Task` instead.
+
 If you were using the `celery.task` decorator you should use 
 `celery.shared_task` instead.
 


### PR DESCRIPTION
## Documentation update for removed functionality

Add extra information in documentation and fix outdated documentation concerning the removal of celery.task
Fixes #6558 