### PR TITLE
Fix: code block formatting for task deprecation

### DIFF
--- a/docs/internals/deprecation.rst
+++ b/docs/internals/deprecation.rst
@@ -34,7 +34,7 @@ Compat Task Modules
 
         from celery import task
 
-- Module ``celery.task`` will be removed 
+- Module ``celery.task`` will be removed
 
     This means you should change:
 
@@ -49,6 +49,7 @@ Compat Task Modules
         from celery import shared_task
 
     -- and:
+
     .. code-block:: python
 
         from celery import task


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

This fixes a code block formatting issue in the task deprecation warnings.

Currently you'll see on [here](https://docs.celeryq.dev/en/stable/internals/deprecation.html?highlight=shared_task#compat-task-modules); 
<img width="326" alt="Screenshot 2022-04-12 at 16 01 44" src="https://user-images.githubusercontent.com/1461191/162994178-7f459bac-a84f-4c49-9bcc-053ec1926144.png">

This is a simple line break fix that then renders the code block as expected;
<img width="451" alt="Screenshot 2022-04-12 at 16 06 01" src="https://user-images.githubusercontent.com/1461191/162994446-e805692c-6d30-4135-a3dc-74370c8b40b8.png">


