### PR TITLE
docs: add sqs broker url setup warning

### DIFF
--- a/docs/getting-started/backends-and-brokers/sqs.rst
+++ b/docs/getting-started/backends-and-brokers/sqs.rst
@@ -38,13 +38,24 @@ encode the password so it can always be parsed correctly. For example:
 .. code-block:: python
 
     from kombu.utils.url import safequote
-    
+
     aws_access_key = safequote("ABCDEFGHIJKLMNOPQRST")
     aws_secret_key = safequote("ZYXK7NiynG/TogH8Nj+P9nlE73sq3")
-    
+
     broker_url = "sqs://{aws_access_key}:{aws_secret_key}@".format(
         aws_access_key=aws_access_key, aws_secret_key=aws_secret_key,
     )
+
+.. warning::
+
+    Don't use this setup option with django's ``debug=True``.
+    It may lead to security issues within deployed django apps.
+
+    In debug mode django shows environment variables and the SQS URL
+    may be exposed to the internet including your AWS access and secret keys.
+    Please turn off debug mode on your deployed django application or
+    consider a setup option described below.
+
 
 The login credentials can also be set using the environment variables
 :envvar:`AWS_ACCESS_KEY_ID` and :envvar:`AWS_SECRET_ACCESS_KEY`,
@@ -252,7 +263,7 @@ Caveats
 - With FIFO queues it might be necessary to set additional message properties such as ``MessageGroupId`` and ``MessageDeduplicationId`` when publishing a message.
 
   Message properties can be passed as keyword arguments to :meth:`~celery.app.task.Task.apply_async`:
-    
+
   .. code-block:: python
 
     message_properties = {


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Added warning text after description of SQS broker setup with access and secret keys in the url

Refs: #7169 