### PR TITLE
Split Signature.__or__ into subclasses' __or__

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -396,15 +396,15 @@ class Signature(dict):
     def __or__(self, other):
         # These could be implemented in each individual class,
         # I'm sure, but for now we have this.
-        if isinstance(other, _chain):
-            # task | chain -> chain
-            return _chain(seq_concat_seq(
-                (self,), other.unchain_tasks()), app=self._app)
-        elif isinstance(self, chord) and not isinstance(other, group):
+        if isinstance(self, chord) and not isinstance(other, (group, _chain)):
             # chord | task ->  attach to body
             sig = self.clone()
             sig.body = sig.body | other
             return sig
+        elif isinstance(other, _chain):
+            # task | chain -> chain
+            return _chain(seq_concat_seq(
+                (self,), other.unchain_tasks()), app=self._app)
         elif isinstance(other, group):
             # unroll group with one member
             other = maybe_unroll_group(other)

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -394,8 +394,6 @@ class Signature(dict):
         )))
 
     def __or__(self, other):
-        # These could be implemented in each individual class,
-        # I'm sure, but for now we have this.
         if isinstance(other, _chain):
             # task | chain -> chain
             return _chain(seq_concat_seq(

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -396,8 +396,8 @@ class Signature(dict):
     def __or__(self, other):
         # These could be implemented in each individual class,
         # I'm sure, but for now we have this.
-        if not isinstance(other, (group, _chain)) and isinstance(other, Signature):
-            if isinstance(self, _chain):
+        if isinstance(self, _chain):
+            if not isinstance(other, (group, _chain)) and isinstance(other, Signature):
                 if self.tasks and isinstance(self.tasks[-1], group):
                     # CHAIN [last item is group] | TASK -> chord
                     sig = self.clone()
@@ -413,6 +413,7 @@ class Signature(dict):
                     # chain | task -> chain
                     return _chain(seq_concat_item(
                         self.unchain_tasks(), other), app=self._app)
+        elif not isinstance(other, (group, _chain)) and isinstance(other, Signature):
             # task | task -> chain
             return _chain(self, other, app=self._app)
         elif isinstance(other, _chain):

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -396,14 +396,14 @@ class Signature(dict):
     def __or__(self, other):
         # These could be implemented in each individual class,
         # I'm sure, but for now we have this.
-        if not isinstance(self, _chain) and isinstance(other, _chain):
-            # task | chain -> chain
-            return _chain(seq_concat_seq(
-                (self,), other.unchain_tasks()), app=self._app)
-        elif isinstance(other, _chain):
+        if isinstance(self, _chain) and isinstance(other, _chain):
             # chain | chain -> chain
             return _chain(seq_concat_seq(
                 self.unchain_tasks(), other.unchain_tasks()), app=self._app)
+        elif isinstance(other, _chain):
+            # task | chain -> chain
+            return _chain(seq_concat_seq(
+                (self,), other.unchain_tasks()), app=self._app)
         elif isinstance(self, chord) and not isinstance(other, group):
             # chord | task ->  attach to body
             sig = self.clone()

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -396,10 +396,7 @@ class Signature(dict):
     def __or__(self, other):
         # These could be implemented in each individual class,
         # I'm sure, but for now we have this.
-        if isinstance(self, group):
-            # group() | task -> chord
-            return chord(self, body=other, app=self._app)
-        elif isinstance(other, group):
+        if isinstance(other, group):
             # unroll group with one member
             other = maybe_unroll_group(other)
             if isinstance(self, _chain):
@@ -1070,6 +1067,10 @@ class group(Signature):
 
     def __call__(self, *partial_args, **options):
         return self.apply_async(partial_args, **options)
+
+    def __or__(self, other):
+        # group() | task -> chord
+        return chord(self, body=other, app=self._app)
 
     def skew(self, start=1.0, stop=None, step=1.0):
         it = fxrange(start, stop, step, repeatlast=True)

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1379,7 +1379,8 @@ class _chord(Signature):
         return self.apply_async((), {'body': body} if body else {}, **options)
 
     def __or__(self, other):
-        if not isinstance(other, (group, _chain)):
+        if (not isinstance(other, (group, _chain)) and
+           isinstance(other, Signature)):
             # chord | task ->  attach to body
             sig = self.clone()
             sig.body = sig.body | other

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -396,12 +396,7 @@ class Signature(dict):
     def __or__(self, other):
         # These could be implemented in each individual class,
         # I'm sure, but for now we have this.
-        if isinstance(self, chord) and not isinstance(other, (group, _chain)):
-            # chord | task ->  attach to body
-            sig = self.clone()
-            sig.body = sig.body | other
-            return sig
-        elif isinstance(other, _chain):
+        if isinstance(other, _chain):
             # task | chain -> chain
             return _chain(seq_concat_seq(
                 (self,), other.unchain_tasks()), app=self._app)
@@ -1382,6 +1377,15 @@ class _chord(Signature):
 
     def __call__(self, body=None, **options):
         return self.apply_async((), {'body': body} if body else {}, **options)
+
+    def __or__(self, other):
+        if not isinstance(other, (group, _chain)):
+            # chord | task ->  attach to body
+            sig = self.clone()
+            sig.body = sig.body | other
+            return sig
+        else:
+            return super().__or__(other)
 
     def freeze(self, _id=None, group_id=None, chord=None,
                root_id=None, parent_id=None, group_index=None):

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -396,17 +396,19 @@ class Signature(dict):
     def __or__(self, other):
         # These could be implemented in each individual class,
         # I'm sure, but for now we have this.
-        if isinstance(other, group):
+        if isinstance(self, _chain) and isinstance(other, group):
             # unroll group with one member
             other = maybe_unroll_group(other)
-            if isinstance(self, _chain):
-                # chain | group() -> chain
-                tasks = self.unchain_tasks()
-                if not tasks:
-                    # If the chain is empty, return the group
-                    return other
-                return _chain(seq_concat_item(
-                    tasks, other), app=self._app)
+            # chain | group() -> chain
+            tasks = self.unchain_tasks()
+            if not tasks:
+                # If the chain is empty, return the group
+                return other
+            return _chain(seq_concat_item(
+                tasks, other), app=self._app)
+        elif isinstance(other, group):
+            # unroll group with one member
+            other = maybe_unroll_group(other)
             # task | group() -> chain
             return _chain(self, other, app=self.app)
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -396,10 +396,7 @@ class Signature(dict):
     def __or__(self, other):
         # These could be implemented in each individual class,
         # I'm sure, but for now we have this.
-        if not isinstance(other, (group, _chain)) and isinstance(other, Signature):
-            # task | task -> chain
-            return _chain(self, other, app=self._app)
-        elif isinstance(other, _chain):
+        if isinstance(other, _chain):
             # task | chain -> chain
             return _chain(seq_concat_seq(
                 (self,), other.unchain_tasks()), app=self._app)
@@ -408,6 +405,9 @@ class Signature(dict):
             other = maybe_unroll_group(other)
             # task | group() -> chain
             return _chain(self, other, app=self.app)
+        elif isinstance(other, Signature):
+            # task | task -> chain
+            return _chain(self, other, app=self._app)
         return NotImplemented
 
     def __ior__(self, other):

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -396,16 +396,7 @@ class Signature(dict):
     def __or__(self, other):
         # These could be implemented in each individual class,
         # I'm sure, but for now we have this.
-        if isinstance(other, _chain):
-            # task | chain -> chain
-            return _chain(seq_concat_seq(
-                (self,), other.unchain_tasks()), app=self._app)
-        elif isinstance(other, group):
-            # unroll group with one member
-            other = maybe_unroll_group(other)
-            # task | group() -> chain
-            return _chain(self, other, app=self.app)
-        elif isinstance(other, Signature):
+        if not isinstance(other, (group, _chain)) and isinstance(other, Signature):
             if isinstance(self, _chain):
                 if self.tasks and isinstance(self.tasks[-1], group):
                     # CHAIN [last item is group] | TASK -> chord
@@ -424,6 +415,15 @@ class Signature(dict):
                         self.unchain_tasks(), other), app=self._app)
             # task | task -> chain
             return _chain(self, other, app=self._app)
