### PR TITLE
Fix: Celery beat sleeps 300 seconds sometimes even when it should run a task within a few seconds (e.g. 13 seconds) #7290

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -22,6 +22,7 @@ from kombu.utils.objects import cached_property
 from . import __version__, platforms, signals
 from .exceptions import reraise
 from .schedules import crontab, maybe_schedule
+from .utils.functional import is_numeric_value
 from .utils.imports import load_extension_class_names, symbol_by_name
 from .utils.log import get_logger, iter_open_logger_fds
 from .utils.time import humanize_seconds, maybe_make_aware
@@ -361,7 +362,9 @@ class Scheduler:
             else:
                 heappush(H, verify)
                 return min(verify[0], max_interval)
-        return min(adjust(next_time_to_run) or max_interval, max_interval)
+        adjusted_next_time_to_run = adjust(next_time_to_run)
+        return min(adjusted_next_time_to_run if is_numeric_value(adjusted_next_time_to_run) else max_interval,
+                   max_interval)
 
     def schedules_equal(self, old_schedules, new_schedules):
         if old_schedules is new_schedules is None:

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -389,3 +389,7 @@ def seq_concat_seq(a, b):
     if not isinstance(b, prefer):
         b = prefer(b)
     return a + b
+
+
+def is_numeric_value(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool)

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -164,6 +164,7 @@ class mocked_schedule(schedule):
 
 always_due = mocked_schedule(True, 1)
 always_pending = mocked_schedule(False, 1)
+always_pending_left_10_milliseconds = mocked_schedule(False, 0.01)
 
 
 class test_Scheduler:
@@ -353,6 +354,12 @@ class test_Scheduler:
         scheduler.add(name='test_pending_tick',
                       schedule=always_pending)
         assert scheduler.tick() == 1 - 0.010
+
+    def test_pending_left_10_milliseconds_tick(self):
+        scheduler = mScheduler(app=self.app)
+        scheduler.add(name='test_pending_left_10_milliseconds_tick',
+                      schedule=always_pending_left_10_milliseconds)
+        assert scheduler.tick() == 0.010 - 0.010
 
     def test_honors_max_interval(self):
         scheduler = mScheduler(app=self.app)

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -6,7 +6,7 @@ from kombu.utils.functional import lazy
 
 from celery.utils.functional import (DummyContext, first, firstmethod, fun_accepts_kwargs, fun_takes_argument,
                                      head_from_fun, lookahead, maybe_list, mlazy, padlist, regen, seq_concat_item,
-                                     seq_concat_seq)
+                                     seq_concat_seq, is_numeric_value)
 
 
 def test_DummyContext():
@@ -471,3 +471,20 @@ class test_fun_accepts_kwargs:
     ])
     def test_rejects(self, fun):
         assert not fun_accepts_kwargs(fun)
+
+
+@pytest.mark.parametrize('value,expected', [
+    (5, True),
+    (5.0, True),
+    (0, True),
+    (0.0, True),
+    (True, False),
+    ('value', False),
+    ('5', False),
+    ('5.0', False),
+    (None, False),
+])
+def test_is_numeric_value(value, expected):
+    res = is_numeric_value(value)
+    assert type(res) is type(expected)
+    assert res == expected

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -5,8 +5,8 @@ import pytest_subtests  # noqa: F401
 from kombu.utils.functional import lazy
 
 from celery.utils.functional import (DummyContext, first, firstmethod, fun_accepts_kwargs, fun_takes_argument,
-                                     head_from_fun, lookahead, maybe_list, mlazy, padlist, regen, seq_concat_item,
-                                     seq_concat_seq, is_numeric_value)
+                                     head_from_fun, is_numeric_value, lookahead, maybe_list, mlazy, padlist, regen,
+                                     seq_concat_item, seq_concat_seq)
 
 
 def test_DummyContext():


### PR DESCRIPTION
Fixes the issue reported in #7290 
