### PR TITLE
Upgrade required pymongo version to 3.11.1

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -265,16 +265,7 @@ class MongoBackend(BaseBackend):
 
     def _get_database(self):
         conn = self._get_connection()
-        db = conn[self.database_name]
-        if self.user and self.password:
-            source = self.options.get(
-                'authsource',
-                self.database_name or 'admin'
-            )
-            if not db.authenticate(self.user, self.password, source=source):
-                raise ImproperlyConfigured(
-                    'Invalid MongoDB username or password.')
-        return db
+        return conn[self.database_name]
 
     @cached_property
     def database(self):

--- a/requirements/extras/mongodb.txt
+++ b/requirements/extras/mongodb.txt
@@ -1,1 +1,1 @@
-pymongo[srv]>=3.3.0,<3.12.1
+pymongo[srv]>=3.11.1

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -183,6 +183,7 @@ class test_MongoBackend:
                 tls=True
             )
 
+
     def perform_seedlist_assertions(self):
         mb = MongoBackend(app=self.app, url=MONGODB_SEEDLIST_URI)
         assert mb.mongo_host == MONGODB_BACKEND_HOST

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -1,5 +1,3 @@
-import perform as perform
-
 import datetime
 from pickle import dumps, loads
 from unittest.mock import ANY, MagicMock, Mock, patch, sentinel

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -273,8 +273,6 @@ class test_MongoBackend:
 
         assert database is mock_database
         assert self.backend.__dict__['database'] is mock_database
-        mock_database.authenticate.assert_called_once_with(
-            MONGODB_USER, MONGODB_PASSWORD, source=self.backend.database_name)
 
     @patch('celery.backends.mongodb.MongoBackend._get_connection')
     def test_get_database_no_existing_no_auth(self, mock_get_connection):
@@ -290,7 +288,6 @@ class test_MongoBackend:
         database = self.backend.database
 
         assert database is mock_database
-        mock_database.authenticate.assert_not_called()
         assert self.backend.__dict__['database'] is mock_database
 
     @patch('celery.backends.mongodb.MongoBackend._get_database')
@@ -488,19 +485,6 @@ class test_MongoBackend:
 
         self.backend.cleanup()
         mock_collection.delete_many.assert_not_called()
-
-    def test_get_database_authfailure(self):
-        x = MongoBackend(app=self.app)
-        x._get_connection = Mock()
-        conn = x._get_connection.return_value = {}
-        db = conn[x.database_name] = Mock()
-        db.authenticate.return_value = False
-        x.user = 'jerry'
-        x.password = 'cere4l'
-        with pytest.raises(ImproperlyConfigured):
-            x._get_database()
-        db.authenticate.assert_called_with('jerry', 'cere4l',
-                                           source=x.database_name)
 
     def test_prepare_client_options(self):
         with patch('pymongo.version_tuple', new=(3, 0, 3)):

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -183,7 +183,6 @@ class test_MongoBackend:
                 tls=True
             )
 
-
     def perform_seedlist_assertions(self):
         mb = MongoBackend(app=self.app, url=MONGODB_SEEDLIST_URI)
         assert mb.mongo_host == MONGODB_BACKEND_HOST


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Fixes https://github.com/celery/celery/issues/6529 

Upgrade required pymongo version to 3.11.1 
Remove database authentication which was deprecated in pymongo version 3.5.
This authentication is redundant since the user is authenticated when MongoClient is initialized. 

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
