### PR TITLE
Limit pymongo version: <3.12.1

### DIFF
--- a/requirements/extras/mongodb.txt
+++ b/requirements/extras/mongodb.txt
@@ -1,1 +1,1 @@
-pymongo[srv]>=3.3.0
+pymongo[srv]>=3.3.0,<3.12.1


### PR DESCRIPTION
## Description

Limit pymongo version to be less than 3.12.1, because CI fails with this latest version. 

See fail here: https://github.com/celery/celery/actions/runs/1412073916 

Error: pymongo.errors.ConfigurationError: The DNS query name does not exist: _mongodb._tcp.dns-seedlist-host.example.com.

I will open an issue for compatibility with pymongo-3.12.1