### PR TITLE
Make start_worker, setup_default_app reusable outside of pytest

### DIFF
--- a/t/unit/contrib/test_worker.py
+++ b/t/unit/contrib/test_worker.py
@@ -1,0 +1,56 @@
+import pytest
+
+from celery import Celery
+from celery.contrib.testing.worker import start_worker
+
+app = Celery('celerytest',
+             backend='cache+memory://',
+             broker='memory://',
+             )
+
+
+@app.task
+def add(x, y):
+    return x + y
+
+
+def test_start_worker():
+    app.config_from_object({
+        'worker_hijack_root_logger': False,
+    })
+    # this import adds a @shared_task, which uses connect_on_app_finalize
+    # to install the celery.ping task that the test lib uses
+    import celery.contrib.testing.tasks  # noqa: F401
+
+    # to avoid changing the root logger level to ERROR,
+    # we have we have to set both app.log.loglevel start_worker arg to 0
+    # (see celery.app.log.setup_logging_subsystem)
+    app.log.loglevel = 0
+    with start_worker(app=app, loglevel=0):
+        result = add.s(1, 2).apply_async()
+        val = result.get(timeout=5)
+    assert val == 3
+
+
+@app.task
+def error_task():
+    raise NotImplementedError()
+
+
+def test_start_worker_with_exception():
+    """Make sure that start_worker does not hang on exception"""
+    app.config_from_object({
+        'worker_hijack_root_logger': False,
+    })
+    # this import adds a @shared_task, which uses connect_on_app_finalize
+    # to install the celery.ping task that the test lib uses
+    import celery.contrib.testing.tasks  # noqa: F401
+
+    # to avoid changing the root logger level to ERROR,
+    # we have we have to set both app.log.loglevel start_worker arg to 0
+    # (see celery.app.log.setup_logging_subsystem)
+    app.log.loglevel = 0
+    with pytest.raises(NotImplementedError):
+        with start_worker(app=app, loglevel=0):
+            result = error_task.apply_async()
+            result.get(timeout=5)


### PR DESCRIPTION
`start_worker` and `setup_default_app` are generator functions wrapped in `@contextmanager`. Generally, @contextmanager requires the `yield` statement to be wrapped in a `try`-`finally` statement to guarantee cleanup. This is not an issue if these functions are only called from @pytest.fixture, which never passes exceptions to the generator. But to use these context managers outside of @pytest.fixture, they need to use the more general try-finally pattern so that they do not hang.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

I don’t use pytest at my firm, but I would like to use the `start_worker` helper function because the [testing guide](https://docs.celeryq.dev/en/stable/userguide/testing.html) says that “The eager mode enabled by the [`task_always_eager`](https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_always_eager) setting is by definition not suitable for unit tests.” However, when I tried using `start_worker` in a `with` statement, when the code raised an exception it would cause python to hang forever.

Make start_worker and setup_default_app follow the [@contextmanager](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager) pattern of wrapping the `yield` statement in a `try`-`finally` compound statement.