### PR TITLE
fix: Syntax error in arango query

### DIFF
--- a/celery/backends/arangodb.py
+++ b/celery/backends/arangodb.py
@@ -168,7 +168,7 @@ class ArangoDbBackend(KeyValueStoreBackend):
             logging.debug(
                 """
                 FOR key in {keys}
-                    RETURN DOCUMENT(CONCAT("{collection}/", key).task
+                    RETURN DOCUMENT(CONCAT("{collection}/", key)).task
                 """.format(
                     collection=self.collection, keys=json_keys
                 )
@@ -176,7 +176,7 @@ class ArangoDbBackend(KeyValueStoreBackend):
             query = self.db.AQLQuery(
                 """
                 FOR key in {keys}
-                    RETURN DOCUMENT(CONCAT("{collection}/", key).task
+                    RETURN DOCUMENT(CONCAT("{collection}/", key)).task
                 """.format(
                     collection=self.collection, keys=json_keys
                 )


### PR DESCRIPTION
Add missing closing bracket for the DOCUMENT function

## Description

This pull request fixes a syntax error in the arango query. The query uses the `DOCUMENT` function & the `CONCAT` function of AQL (arango query language). The `CONCAT` function is closed, but the `DOCUMENT` function was missing a closing bracket. Thus throwing a syntax error when executed. Adding the closing bracket resolved this syntax error.
