### PR TITLE
Remove Python 3.4 compatibility code

### DIFF
--- a/celery/utils/saferepr.py
+++ b/celery/utils/saferepr.py
@@ -136,14 +136,7 @@ def _repr_binary_bytes(val):
         return val.decode('utf-8')
     except UnicodeDecodeError:
         # possibly not unicode, but binary data so format as hex.
-        try:
-            ashex = val.hex
-        except AttributeError:  # pragma: no cover
-            # Python 3.4
-            return val.decode('utf-8', errors='replace')
-        else:
-            # Python 3.5+
-            return ashex()
+        return val.hex()
 
 
 def _format_chars(val, maxlen):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Since we don't support Python 3.4 anymore, we don't need this code.
This PR removes it.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
