### PR TITLE
Modify example debug_task to ignore result

### DIFF
--- a/examples/django/proj/celery.py
+++ b/examples/django/proj/celery.py
@@ -17,6 +17,6 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
 
 
-@app.task(bind=True)
+@app.task(bind=True, ignore_result=True)
 def debug_task(self):
     print(f'Request: {self.request!r}')


### PR DESCRIPTION
To allow:
```
debug_task.delay().get()
```