### PR TITLE
 Use importlib instead of discouraged pkg_resources

### DIFF
--- a/celery/app/backends.py
+++ b/celery/app/backends.py
@@ -44,8 +44,7 @@ def by_name(backend=None, loader=None,
     backend = backend or 'disabled'
     loader = loader or current_app.loader
     aliases = dict(BACKEND_ALIASES, **loader.override_backends)
-    aliases.update(
-        load_extension_class_names(extension_namespace) or {})
+    aliases.update(load_extension_class_names(extension_namespace))
     try:
         cls = symbol_by_name(backend, aliases)
     except ValueError as exc:

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -666,8 +666,7 @@ class Service:
     def get_scheduler(self, lazy=False,
                       extension_namespace='celery.beat_schedulers'):
         filename = self.schedule_filename
-        aliases = dict(
-            load_extension_class_names(extension_namespace) or {})
+        aliases = dict(load_extension_class_names(extension_namespace))
         return symbol_by_name(self.scheduler_cls, aliases=aliases)(
             app=self.app,
             schedule_filename=filename,

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -3,12 +3,16 @@ import os
 import pathlib
 import traceback
 
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
+
 import click
 import click.exceptions
 from click.types import ParamType
 from click_didyoumean import DYMGroup
 from click_plugins import with_plugins
-from pkg_resources import iter_entry_points
 
 from celery import VERSION_BANNER
 from celery.app.utils import find_app
@@ -71,7 +75,7 @@ class App(ParamType):
 APP = App()
 
 
-@with_plugins(iter_entry_points('celery.commands'))
+@with_plugins(entry_points().get('celery.commands', []))
 @click.group(cls=DYMGroup, invoke_without_command=True)
 @click.option('-A',
               '--app',

--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -6,6 +6,11 @@ import warnings
 from contextlib import contextmanager
 from importlib import reload
 
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
+
 from kombu.utils.imports import symbol_by_name
 
 #: Billiard sets this when execv is enabled.
@@ -137,12 +142,7 @@ def gen_task_name(app, name, module_name):
 
 
 def load_extension_class_names(namespace):
-    try:
-        from pkg_resources import iter_entry_points
-    except ImportError:  # pragma: no cover
-        return
-
-    for ep in iter_entry_points(namespace):
+    for ep in entry_points().get(namespace, []):
         yield ep.name, ':'.join([ep.module_name, ep.attrs[0]])
 
 

--- a/docs/userguide/extending.rst
+++ b/docs/userguide/extending.rst
@@ -829,7 +829,7 @@ New commands can be added to the :program:`celery` umbrella command by using
 
 
 Entry-points is special meta-data that can be added to your packages ``setup.py`` program,
-and then after installation, read from the system using the :mod:`pkg_resources` module.
+and then after installation, read from the system using the :mod:`importlib` module.
 
 Celery recognizes ``celery.commands`` entry-points to install additional
 sub-commands, where the value of the entry-point must point to a valid click

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,4 +6,4 @@ click>=8.0.3,<9.0
 click-didyoumean>=0.0.3
 click-repl>=0.2.0
 click-plugins>=1.1.1
-setuptools>=59.1.1,<59.7.0
+importlib-metadata>=1.4.0; python_version < '3.8'


### PR DESCRIPTION
## Description

Use importlib instead of discouraged pkg_resources. This avoids runtime dependency on setuptools (which caused problems because of pinning see for example #7214) and adds importlib backport dependency on Python 3.7.

From https://setuptools.pypa.io/en/latest/pkg_resources.html:

> Use of pkg_resources is discouraged in favor of importlib.resources, importlib.metadata, and their backports (resources, metadata). Please consider using those libraries instead of pkg_resources.



<!-- Please describe your pull request.

Based on https://github.com/celery/kombu/pull/1071
-->
