### PR TITLE
Docs: change systemd-tmpfiles to /var/run/celery

### DIFF
--- a/docs/userguide/daemonizing.rst
+++ b/docs/userguide/daemonizing.rst
@@ -433,7 +433,7 @@ You can also use systemd-tmpfiles in order to create working directories (for lo
 
 .. code-block:: bash
 
-  d /run/celery 0755 celery celery -
+  d /var/run/celery 0755 celery celery -
   d /var/log/celery 0755 celery celery -
 
 


### PR DESCRIPTION
Update systemd-tmpfiles proposal in daemonizing doc to use `/var/run/celery` instead of `/run/celery`, so that it match following config files

## Description

I've found out that systemd-tmpfiles proposal in daemonizing doc use `/run/celery` for pid files, and later in that page, pid files are configured to go in `/var/run/celery`, which does not exist after following this user guide.

This MR change the systemd-tmpfiles proposal to match later examples config to be more consistent across the user guide.
