### PR TITLE
Set max_line_length in .editorconfig to match flake8 config.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 charset = utf-8
 end_of_line = lf
-max_line_length = 78
+max_line_length = 117
 
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
https://github.com/celery/celery/blob/master/setup.cfg#L9 I think these two values should be identical.