### PR TITLE
hotfix: add requirement module 'ephem'

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -7,3 +7,4 @@ click-didyoumean>=0.0.3
 click-repl>=0.2.0
 click-plugins>=1.1.1
 importlib-metadata>=1.4.0; python_version < '3.8'
+ephem>=4.1.3


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

Need to add a module 'ephem' to requirements. 
celery/schedules.py, line 736, in __init__:
```
self.ephem = __import__('ephem')
```