### PR TITLE
fix #7245 remove duplicated uid in command params

### DIFF
--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -179,7 +179,6 @@ class CeleryDaemonCommand(CeleryCommand):
         self.params.append(CeleryOption(('-f', '--logfile'), help_group="Daemonization Options"))
         self.params.append(CeleryOption(('--pidfile',), help_group="Daemonization Options"))
         self.params.append(CeleryOption(('--uid',), help_group="Daemonization Options"))
-        self.params.append(CeleryOption(('--uid',), help_group="Daemonization Options"))
         self.params.append(CeleryOption(('--gid',), help_group="Daemonization Options"))
         self.params.append(CeleryOption(('--umask',), help_group="Daemonization Options"))
         self.params.append(CeleryOption(('--executable',), help_group="Daemonization Options"))


### PR DESCRIPTION
## Description

Fix https://github.com/celery/celery/issues/7245 by removing the duplicated line for the 'uid' option
