### PR TITLE
Make default worker state limits configurable

### DIFF
--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -32,18 +32,18 @@ SOFTWARE_INFO = {
 }
 
 #: maximum number of revokes to keep in memory.
-REVOKES_MAX = 50000
+REVOKES_MAX = int(os.environ.get('CELERY_WORKER_REVOKES_MAX', 50000))
 
 #: maximum number of successful tasks to keep in memory.
-SUCCESSFUL_MAX = 1000
+SUCCESSFUL_MAX = int(os.environ.get('CELERY_WORKER_SUCCESSFUL_MAX', 1000))
 
 #: how many seconds a revoke will be active before
 #: being expired when the max limit has been exceeded.
-REVOKE_EXPIRES = 10800
+REVOKE_EXPIRES = float(os.environ.get('CELERY_WORKER_REVOKE_EXPIRES', 10800))
 
 #: how many seconds a successful task will be cached in memory
 #: before being expired when the max limit has been exceeded.
-SUCCESSFUL_EXPIRES = 10800
+SUCCESSFUL_EXPIRES = float(os.environ.get('CELERY_WORKER_SUCCESSFUL_EXPIRES', 10800))
 
 #: Mapping of reserved task_id->Request.
 requests = {}

--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -358,6 +358,20 @@ Commands
 All worker nodes keeps a memory of revoked task ids, either in-memory or
 persistent on disk (see :ref:`worker-persistent-revokes`).
 
+.. note::
+
+    The maximum number of revoked tasks to keep in memory can be
+    specified using the ``CELERY_WORKER_REVOKES_MAX`` environment
+    variable, which defaults to 50000. When the limit has been exceeded,
+    the revokes will be active for 10800 seconds (3 hours) before being
+    expired. This value can be changed using the
+    ``CELERY_WORKER_REVOKE_EXPIRES`` environment variable.
+
+    Memory limits can also be set for successful tasks through the
+    ``CELERY_WORKER_SUCCESSFUL_MAX`` and
+    ``CELERY_WORKER_SUCCESSFUL_EXPIRES`` environment variables, and
+    default to 1000 and 10800 respectively.
+
 When a worker receives a revoke request it will skip executing
 the task, but it won't terminate an already executing task unless
 the `terminate` option is set.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

Previously, `REVOKES_MAX`, `REVOKE_EXPIRES`, `SUCCESSFUL_MAX` and
`SUCCESSFUL_EXPIRES` were hardcoded in `celery.worker.state`. This patch
introduces `CELERY_WORKER_` prefixed environment variables with the same
names that allow you to customize these values should you need to.

Fixes #3576.
