### PR TITLE
celeryproject.org links in github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug-Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug-Report.md
@@ -15,7 +15,7 @@ To check an item on the list replace [ ] with [x].
 - [ ] I have verified that the issue exists against the `master` branch of Celery.
 - [ ] This has already been asked to the [discussions forum](https://github.com/celery/celery/discussions) first.
 - [ ] I have read the relevant section in the
-  [contribution guide](http://docs.celeryproject.org/en/latest/contributing.html#other-bugs)
+  [contribution guide](https://docs.celeryq.dev/en/master/contributing.html#other-bugs)
   on reporting bugs.
 - [ ] I have checked the [issues list](https://github.com/celery/celery/issues?q=is%3Aissue+label%3A%22Issue+Type%3A+Bug+Report%22+-label%3A%22Category%3A+Documentation%22)
   for similar or identical bug reports.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 *Note*: Before submitting this pull request, please review our [contributing
-guidelines](https://docs.celeryproject.org/en/master/contributing.html).
+guidelines](https://docs.celeryq.dev/en/master/contributing.html).
 
 ## Description
 


### PR DESCRIPTION
## Description

fix some left over links to `celeryproject.org`

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
