### PR TITLE
Fix minor typo in documentation

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2182,7 +2182,7 @@ Examples:
         },
     }
 
-    task_routes = ('myapp.tasks.route_task', {'celery.ping': 'default})
+    task_routes = ('myapp.tasks.route_task', {'celery.ping': 'default'})
 
 Where ``myapp.tasks.route_task`` could be:
 


### PR DESCRIPTION
Fix typo causing syntax error in documentation

## Description

Fix a small typo in the documentation causing a syntax error.