### PR TITLE
Add API to schedules to get next run time

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -400,6 +400,8 @@ class Scheduler:
         try:
             entry_args = _evaluate_entry_args(entry.args)
             entry_kwargs = _evaluate_entry_kwargs(entry.kwargs)
+            if entry.schedule and "eta" not in entry_kwargs:
+                entry_kwargs["eta"] = entry.schedule.next_scheduled_run(entry.last_run_at)
             if task:
                 return task.apply_async(entry_args, entry_kwargs,
                                         producer=producer,

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -12,7 +12,8 @@ from kombu.utils.objects import cached_property
 from . import current_app
 from .utils.collections import AttributeDict
 from .utils.time import (ffwd, humanize_seconds, localize, maybe_make_aware,
-                         maybe_timedelta, remaining, timezone, weekday)
+                         maybe_timedelta, remaining, timezone, weekday,
+                         delta_resolution)
 
 __all__ = (
     'ParseException', 'schedule', 'crontab', 'crontab_parser',
@@ -65,6 +66,9 @@ class BaseSchedule:
 
     def now(self):
         return (self.nowfun or self.app.now)()
+
+    def next_scheduled_run(self, last_run_at, now=None):
+        raise NotImplementedError()
 
     def remaining_estimate(self, last_run_at):
         raise NotImplementedError()
@@ -121,11 +125,23 @@ class schedule(BaseSchedule):
         self.relative = relative
         super().__init__(nowfun=nowfun, app=app)
 
+    def next_scheduled_run(self, last_run_at, now=None):
+        now = now or self.maybe_make_aware(self.now())
+        ends_in = self.run_every
+        start = self.maybe_make_aware(last_run_at)
+        if str(start.tzinfo) == str(now.tzinfo) and now.utcoffset() != start.utcoffset():
+            # DST started/ended
+            start = start.replace(tzinfo=now.tzinfo)
+        end_date = start + ends_in
+        if self.relative:
+            end_date = delta_resolution(end_date, ends_in).replace(
+                microsecond=0)
+        return end_date
+
     def remaining_estimate(self, last_run_at):
-        return remaining(
-            self.maybe_make_aware(last_run_at), self.run_every,
-            self.maybe_make_aware(self.now()), self.relative,
-        )
+        now = self.maybe_make_aware(self.now())
+        next = self.next_scheduled_run(last_run_at, now=now)
+        return next - now
 
     def is_due(self, last_run_at):
         """Return tuple of ``(is_due, next_time_to_check)``.
@@ -767,15 +783,7 @@ class solar(BaseSchedule):
             self.event, self.lat, self.lon,
         )
 
-    def remaining_estimate(self, last_run_at):
-        """Return estimate of next time to run.
-
-        Returns:
-            ~datetime.timedelta: when the periodic task should
-                run next, or if it shouldn't run today (e.g., the sun does
-                not rise today), returns the time when the next check
-                should take place.
-        """
+    def next_scheduled_run(self, last_run_at, now=None):
         last_run_at = self.maybe_make_aware(last_run_at)
         last_run_at_utc = localize(last_run_at, timezone.utc)
         self.cal.date = last_run_at_utc
@@ -797,10 +805,20 @@ class solar(BaseSchedule):
                 self.cal.next_antitransit(self.ephem.Sun()) +
                 timedelta(minutes=1)
             )
-        next = self.maybe_make_aware(next_utc.datetime())
+        return self.maybe_make_aware(next_utc.datetime())
+
+    def remaining_estimate(self, last_run_at):
+        """Return estimate of next time to run.
+
+        Returns:
+            ~datetime.timedelta: when the periodic task should
+                run next, or if it shouldn't run today (e.g., the sun does
+                not rise today), returns the time when the next check
+                should take place.
+        """
         now = self.maybe_make_aware(self.now())
-        delta = next - now
-        return delta
+        next = self.next_scheduled_run(last_run_at)
+        return next - now
 
     def is_due(self, last_run_at):
         """Return tuple of ``(is_due, next_time_to_run)``.


### PR DESCRIPTION
This would fix #6974 by

1. introducing a new `next_scheduled_run` API to `BaseSchedule` subclasses (i.e. all concrete schedule classes); and
2. using this API in the beat process to pass the trigger time to the task through the `eta` parameter.

While some users have raised potential drawbacks of (effectively) overloading the `eta` parameter in this way (https://github.com/celery/celery/issues/6974#issuecomment-956323126), I would argue that it is the right approach to provide this new functionality.

Firstly, there is the problem that the `eta` parameter has a side effect - it prevents a task being run before the given datetime. However, this should be no problem for us as (assuming correctness of the implementation) the beat process should not even schedule the task before the eta has occurred, so the eta should always be in the past.

Second, users may already be using the `eta` parameter somehow. While I would think this unlikely, as I cannot see a way in which it could be set per instance of a schedule at runtime given the current codebase - and without this ability it would be functionally redundant - it is technically possible I think. Therefore, my solution only sets the `eta` if it is not already set, maintaining backwards compatibility just in case.

I am open to hearing other suggestions about how to achieve this functionality (all I really want is a reliable and precise solution to #6974, I don't mind how), but in my opinion this is a sensible approach to at least consider.