### PR TITLE
update doc to reflect Celery 5.2.x

### DIFF
--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -39,14 +39,15 @@ What do I need?
 ===============
 
 .. sidebar:: Version Requirements
-    :subtitle: Celery version 5.1 runs on
+    :subtitle: Celery version 5.2 runs on
 
-    - Python ❨3.6, 3.7, 3.8❩
+    - Python ❨3.7, 3.8, 3.9❩
     - PyPy3.6 ❨7.3❩
 
     Celery 4.x was the last version to support Python 2.7,
     Celery 5.x requires Python 3.6 or newer.
-    Celery 5.1.x also requires Python 3.6 or newer.
+    Celery 5.1.x also requires Python 3.6 or newer
+    and Celery 5.2.x requires Python 3.7 or newer.
 
 
     If you're running an older version of Python, you need to be running

--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -46,8 +46,8 @@ What do I need?
 
     Celery 4.x was the last version to support Python 2.7,
     Celery 5.x requires Python 3.6 or newer.
-    Celery 5.1.x also requires Python 3.6 or newer
-    and Celery 5.2.x requires Python 3.7 or newer.
+    Celery 5.1.x also requires Python 3.6 or newer.
+    Celery 5.2.x requires Python 3.7 or newer.
 
 
     If you're running an older version of Python, you need to be running

--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -42,7 +42,7 @@ What do I need?
     :subtitle: Celery version 5.2 runs on
 
     - Python ❨3.7, 3.8, 3.9, 3.10❩
-    - PyPy3.6 ❨7.3❩
+    - PyPy3.7, 3.8 ❨7.3.7❩
 
     Celery 4.x was the last version to support Python 2.7,
     Celery 5.x requires Python 3.6 or newer.

--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -41,7 +41,7 @@ What do I need?
 .. sidebar:: Version Requirements
     :subtitle: Celery version 5.2 runs on
 
-    - Python ❨3.7, 3.8, 3.9❩
+    - Python ❨3.7, 3.8, 3.9, 3.10❩
     - PyPy3.6 ❨7.3❩
 
     Celery 4.x was the last version to support Python 2.7,


### PR DESCRIPTION
## Description

https://github.com/celery/celery/blob/master/docs/whatsnew-5.2.rst states
```
This version is officially supported on CPython 3.7 & 3.8 & 3.9 and is also supported on PyPy3.
```
 

but https://github.com/celery/celery/blob/master/docs/getting-started/introduction.rst wasn't updated (it still has 5.1 as latest version and no mention of 3.9 support or the discontinuation of 3.6 support in 5.2.x)