### PR TITLE
Annotate `celery/security/certificate.py`

### DIFF
--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 import glob
 import os
-from typing import TYPE_CHECKING, Dict, Iterator, Union
+from typing import TYPE_CHECKING, Iterator
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
@@ -70,7 +70,7 @@ class Certificate:
                 mgf=padding.MGF1(digest),
                 salt_length=padding.PSS.MAX_LENGTH)
 
-            self.get_pubkey().verify(signature, ensure_bytes(data), padd, digest)
+            self.get_pubkey().verify(signature, ensure_bytes(data), pad, digest)
 
 
 class CertStore:

--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -2,6 +2,7 @@
 import datetime
 import glob
 import os
+from typing import TYPE_CHECKING, Dict, Iterator, Union
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
@@ -12,13 +13,23 @@ from celery.exceptions import SecurityError
 
 from .utils import reraise_errors
 
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.dsa import DSAPublicKey
+    from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
+    from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PublicKey
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+    from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+    from cryptography.hazmat.primitives.hashes import HashAlgorithm
+
+
 __all__ = ('Certificate', 'CertStore', 'FSCertStore')
 
 
 class Certificate:
     """X.509 certificate."""
 
-    def __init__(self, cert):
+    def __init__(self, cert: str):
         with reraise_errors(
             'Invalid certificate: {0!r}', errors=(ValueError,)
         ):
@@ -28,27 +39,28 @@ class Certificate:
             if not isinstance(self._cert.public_key(), rsa.RSAPublicKey):
                 raise ValueError("Non-RSA certificates are not supported.")
 
-    def has_expired(self):
+    def has_expired(self) -> bool:
         """Check if the certificate has expired."""
         return datetime.datetime.utcnow() >= self._cert.not_valid_after
 
-    def get_pubkey(self) -> rsa.RSAPublicKey:
-        """Get public key from certificate. Public key type is checked in __init__."""
+    def get_pubkey(self) -> Union[
+        "DSAPublicKey", "EllipticCurvePublicKey", "Ed448PublicKey", "Ed25519PublicKey", "RSAPublicKey"
+    ]:
         return self._cert.public_key()
 
-    def get_serial_number(self):
+    def get_serial_number(self) -> int:
         """Return the serial number in the certificate."""
         return self._cert.serial_number
 
-    def get_issuer(self):
+    def get_issuer(self) -> str:
         """Return issuer (CA) as a string."""
         return ' '.join(x.value for x in self._cert.issuer)
 
-    def get_id(self):
+    def get_id(self) -> str:
         """Serial number/issuer pair uniquely identifies a certificate."""
         return f'{self.get_issuer()} {self.get_serial_number()}'
 
-    def verify(self, data, signature, digest):
+    def verify(self, data: bytes, signature: bytes, digest: Union["HashAlgorithm", "Prehashed"]) -> None:
         """Verify signature for string containing data."""
         with reraise_errors('Bad signature: {0!r}'):
 
@@ -56,28 +68,27 @@ class Certificate:
                 mgf=padding.MGF1(digest),
                 salt_length=padding.PSS.MAX_LENGTH)
 
-            self.get_pubkey().verify(signature,
-                                     ensure_bytes(data), pad, digest)
+            self.get_pubkey().verify(signature, ensure_bytes(data), padd, digest)
 
 
 class CertStore:
     """Base class for certificate stores."""
 
-    def __init__(self):
-        self._certs = {}
+    def __init__(self) -> None:
+        self._certs: Dict[str, Certificate] = {}
 
-    def itercerts(self):
+    def itercerts(self) -> Iterator[Certificate]:
         """Return certificate iterator."""
         yield from self._certs.values()
 
-    def __getitem__(self, id):
+    def __getitem__(self, id: str) -> Certificate:
         """Get certificate by id."""
         try:
             return self._certs[bytes_to_str(id)]
         except KeyError:
             raise SecurityError(f'Unknown certificate: {id!r}')
 
