### PR TITLE
Fix expiration check

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -733,10 +733,9 @@ class Celery:
         options = router.route(
             options, route_name or name, args, kwargs, task_type)
         if expires is not None:
-            if isinstance(expires, (str, datetime)):
-                expires_s = (
-                    maybe_make_aware(maybe_iso8601(expires)) - self.now()
-                ).total_seconds()
+            if isinstance(expires, datetime):
+                expires_s = (maybe_make_aware(
+                    expires) - self.now()).total_seconds()
             else:
                 expires_s = expires
 

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -30,8 +30,7 @@ from celery.utils.functional import first, head_from_fun, maybe_list
 from celery.utils.imports import gen_task_name, instantiate, symbol_by_name
 from celery.utils.log import get_logger
 from celery.utils.objects import FallbackContext, mro_lookup
-from celery.utils.time import (maybe_iso8601, maybe_make_aware, timezone,
-                               to_utc)
+from celery.utils.time import maybe_make_aware, timezone, to_utc
 
 # Load all builtin tasks
 from . import builtins  # noqa

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -30,7 +30,8 @@ from celery.utils.functional import first, head_from_fun, maybe_list
 from celery.utils.imports import gen_task_name, instantiate, symbol_by_name
 from celery.utils.log import get_logger
 from celery.utils.objects import FallbackContext, mro_lookup
-from celery.utils.time import maybe_make_aware, timezone, to_utc
+from celery.utils.time import (maybe_iso8601, maybe_make_aware, timezone,
+                               to_utc)
 
 # Load all builtin tasks
 from . import builtins  # noqa
@@ -732,8 +733,10 @@ class Celery:
         options = router.route(
             options, route_name or name, args, kwargs, task_type)
         if expires is not None:
-            if isinstance(expires, datetime):
-                expires_s = (maybe_make_aware(expires) - self.now()).total_seconds()
+            if isinstance(expires, (str, datetime)):
+                expires_s = (
+                    maybe_make_aware(maybe_iso8601(expires)) - self.now()
+                ).total_seconds()
             else:
                 expires_s = expires
 

--- a/requirements/test-ci-default.txt
+++ b/requirements/test-ci-default.txt
@@ -18,6 +18,7 @@
 -r extras/cosmosdbsql.txt
 -r extras/cassandra.txt
 -r extras/azureblockblob.txt
+git+https://github.com/celery/kombu.git
 
 # SQS dependencies other than boto
 pycurl==7.43.0.5  # Latest version with wheel built (for appveyor)

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -987,7 +987,7 @@ class test_tasks(TasksCase):
             presult2 = self.mytask.apply_async(
                 kwargs={'name': 'George Costanza'},
                 eta=self.now() + timedelta(days=1),
-                expires=(self.now() - timedelta(days=2)).isoformat(),
+                expires=self.now() - timedelta(days=2),
             )
             self.assert_next_task_data_equal(
                 consumer, presult2, self.mytask.name,

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -983,6 +983,17 @@ class test_tasks(TasksCase):
                 name='George Costanza', test_eta=True, test_expires=True,
             )
 
+            # With ETA, absolute expires in the past in ISO format.
+            presult2 = self.mytask.apply_async(
+                kwargs={'name': 'George Costanza'},
+                eta=self.now() + timedelta(days=1),
+                expires=(self.now() - timedelta(days=2)).isoformat(),
+            )
+            self.assert_next_task_data_equal(
+                consumer, presult2, self.mytask.name,
+                name='George Costanza', test_eta=True, test_expires=True,
+            )
+
             # Default argsrepr/kwargsrepr behavior
             presult2 = self.mytask.apply_async(
                 args=('spam',), kwargs={'name': 'Jerry Seinfeld'}


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

Migrated test from #7190 
expires can be only float or datetime, so the test wasn't completely valid. Datetime serialization fixed in kombu

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
