### PR TITLE
Removed a pitfall case where an attribute was being defined outside the init

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,7 @@ def long_description():
 
 class pytest(setuptools.command.test.test):
     user_options = [('pytest-args=', 'a', 'Arguments to pass to pytest')]
+    pytest_args = None
 
     def initialize_options(self):
         super().initialize_options()


### PR DESCRIPTION
I just removed a pitfall that was falling into the definition of the W0201 Pylint error as described here:
https://vald-phoenix.github.io/pylint-errors/plerr/errors/classes/W0201