### PR TITLE
Pass logfile to ExecStop in celery.service example systemd file

### DIFF
--- a/docs/userguide/daemonizing.rst
+++ b/docs/userguide/daemonizing.rst
@@ -403,7 +403,8 @@ This is an example systemd file:
         --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} \
         --loglevel="${CELERYD_LOG_LEVEL}" $CELERYD_OPTS'
     ExecStop=/bin/sh -c '${CELERY_BIN} multi stopwait $CELERYD_NODES \
-        --pidfile=${CELERYD_PID_FILE} --loglevel="${CELERYD_LOG_LEVEL}"'
+        --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} \
+        --loglevel="${CELERYD_LOG_LEVEL}"'
     ExecReload=/bin/sh -c '${CELERY_BIN} -A $CELERY_APP multi restart $CELERYD_NODES \
         --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} \
         --loglevel="${CELERYD_LOG_LEVEL}" $CELERYD_OPTS'


### PR DESCRIPTION
We had issues on our server where the service would crash on stop due to not being able to write to (default) `/var/log/celery`.

Since we pass the log level, I guess it is consistent to also pass the log file path.