### PR TITLE
call ping to set connection for avoiding error (take place of #7215)

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -112,6 +112,8 @@ class ResultConsumer(BaseResultConsumer):
         )
         if self.subscribed_to:
             self._pubsub.subscribe(*self.subscribed_to)
+        else:
+            self._pubsub.ping()
 
     @contextmanager
     def reconnect_on_error(self):


### PR DESCRIPTION
 fix an error which is introduced by [pr7040](https://github.com/celery/celery/pull/7040).

## Description
when subscribed_to is empty , call ping to set connection attr .  
After this operation,  `drain_events` exec self._pubsub.get_message is ok,    
and redis parse_response no error .