### PR TITLE
WIP: Include `dont_autoretry_for` option in tasks.

### DIFF
--- a/celery/app/autoretry.py
+++ b/celery/app/autoretry.py
@@ -11,6 +11,10 @@ def add_autoretry_behaviour(task, **options):
         options.get('autoretry_for',
                     getattr(task, 'autoretry_for', ()))
     )
+    dont_autoretry_for = tuple(
+        options.get('dont_autoretry_for',
+                    getattr(task, 'dont_autoretry_for', ()))
+    )
     retry_kwargs = options.get(
         'retry_kwargs', getattr(task, 'retry_kwargs', {})
     )
@@ -37,6 +41,8 @@ def add_autoretry_behaviour(task, **options):
                 # even if it suits autoretry_for list
                 raise
             except Retry:
+                raise
+            except dont_autoretry_for:
                 raise
             except autoretry_for as exc:
                 if retry_backoff:

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -785,6 +785,15 @@ You can also set `autoretry_for`, `max_retries`, `retry_backoff`, `retry_backoff
     and the actual delay value will be a random number between zero and that
     maximum. By default, this option is set to ``True``.
 
+.. versionadded:: 5.2.4
+
+.. attribute:: Task.dont_autoretry_for
+
+    A list/tuple of exception classes.  These exceptions won't be autoretried.
+	This allows to exclude some exceptions that match `autoretry_for
+	<Task.autoretry_for>`:attr: but for which you don't want a retry.
+
+
 .. _task-options:
 
 List of Options


### PR DESCRIPTION
## Description

Add an option `dont_autoretry_for` to exclude some types of exceptions from retrying. 

This allows to opt-out from exceptions which you know are not worthy retrying, but still might be caught by `autoretry_for`.