### PR TITLE
Move pytest configuration from setup.cfg to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,1 +1,5 @@
-
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+testpaths = "t/unit/"
+python_classes = "test_*"
+xdfail_strict=true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
-[tool:pytest]
-addopts = --strict-markers
-testpaths = t/unit/
-python_classes = test_*
-xfail_strict=true
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build


### PR DESCRIPTION
Pytest documentation does not recommend to use setup.cfg as pytest
confguration - see warning here:

https://docs.pytest.org/en/6.2.x/customize.html#setup-cfg
