### PR TITLE
feat: add global keyprefix for backend result keys

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -290,3 +290,4 @@ Gabor Boros, 2021/11/09
 Tizian Seehaus, 2022/02/09
 Oleh Romanovskyi, 2022/06/09
 JoonHwan Kim, 2022/08/01
+Kaustav Banerjee, 2022/11/10

--- a/docs/getting-started/backends-and-brokers/redis.rst
+++ b/docs/getting-started/backends-and-brokers/redis.rst
@@ -100,6 +100,24 @@ If you are using Sentinel, you should specify the master_name using the :setting
 
     app.conf.result_backend_transport_options = {'master_name': "mymaster"}
 
+.. _redis-result-backend-global-keyprefix:
+
+Global keyprefix
+^^^^^^^^^^^^^^^^
+
+The global key prefix will be prepended to all keys used for the result backend,
+which can be useful when a redis database is shared by different users.
+By default, no prefix is prepended.
+
+To configure the global keyprefix for the Redis result backend, use the ``global_keyprefix`` key under :setting:`result_backend_transport_options`:
+
+
+.. code-block:: python
+
+    app.conf.result_backend_transport_options = {
+        'global_keyprefix': 'my_prefix_'
+    }
+
 .. _redis-result-backend-timeout:
 
 Connection timeouts


### PR DESCRIPTION
## Description

While using celery with a shared redis instance, we can currently add custom global key prefixes to keys used in kombu. However, there is currently no way to configure such a global key prefix when the shared redis instance is used as a result backend. This make it impossbile for multple applications to use a shared redis instance as a result backend.

This PR adds the capabliity to configure a global key prefix through `result_backend_transport_options` for the keys used to store the results in backend .

#### Testing instructions:

1. Start redis (`redis-server`)
2. In a different window connect to redis using redis-cli
3. Execute `FLUSHALL`
4. Create a file `tasks1.py` and add the following task :
```
from celery import Celery

app = Celery("tasks", broker='redis://localhost:6379/0', backend='redis://localhost:6379/0')

app.conf.result_backend_transport_options = {'global_keyprefix': 'test_prefix_'}

@app.task
def add(x, y):
    return x+y
```
5. Start the celery worker server `celery -A tasks1 worker --loglevel=INFO`
6. In a different window call the task 
```
>>> from tasks1 import add
>>> add.delay(4,4)
```
7. From redis-cli, execute `KEYS *`
8. Verify there is a key like `test_prefix__celery-task-meta-<task_id>`
9. Execute `FLUSHALL`
10. Create a new file `tasks2.py` with the below content :
```
from celery import Celery

app = Celery("tasks", broker='redis://localhost:6379/0', backend='redis://localhost:6379/0')

@app.task
def add(x, y):
    return x+y
```
11. Repeat steps 5, 6 and 7, replacing `tasks1` with `tasks2`
12. Verify there is a key like `celery-task-meta-<task_id>`