### PR TITLE
Annotate `celery/security`

### DIFF
--- a/celery/security/__init__.py
+++ b/celery/security/__init__.py
@@ -1,5 +1,5 @@
 """Message Signing Serializer."""
-from typing import TYPE_CHECKING, Iterable, Literal, Optional
+from typing import TYPE_CHECKING, Iterable, Optional
 
 from kombu.serialization import disable_insecure_serializers as _disable_insecure_serializers
 from kombu.serialization import registry
@@ -9,7 +9,14 @@ from celery.exceptions import ImproperlyConfigured
 from .serialization import register_auth  # : need cryptography first
 
 if TYPE_CHECKING:
+    import sys
+
     from celery.app.base import Celery, Settings
+
+    if sys.version_info < (3, 8):
+        from typing_extensions import Literal
+    else:
+        from typing import Literal
 
     _Serializer = Literal["json", "msgpack", "yaml", "pickle"]
 

--- a/celery/security/__init__.py
+++ b/celery/security/__init__.py
@@ -51,7 +51,7 @@ except ImportError:
 def setup_security(allowed_serializers: Optional[Iterable[str]] = None,
                    key: Optional[str] = None, key_password: Optional[str] = None,
                    cert: Optional[str] = None, store: Optional[str] = None,
-                   digest: Optional[str] = None, serializer: _Serializer = 'json',
+                   digest: Optional[str] = None, serializer: "_Serializer" = 'json',
                    app: Optional["Celery"] = None) -> None:
     """See :meth:`@Celery.setup_security`."""
     if app is None:
@@ -80,5 +80,5 @@ def setup_security(allowed_serializers: Optional[Iterable[str]] = None,
     registry._set_default_serializer('auth')
 
 
-def disable_untrusted_serializers(whitelist: Optional[Iterable[_Serializer]] = None) -> None:
+def disable_untrusted_serializers(whitelist: Optional[Iterable["_Serializer"]] = None) -> None:
     _disable_insecure_serializers(allowed=whitelist)

--- a/celery/security/key.py
+++ b/celery/security/key.py
@@ -1,4 +1,7 @@
 """Private keys for the security serializer."""
+from ctypes import Union
+from typing import TYPE_CHECKING, Optional
+
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -6,13 +9,18 @@ from kombu.utils.encoding import ensure_bytes
 
 from .utils import reraise_errors
 
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+    from cryptography.hazmat.primitives.hashes import HashAlgorithm
+
+
 __all__ = ('PrivateKey',)
 
 
 class PrivateKey:
     """Represents a private key."""
 
-    def __init__(self, key, password=None):
+    def __init__(self, key: str, password: Optional[str] = None) -> None:
         with reraise_errors(
             'Invalid private key: {0!r}', errors=(ValueError,)
         ):
@@ -21,7 +29,7 @@ class PrivateKey:
                 password=ensure_bytes(password),
                 backend=default_backend())
 
-    def sign(self, data, digest):
+    def sign(self, data: Union[bytes, str], digest: Union["HashAlgorithm", "Prehashed"]) -> bytes:
         """Sign string containing data."""
         with reraise_errors('Unable to sign data: {0!r}'):
 

--- a/celery/security/key.py
+++ b/celery/security/key.py
@@ -1,6 +1,5 @@
 """Private keys for the security serializer."""
-from ctypes import Union
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization

--- a/celery/security/serialization.py
+++ b/celery/security/serialization.py
@@ -1,5 +1,5 @@
 """Secure serializer."""
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from kombu.serialization import dumps, loads, registry
 from kombu.utils.encoding import bytes_to_str, ensure_bytes, str_to_bytes
@@ -12,6 +12,13 @@ from .key import PrivateKey
 from .utils import get_digest_algorithm, reraise_errors
 
 if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info < (3.8):
