### PR TITLE
Use `callable` built-in

### DIFF
--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -311,7 +311,7 @@ def head_from_fun(fun, bound=False, debug=False):
     # with an empty body, meaning it has the same performance as
     # as just calling a function.
     is_function = inspect.isfunction(fun)
-    is_callable = hasattr(fun, '__call__')
+    is_callable = callable(fun)
     is_cython = fun.__class__.__name__ == 'cython_function_or_method'
     is_method = inspect.ismethod(fun)
 


### PR DESCRIPTION
Closes #3964.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Use `callable` built-in in `utils.functional.head_from_fun` instead of checking for the existence of a `__call__` attribute.