### PR TITLE
Hotfix: Expose more debugging information when receiving unkown tasks

### DIFF
--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -81,6 +81,12 @@ for more information.
 
 The full contents of the message body was:
 %s
+
+Thw full contents of the message headers:
+%s
+
+The delivery info for this task is:
+%s
 """
 
 #: Error message for when an invalid task message is received.
@@ -511,7 +517,11 @@ class Consumer:
         signals.task_rejected.send(sender=self, message=message, exc=None)
 
     def on_unknown_task(self, body, message, exc):
-        error(UNKNOWN_TASK_ERROR, exc, dump_body(message, body),
+        error(UNKNOWN_TASK_ERROR,
+              exc,
+              dump_body(message, body),
+              message.headers,
+              message.delivery_info,
               exc_info=True)
         try:
             id_, name = message.headers['id'], message.headers['task']


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Since the message might have been delivered to the wrong worker due to a
routing error,
we need to emit the headers and delivery_info when logging the error as
well as the message's body.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