+        from typing_extensions import Literal, TypedDict
+    else:
+        from typing import Literal, TypedDict
+
     _Serializer = Literal["json", "msgpack", "yaml", "pickle"]
 
     class _UnpackReturn(TypedDict):

--- a/celery/security/serialization.py
+++ b/celery/security/serialization.py
@@ -1,4 +1,6 @@
 """Secure serializer."""
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict, Union
+
 from kombu.serialization import dumps, loads, registry
 from kombu.utils.encoding import bytes_to_str, ensure_bytes, str_to_bytes
 
@@ -9,21 +11,33 @@ from .certificate import Certificate, FSCertStore
 from .key import PrivateKey
 from .utils import get_digest_algorithm, reraise_errors
 
+if TYPE_CHECKING:
+    _Serializer = Literal["json", "msgpack", "yaml", "pickle"]
+
+    class _UnpackReturn(TypedDict):
+        signer: bytes
+        signature: bytes
+        content_type: str
+        content_encoding: str
+        body: str
+
+
 __all__ = ('SecureSerializer', 'register_auth')
 
 
 class SecureSerializer:
     """Signed serializer."""
 
-    def __init__(self, key=None, cert=None, cert_store=None,
-                 digest=DEFAULT_SECURITY_DIGEST, serializer='json'):
+    def __init__(self, key: Optional[PrivateKey] = None, cert: Optional[Certificate] = None,
+                 cert_store: Optional[FSCertStore] = None, digest: str = DEFAULT_SECURITY_DIGEST,
+                 serializer: "_Serializer" = 'json'):
         self._key = key
         self._cert = cert
         self._cert_store = cert_store
         self._digest = get_digest_algorithm(digest)
         self._serializer = serializer
 
-    def serialize(self, data):
+    def serialize(self, data: Union[bytes, str]) -> str:
         """Serialize data structure into string."""
         assert self._key is not None
         assert self._cert is not None
@@ -39,7 +53,7 @@ class SecureSerializer:
                               signature=self._key.sign(body, self._digest),
                               signer=self._cert.get_id())
 
-    def deserialize(self, data):
+    def deserialize(self, data: Union[bytes, str]) -> Any:
         """Deserialize data structure from string."""
         assert self._cert_store is not None
         with reraise_errors('Unable to deserialize: {0!r}', (Exception,)):
@@ -51,15 +65,16 @@ class SecureSerializer:
         return loads(bytes_to_str(body), payload['content_type'],
                      payload['content_encoding'], force=True)
 
-    def _pack(self, body, content_type, content_encoding, signer, signature,
-              sep=str_to_bytes('\x00\x01')):
+    def _pack(self, body: bytes, content_type: str, content_encoding: str,
+              signer: Union[bytes, str], signature: Union[bytes, str],
+              sep: bytes = str_to_bytes('\x00\x01')) -> str:
         fields = sep.join(
             ensure_bytes(s) for s in [signer, signature, content_type,
                                       content_encoding, body]
         )
         return b64encode(fields)
 
-    def _unpack(self, payload, sep=str_to_bytes('\x00\x01')):
+    def _unpack(self, payload: Union[bytes, str], sep: bytes = str_to_bytes('\x00\x01')) -> "_UnpackReturn":
         raw_payload = b64decode(ensure_bytes(payload))
         first_sep = raw_payload.find(sep)
 
@@ -88,9 +103,9 @@ class SecureSerializer:
         }
 
 
