### PR TITLE
Fix small issues found with static analysis

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -576,8 +576,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
     def __reduce__(self, args=(), kwargs=None):
         kwargs = {} if not kwargs else kwargs
         return super().__reduce__(
-            (self.url,), {'expires': self.expires},
-        )
+            args, dict(kwargs, expires=self.expires, url=self.url))
 
 
 if getattr(redis, "sentinel", None):

--- a/celery/contrib/testing/manager.py
+++ b/celery/contrib/testing/manager.py
@@ -153,7 +153,7 @@ class ManagerMixin:
     def assert_received(self, ids, interval=0.5,
                         desc='waiting for tasks to be received', **policy):
         return self.assert_task_worker_state(
-            self.is_accepted, ids, interval=interval, desc=desc, **policy
+            self.is_received, ids, interval=interval, desc=desc, **policy
         )
 
     def assert_result_tasks_in_progress_or_completed(

--- a/celery/local.py
+++ b/celery/local.py
@@ -506,12 +506,11 @@ def create_module(name, attrs, cls_attrs=None, pkg=None,
 
 def recreate_module(name, compat_modules=None, by_module=None, direct=None,
                     base=LazyModule, **attrs):
-    compat_modules = compat_modules or ()
+    compat_modules = compat_modules or COMPAT_MODULES.get(name, ())
     by_module = by_module or {}
     direct = direct or {}
     old_module = sys.modules[name]
     origins = get_origins(by_module)
-    compat_modules = COMPAT_MODULES.get(name, ())
 
     _all = tuple(set(reduce(
         operator.add,

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -539,9 +539,7 @@ class crontab(BaseSchedule):
         super().__init__(**state)
 
     def remaining_delta(self, last_run_at, tz=None, ffwd=ffwd):
-        # pylint: disable=redefined-outer-name
         # caching global ffwd
-        tz = tz or self.tz
         last_run_at = self.maybe_make_aware(last_run_at)
         now = self.maybe_make_aware(self.now())
         dow_num = last_run_at.isoweekday() % 7  # Sunday is day 0, not day 7


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

This patch fixes potential issues found using SonarQube Community Edition and LGTM.

* [Use the previously unused parameter compat_modules](https://github.com/celery/celery/commit/bc840644be81aa9755af77d8dd1ff4448d815834)

  Previously this parameter was always overwritten by the value of
`COMPAT_MODULES.get(name, ())`, which was very likely unintentional.

* [Remove unused local variable tz](https://github.com/celery/celery/commit/9922776bc685894accaa55b5bd9ea162253ce12f)

  The parameter wasn't used anywhere either but I didn't want to change the method's signature to remove it, which would be a breaking change.

* [Make assert_received actually check for is_received](https://github.com/celery/celery/commit/8c8d097a7c45995c96a005f2fb23fbdd1b18fc73)

  Previously, it called `is_accepted`, which was likely a copy-paste
mistake from the `assert_accepted` method.

* [Use previously unused args and kwargs params](https://github.com/celery/celery/commit/cebccccda1171ccdf3f748eddcf3a8c3e95a86bb)

  Unlike other backends' `__reduce__` methods, the one from `RedisBackend`
simply overwrites `args` and `kwargs` instead of adding to them. This
change makes it more in line with other backends.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
