### PR TITLE
added ability to globally override resultrepr_maxsize

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -288,6 +288,7 @@ NAMESPACES = Namespace(
         ),
         store_errors_even_if_ignored=Option(False, type='bool'),
         track_started=Option(False, type='bool'),
+        resultrepr_maxsize=Option(1024, type='int')
     ),
     worker=Namespace(
         __old__=OLD_NS_WORKER,

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -363,7 +363,7 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
     push_task = _task_stack.push
     pop_task = _task_stack.pop
     _does_info = logger.isEnabledFor(logging.INFO)
-    resultrepr_maxsize = task.resultrepr_maxsize
+    resultrepr_maxsize = app.conf.task_resultrepr_maxsize or task.resultrepr_maxsize
 
     prerun_receivers = signals.task_prerun.receivers
     postrun_receivers = signals.task_postrun.receivers


### PR DESCRIPTION
Resolves a feature request #6884

Example configuration
```
app = Celery(
    task_resultrepr_maxsize=102400,
    ...
)
```