### PR TITLE
worker: Fix warm shutdown hanging due to timing of signal handler

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -19,7 +19,6 @@ from kombu.utils.encoding import safe_str
 
 from celery import VERSION_BANNER, platforms, signals
 from celery.app import trace
-from celery.exceptions import WorkerShutdown, WorkerTerminate
 from celery.loaders.app import AppLoader
 from celery.platforms import EX_FAILURE, EX_OK, check_privileges, isatty
 from celery.utils import static, term
@@ -280,7 +279,7 @@ class Worker(WorkController):
 
 
 def _shutdown_handler(worker, sig='TERM', how='Warm',
-                      exc=WorkerShutdown, callback=None, exitcode=EX_OK):
+                      callback=None, exitcode=EX_OK):
     def _handle_request(*args):
         with in_sighandler():
             from celery.worker import state
@@ -292,27 +291,24 @@ def _shutdown_handler(worker, sig='TERM', how='Warm',
                     sender=worker.hostname, sig=sig, how=how,
                     exitcode=exitcode,
                 )
-            if active_thread_count() > 1:
-                setattr(state, {'Warm': 'should_stop',
-                                'Cold': 'should_terminate'}[how], exitcode)
-            else:
-                raise exc(exitcode)
+            setattr(state, {'Warm': 'should_stop',
+                            'Cold': 'should_terminate'}[how], exitcode)
     _handle_request.__name__ = str(f'worker_{how}')
     platforms.signals[sig] = _handle_request
 
 
 if REMAP_SIGTERM == "SIGQUIT":
     install_worker_term_handler = partial(
-        _shutdown_handler, sig='SIGTERM', how='Cold', exc=WorkerTerminate, exitcode=EX_FAILURE,
+        _shutdown_handler, sig='SIGTERM', how='Cold', exitcode=EX_FAILURE,
     )
 else:
     install_worker_term_handler = partial(
-        _shutdown_handler, sig='SIGTERM', how='Warm', exc=WorkerShutdown,
+        _shutdown_handler, sig='SIGTERM', how='Warm',
     )
 
 if not is_jython:  # pragma: no cover
     install_worker_term_hard_handler = partial(
-        _shutdown_handler, sig='SIGQUIT', how='Cold', exc=WorkerTerminate,
+        _shutdown_handler, sig='SIGQUIT', how='Cold',
         exitcode=EX_FAILURE,
     )
 else:  # pragma: no cover


### PR DESCRIPTION
## Description

My company has been experiencing a persistent issue with our Django/Celery/RabbitMQ instances; there is a 1 in 1000 chance the Celery worker MainProcess would hang during a warm shutdown while flushing the transport and require a SIGKILL, with no errors and no discernable relation to the type or duration of work. As we rely on acks_late, this means the ACK for the final job was not being sent to RabbitMQ and that work is performed a second time. Of course, the occurrences multiplied with the number of workers, meaning duplicate jobs would crop up several times an hour.

We've managed to isolate and trace it through after plastering the code with debug statements and drop testing the Celery worker hundreds of thousands of times. The issue is that the AMQP transport can be left in an undefined state once the warm shutdown is signalled. An example: 
- Celery worker is running normally, in the middle of running a job on the ForkPoolWorker thread
- The transport fetches 7 bytes of a header from the AMQP socket
- At that instant, Docker sends a SIGTERM to turn off the worker, as part of normal load balancing activity
- Celery worker drops everything (???) and starts a warm shutdown
- Celery reaches the "Stopping Heart" step of the warm shutdown and tries to flush the AMQP transport
- The transport fetches 7 bytes from the AMQP socket; except it's not a header, it's now the payload of the previous unread packet
- But the data is interpreted as a header, and the payload size component is read as 0x50000000
- The transport tries to fetch 1.3GB of payload from the AMQP socket
- MainProcess hangs
- After a 5 minute grace period Docker SIGKILLs the worker

Given the modus of the bug, this could happen with any of the backends and not just AMQP. No active jobs are required to trigger this failure state. Based on the date of [this commit](https://github.com/celery/celery/commit/381dec4f44b8edfc47c2b479177aad9000b7f938), this would affect every version of Celery since 4.4.0rc1.

The solution has been to make the signal handler always raise a state change, and never throw an exception. I don't think there's any safe way of throwing an exception in the signal handler, you can't guarantee that the code can survive being interrupted. At a guess this appears to have been added back in 2012 as a speedup for a single-threaded worker case?

As an aside; this took nearly two months to debug and patch. The process was made very difficult by Celery's inscrutible use of callbacks, the absence of type hints, and the regularity of classes modifying other classes. I don't wish to talk down the hard work of the Celery team, but this experience has certainly convinced me that there's a substantial risk involved with remaining on Celery.

## Steps to Reproduce

In py-amqp/amqp/transport/transport.py, make the following modification:

```
diff --git a/amqp/transport.py b/amqp/transport.py
index b5a0d4b..bfde74c 100644
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -2,10 +2,12 @@
 # Copyright (C) 2009 Barry Pederson <bp@barryp.org>
 
 import errno
+import logging
 import os
 import re
 import socket
 import ssl
+import time
 from contextlib import contextmanager
 from ssl import SSLError
 from struct import pack, unpack
@@ -16,6 +18,7 @@ from .utils import set_cloexec
 
 _UNAVAIL = {errno.EAGAIN, errno.EINTR, errno.ENOENT, errno.EWOULDBLOCK}
 
+AMQP_LOGGER = logging.getLogger('amqp')
 AMQP_PORT = 5672
 
 EMPTY_BUFFER = bytes()
@@ -326,6 +329,11 @@ class _AbstractTransport:
             frame_header = read(7, True)
             read_frame_buffer += frame_header
             frame_type, channel, size = unpack('>BHI', frame_header)
+
+            AMQP_LOGGER.debug("Frame header just read, throw a SIGTERM now!")
+            time.sleep(2)
+            AMQP_LOGGER.debug(f"Missed, continuing! Next payload is {size} bytes big")
+
             # >I is an unsigned int, but the argument to sock.recv is signed,
             # so we know the size can be at most 2 * SIGNED_INT_MAX
             if size > SIGNED_INT_MAX:
```
Start up a single instance of a Celery worker with debug logging enabled and concurrency=1:

```
/vp/bin/celery -A [django_app_name] worker -l debug -P prefork --without-mingle --without-gossip -Ofair --concurrency=1 --task-events --queues=automation
```
Wait for the worker to start up, then following one of the cues given by the debug text, send a SIGTERM to the worker.


## Expected Behavior
The AMQP transport should finish reading the payload, and on the next loop of MainProcess the worker should begin a warm shutdown.

## Actual Behavior
The signal handler throws an exception, which interrupts reading from the AMQP transport. Once the worker tries to use that transport again, it will read the unread payload from the previous packet as a header, get e.g. 0x50000000 for payload size, and hang while attempting to read 1.3GB data from the socket.