### PR TITLE
beat: Suppress banner output with the quiet option

### DIFF
--- a/celery/apps/beat.py
+++ b/celery/apps/beat.py
@@ -44,7 +44,8 @@ class Beat:
                  scheduler=None,
                  scheduler_cls=None,  # XXX use scheduler
                  redirect_stdouts=None,
-                 redirect_stdouts_level=None, **kwargs):
+                 redirect_stdouts_level=None,
+                 quiet=False, **kwargs):
         self.app = app = app or self.app
         either = self.app.either
         self.loglevel = loglevel
@@ -56,6 +57,7 @@ class Beat:
             'worker_redirect_stdouts', redirect_stdouts)
         self.redirect_stdouts_level = either(
             'worker_redirect_stdouts_level', redirect_stdouts_level)
+        self.quiet = quiet
 
         self.max_interval = max_interval
         self.socket_timeout = socket_timeout
@@ -70,8 +72,9 @@ class Beat:
             self.loglevel = LOG_LEVELS[self.loglevel.upper()]
 
     def run(self):
-        print(str(self.colored.cyan(
-            f'celery beat v{VERSION_BANNER} is starting.')))
+        if not self.quiet:
+            print(str(self.colored.cyan(
+                f'celery beat v{VERSION_BANNER} is starting.')))
         self.init_loader()
         self.set_process_title()
         self.start_scheduler()
@@ -93,7 +96,8 @@ class Beat:
             schedule_filename=self.schedule,
         )
 
-        print(self.banner(service))
+        if not self.quiet:
+            print(self.banner(service))
 
         self.setup_logging()
         if self.socket_timeout:

--- a/celery/bin/beat.py
+++ b/celery/bin/beat.py
@@ -62,7 +62,8 @@ def beat(ctx, detach=False, logfile=None, pidfile=None, uid=None,
         maybe_drop_privileges(uid=uid, gid=gid)
 
     beat = partial(app.Beat,
-                   logfile=logfile, pidfile=pidfile, **kwargs)
+                   logfile=logfile, pidfile=pidfile,
+                   quiet=ctx.obj.quiet, **kwargs)
 
     if detach:
         with detached(logfile, pidfile, uid, gid, umask, workdir):

--- a/t/unit/bin/proj/scheduler.py
+++ b/t/unit/bin/proj/scheduler.py
@@ -1,0 +1,6 @@
+from celery.beat import Scheduler
+
+
+class mScheduler(Scheduler):
+    def tick(self):
+        raise Exception

--- a/t/unit/bin/test_beat.py
+++ b/t/unit/bin/test_beat.py
@@ -1,0 +1,34 @@
+import pytest
+from click.testing import CliRunner
+
+from celery.app.log import Logging
+from celery.bin.celery import celery
+
+
+@pytest.fixture(scope='session')
+def use_celery_app_trap():
+    return False
+
+
+def test_cli(isolated_cli_runner: CliRunner):
+    Logging._setup = True  # To avoid hitting the logging sanity checks
+    res = isolated_cli_runner.invoke(
+        celery,
+        ["-A", "t.unit.bin.proj.app", "beat", "-S", "t.unit.bin.proj.scheduler.mScheduler"],
+        catch_exceptions=True
+    )
+    assert res.exit_code == 1, (res, res.stdout)
+    assert res.stdout.startswith("celery beat")
+    assert "Configuration ->" in res.stdout
+
+
+def test_cli_quiet(isolated_cli_runner: CliRunner):
+    Logging._setup = True  # To avoid hitting the logging sanity checks
+    res = isolated_cli_runner.invoke(
+        celery,
+        ["-A", "t.unit.bin.proj.app", "--quiet", "beat", "-S", "t.unit.bin.proj.scheduler.mScheduler"],
+        catch_exceptions=True
+    )
+    assert res.exit_code == 1, (res, res.stdout)
+    assert not res.stdout.startswith("celery beat")
+    assert "Configuration -> " not in res.stdout


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

This adds missing support for the quiet command line option
(`--quiet` or `-q`) for the celery beat command, which suppresses
banner and version information output.

Fixes #5836.
