### PR TITLE
Exclude pypy-windows checks from CI temporarily

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,11 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8']
         os: ["ubuntu-20.04", "windows-latest"]
-
+        exclude:
+            - python-version: 'pypy-3.7'
+              os: "windows-latest"
+            - python-version: 'pypy-3.8'
+              os: "windows-latest"
     steps:
     - name: Install apt packages
       if: startsWith(matrix.os, 'ubuntu-')

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -29,14 +29,14 @@ MONGODB_COLLECTION = 'collection1'
 MONGODB_GROUP_COLLECTION = 'group_collection1'
 # uri with user, password, database name, replica set, DNS seedlist format
 MONGODB_SEEDLIST_URI = ('srv://'
-                      'celeryuser:celerypassword@'
-                      'dns-seedlist-host.example.com/'
-                      'celerydatabase')
+                        'celeryuser:celerypassword@'
+                        'dns-seedlist-host.example.com/'
+                        'celerydatabase')
 MONGODB_BACKEND_HOST = [
-                'mongo1.example.com:27017',
-                'mongo2.example.com:27017',
-                'mongo3.example.com:27017',
-            ]
+    'mongo1.example.com:27017',
+    'mongo2.example.com:27017',
+    'mongo3.example.com:27017',
+]
 CELERY_USER = 'celeryuser'
 CELERY_PASSWORD = 'celerypassword'
 CELERY_DATABASE = 'celerydatabase'
@@ -63,6 +63,7 @@ def fake_resolver_dnspython():
             return [TXT(0, 0, [b'replicaSet=rs0'])]
 
     return mock_resolver
+
 
 class test_MongoBackend:
     default_url = 'mongodb://uuuu:pwpw@hostname.dom/database'
@@ -235,7 +236,7 @@ class test_MongoBackend:
         assert compliant_uri('mongodb://') == 'mongodb://localhost'
 
         assert compliant_uri('mongodb+something://host') == \
-               'mongodb+something://host'
+            'mongodb+something://host'
 
         assert compliant_uri('something://host') == 'mongodb+something://host'
 
@@ -694,7 +695,7 @@ class test_MongoBackend_store_get_result:
     @pytest.mark.parametrize("serializer,result_type,result", [
         (s, type(i['result']), i['result']) for i in SUCCESS_RESULT_TEST_DATA
         for s in i['serializers']]
-                             )
+    )
     def test_encode_success_results(self, mongo_backend_factory, serializer,
                                     result_type, result):
         backend = mongo_backend_factory(serializer=serializer)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

A temporary solution to make master green while we investigate the issue with cryptography for WindowsOS/pypy: https://github.com/celery/celery/runs/4426384762?check_suite_focus=true#step:8:628 

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