+        elif isinstance(other, _chain):
+            # task | chain -> chain
+            return _chain(seq_concat_seq(
+                (self,), other.unchain_tasks()), app=self._app)
+        elif isinstance(other, group):
+            # unroll group with one member
+            other = maybe_unroll_group(other)
+            # task | group() -> chain
+            return _chain(self, other, app=self.app)
         return NotImplemented
 
     def __ior__(self, other):

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -396,11 +396,7 @@ class Signature(dict):
     def __or__(self, other):
         # These could be implemented in each individual class,
         # I'm sure, but for now we have this.
-        if isinstance(self, _chain) and isinstance(other, _chain):
-            # chain | chain -> chain
-            return _chain(seq_concat_seq(
-                self.unchain_tasks(), other.unchain_tasks()), app=self._app)
-        elif isinstance(other, _chain):
+        if isinstance(other, _chain):
             # task | chain -> chain
             return _chain(seq_concat_seq(
                 (self,), other.unchain_tasks()), app=self._app)
@@ -612,6 +608,10 @@ class _chain(Signature):
                 return other
             return _chain(seq_concat_item(
                 tasks, other), app=self._app)
+        elif isinstance(other, _chain):
+            # chain | chain -> chain
+            return _chain(seq_concat_seq(
+                self.unchain_tasks(), other.unchain_tasks()), app=self._app)
         else:
             return super().__or__(other)
 

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -402,6 +402,27 @@ class test_chain(CanvasCase):
         tasks2, _ = c2.prepare_steps((), {}, c2.tasks)
         assert isinstance(tasks2[0], group)
 
+    def test_chord_to_chain(self):
+        c = (
+            chord([self.add.s('x0', 'y0'), self.add.s('x1', 'y1')],
+                  self.add.s(['foo'])) |
+            chain(self.add.s(['y']), self.add.s(['z']))
+        )
+        assert isinstance(c, _chain)
+        assert c.apply().get() == ['x0y0', 'x1y1', 'foo', 'y', 'z']
+
+    def test_chord_to_group(self):
+        c = (
+            chord([self.add.s('x0', 'y0'), self.add.s('x1', 'y1')],
+                  self.add.s(['foo'])) |
+            group([self.add.s(['y']), self.add.s(['z'])])
+        )
+        assert isinstance(c, _chain)
+        assert c.apply().get() == [
+            ['x0y0', 'x1y1', 'foo', 'y'],
+            ['x0y0', 'x1y1', 'foo', 'z']
+        ]
+
     def test_apply_options(self):
 
         class static(Signature):


### PR DESCRIPTION
## Description
When task chaining with the bar operator (`X | Y | Z`) was introduced in 2016, the following comment was put in `Signature.__or__`:

> These could be implemented in each individual class, I'm sure, but for now we have this.

I saw this as an invitation to move the quite complex branching into `_chain.__or__`, `group.__or__` and `_chord.__or__`.

The commits of micro-refactoring steps are left as is for easier review.

