### PR TITLE
doc: fix broken reference to schedule.is_due method

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -156,7 +156,7 @@ class ScheduleEntry:
         })
 
     def is_due(self):
-        """See :meth:`~celery.schedule.schedule.is_due`."""
+        """See :meth:`~celery.schedules.schedule.is_due`."""
         return self.schedule.is_due(self.last_run_at)
 
     def __iter__(self):


### PR DESCRIPTION
Signed-off-by: Oleg Hoefling <oleg.hoefling@gmail.com>

## Description

The reference to ``celery.schedule.schedule.is_due()`` is broken in current docs -- this PR amends that. No changes to code whatsoever, purely a documentation fix.