### PR TITLE
load_extension_class_names - correct module_name

### DIFF
--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -143,7 +143,7 @@ def gen_task_name(app, name, module_name):
 
 def load_extension_class_names(namespace):
     for ep in entry_points().get(namespace, []):
-        yield ep.name, ':'.join([ep.module_name, ep.attrs[0]])
+        yield ep.name, ep.value
 
 
 def load_extension_classes(namespace):


### PR DESCRIPTION
95015a changed over to using importlib rather than pkg_resources,
unfortunately the object is not exactly the same.

Attempting to start up a celery instance with `django-celery-results`
installed results in an exception during `load_extension_class_names`;

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/celery/worker/worker.py", line 203, in start
    self.blueprint.start(self)
  File "/usr/lib/python3.10/site-packages/celery/bootsteps.py", line 112, in start
    self.on_start()
  File "/usr/lib/python3.10/site-packages/celery/apps/worker.py", line 136, in on_start
    self.emit_banner()
  File "/usr/lib/python3.10/site-packages/celery/apps/worker.py", line 170, in emit_banner
    ' \n', self.startup_info(artlines=not use_image))),
  File "/usr/lib/python3.10/site-packages/celery/apps/worker.py", line 232, in startup_info
    results=self.app.backend.as_uri(),
  File "/usr/lib/python3.10/site-packages/celery/app/base.py", line 1252, in backend
    self._local.backend = new_backend = self._get_backend()
  File "/usr/lib/python3.10/site-packages/celery/app/base.py", line 955, in _get_backend
    backend, url = backends.by_url(
  File "/usr/lib/python3.10/site-packages/celery/app/backends.py", line 69, in by_url
    return by_name(backend, loader), url
  File "/usr/lib/python3.10/site-packages/celery/app/backends.py", line 47, in by_name
    aliases.update(load_extension_class_names(extension_namespace))
  File "/usr/lib/python3.10/site-packages/celery/utils/imports.py", line 146, in load_extension_class_names
    yield ep.name, ':'.join([ep.module_name, ep.attrs[0]])
AttributeError: 'EntryPoint' object has no attribute 'module_name'
```

Move over to using the direct value should resolve this issue;

```
>>> from pkg_resources import iter_entry_points
>>> list(iter_entry_points('celery.result_backends'))[0].__dict__
{'name': 'django-cache', 'module_name': 'django_celery_results.backends', 'attrs': ('CacheBackend',), 'extras': (), 'dist': django-celery-results 2.3.0 (/usr/lib/python3.10/site-packages)}
```
vs
```
>>> from importlib.metadata import entry_points
>>> entry_points().get('celery.result_backends')[0]
EntryPoint(name='django-cache', value='django_celery_results.backends:CacheBackend', group='celery.result_backends')
```

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
