### PR TITLE
[WIP] - intial tox-docker config for dockerised integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 requires =
     tox-gh-actions
+    tox-docker>=3.0
 envlist =
     {3.7,3.8,3.9,3.10,pypy3}-unit
     {3.7,3.8,3.9,3.10,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
@@ -48,6 +49,7 @@ setenv =
     BOTO_CONFIG = /dev/null
     WORKER_LOGLEVEL = INFO
     PYTHONIOENCODING = UTF-8
+    C_DEBUG_TEST = 1
 
     cache: TEST_BROKER=redis://
     cache: TEST_BACKEND=cache+pylibmc://
@@ -80,6 +82,33 @@ basepython =
     pypy3: pypy3
     lint,apicheck,linkcheck,configcheck,bandit: python3.9
 usedevelop = True
+
+
+docker =
+    integration-rabbitmq: rabbitmq
+    integration-redis: redis
+
+dockerenv =
+    PYAMQP_INTEGRATION_INSTANCE=1
+    RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit tcp_listeners [5672]
+
+[docker:rabbitmq]
+image = rabbitmq
+ports = 5672:5672/tcp
+healthcheck_cmd = /bin/bash -c 'rabbitmq-diagnostics ping -q'
+healthcheck_interval = 10
+healthcheck_timeout = 10
+healthcheck_retries = 30
+healthcheck_start_period = 5
+
+[docker:redis]
+image = redis
+ports = 6379:6379/tcp
+healthcheck_cmd = /bin/sh -c 'redis-cli ping'
+healthcheck_interval = 10
+healthcheck_timeout = 10
+healthcheck_retries = 30
+healthcheck_start_period = 5
 
 
 [testenv:apicheck]

--- a/tox.ini
+++ b/tox.ini
@@ -92,23 +92,23 @@ dockerenv =
     PYAMQP_INTEGRATION_INSTANCE=1
     RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit tcp_listeners [5672]
 
-[docker:rabbitmq]
-image = rabbitmq
-ports = 5672:5672/tcp
-healthcheck_cmd = /bin/bash -c 'rabbitmq-diagnostics ping -q'
+[docker:common-healthcheck]
 healthcheck_interval = 10
 healthcheck_timeout = 10
 healthcheck_retries = 30
 healthcheck_start_period = 5
 
+[docker:rabbitmq]
+extends = docker:common-healthcheck
+image = rabbitmq
+ports = 5672:5672/tcp
+healthcheck_cmd = /bin/bash -c 'rabbitmq-diagnostics ping -q'
+
 [docker:redis]
+extends = docker:common-healthcheck
 image = redis
 ports = 6379:6379/tcp
 healthcheck_cmd = /bin/sh -c 'redis-cli ping'
-healthcheck_interval = 10
-healthcheck_timeout = 10
-healthcheck_retries = 30
-healthcheck_start_period = 5
 
 
 [testenv:apicheck]


### PR DESCRIPTION
A different approach to  https://github.com/celery/celery/pull/6649 to run integration tests in github action using tox-docker. going to add github action part as well and tweak both. to be  able to make the integrations tests running 