### PR TITLE
Extend cassandra to cover AstraDB as well

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1170,7 +1170,7 @@ that require third-party libraries must be added.
 
     .. code-block:: console
 
-        $ pip install -U requirements/pkgutils.txt
+        $ pip install -U -r requirements/pkgutils.txt
         $ make readme
 
 

--- a/README.rst
+++ b/README.rst
@@ -307,7 +307,7 @@ Transports and Backends
     for using Memcached as a result backend (pure-Python implementation).
 
 :``celery[cassandra]``:
-    for using Apache Cassandra as a result backend with DataStax driver.
+    for using Apache Cassandra/Astra DB as a result backend with DataStax driver.
 
 :``celery[azureblockblob]``:
     for using Azure Storage as a result backend (using ``azure-storage``)

--- a/README.rst
+++ b/README.rst
@@ -307,7 +307,7 @@ Transports and Backends
     for using Memcached as a result backend (pure-Python implementation).
 
 :``celery[cassandra]``:
-    for using Apache Cassandra/Astra DB as a result backend with DataStax driver.
+    for using Apache Cassandra/Astra DB as a result backend with the DataStax driver.
 
 :``celery[azureblockblob]``:
     for using Azure Storage as a result backend (using ``azure-storage``)

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -114,6 +114,7 @@ NAMESPACES = Namespace(
         port=Option(type='string'),
         read_consistency=Option(type='string'),
         servers=Option(type='list'),
+        bundle_path=Option(type='string'),
         table=Option(type='string'),
         write_consistency=Option(type='string'),
         auth_provider=Option(type='string'),

--- a/docs/includes/installation.txt
+++ b/docs/includes/installation.txt
@@ -77,7 +77,7 @@ Transports and Backends
     for using Memcached as a result backend (pure-Python implementation).
 
 :``celery[cassandra]``:
-    for using Apache Cassandra as a result backend with DataStax driver.
+    for using Apache Cassandra/Astra DB as a result backend with DataStax driver.
 
 :``celery[couchbase]``:
     for using Couchbase as a result backend.

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1315,7 +1315,7 @@ used by the redis result backend.
 .. _conf-cassandra-result-backend:
 
 Cassandra/AstraDB backend settings
---------------------------
+----------------------------------
 
 .. note::
 
@@ -1354,7 +1354,7 @@ to :setting:`cassandra_secure_bundle_path`. Example::
 .. setting:: cassandra_secure_bundle_path
 
 ``cassandra_secure_bundle_path``
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Default: None.
 
@@ -1475,7 +1475,7 @@ Named arguments to pass into the ``cassandra.cluster`` class.
     }
 
 Example configuration (Cassandra)
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
@@ -1488,7 +1488,7 @@ Example configuration (Cassandra)
     cassandra_entry_ttl = 86400
 
 Example configuration (Astra DB)
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1387,7 +1387,7 @@ Port to contact the Cassandra servers on.
 
 Default: None.
 
-The key-space in which to store the results. For example::
+The keyspace in which to store the results. For example::
 
     cassandra_keyspace = 'tasks_keyspace'
 
@@ -1504,6 +1504,54 @@ Example configuration (Astra DB)
     }
     cassandra_secure_bundle_path = '/path/to/secure-connect-bundle.zip'
     cassandra_entry_ttl = 86400
