### PR TITLE
Add changelog to PyPI sidebar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,8 @@ setuptools.setup(
         ]
     },
     project_urls={
-        "Documentation": "http://docs.celeryproject.org/en/latest/index.html",
+        "Documentation": "https://docs.celeryproject.org/en/latest/index.html",
+        "Changelog": "https://docs.celeryproject.org/en/stable/changelog.html",
         "Code": "https://github.com/celery/celery",
         "Tracker": "https://github.com/celery/celery/issues",
         "Funding": "https://opencollective.com/celery"


### PR DESCRIPTION
## Description
This `setup.py` modification adds a "Changelog" link in the PyPI project page sidebar.
This is an officially-support link type, with its own icon. You can see it in action in the [cryptography package page](https://pypi.org/project/cryptography/). Any link name whose lowercase matches one of `["changelog", "change log", "changes", "release notes", "news", "what's new", "history"]` will get a scroll icon.

Whenever I wish to update a package, I go into PyPI to see how many versions I'm missing, and then I hunt for the changelog. This makes it much more accessible.

Note that if you're wondering about the ordering of the links, PyPI currently [has a bug](https://github.com/pypa/warehouse/issues/3097) where it shows all the `project_urls` in reverse order.

