### PR TITLE
Silence backend warning when eager results are stored

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -569,9 +569,10 @@ class Backend:
             pass
 
     def _ensure_not_eager(self):
-        if self.app.conf.task_always_eager:
+        if self.app.conf.task_always_eager and not self.app.conf.task_store_eager_result:
             warnings.warn(
-                "Shouldn't retrieve result with task_always_eager enabled.",
+                "Results are not stored in backend and should not be retrieved when "
+                "task_always_eager is enabled, unless task_store_eager_result is enabled.",
                 RuntimeWarning
             )
 


### PR DESCRIPTION


## Description

When task_always_eager is enabled, the backend issues a warning when trying to get task data, This cancels this warning in case task_store_eager_result is enabled as well.

This began with #2275, and closed in c71cd08 (later changed from an error to a warning), but v5.1 introduced `task_store_eager_result ` and this wasn't updated.