+
+Additional configuration
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Cassandra driver, when estabilishing the connection, undergoes a stage
+of negotiating the protocol version with the server(s). Similarly,
+a load-balancing policy is automatically supplied (by default
+``DCAwareRoundRobinPolicy``, which in turn has a ``local_dc`` setting, also
+determined by the driver upon connection).
+When possible, one should explicitly provide these in the configuration:
+moreover, future versions of the Cassandra driver will require at least the
+load-balancing policy to be specified (using `execution profiles <https://docs.datastax.com/en/developer/python-driver/3.25/execution_profiles/>`_,
+as shown below).
+
+A full configuration for the Cassandra backend would thus have the
+following additional lines:
+
+.. code-block:: python
+
+    from cassandra.policies import DCAwareRoundRobinPolicy
+    from cassandra.cluster import ExecutionProfile
+    from cassandra.cluster import EXEC_PROFILE_DEFAULT
+    myEProfile = ExecutionProfile(
+      load_balancing_policy=DCAwareRoundRobinPolicy(
+        local_dc='datacenter1', # replace with your DC name
+      )
+    )
+    cassandra_options = {
+      'protocol_version': 5,    # for Cassandra 4, change if needed
+      'execution_profiles': {EXEC_PROFILE_DEFAULT: myEProfile},
+    }
+
+And similarly for Astra DB:
+
+.. code-block:: python
+
+    from cassandra.policies import DCAwareRoundRobinPolicy
+    from cassandra.cluster import ExecutionProfile
+    from cassandra.cluster import EXEC_PROFILE_DEFAULT
+    myEProfile = ExecutionProfile(
+      load_balancing_policy=DCAwareRoundRobinPolicy(
+        local_dc='europe-west1',  # for Astra DB, region name = dc name
+      )
+    )
+    cassandra_options = {
+      'protocol_version': 4,      # for Astra DB
+      'execution_profiles': {EXEC_PROFILE_DEFAULT: myEProfile},
+    }
 
 .. _conf-s3-result-backend:
 

--- a/requirements/extras/cassandra.txt
+++ b/requirements/extras/cassandra.txt
@@ -1,1 +1,1 @@
-cassandra-driver<3.21.0
+cassandra-driver==3.24.0

--- a/requirements/extras/cassandra.txt
+++ b/requirements/extras/cassandra.txt
@@ -1,1 +1,1 @@
-cassandra-driver==3.24.0
+cassandra-driver~=3.24.0

--- a/requirements/extras/cassandra.txt
+++ b/requirements/extras/cassandra.txt
@@ -1,1 +1,1 @@
-cassandra-driver~=3.24.0
+cassandra-driver>=3.24.0,<4

--- a/t/unit/backends/test_cassandra.py
+++ b/t/unit/backends/test_cassandra.py
@@ -53,9 +53,19 @@ class test_CassandraBackend:
         cons.LOCAL_FOO = 'bar'
         mod.CassandraBackend(app=self.app)
 
-        # no servers raises ImproperlyConfigured
+        # no servers and no bundle_path raises ImproperlyConfigured
         with pytest.raises(ImproperlyConfigured):
             self.app.conf.cassandra_servers = None
+            self.app.conf.cassandra_secure_bundle_path = None
+            mod.CassandraBackend(
+                app=self.app, keyspace='b', column_family='c',
+            )
+
+        # both servers no bundle_path raises ImproperlyConfigured
+        with pytest.raises(ImproperlyConfigured):
+            self.app.conf.cassandra_servers = ['localhost']
+            self.app.conf.cassandra_secure_bundle_path = (
+                '/home/user/secure-connect-bundle.zip')
             mod.CassandraBackend(
                 app=self.app, keyspace='b', column_family='c',
             )


### PR DESCRIPTION
## Description

Extension of the Cassandra backend to support Astra DB instances
(a 100% Cassandra-compatible DBaaS).

Astra DB is a managed solution built on Cassandra; as such, the
`cassandra-driver` package, once bumped to a slightly higher version,
is all is needed.

This PR implements the little change needed to support the (slightly different)
way the DB session is created on Astra DB and the related backend documentation.
A small change in the unit test has been done as well.

#### Connection

While a regular Cassandra requires one or more hostnames/addresses for
the connection (parameter `cassandra_servers` in the celeryconfig), for Astra DB
a zip file must be provided, containing proxy information and certificates.
The modified `cassandra.py` backend code accepts either, and initializes the
connection to the database accordingly.

Connecting to Astra DB requires version at least 3.24 of `cassandra-driver`,
hence the requirements file was bumped to that (`==3.24.0`).

#### Documentation

The documentation has been updated to reflect that exactly one of the
two parameters `cassandra_servers` or `cassandra_secure_bundle_path`
should be provided to the backend, and the existing
example celeryconfig has been made into two separate ones for ease of reference.