-def register_auth(key=None, key_password=None, cert=None, store=None,
-                  digest=DEFAULT_SECURITY_DIGEST,
-                  serializer='json'):
+def register_auth(key: Optional[str] = None, key_password: Optional[str] = None,
+                  cert: Optional[str] = None, store: Optional[str] = None, digest: str = DEFAULT_SECURITY_DIGEST,
+                  serializer: "_Serializer" = 'json') -> None:
     """Register security serializer."""
     s = SecureSerializer(key and PrivateKey(key, password=key_password),
                          cert and Certificate(cert),

--- a/celery/security/utils.py
+++ b/celery/security/utils.py
@@ -1,23 +1,27 @@
 """Utilities used by the message signing serializer."""
 import sys
 from contextlib import contextmanager
+from typing import TYPE_CHECKING, Iterable, Iterator, Optional
 
 import cryptography.exceptions
 from cryptography.hazmat.primitives import hashes
 
 from celery.exceptions import SecurityError, reraise
 
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.hashes import HashAlgorithm
+
 __all__ = ('get_digest_algorithm', 'reraise_errors',)
 
 
-def get_digest_algorithm(digest='sha256'):
+def get_digest_algorithm(digest: str = 'sha256') -> HashAlgorithm:
     """Convert string to hash object of cryptography library."""
     assert digest is not None
     return getattr(hashes, digest.upper())()
 
 
 @contextmanager
-def reraise_errors(msg='{0!r}', errors=None):
+def reraise_errors(msg: str = '{0!r}', errors: Optional[Iterable[BaseException]] = None) -> Iterator[None]:
     """Context reraising crypto errors as :exc:`SecurityError`."""
     errors = (cryptography.exceptions,) if errors is None else errors
     try:

--- a/celery/security/utils.py
+++ b/celery/security/utils.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 __all__ = ('get_digest_algorithm', 'reraise_errors',)
 
 
-def get_digest_algorithm(digest: str = 'sha256') -> HashAlgorithm:
+def get_digest_algorithm(digest: str = 'sha256') -> "HashAlgorithm":
     """Convert string to hash object of cryptography library."""
     assert digest is not None
     return getattr(hashes, digest.upper())()

--- a/celery/security/utils.py
+++ b/celery/security/utils.py
@@ -1,7 +1,7 @@
 """Utilities used by the message signing serializer."""
 import sys
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterable, Iterator, Optional
+from typing import TYPE_CHECKING, Iterable, Iterator, Optional, Type
 
 import cryptography.exceptions
 from cryptography.hazmat.primitives import hashes
@@ -21,7 +21,7 @@ def get_digest_algorithm(digest: str = 'sha256') -> HashAlgorithm:
 
 
 @contextmanager
-def reraise_errors(msg: str = '{0!r}', errors: Optional[Iterable[BaseException]] = None) -> Iterator[None]:
+def reraise_errors(msg: str = '{0!r}', errors: Optional[Iterable[Type[BaseException]]] = None) -> Iterator[None]:
     """Context reraising crypto errors as :exc:`SecurityError`."""
     errors = (cryptography.exceptions,) if errors is None else errors
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,5 @@ files = [
     "celery/signals.py",
     "celery/security/key.py",
     "celery/security/serialization.py",
-    "celery/security/utils.py",
     "celery/security/__init__.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,5 @@ files = [
     "celery/states.py",
     "celery/signals.py",
     "celery/security/key.py",
-    "celery/security/serialization.py",
     "celery/security/__init__.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,8 @@ files = [
     "celery/__main__.py",
     "celery/states.py",
     "celery/signals.py",
+    "celery/security/key.py",
+    "celery/security/serialization.py",
+    "celery/security/utils.py",
+    "celery/security/__init__.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ markers = ["sleepdeprived_patched_module", "masked_modules", "patched_environ", 
 [tool.mypy]
 warn_unused_configs = true
 strict = false
-warn_return_any = true
 follow_imports = "skip"
 show_error_codes = true
 disallow_untyped_defs = true


### PR DESCRIPTION
- Related to #7394

I had to remove `utils.py` and `serialization.py` from the `mypy` files, as there are some `mypy` errors that are sensitive i.e. I'd need to implement further changes (which can be considered breaking changes). I don't want to implement breaking changes on annotation PRs, so I'll open separate ones later on. If you want to know which are the sensitive ones I'm mentioning, you just need to add those two files on the `pyproject.toml`, and you'll understand the changes that are needed.