### PR TITLE
Clarify relation between visibility timeout & predefined queues in SQS

### DIFF
--- a/docs/getting-started/backends-and-brokers/sqs.rst
+++ b/docs/getting-started/backends-and-brokers/sqs.rst
@@ -167,7 +167,7 @@ setting::
     }
 
 When using this option, the visibility timeout should be set in the SQS queue
-rather than via the :setting:`broker_transport_options` setting
+in AWS rather than via the :setting:`broker_transport_options` setting.
 
 Back-off policy
 ------------------------

--- a/docs/getting-started/backends-and-brokers/sqs.rst
+++ b/docs/getting-started/backends-and-brokers/sqs.rst
@@ -95,6 +95,9 @@ This option is set via the :setting:`broker_transport_options` setting::
 
 The default visibility timeout is 30 minutes.
 
+This option is used when creating the SQS queue and has no effect if
+using :ref:`predefined queues <tpredefined-queues>`.
+
 Polling Interval
 ----------------
 
@@ -143,6 +146,8 @@ using the :setting:`broker_transport_options` setting::
 
     broker_transport_options = {'queue_name_prefix': 'celery-'}
 
+.. _predefined-queues:
+
 Predefined Queues
 -----------------
 
@@ -160,6 +165,9 @@ setting::
             }
         }
     }
+
+When using this option, the visibility timeout should be set in the SQS queue
+rather than via the :setting:`broker_transport_options` setting
 
 Back-off policy
 ------------------------

--- a/docs/getting-started/backends-and-brokers/sqs.rst
+++ b/docs/getting-started/backends-and-brokers/sqs.rst
@@ -82,6 +82,8 @@ by configuring the :setting:`broker_transport_options` setting::
 
         http://aws.amazon.com/about-aws/globalinfrastructure/
 
+.. _sqs-visibility-timeout:
+
 Visibility Timeout
 ------------------
 
@@ -96,7 +98,7 @@ This option is set via the :setting:`broker_transport_options` setting::
 The default visibility timeout is 30 minutes.
 
 This option is used when creating the SQS queue and has no effect if
-using :ref:`predefined queues <tpredefined-queues>`.
+using :ref:`predefined queues <predefined-queues>`.
 
 Polling Interval
 ----------------
@@ -167,7 +169,8 @@ setting::
     }
 
 When using this option, the visibility timeout should be set in the SQS queue
-in AWS rather than via the :setting:`broker_transport_options` setting.
+(in AWS) rather than via the :ref:`visibility timeout <sqs-visibility-timeout>`
+option.
 
 Back-off policy
 ------------------------


### PR DESCRIPTION
## Description

Clarify documentation about SQS. 

With SQS, the `visibility_timeout` setting is only used when Celery creates a queue in AWS. It is therefore not used when `predefined_queues` is also configured. I had no idea these 2 settings were related like this, hopefully this change will clarify this point in the docs.

The relevant code is [in Kombu](https://github.com/celery/kombu/blob/master/kombu/transport/SQS.py#L364).