Building the documentation with the Docker command given
[here](https://github.com/celery/celery/blob/master/CONTRIBUTING.rst#build-the-documentation-using-docker)
would not re-inspect the source code, so I resorted to my environment and did `make html`,
which also refreshed the source code as part of the docs.

## Checklist for this PR

I tried to follow the checklist for submissions described in
`CONTRIBUTING.rst` but could not complete some of the suggested steps.
For some reason, the `docker-compose` way of running tests suggested would
error with `make: python: No such file or directory`, so I turned to
my own environment. I worked in a virtualenv, specifically with Python3.9,
but the kind of changes introduced with this PR would hardly have any impact
elsewhere in the codebase.

Contrary to the instructions [here](https://github.com/celery/celery/blob/master/CONTRIBUTING.rst#contributing-features-requiring-additional-libraries),
I did **not** regenerate the README with `pip install -U requirements/pkgutils.txt; make readme`,
since that seemed to overwrite what looked largely like a manually-curated readme file.

I apologize for the steps I could not complete, hoping those would not be
a blocker for a possible merge.

And now, for each of the checkboxes in the "what to do before a PR" list
[here](https://github.com/celery/celery/blob/master/CONTRIBUTING.rst#creating-pull-requests):

#### New tests

No new features. Added small things to test the both-settings-should-throw-error
case, as well as no-settings-should-throw-error.

#### Unit test coverage does not decrease

On this branch it says 87%, last value by codecov (currently March 9)
says 89.31%, but running the calculation on live `master` also gives 87%.
I take this to mean "did not decrease with this branch".

#### Pre-commit

Ok.

#### Build docs

`make apicheck` fails after giving a few warnings, and so do the `tox -e apicheck` and the `sphinx-build` commands.
But the `make html` mentioned [earlier](https://github.com/celery/celery/blob/master/CONTRIBUTING.rst#building-the-documentation)
in CONTRIBUTING.rst works fine.

#### Build configcheck

I get a series of makefile errors (broken refs in index.rst) and rst syntax warnings.
Also I get `InvocationError`s with sphinx-build.

#### Bandit

`bandit -b bandit.json celery/` fails (finds zero lines to inspect).

The tox invocation lists a lot of issues with mostly low severity and two with "medium" severity (`pickle` and use of `exec`). This is surely not due to the code from this PR.

#### Unit/integration tests for all Pythons

I could not run integration test at all, in any way. The test hang up for hours
(is that expected? Do I have to spin up containers to provide backends or so?).
As said above I have other problems with doing everything in Docker.

Using `tox` I get a lot of problems for most python versions
(`ERROR: could not install deps [...` and `ERROR: invocation failed (exit code 1), logfile: [...]`).

Output of `tox -v` (in my own environment, not Docker):
```
ERROR:  3.10-integration-rabbitmq: InterpreterNotFound: python3.10
ERROR:  3.10-integration-redis: InterpreterNotFound: python3.10
ERROR:  3.10-integration-dynamodb: InterpreterNotFound: python3.10
ERROR:  3.10-integration-azureblockblob: InterpreterNotFound: python3.10
ERROR:  3.10-integration-cache: InterpreterNotFound: python3.10
ERROR:  3.10-integration-cassandra: InterpreterNotFound: python3.10
ERROR:  3.10-integration-elasticsearch: InterpreterNotFound: python3.10
ERROR:  pypy3-integration-rabbitmq: InterpreterNotFound: pypy3
ERROR:  pypy3-integration-redis: InterpreterNotFound: pypy3
ERROR:  pypy3-integration-dynamodb: InterpreterNotFound: pypy3
ERROR:  pypy3-integration-azureblockblob: InterpreterNotFound: pypy3
ERROR:  pypy3-integration-cache: InterpreterNotFound: pypy3
ERROR:  pypy3-integration-cassandra: InterpreterNotFound: pypy3
ERROR:  pypy3-integration-elasticsearch: InterpreterNotFound: pypy3
ERROR:  flake8: InterpreterNotFound: 
ERROR:   apicheck: commands failed
ERROR:   configcheck: commands failed
ERROR:   bandit: commands failed
```

Honestly, at the moment I had to skip testing (sorry); most likely nothing
in the test would be affected by the contents of this PR.

#### isort

I'm not sure what to conclude from this. `isort my_module.py --diff`
gives: `Broken 1 paths`, but I don't have touched any import. I guess
`master` would yield the same.

#### Miscellanea

`make flakecheck` gives errors that seem clearly unrelated
to this PR. Also `make flakes` errors out with an issue of
trying to use `iteritems()` under Python 2.7.
