### PR TITLE
revert celery#5941 so note below makes sense again

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -639,7 +639,7 @@ class Task:
             ...         twitter.post_status_update(message)
             ...     except twitter.FailWhale as exc:
             ...         # Retry in 5 minutes.
-            ...         self.retry(countdown=60 * 5, exc=exc)
+            ...         raise self.retry(countdown=60 * 5, exc=exc)
 
         Note:
             Although the task will never return above as `retry` raises an


### PR DESCRIPTION
## Description

#5941 removed `raise` in the docstring example for `.retry()` but didn't edit the "Note" directly below that explained why the `raise` was there and that it was optional.   This reverts that change so that the docstring makes sense again.  This also [follows the convention that seems to be used several times in the docs](https://docs.celeryq.dev/en/stable/userguide/tasks.html).

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
