### PR TITLE
Update documentation on docs/userguide/application.rst file

### DIFF
--- a/docs/userguide/application.rst
+++ b/docs/userguide/application.rst
@@ -81,7 +81,8 @@ with :meth:`@worker_main`:
     def add(x, y): return x + y
 
     if __name__ == '__main__':
-        app.worker_main()
+        args = ['worker', '--loglevel=INFO']
+        app.worker_main(argv=args)
 
 When this module is executed the tasks will be named starting with "``__main__``",
 but when the module is imported by another process, say to call a task,


### PR DESCRIPTION
## Description

This PR updates the [application](docs/userguide/application.rst) file.
The call to `app.worker_main()` below no longer works without the `argv` argument

```python
from celery import Celery
app = Celery()

@app.task
def add(x, y): return x + y

if __name__ == '__main__':
    app.worker_main()  # <-- It's missing the 'argv' argument
```

So it should look like this:
```python
app.worker_main(argv=['worker', '--loglevel=INFO', '-Q celery', '--autoscale=10,4']) 
```