### PR TITLE
Fix subscribed_to maybe empty

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -118,9 +118,8 @@ class ResultConsumer(BaseResultConsumer):
             self._pubsub.connection = self._pubsub.connection_pool.get_connection(
                 'pubsub', self._pubsub.shard_hint
             )
-            # even if nothing to subscribe, we should not lost the callback after being connected.
-            # maybe on_connect will be changed in the future. at present, this callback
-            # re-subscribe to any channels previously subscribed to.
+            # even if there is nothing to subscribe, we should not lose the callback after connecting.
+            # The on_connect callback will re-subscribe to any channels we previously subscribed to.
             self._pubsub.connection.register_connect_callback(self._pubsub.on_connect)
 
     @contextmanager

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -118,6 +118,9 @@ class ResultConsumer(BaseResultConsumer):
             self._pubsub.connection = self._pubsub.connection_pool.get_connection(
                 'pubsub', self._pubsub.shard_hint
             )
+            # even if nothing to subscribe, we should not lost the callback after being connected.
+            # maybe on_connect will be changed in the future. at present, this callback
+            # re-subscribe to any channels previously subscribed to.
             self._pubsub.connection.register_connect_callback(self._pubsub.on_connect)
 
     @contextmanager


### PR DESCRIPTION
## Description
According to these pull requests:  https://github.com/celery/celery/pull/7040 and https://github.com/celery/celery/pull/7220, I improved the behavior when subscribed_to has been  empty, no additional requests.