### PR TITLE
Prevent from subscribing to emtpy channels

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -110,7 +110,8 @@ class ResultConsumer(BaseResultConsumer):
         self._pubsub = self.backend.client.pubsub(
             ignore_subscribe_messages=True,
         )
-        self._pubsub.subscribe(*self.subscribed_to)
+        if self.subscribed_to:
+            self._pubsub.subscribe(*self.subscribed_to)
 
     @contextmanager
     def reconnect_on_error(self):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

If an error occurs while calling `self._pubsub.get_message`, method `_reconnect_pubsub` will be called.
after the following loop is completed:
```
  for meta in metas:
      self.on_state_change(self._decode_result(meta), None)
```
all subscribed tasks might be discarded and the set `self.subscribed_to` will be empty.  Thus a call to `self._pubsub.subscribe(*self.subscribed_to)` will leads the following error:

> redis.exceptions.ResponseError: wrong number of arguments for 'subscribe' command

Maybe related issues:
https://github.com/redis/redis-py/issues/1351
https://github.com/celery/celery/issues/6993


