### PR TITLE
update website url in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp| |ocbackerbadge| |ocsponsorbadge|
 
 :Version: 5.2.3 (dawn-chorus)
-:Web: https://docs.celeryproject.org/en/stable/index.html
+:Web: https://docs.celeryq.dev/en/stable/index.html
 :Download: https://pypi.org/project/celery/
 :Source: https://github.com/celery/celery/
 :Keywords: task, queue, job, async, rabbitmq, amqp, redis,


### PR DESCRIPTION
A new website url is on GitHub repo's sidebar, but README shows old one. This PR changes README to be consistent with sidebar