### PR TITLE
fix userguide deamonizing by changing the systemd --version by system…

### DIFF
--- a/docs/userguide/daemonizing.rst
+++ b/docs/userguide/daemonizing.rst
@@ -14,9 +14,9 @@ You can check if your Linux distribution uses systemd by typing:
 
 .. code-block:: console
 
-  $ systemd --version
-  systemd 237
-  +PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid
+    $ systemctl --version
+    systemd 249 (v249.9-1.fc35)
+    +PAM +AUDIT +SELINUX -APPARMOR +IMA +SMACK +SECCOMP +GCRYPT +GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 +PWQUALITY +P11KIT +QRENCODE +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified
 
 If you have output similar to the above, please refer to
 :ref:`our systemd documentation <daemon-systemd-generic>` for guidance.


### PR DESCRIPTION
## Description

Most modern linux distros uses systemd, but not every one of them add systemd command o the path (ex: fedora 35). However, all of them provides by default the systemctl command. Therefore, it is better to use the systemctl --version instead of the systemd --version command to check if your operating system uses systemd.
