### PR TITLE
Removed Flower monitor screenshot

### DIFF
--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -266,9 +266,6 @@ Features
 .. figure:: ../images/dashboard.png
    :width: 700px
 
-.. figure:: ../images/monitor.png
-   :width: 700px
-
 More screenshots_:
 
 .. _screenshots: https://github.com/mher/flower/tree/master/docs/screenshots


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Removed Flower monitor screenshot from Celery's [_Monitoring and Management Guide_](https://docs.celeryq.dev/en/stable/userguide/monitoring.html#flower-real-time-celery-web-monitor:~:text=OpenID%20authentication-,Screenshots,-More%20screenshots%3A) since Flower [removed this feature](https://github.com/mher/flower/commit/201f2407f3eba951e3ad95d52f5a3e94c9438057) and replaced it with [Prometheus and Grafana integration](https://flower.readthedocs.io/en/latest/prometheus-integration.html#celery-flower-prometheus-grafana-integration-guide).