### PR TITLE
[Documentation] Fix order of arguments for clarity

### DIFF
--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -244,7 +244,7 @@ arguments:
     >>> add.apply_async((2, 2), link=add.s(8))
 
 As expected this will first launch one task calculating :math:`2 + 2`, then
-another task calculating :math:`4 + 8`.
+another task calculating :math:`8 + 4`.
 
 The Primitives
 ==============


### PR DESCRIPTION
## Description

I'm a little new to celery, but if I understand callbacks correctly, there's a typo in the documentation:
the order of the arguments applied will be `8+4` because the `8` comes first in the `signature` and then the `4` gets applied second.