### PR TITLE
Avoid negating a constant in a loop.

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -299,6 +299,8 @@ class AsyncResult(ResultBase):
 
     def iterdeps(self, intermediate=False):
         stack = deque([(None, self)])
+        
+        is_incomplete_stream = not intermediate
 
         while stack:
             parent, node = stack.popleft()
@@ -306,7 +308,7 @@ class AsyncResult(ResultBase):
             if node.ready():
                 stack.extend((node, child) for child in node.children or [])
             else:
-                if not intermediate:
+                if is_incomplete_stream:
                     raise IncompleteStream()
 
     def ready(self):

--- a/celery/result.py
+++ b/celery/result.py
@@ -299,7 +299,7 @@ class AsyncResult(ResultBase):
 
     def iterdeps(self, intermediate=False):
         stack = deque([(None, self)])
-        
+
         is_incomplete_stream = not intermediate
 
         while stack:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Since `intermediate` is a constant, we can negate it in advance instead of every time
in a loop.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
