### PR TITLE
Switch from pkg_resources importlib-metadata

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -8,6 +8,12 @@ This document contains change notes for bugfix & new features
 in the & 5.2.x series, please see :ref:`whatsnew-5.2` for
 an overview of what's new in Celery 5.2.
 
+Unreleased
+==========
+
+- Use importlib-metadata instead of pkg_resources for better performance and compatibility
+
+
 .. _version-5.2.3:
 
 5.2.3

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -3,12 +3,17 @@ import os
 import pathlib
 import traceback
 
+try:
+    from importlib import metadata as importlib_metadata
+except ImportError:
+    # TODO: Remove this when we drop support for Python 3.7
+    import importlib_metadata
+
 import click
 import click.exceptions
 from click.types import ParamType
 from click_didyoumean import DYMGroup
 from click_plugins import with_plugins
-from pkg_resources import iter_entry_points
 
 from celery import VERSION_BANNER
 from celery.app.utils import find_app
@@ -71,7 +76,7 @@ class App(ParamType):
 APP = App()
 
 
-@with_plugins(iter_entry_points('celery.commands'))
+@with_plugins(importlib_metadata.entry_points().get('celery.commands', []))
 @click.group(cls=DYMGroup, invoke_without_command=True)
 @click.option('-A',
               '--app',

--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -138,11 +138,12 @@ def gen_task_name(app, name, module_name):
 
 def load_extension_class_names(namespace):
     try:
-        from pkg_resources import iter_entry_points
-    except ImportError:  # pragma: no cover
-        return
+        from importlib import metadata as importlib_metadata
+    except ImportError:
+        # TODO: Remove this when we drop support for Python 3.7
+        import importlib_metadata
 
-    for ep in iter_entry_points(namespace):
+    for ep in importlib_metadata.entry_points().get(namespace, []):
         yield ep.name, ':'.join([ep.module_name, ep.attrs[0]])
 
 

--- a/docs/userguide/extending.rst
+++ b/docs/userguide/extending.rst
@@ -829,7 +829,7 @@ New commands can be added to the :program:`celery` umbrella command by using
 
 
 Entry-points is special meta-data that can be added to your packages ``setup.py`` program,
-and then after installation, read from the system using the :mod:`pkg_resources` module.
+and then after installation, read from the system using the :mod:`importlib.metadata` module.
 
 Celery recognizes ``celery.commands`` entry-points to install additional
 sub-commands, where the value of the entry-point must point to a valid click

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,4 +6,4 @@ click>=8.0.3,<9.0
 click-didyoumean>=0.0.3
 click-repl>=0.2.0
 click-plugins>=1.1.1
-setuptools>=59.1.1,<59.7.0
+importlib-metadata>=0.18; python_version<"3.8"


### PR DESCRIPTION
Based on https://github.com/celery/kombu/pull/1071

Rationale:
- Use of pkg_resources is discouraged in favor of importlib.resources, importlib.metadata, and their backports (resources, metadata). Please consider using those libraries instead of pkg_resources.
- setuptools package is considered to be unsafe in a requirements file