### PR TITLE
fix an error which is introduced by pr7040. 

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -107,11 +107,13 @@ class ResultConsumer(BaseResultConsumer):
         metas = [meta for meta in metas if meta]
         for meta in metas:
             self.on_state_change(self._decode_result(meta), None)
-        if self.subscribed_to:
-            self._pubsub = self.backend.client.pubsub(
+        self._pubsub = self.backend.client.pubsub(
                 ignore_subscribe_messages=True,
             )
+        if self.subscribed_to:
             self._pubsub.subscribe(*self.subscribed_to)
+        else:
+            self._pubsub.ping()
 
     @contextmanager
     def reconnect_on_error(self):

--- a/celery/utils/saferepr.py
+++ b/celery/utils/saferepr.py
@@ -136,14 +136,7 @@ def _repr_binary_bytes(val):
         return val.decode('utf-8')
     except UnicodeDecodeError:
         # possibly not unicode, but binary data so format as hex.
-        try:
-            ashex = val.hex
-        except AttributeError:  # pragma: no cover
-            # Python 3.4
-            return val.decode('utf-8', errors='replace')
-        else:
-            # Python 3.5+
-            return ashex()
+        return val.hex()
 
 
 def _format_chars(val, maxlen):


### PR DESCRIPTION
## Description

Nothing to subscribe so should not  assign to _pubsub ,  then  drain_events  just sleep.    The error   introduced by pr7040 :  `RuntimeError: pubsub connection not set: did you forget to call subscribe() or psubscribe()?`

[discussion](https://github.com/celery/celery/discussions/7212)