-    def add_cert(self, cert):
+    def add_cert(self, cert: Certificate) -> None:
         cert_id = bytes_to_str(cert.get_id())
         if cert_id in self._certs:
             raise SecurityError(f'Duplicate certificate: {id!r}')
@@ -87,7 +98,7 @@ class CertStore:
 class FSCertStore(CertStore):
     """File system certificate store."""
 
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         super().__init__()
         if os.path.isdir(path):
             path = os.path.join(path, '*')

--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -1,4 +1,6 @@
 """X.509 certificates."""
+from __future__ import annotations
+
 import datetime
 import glob
 import os

--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -45,9 +45,9 @@ class Certificate:
         """Check if the certificate has expired."""
         return datetime.datetime.utcnow() >= self._cert.not_valid_after
 
-    def get_pubkey(self) -> Union[
-        DSAPublicKey, EllipticCurvePublicKey, Ed448PublicKey, Ed25519PublicKey, RSAPublicKey
-    ]:
+    def get_pubkey(self) -> (
+        DSAPublicKey | EllipticCurvePublicKey | Ed448PublicKey | Ed25519PublicKey | RSAPublicKey
+    ):
         return self._cert.public_key()
 
     def get_serial_number(self) -> int:
@@ -62,7 +62,7 @@ class Certificate:
         """Serial number/issuer pair uniquely identifies a certificate."""
         return f'{self.get_issuer()} {self.get_serial_number()}'
 
-    def verify(self, data: bytes, signature: bytes, digest: Union[HashAlgorithm, Prehashed]) -> None:
+    def verify(self, data: bytes, signature: bytes, digest: HashAlgorithm | Prehashed) -> None:
         """Verify signature for string containing data."""
         with reraise_errors('Bad signature: {0!r}'):
 

--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -31,7 +31,7 @@ __all__ = ('Certificate', 'CertStore', 'FSCertStore')
 class Certificate:
     """X.509 certificate."""
 
-    def __init__(self, cert: str):
+    def __init__(self, cert: str) -> None:
         with reraise_errors(
             'Invalid certificate: {0!r}', errors=(ValueError,)
         ):

--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -46,7 +46,7 @@ class Certificate:
         return datetime.datetime.utcnow() >= self._cert.not_valid_after
 
     def get_pubkey(self) -> Union[
-        "DSAPublicKey", "EllipticCurvePublicKey", "Ed448PublicKey", "Ed25519PublicKey", "RSAPublicKey"
+        DSAPublicKey, EllipticCurvePublicKey, Ed448PublicKey, Ed25519PublicKey, RSAPublicKey
     ]:
         return self._cert.public_key()
 
@@ -62,7 +62,7 @@ class Certificate:
         """Serial number/issuer pair uniquely identifies a certificate."""
         return f'{self.get_issuer()} {self.get_serial_number()}'
 
-    def verify(self, data: bytes, signature: bytes, digest: Union["HashAlgorithm", "Prehashed"]) -> None:
+    def verify(self, data: bytes, signature: bytes, digest: Union[HashAlgorithm, Prehashed]) -> None:
         """Verify signature for string containing data."""
         with reraise_errors('Bad signature: {0!r}'):
 
@@ -77,7 +77,7 @@ class CertStore:
     """Base class for certificate stores."""
 
     def __init__(self) -> None:
-        self._certs: Dict[str, Certificate] = {}
+        self._certs: dict[str, Certificate] = {}
 
     def itercerts(self) -> Iterator[Certificate]:
         """Return certificate iterator."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ files = [
     "celery/states.py",
     "celery/signals.py",
     "celery/fixups",
-    "celery/concurrency/thread.py"
+    "celery/concurrency/thread.py",
+    "celery/security/certificate.py",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
- Related to #7394

I've disabled `warn_return_any`, as it was not intended to be included in the configuration. Also, there are some issues with it: https://github.com/python/mypy/issues/5697. In this file, there were some comparison (`__eq__` and `__gt__`) that caused the issue.