### PR TITLE
Documenting the default consumer_timeout value for rabbitmq >= 3.8.15

### DIFF
--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -252,6 +252,31 @@ and timezone information):
     >>> tomorrow = datetime.utcnow() + timedelta(days=1)
     >>> add.apply_async((2, 2), eta=tomorrow)
 
+.. warning::
+
+    When using RabbitMQ as a message broker when specifying a ``countdown``
+    over 15 minutes, you may encounter the problem that the worker terminates
+    with an :exc:`~amqp.exceptions.PreconditionFailed` error will be raised:
+
+    .. code-block:: pycon
+
+        amqp.exceptions.PreconditionFailed: (0, 0): (406) PRECONDITION_FAILED - consumer ack timed out on channel
+
+    In RabbitMQ since version 3.8.15 the default value for
+    ``consumer_timeout`` is 15 minutes.
+    Since version 3.8.17 it was increased to 30 minutes. If a consumer does
+    not ack its delivery for more than the timeout value, its channel will be
+    closed with a ``PRECONDITION_FAILED`` channel exception.
+    See `Delivery Acknowledgement Timeout`_ for more information.
+
+    To solve the problem, in RabbitMQ configuration file ``rabbitmq.conf`` you
+    should specify the ``consumer_timeout`` parameter greater than or equal to
+    your countdown value. For example, you can specify a very large value
+    of ``consumer_timeout = 31622400000``, which is equal to 1 year
+    in milliseconds, to avoid problems in the future.
+
+.. _`Delivery Acknowledgement Timeout`: https://www.rabbitmq.com/consumers.html#acknowledgement-timeout
+
 .. _calling-expiration:
 
 Expiration


### PR DESCRIPTION
## Description

Since rabbitmq version 3.8.15, the default value for consumer_timeout has been set. Tasks with a countdown greater than 15 minutes (30 minutes) raise a PreconditionFailed exception

Related to issue #6760