### PR TITLE
Documentation updates related to task names

### DIFF
--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -170,6 +170,10 @@ Available Fields
 
     The name of the task to execute.
 
+    Task names are described in the :ref:`task-names` section of the User Guide.
+    Note that this is not the import path of the task, even though the default
+    naming pattern is built like it is.
+
 * `schedule`
 
     The frequency of execution.

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -237,6 +237,12 @@ named :file:`tasks.py`:
     >>> add.name
     'tasks.add'
 
+.. note::
+
+   You can use the `inspect` command in a worker to view the names of
+   all registered tasks. See the `inspect registered` command in the
+   :ref:`monitoring-control` section of the User Guide.
+
 .. _task-name-generator-info:
 
 Changing the automatic naming behavior


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
These are some suggestions for updating the documentation around task names and celery beat. I spent some time trying to get a task working in celery beat and it was because I incorrectly associated the task name with its import path. I was finally able to fix my issue by running `inspect registered`. Maybe these documentation updates will save others from my same confusion.

Replaces #7221 and #7222.