### PR TITLE
fix: task expiration is timezone aware if needed

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -285,3 +285,4 @@ Garry Lawrence, 2021/06/19
 Patrick Zhang, 2017/08/19
 Konstantin Kochin, 2021/07/11
 kronion, 2021/08/26
+Gabor Boros, 2021/11/09

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -32,7 +32,7 @@ from celery.utils.functional import first, head_from_fun, maybe_list
 from celery.utils.imports import gen_task_name, instantiate, symbol_by_name
 from celery.utils.log import get_logger
 from celery.utils.objects import FallbackContext, mro_lookup
-from celery.utils.time import timezone, to_utc
+from celery.utils.time import maybe_make_aware, timezone, to_utc
 
 # Load all builtin tasks
 from . import builtins  # noqa
@@ -734,7 +734,7 @@ class Celery:
             options, route_name or name, args, kwargs, task_type)
         if expires is not None:
             if isinstance(expires, datetime):
-                expires_s = (expires - self.now()).total_seconds()
+                expires_s = (maybe_make_aware(expires) - self.now()).total_seconds()
             else:
                 expires_s = expires
 

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -941,6 +941,17 @@ class test_tasks(TasksCase):
                 name='George Costanza', test_eta=True, test_expires=True,
             )
 
+            # With ETA, absolute expires without timezone.
+            presult2 = self.mytask.apply_async(
+                kwargs={'name': 'George Constanza'},
+                eta=self.now() + timedelta(days=1),
+                expires=(self.now() + timedelta(hours=2)).replace(tzinfo=None),
+            )
+            self.assert_next_task_data_equal(
+                consumer, presult2, self.mytask.name,
+                name='George Constanza', test_eta=True, test_expires=True,
+            )
+
             # With ETA, absolute expires in the past.
             presult2 = self.mytask.apply_async(
                 kwargs={'name': 'George Costanza'},


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

In #6957 the changes introduced checking for datetime objects for task expiration, though the implementation is not considering that the expiration date can be set with or without timezone. Therefore the expiration second calculation for the task can raise a `TypeError`.

This fix is related to a conversation on #6736.
