### PR TITLE
Use spawn pool on POSIX platforms

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -28,6 +28,7 @@ from weakref import WeakValueDictionary, ref
 
 from billiard import pool as _pool
 from billiard.compat import isblocking, setblocking
+from billiard.context import SpawnContext
 from billiard.pool import ACK, NACK, RUN, TERMINATE, WorkersJoined
 from billiard.queues import _SimpleQueue
 from kombu.asynchronous import ERR, WRITE
@@ -460,7 +461,7 @@ class AsynPool(_pool.Pool):
 
         self.write_stats = Counter()
 
-        super().__init__(processes, *args, **kwargs)
+        super().__init__(processes, context=SpawnContext(), *args, **kwargs)
 
         for proc in self._pool:
             # create initial mappings, these will be updated

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -1,4 +1,4 @@
-"""Prefork execution pool.
+"""Subprocess execution pool.
 
 Pool implementation using :mod:`multiprocessing`.
 """
@@ -6,8 +6,8 @@ import os
 
 from billiard import forking_enable
 from billiard.common import REMAP_SIGTERM, TERM_SIGNAME
+from billiard.context import SpawnProcess
 from billiard.pool import CLOSE, RUN
-from billiard.pool import Pool as BlockingPool
 
 from celery import platforms, signals
 from celery._state import _set_task_join_will_block, set_default_app
@@ -93,7 +93,10 @@ class TaskPool(BasePool):
     """Multiprocessing Pool implementation."""
 
     Pool = AsynPool
-    BlockingPool = BlockingPool
+
+    @staticmethod
+    def BlockingPool(*args, **kwargs):
+        return SpawnProcess().Pool(*args, **kwargs)
 
     uses_semaphore = True
     write_stats = None

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -2,7 +2,6 @@
 
 Pool implementation using :mod:`multiprocessing`.
 """
-from functools import partial
 import os
 
 from billiard import forking_enable

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -4,7 +4,6 @@ Pool implementation using :mod:`multiprocessing`.
 """
 import os
 
-from billiard import forking_enable
 from billiard.common import REMAP_SIGTERM, TERM_SIGNAME
 from billiard.pool import CLOSE, RUN
 from billiard.pool import Pool as BlockingPool
@@ -99,7 +98,6 @@ class TaskPool(BasePool):
     write_stats = None
 
     def on_start(self):
-        forking_enable(self.forking_enable)
         Pool = (self.BlockingPool if self.options.get('threads', True)
                 else self.Pool)
         proc_alive_timeout = (

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -2,12 +2,13 @@
 
 Pool implementation using :mod:`multiprocessing`.
 """
+from functools import partial
 import os
 
 from billiard import forking_enable
 from billiard.common import REMAP_SIGTERM, TERM_SIGNAME
-from billiard.context import SpawnProcess
 from billiard.pool import CLOSE, RUN
+from billiard.pool import Pool as BlockingPool
 
 from celery import platforms, signals
 from celery._state import _set_task_join_will_block, set_default_app
@@ -93,10 +94,7 @@ class TaskPool(BasePool):
     """Multiprocessing Pool implementation."""
 
     Pool = AsynPool
-
-    @staticmethod
-    def BlockingPool(*args, **kwargs):
-        return SpawnProcess().Pool(*args, **kwargs)
+    BlockingPool = BlockingPool
 
     uses_semaphore = True
     write_stats = None

--- a/celery/worker/components.py
+++ b/celery/worker/components.py
@@ -160,7 +160,6 @@ class Pool(bootsteps.StartStopStep):
             threads=threaded,
             max_restarts=max_restarts,
             allow_restart=allow_restart,
-            forking_enable=True,
             semaphore=semaphore,
             sched_strategy=self.optimization,
             app=w.app,

--- a/t/unit/concurrency/test_asynpool.py
+++ b/t/unit/concurrency/test_asynpool.py
@@ -1,0 +1,46 @@
+"""Tests for celery.concurrency.asynpool."""
+
+from os import getpid
+
+from billiard import forking_enable
+from kombu.asynchronous import Hub
+
+from celery.concurrency.asynpool import AsynPool
+
+
+def noop(*args, **kwargs):
+    pass
+
+
+def check_if_state_persisted():
+    from t.unit.concurrency import test_asynpool
+
+    return getpid(), hasattr(test_asynpool, "only_in_parent_process")
+
+
+class test_AsynPool:
+    def test_subprocesses_are_spawned(self):
+        """
+        Subprocesses are new, indepenent processes, rather than
+        buggy fork()-without-execve() subprocesses.
+        """
+        # Add some state to this module, in the parent; only if we're
+        # doing fork() without execve() will this be visible to worker
+        # processes.
+        global only_in_parent_process
+        only_in_parent_process = True
+
+        pool = AsynPool(processes=1, threads=False)
+        hub = Hub()
+        pool.register_with_event_loop(hub)
+        result = pool.apply_async(check_if_state_persisted)
+        for i in range(100):
+            if result.ready():
+                break
+            hub.run_once()
+        assert result.ready()
+        del only_in_parent_process
+
+        worker_pid, state_leaked_to_worker = result.get()
+        assert getpid() != worker_pid
+        assert not state_leaked_to_worker

--- a/t/unit/concurrency/test_asynpool.py
+++ b/t/unit/concurrency/test_asynpool.py
@@ -2,14 +2,9 @@
 
 from os import getpid
 
-from billiard import forking_enable
 from kombu.asynchronous import Hub
 
 from celery.concurrency.asynpool import AsynPool
-
-
-def noop(*args, **kwargs):
-    pass
 
 
 def check_if_state_persisted():

--- a/t/unit/concurrency/test_asynpool.py
+++ b/t/unit/concurrency/test_asynpool.py
@@ -6,6 +6,8 @@ from kombu.asynchronous import Hub
 
 from celery.concurrency.asynpool import AsynPool
 
+from ... import skip
+
 
 def check_if_state_persisted():
     from t.unit.concurrency import test_asynpool
@@ -14,10 +16,14 @@ def check_if_state_persisted():
 
 
 class test_AsynPool:
+    @skip.if_win32
     def test_subprocesses_are_spawned(self):
         """
         Subprocesses are new, indepenent processes, rather than
         buggy fork()-without-execve() subprocesses.
+
+        On Windows fork()-without-execve() isn't even possible... and apparently
+        processes aren't used on Windows at all, in any case, so we skip.
         """
         # Add some state to this module, in the parent; only if we're
         # doing fork() without execve() will this be visible to worker


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

Fixes #6036 

Rather than making the pool strategy configurable, this always uses `spawn`, for the following reason:

* `fork()` without `execve()` is fundamentally broken. See the many many complaints in #6036, and also https://pythonspeed.com/articles/python-multiprocessing/. I have helped multiple people fix mysterious problems caused by `fork()` without `execve()` as well in non-Celery contexts; it's just not possible to work correctly.
* `fork()` without `execve()` has no benefits! It won't save much memory: shared libraries and the Python executable will already be shared by the OS, and Python objects trigger copy-on-write anytime e.g. a refcount changes. It will speed up startup, very slightly. Neither is particularly useful.
* ~`spawn` is already what Windows uses, so it's known to work.~ Turns out Windows always uses threads (https://github.com/celery/celery/blob/master/celery/worker/components.py#L140).

So instead of an extra knob to disable a broken-by-default feature, this just uses a correct-by-default and consistent-across-platforms default, with no knob to turn it off. (The blocking issue on Windows is not related to spawn AFAICT, and Windows always spawn).