### PR TITLE
Show connection url for azure block blob results backend

### DIFF
--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -165,3 +165,30 @@ class test_AzureBlockBlobBackend:
             url=self.url
         )
         assert backend.base_path == ''
+
+
+class test_as_uri:
+    def setup(self):
+        self.url = (
+            "azureblockblob://"
+            "DefaultEndpointsProtocol=protocol;"
+            "AccountName=name;"
+            "AccountKey=account_key;"
+            "EndpointSuffix=suffix"
+        )
+        self.backend = AzureBlockBlobBackend(
+            app=self.app,
+            url=self.url
+        )
+
+    def test_as_uri_include_password(self):
+        assert self.backend.as_uri(include_password=True) == self.url
+
+    def test_as_uri_exclude_password(self):
+        assert self.backend.as_uri(include_password=False) == (
+            "azureblockblob://"
+            "DefaultEndpointsProtocol=protocol;"
+            "AccountName=name;"
+            "AccountKey=**;"
+            "EndpointSuffix=suffix"
+        )


### PR DESCRIPTION
Currently when celery boots with azure block blob as results backend it shows an empty string as its URL which is a bit confusing and made me question my configuration a few times :).

```
 -------------- celery@default v5.1.2 (sun-harmonics)
--- ***** ----- 
-- ******* ---- macOS-11.6-x86_64-i386-64bit 2021-10-09 15:59:42
- *** --- * --- 
- ** ---------- [config]
- ** ---------- .> app:         app:0x1174bdfd0
- ** ---------- .> transport:   amqp://guest:**@localhost:5672//
- ** ---------- .> results:     
- *** --- * --- .> concurrency: 3 (prefork)
-- ******* ---- .> task events: ON
--- ***** ----- 
 -------------- [queues]
                .> default          exchange=default(direct) key=default
```

With the change proposed the URL is shown with AccountKey redacted by default as below (note - I have removed account name from it manually to avoid showing some sensitive information, if we think that should also be automatically redacted - plz let me know.

```
 -------------- celery@default v5.2.0rc1 (dawn-chorus)
--- ***** ----- 
-- ******* ---- macOS-11.6-x86_64-i386-64bit 2021-10-09 16:02:43
- *** --- * --- 
- ** ---------- [config]
- ** ---------- .> app:         app:0x11626a1c0
- ** ---------- .> transport:   amqp://guest:**@localhost:5672//
- ** ---------- .> results:     azureblockblob://DefaultEndpointsProtocol=https;AccountName=<account-name>;AccountKey=**;EndpointSuffix=core.windows.net
- *** --- * --- .> concurrency: 3 (prefork)
-- ******* ---- .> task events: ON
--- ***** ----- 
 -------------- [queues]
                .> default          exchange=default(direct) key=default
```
