### PR TITLE
Celery set prefetch count on restart

### DIFF
--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -622,9 +622,9 @@ class Consumer:
                 try:
                     ack_log_error_promise = promise(call_soon, (message.ack_log_error,),
                                                     on_error=self._restore_prefetch_count_after_connection_restart)
-                    reject_log_error_promise = promise(call_soon,
-                                                       (message.reject_log_error,),
-                                                       on_error=self._restore_prefetch_count_after_connection_restart)
+                    reject_log_error_promise = \
+                        promise(call_soon, (message.reject_log_error,),
+                                on_error=self._restore_prefetch_count_after_connection_restart)
 
                     if (
                         not self._maximum_prefetch_restored
@@ -649,7 +649,7 @@ class Consumer:
 
         return on_task_received
 
-    def _restore_prefetch_count_after_connection_restart(self, p):
+    def _restore_prefetch_count_after_connection_restart(self, p, *args):
         with self.qos._mutex:
             if self._maximum_prefetch_restored:
                 p.cancel()

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -620,11 +620,16 @@ class Consumer:
                 return on_unknown_task(None, message, exc)
             else:
                 try:
-                    ack_log_error_promise = promise(call_soon, (message.ack_log_error,),
-                                                    on_error=self._restore_prefetch_count_after_connection_restart)
-                    reject_log_error_promise = \
-                        promise(call_soon, (message.reject_log_error,),
-                                on_error=self._restore_prefetch_count_after_connection_restart)
+                    ack_log_error_promise = promise(
+                        call_soon,
+                        (message.ack_log_error,),
+                        on_error=self._restore_prefetch_count_after_connection_restart,
+                    )
+                    reject_log_error_promise = promise(
+                        call_soon,
+                        (message.reject_log_error,),
+                        on_error=self._restore_prefetch_count_after_connection_restart,
+                    )
 
                     if (
                         not self._maximum_prefetch_restored

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -1,7 +1,7 @@
 import errno
 import socket
 from collections import deque
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, call, patch, MagicMock
 
 import pytest
 from billiard.exceptions import RestartFreqExceeded
@@ -94,7 +94,8 @@ class test_Consumer(ConsumerTestCase):
         ]
     )
     @patch('celery.worker.consumer.consumer.active_requests', new_callable=set)
-    def test_restore_prefetch_count_on_restart(self, active_requests_mock, active_requests_count, expected_initial, expected_maximum, subtests):
+    def test_restore_prefetch_count_on_restart(self, active_requests_mock, active_requests_count,
+                                               expected_initial, expected_maximum, subtests):
         reqs = {Mock() for _ in range(active_requests_count)}
         active_requests_mock.update(reqs)
 
@@ -118,9 +119,36 @@ class test_Consumer(ConsumerTestCase):
         with subtests.test(f"initial prefetch count is equal to {expected_initial}"):
             assert c.initial_prefetch_count == expected_initial
 
-        with subtests.test(f"maximum prefetch is reached"):
+        with subtests.test("maximum prefetch is reached"):
             assert c._maximum_prefetch_restored is expected_maximum
 
+    def test_create_task_handler(self, subtests):
+        c = self.get_consumer()
+        c.qos = MagicMock()
+        c.qos.value = 1
+        c._maximum_prefetch_restored = False
+
+        def raise_exception():
+            raise KeyError('Foo')
+
+        def strategy(_, __, ack_log_error_promise, ___, ____):
+            ack_log_error_promise()
+
+        c.strategies = {'strategy': strategy}
+        c.call_soon = raise_exception
+        on_task_received = c.create_task_handler()
+        message = Mock()
+        message.headers = {'task': 'strategy'}
+        on_task_received(message)
+
+        with subtests.test("initial prefetch count is never 0"):
+            assert c.initial_prefetch_count != 0
+
+        with subtests.test("initial prefetch count is 2"):
+            assert c.initial_prefetch_count == 2
+
+        with subtests.test("maximum prefetch is reached"):
+            assert c._maximum_prefetch_restored is True
 
     def test_flush_events(self):
         c = self.get_consumer()

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -293,6 +293,7 @@ class test_Consumer(ConsumerCase):
             yield SyntaxError('bar')
         c = self.NoopConsumer(task_events=False, pool=BasePool())
         c.loop.side_effect = loop_side_effect()
+        c.pool.num_processes = 2
         c.connection_errors = (KeyError,)
         try:
             with pytest.raises(SyntaxError):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
