### PR TITLE
docs: remove super old django 1.11 reference

### DIFF
--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -17,11 +17,6 @@ Using Celery with Django
     first and come back to this tutorial. When you have a working example you can
     continue to the :ref:`next-steps` guide.
 
-.. note::
-
-    Celery 5.0.x supports Django 1.11 LTS or newer versions. Please use Celery 4.4.x
-    for versions older than Django 1.11.
-
 To use Celery with your Django project you must first define
 an instance of the Celery library (called an "app")
 


### PR DESCRIPTION
Support ended on 1 April 2020

Signed-off-by: Sebastian Wagner <sebastian@inter.link>

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
