### PR TITLE
added reuse_task_id to replace()

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -886,7 +886,7 @@ class Task:
                 type_,
                 uuid=req.id, retry=retry, retry_policy=retry_policy, **fields)
 
-    def replace(self, sig):
+    def replace(self, sig, reuse_task_id=True):
         """Replace this task, with a new task inheriting the task id.
 
         Execution of the host task ends immediately and no subsequent statements
@@ -896,6 +896,9 @@ class Task:
 
         Arguments:
             sig (Signature): signature to replace with.
+            reuse_task_id (bool): If False, then dont reuse task id of current
+            task as o/w it breaks task monitoring. If False, AsyncResult.get()
+            will not work.
 
         Raises:
             ~@Ignore: This is always raised when called in asynchronous context.
@@ -927,7 +930,8 @@ class Task:
         # We need to freeze the replacement signature with the current task's
         # ID to ensure that we don't disassociate it from the existing task IDs
         # which would break previously constructed results objects.
-        sig.freeze(self.request.id)
+        if reuse_task_id:
+            sig.freeze(self.request.id)
         # Ensure the important options from the original signature are retained
         replaced_task_nesting = self.request.get('replaced_task_nesting', 0) + 1
         sig.set(


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

`self.replace(sig_chain)` reuses task id 123 of the current task with taskname 1_2_3 and sets the task id of the last task in sig_chain say taskname 4_5_6 to be that task_id 123. Hence a task 1_2_3 runs with task id 123, then after some time task 4_5_6 with task id 123 again. This causes problems in task monitoring 
- worker logs show the same task id repeated
- storing task id + taskname in some db shows that 2 tasks ran with same id

I understand task id being reused in self.replace() was done to preserve AsyncResult.get() behavior. But we don't use AsyncResult.get(). We store results per task id using db backend.

Hence, this PR to allow users that dont use AsyncResult.get() to use self.replace without reusing task id . 
I believe nothing in Celery breaks if we dont reuse task id and dont use AsyncResult.get()
