### PR TITLE
Update task-rejected signature

### DIFF
--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -736,7 +736,7 @@ Sent if the execution of the task failed.
 task-rejected
 ~~~~~~~~~~~~~
 
-:signature: ``task-rejected(uuid, requeued)``
+:signature: ``task-rejected(uuid, requeue)``
 
 The task was rejected by the worker, possibly to be re-queued or moved to a
 dead letter queue.


### PR DESCRIPTION
## Description
Fixed the following mistakes in the documentation.
Actual task-rejected signature is 'requeue'
https://github.com/celery/celery/blob/v5.2.7/celery/worker/request.py#L609

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
