### PR TITLE
fix #7200 uid and gid

### DIFF
--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -327,6 +327,10 @@ def worker(ctx, hostname=None, pool_cls=None, app=None, uid=None, gid=None,
                 argv.remove('--detach')
             if '-D' in argv:
                 argv.remove('-D')
+            if "--uid" in argv:
+                argv.remove('--uid')
+            if "--gid" in argv:
+                argv.remove('--gid')
 
             return detach(sys.executable,
                           argv,


### PR DESCRIPTION
## Description

Fixes #7200 by removing the uid and gid arguments from argv before running in detached mode and passing it into the already changed uid/gid.