### PR TITLE
Fix custom headers propagation on task retries

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -287,3 +287,4 @@ Konstantin Kochin, 2021/07/11
 kronion, 2021/08/26
 Gabor Boros, 2021/11/09
 Tizian Seehaus, 2022/02/09
+Oleh Romanovskyi, 2022/06/09

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -96,6 +96,18 @@ class Context:
 
     def __init__(self, *args, **kwargs):
         self.update(*args, **kwargs)
+        if self.headers is None:
+            self.headers = self._get_custom_headers(*args, **kwargs)
+
+    def _get_custom_headers(self, *args, **kwargs):
+        headers = {}
+        headers.update(*args, **kwargs)
+        celery_keys = {*Context.__dict__.keys(), 'lang', 'task', 'argsrepr', 'kwargsrepr'}
+        for key in celery_keys:
+            headers.pop(key, None)
+        if not headers:
+            return None
+        return headers
 
     def update(self, *args, **kwargs):
         return self.__dict__.update(*args, **kwargs)

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -217,6 +217,16 @@ def retry_once_priority(self, *args, expires=60.0, max_retries=1,
                      max_retries=max_retries)
 
 
+@shared_task(bind=True, max_retries=1)
+def retry_once_headers(self, *args, max_retries=1,
+                       countdown=0.1):
+    """Task that fails and is retried. Returns headers."""
+    if self.request.retries:
+        return self.request.headers
+    raise self.retry(countdown=countdown,
+                     max_retries=max_retries)
+
+
 @shared_task
 def redis_echo(message, redis_key="redis-echo"):
     """Task that appends the message to a redis list."""

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -8,7 +8,8 @@ from celery import group
 
 from .conftest import get_active_redis_channels
 from .tasks import (ClassBasedAutoRetryTask, ExpectedException, add, add_ignore_result, add_not_typed, fail,
-                    print_unicode, retry, retry_once, retry_once_priority, return_properties, sleeping)
+                    print_unicode, retry, retry_once, retry_once_headers, retry_once_priority, return_properties,
+                    sleeping)
 
 TIMEOUT = 10
 
@@ -266,6 +267,13 @@ class test_tasks:
     def test_task_retried_priority(self, manager):
         res = retry_once_priority.apply_async(priority=7)
         assert res.get(timeout=TIMEOUT) == 7  # retried once with priority 7
+
+    @flaky
+    def test_task_retried_headers(self, manager):
+        res = retry_once_headers.apply_async(headers={'x-test-header': 'test-value'})
+        headers = res.get(timeout=TIMEOUT)
+        assert headers is not None  # retried once with headers
+        assert 'x-test-header' in headers  # retry keeps custom headers
 
     @flaky
     def test_unicode_task(self, manager):

--- a/t/unit/tasks/test_context.py
+++ b/t/unit/tasks/test_context.py
@@ -63,3 +63,24 @@ class test_Context:
         ctx_dict = get_context_as_dict(ctx, getter=Context.get)
         assert ctx_dict == expected
         assert get_context_as_dict(Context()) == default_context
+
+    def test_extract_headers(self):
+        # Should extract custom headers from the request dict
+        request = {
+            'task': 'test.test_task',
+            'id': 'e16eeaee-1172-49bb-9098-5437a509ffd9',
+            'custom-header': 'custom-value',
+        }
+        ctx = Context(request)
+        assert ctx.headers == {'custom-header': 'custom-value'}
+
+    def test_dont_override_headers(self):
+        # Should not override headers if defined in the request
+        request = {
+            'task': 'test.test_task',
+            'id': 'e16eeaee-1172-49bb-9098-5437a509ffd9',
+            'headers': {'custom-header': 'custom-value'},
+            'custom-header-2': 'custom-value-2',
+        }
+        ctx = Context(request)
+        assert ctx.headers == {'custom-header': 'custom-value'}


### PR DESCRIPTION
Fixes #7523

On task retry celery duplicates `headers` from the Context, but that property wasn't initialized with custom headers. Since celery adds custom headers to the same dictionary as other properties, I implemented a method to filter unknown dictionary keys as custom headers.

I also considered another approach, moving custom headers to a separate key. It would be cleaner because you wouldn't need to separate internal properties and custom headers. But it would break backward compatibility.
Provided implementation should be backward compatible with two known workarounds to access custom headers (found in the comments of #4875 ):
- passing them with additional nesting (`headers={"headers":{"sample_header": "value"}`). In this case `if self.headers is None:` would be False and the new method wouldn't be called.
- accessing headers as `self.request.get("sample_header")` - should be working, since updating Context dict from request dict is not modified

As a side effect, it makes accessing headers from a task more intuitive - `self.request.headers`, rather than using the above workarounds.