### PR TITLE
Fix rstrip usage on bytes instance in ProxyLogger.

### DIFF
--- a/celery/utils/log.py
+++ b/celery/utils/log.py
@@ -224,13 +224,13 @@ class LoggingProxy:
         if getattr(self._thread, 'recurse_protection', False):
             # Logger is logging back to this file, so stop recursing.
             return 0
-        data = data.rstrip('\n')
         if data and not self.closed:
             self._thread.recurse_protection = True
             try:
-                safe_data = safe_str(data)
-                self.logger.log(self.loglevel, safe_data)
-                return len(safe_data)
+                safe_data = safe_str(data).rstrip('\n')
+                if safe_data:
+                    self.logger.log(self.loglevel, safe_data)
+                    return len(safe_data)
             finally:
                 self._thread.recurse_protection = False
         return 0


### PR DESCRIPTION
## Description

It's possible for data to be a bytes instance, hence the usage of
safe_str elsewhere in the function. Before mutating the data,
it should be transformed safely into a string. Then we can replace
the new line characters.
<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Fixes #7056
