### PR TITLE
Fix TypeError when retrying

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -28,6 +28,7 @@ from celery.utils.collections import AttributeDictMixin
 from celery.utils.dispatch import Signal
 from celery.utils.functional import first, head_from_fun, maybe_list
 from celery.utils.imports import gen_task_name, instantiate, symbol_by_name
+from celery.utils.iso8601 import parse_iso8601
 from celery.utils.log import get_logger
 from celery.utils.objects import FallbackContext, mro_lookup
 from celery.utils.time import maybe_make_aware, timezone, to_utc
@@ -730,10 +731,12 @@ class Celery:
         options = router.route(
             options, route_name or name, args, kwargs, task_type)
         if expires is not None:
-            if isinstance(expires, datetime):
-                expires_s = (maybe_make_aware(expires) - self.now()).total_seconds()
+            if isinstance(expires, str):
+                expires_s = parse_iso8601(expires)
             else:
                 expires_s = expires
+            if isinstance(expires_s, datetime):
+                expires_s = (maybe_make_aware(expires_s) - self.now()).total_seconds()
 
             if expires_s < 0:
                 logger.warning(


### PR DESCRIPTION
## Description

Fixes the issue reported in https://github.com/celery/celery/discussions/7255

I haven't been able to figure our where the empty string comes from or how to reproduce it deterministically however I regularly see the below traceback. Adding debug printout shows that `expires_s` is an empty string.

```python
  File "/lhcbdev_miniconda/installations/1643967484628291341/envs/lbtaskrun-env/lib/python3.9/site-packages/lbtaskrun/cvmfs/transaction.py", line 217, in __enter__
    raise celery.current_task.retry(countdown=30)
  File "/lhcbdev_miniconda/installations/1643967484628291341/envs/lbtaskrun-env/lib/python3.9/site-packages/celery/app/task.py", line 736, in retry
    raise Reject(exc, requeue=False)
celery.exceptions.Reject: (TypeError("'<' not supported between instances of 'str' and 'int'"), False)
ESC[1;33m2022-02-04 13:28:18,160 - 73e4bc71-30b5-4a59-9ad0-0335196544e6 - lhcbtest_install_nightly - celery.app.trace - WARNING - Task lhcbtest_install_nightly[73e4bc71-30b5-4a59-9ad0-0335196544e6] reject requeue=False: '<' not supported betw
een instances of 'str' and 'int'
Traceback (most recent call last):
  File "/lhcbdev_miniconda/installations/1643967484628291341/envs/lbtaskrun-env/lib/python3.9/site-packages/celery/app/task.py", line 734, in retry
    S.apply_async()
  File "/lhcbdev_miniconda/installations/1643967484628291341/envs/lbtaskrun-env/lib/python3.9/site-packages/celery/canvas.py", line 219, in apply_async
    return _apply(args, kwargs, **options)
  File "/lhcbdev_miniconda/installations/1643967484628291341/envs/lbtaskrun-env/lib/python3.9/site-packages/celery/app/task.py", line 575, in apply_async
    return app.send_task(
  File "/lhcbdev_miniconda/installations/1643967484628291341/envs/lbtaskrun-env/lib/python3.9/site-packages/celery/app/base.py", line 741, in send_task
    if expires_s < 0:
TypeError: '<' not supported between instances of 'str' and 'int'
```