### PR TITLE
fix typo in exception

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -358,7 +358,7 @@ class Backend:
         try:
             exc_type = exc['exc_type']
         except KeyError as e:
-            raise ValueError("Exception information must include"
+            raise ValueError("Exception information must include "
                              "the exception type") from e
         if exc_module is None:
             cls = create_exception_cls(


### PR DESCRIPTION
## Description

Fixed typo in exception that was printed as 
```
ValueError: Exception information must includethe exception type
                                              ^
                                                Notice the missing space
```