### PR TITLE
prevent dupes in event loop on Consumer restart (causing leak?)

### DIFF
--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -344,6 +344,17 @@ class test_AsynPool:
         # Then: all items were removed from the managed data source
         assert fd_iter == {}, "Expected all items removed from managed dict"
 
+    def test_register_with_event_loop__no_on_tick_dupes(self):
+        """Ensure AsynPool's register_with_event_loop only registers
+        on_poll_start in the event loop the first time it's called. This
+        prevents a leak when the Consumer is restarted.
+        """
+        pool = asynpool.AsynPool(threads=False)
+        hub = Mock(name='hub')
+        pool.register_with_event_loop(hub)
+        pool.register_with_event_loop(hub)
+        hub.on_tick.add.assert_called_once()
+
 
 @t.skip.if_win32
 class test_ResultHandler:


### PR DESCRIPTION
## Description
Currently, each time the prefork worker encounters a connection error and restarts the `Consumer`, it will result in an additional `AsynPool._create_write_handlers.<locals>.on_poll_start` getting added to the event loop (in `Hub.on_tick`). This may be causing a minor memory leak and may slow down the event loop after a lot of connection errors.

For more details, I think this is the flow causing the issue:
<details>
    <summary>Expand</summary>

    1. WorkController runs .start(), which starts the Worker's bootsteps
    2. The Worker's Pool Bootstep starts and initializes AsynPool
    3. The Worker's Consumer Bootstep runs .start() on the Consumer's Blueprint, which starts the Consumer's bootsteps.
    4. Consumer's Evloop bootstep starts, which runs Evloop.loop().
    5. Evloop.loop() runs asynloop()
    6. asynloop() calls Worker.register_with_event_loop, which calls register_with_event_loop on all Bootsteps in the Worker's Blueprint.
    7. Worker's Pool bootstep's register_with_event_loop adds AsynPool._create_write_handlers.<locals>.on_poll_start` to Hub.on_tick.
    8. asynloop() calls Consumer.register_with_event_loop, which calls register_with_event_loop on all Bootsteps in the Consumer's Blueprint.
    9. asynloop() starts the event loop to start constantly running all functions in Hub.on_tick.
    10. ConnectionError is caught while running blueprint.start() in Consumer.start()
    12. The Consumer's blueprint is restarted, which will .stop() then start() all the Bootsteps in the Consumer's Blueprint.
    13. The Evloop bootstep stops then starts.
    14. Evloop.loop() runs again, which eventually adds AsynPool._create_write_handlers.<locals>.on_poll_start to Hub.on_tick again.</details>
</details>

This PR prevents the unnecessary duplicate `on_poll_start`s from getting added to the event loop on each Consumer restart by allowing `hub.on_tick.add(self.on_poll_start)` to run only once per instance of `AsynPool`.

