### PR TITLE
Use inspect.getgeneratorstate in asynpool.gen_not_started

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -14,6 +14,7 @@ This code deals with three major challenges:
 """
 import errno
 import gc
+import inspect
 import os
 import select
 import time
@@ -89,8 +90,7 @@ Ack = namedtuple('Ack', ('id', 'fd', 'payload'))
 
 def gen_not_started(gen):
     """Return true if generator is not started."""
-    # gi_frame is None when generator stopped.
-    return gen.gi_frame and gen.gi_frame.f_lasti == -1
+    return inspect.getgeneratorstate(gen) == "GEN_CREATED"
 
 
 def _get_job_writer(job):

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -201,12 +201,24 @@ class test_AsynPool:
 
         def gen():
             yield 1
+            assert not asynpool.gen_not_started(g)
             yield 2
         g = gen()
         assert asynpool.gen_not_started(g)
         next(g)
         assert not asynpool.gen_not_started(g)
         list(g)
+        assert not asynpool.gen_not_started(g)
+
+        def gen2():
+            yield 1
+            raise RuntimeError('generator error')
+        g = gen2()
+        assert asynpool.gen_not_started(g)
+        next(g)
+        assert not asynpool.gen_not_started(g)
+        with pytest.raises(RuntimeError):
+            next(g)
         assert not asynpool.gen_not_started(g)
 
     @patch('select.select', create=True)


### PR DESCRIPTION
This improves compatibility with the nogil Python fork, which does not
have the gi_frame attribute on generators.