### PR TITLE
docs: Linking a task to a group does *not* guarantee all group tasks will finish first

### DIFF
--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -698,6 +698,8 @@ the behaviour can be somewhat surprising due to the fact that groups are not
 real tasks and simply pass linked tasks down to their encapsulated signatures.
 This means that the return values of a group are not collected to be passed to
 a linked callback signature.
+Additionally, linking the task will *not* guarantee that it will activate only 
+when all group tasks have finished.
 As an example, the following snippet using a simple `add(a, b)` task is faulty
 since the linked `add.s()` signature will not received the finalised group
 result as one might expect.


### PR DESCRIPTION
## Description

The current docs do not make this clear, and this behavior does not always manifest, so it can be very surprising when it does.
This was clarified in [this issue](https://github.com/celery/celery/issues/1950), and docs were updated to include good examples, but they make it seem like the difference between a group and a chord is that chords gather results while groups do not, but both only activate linked task after all tasks are done.