### PR TITLE
try to fix deprecation warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ python =
     3.8: 3.8-unit
     3.9: 3.9-unit
     3.10: 3.10-unit
-    pypy3: pypy3-unit
+    pypy-3: pypy3-unit
 
 [testenv]
 sitepackages = False


### PR DESCRIPTION
WARNING: PendingDeprecationWarning
Support of old-style PyPy config keys will be removed in tox-gh-actions v3.
Please use "pypy-2" and "pypy-3" instead of "pypy2" and "pypy3".

Example of tox.ini:
[gh-actions]
python =
    pypy-2: pypy2
    pypy-3: pypy3
    # The followings won't work with tox-gh-actions v3
    # pypy2: pypy2
    # pypy3: pypy3

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
