### PR TITLE
Ensure expiration is of float type when migrating tasks

### DIFF
--- a/celery/contrib/migrate.py
+++ b/celery/contrib/migrate.py
@@ -73,7 +73,8 @@ def republish(producer, message, exchange=None, routing_key=None,
     producer.publish(ensure_bytes(body), exchange=exchange,
                      routing_key=routing_key, compression=compression,
                      headers=headers, content_type=ctype,
-                     content_encoding=enc, **props)
+                     content_encoding=enc, expiration=expiration,
+                     **props)
 
 
 def migrate_task(producer, body_, message, queues=None):

--- a/celery/contrib/migrate.py
+++ b/celery/contrib/migrate.py
@@ -62,6 +62,10 @@ def republish(producer, message, exchange=None, routing_key=None,
     # remove compression header, as this will be inserted again
     # when the message is recompressed.
     compression = headers.pop('compression', None)
+    
+    expiration = props.pop('expiration', None)
+    # ensure expiration is a float
+    expiration = float(expiration) if expiration is not None else None
 
     for key in remove_props:
         props.pop(key, None)

--- a/celery/contrib/migrate.py
+++ b/celery/contrib/migrate.py
@@ -62,7 +62,7 @@ def republish(producer, message, exchange=None, routing_key=None,
     # remove compression header, as this will be inserted again
     # when the message is recompressed.
     compression = headers.pop('compression', None)
-    
+
     expiration = props.pop('expiration', None)
     # ensure expiration is a float
     expiration = float(expiration) if expiration is not None else None


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
This fixes a subtle bug when migrating tasks with `expiration` set from Redis to RabbitMQ broker. The issue is that message properties contain expiration value as a `str` and not a `float` which is expected by the `kombu.messaging.Producer.publish`. This causes a bug where expiration value is multiplied by `1000` (to convert to miliseconds) and this means a string is multiplied 1000x times, e.g.:
```python
expiration = "3000"

# from kombu/messaging.py:163
if expiration is not None:
    properties['expiration'] = str(int(expiration * 1000))

assert len(expiration) == 4000
assert expiration.startswith("3000300030003000")
```

