### PR TITLE
Fix honor Django's TIME_ZONE setting

### DIFF
--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -128,7 +128,7 @@ class Settings(ConfigurationView):
     @property
     def timezone(self):
         # this way we also support django's time zone.
-        return self.first('timezone', 'time_zone')
+        return self.first('timezone', 'TIME_ZONE')
 
     def without_defaults(self):
         """Return the current configuration, but without defaults."""


### PR DESCRIPTION
See #4006

It appears that `app.conf.timezone` is simply `None` when `TIME_ZONE` is set in the Django settings, but the celery `timezone` setting is not set. This contrasts the documentation, which says that 

> Celery recommends and is compatible with the new USE_TZ setting introduced in Django 1.4.
> For Django users the time zone specified in the TIME_ZONE setting will be used, or you can specify a custom time zone for Celery alone by using the timezone setting.

Searching the code (case insensitive) for time_zone reveals only 1 location, the one in this commit.

It appears that's the part that's broken. Looking at the actual contents of the configuration object, I'd say that the latter `time_zone` should simply be upper-cased.