### PR TITLE
Terminate celery entirely on connection error.

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -330,6 +330,10 @@ NAMESPACES = Namespace(
         ),
         state_db=Option(),
         task_log_format=Option(DEFAULT_TASK_LOG_FMT),
+        terminate_on_connection_error=Option(
+            False,
+            type='bool'
+        ),
         timer=Option(type='string'),
         timer_precision=Option(1.0, type='float'),
     ),

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -381,7 +381,7 @@ def get_exponential_backoff_interval(
     # Will be zero if factor equals 0
     countdown = min(maximum, factor * (2 ** retries))
     # Full jitter according to
-    # https://www.awsarchitectureblog.com/2015/03/backoff.html
+    # https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
     if full_jitter:
         countdown = random.randrange(countdown + 1)
     # Adjust according to maximum wait time and account for negative values.

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -339,7 +339,7 @@ class Consumer:
                     raise
                 if self.app.conf.worker_terminate_on_connection_error:
                     crit(TERMINATE_CELERY_ON_CONNECTION_RESTART)
-                    self.controller.terminate()
+                    self.controller.stop()
                     return
                 if isinstance(exc, OSError) and exc.errno == errno.EMFILE:
                     raise  # Too many open files

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -22,8 +22,7 @@ from vine import ppartial, promise
 
 from celery import bootsteps, signals
 from celery.app.trace import build_tracer
-from celery.exceptions import (CPendingDeprecationWarning, InvalidTaskError,
-                               NotRegistered, WorkerShutdown)
+from celery.exceptions import CPendingDeprecationWarning, InvalidTaskError, NotRegistered, WorkerShutdown
 from celery.utils.functional import noop
 from celery.utils.log import get_logger
 from celery.utils.nodenames import gethostname

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -22,7 +22,8 @@ from vine import ppartial, promise
 
 from celery import bootsteps, signals
 from celery.app.trace import build_tracer
-from celery.exceptions import CPendingDeprecationWarning, InvalidTaskError, NotRegistered
+from celery.exceptions import (CPendingDeprecationWarning, InvalidTaskError,
+                               NotRegistered, WorkerShutdown)
 from celery.utils.functional import noop
 from celery.utils.log import get_logger
 from celery.utils.nodenames import gethostname


### PR DESCRIPTION
_Note_: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description
Celery did not provide a way to perform a warm shutdown whenever a connection error occurs.
Production environments are complex and some jobs are long running. It is unacceptable to some of our users to prefetch any new tasks while others are running and `worker_cancel_long_running_tasks_on_connection_loss` is still a compromise to them.

`worker_terminate_on_connection_error`, when set to True will shut down Celery entirely and leave the supervisor the responsibility to revive the Celery process

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

