### PR TITLE
Remove __ne__ methods

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -194,14 +194,6 @@ class ScheduleEntry:
         """
         return self.editable_fields_equal(other)
 
-    def __ne__(self, other):
-        """Test schedule entries inequality.
-
-        Will only compare "editable" fields:
-        ``task``, ``schedule``, ``args``, ``kwargs``, ``options``.
-        """
-        return not self == other
-
 
 def _evaluate_entry_args(entry_args):
     if not entry_args:

--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -137,11 +137,6 @@ def with_unique_field(attr):
             return NotImplemented
         cls.__eq__ = __eq__
 
-        def __ne__(this, other):
-            res = this.__eq__(other)
-            return True if res is NotImplemented else not res
-        cls.__ne__ = __ne__
-
         def __hash__(this):
             return hash(getattr(this, attr))
         cls.__hash__ = __hash__

--- a/celery/result.py
+++ b/celery/result.py
@@ -371,10 +371,6 @@ class AsyncResult(ResultBase):
             return other == self.id
         return NotImplemented
 
-    def __ne__(self, other):
-        res = self.__eq__(other)
-        return True if res is NotImplemented else not res
-
     def __copy__(self):
         return self.__class__(
             self.id, self.backend, None, self.app, self.parent,
@@ -830,10 +826,6 @@ class ResultSet(ResultBase):
             return other.results == self.results
         return NotImplemented
 
-    def __ne__(self, other):
-        res = self.__eq__(other)
-        return True if res is NotImplemented else not res
-
     def __repr__(self):
         return f'<{type(self).__name__}: [{", ".join(r.id for r in self.results)}]>'
 
@@ -924,10 +916,6 @@ class GroupResult(ResultSet):
         elif isinstance(other, str):
             return other == self.id
         return NotImplemented
-
-    def __ne__(self, other):
-        res = self.__eq__(other)
-        return True if res is NotImplemented else not res
 
     def __repr__(self):
         return f'<{type(self).__name__}: {self.id} [{", ".join(r.id for r in self.results)}]>'

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -172,9 +172,6 @@ class schedule(BaseSchedule):
             return self.run_every == other.run_every
         return self.run_every == other
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __reduce__(self):
         return self.__class__, (self.run_every, self.relative, self.nowfun)
 
@@ -638,12 +635,6 @@ class crontab(BaseSchedule):
             )
         return NotImplemented
 
-    def __ne__(self, other):
-        res = self.__eq__(other)
-        if res is NotImplemented:
-            return True
-        return not res
-
 
 def maybe_schedule(s, relative=False, app=None):
     """Return schedule from number, timedelta, or actual schedule."""
@@ -827,9 +818,3 @@ class solar(BaseSchedule):
                 other.lon == self.lon
             )
         return NotImplemented
-
-    def __ne__(self, other):
-        res = self.__eq__(other)
-        if res is NotImplemented:
-            return True
-        return not res

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -628,10 +628,6 @@ class LimitedSet:
         # type: (Any) -> bool
         return self._data == other._data
 
-    def __ne__(self, other):
-        # type: (Any) -> bool
-        return not self.__eq__(other)
-
     def __repr__(self):
         # type: () -> str
         return REPR_LIMITED_SET.format(


### PR DESCRIPTION
I'm not really sure what the sentiments are for this type of change. Python's documentation was slightly unclear to me, and I wrote some sample code to clarify how it works.

https://gist.github.com/atombrella/c16693f564b4bbf375f70e5d56fe30ad

I think this `__ne__` method can be removed as well:

```
def with_unique_field(attr):

        def __ne__(this, other):
            res = this.__eq__(other)
            return True if res is NotImplemented else not res
        cls.__ne__ = __ne__
```

## Description

These are already defined as the opposite of __eq__ in Python 3, and when __eq__
returns NotImplemented, Python by default will return True.