### PR TITLE
Don't warn about DEBUG=True for Django

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -137,7 +137,6 @@ class DjangoWorkerFixup:
 
     def install(self) -> "DjangoWorkerFixup":
         signals.beat_embedded_init.connect(self.close_database)
-        signals.worker_ready.connect(self.on_worker_ready)
         signals.task_prerun.connect(self.on_task_prerun)
         signals.task_postrun.connect(self.on_task_postrun)
         signals.worker_process_init.connect(self.on_worker_process_init)
@@ -211,8 +210,3 @@ class DjangoWorkerFixup:
             self._cache.close_caches()
         except (TypeError, AttributeError):
             pass
-
-    def on_worker_ready(self, **kwargs: Any) -> None:
-        if self._settings.DEBUG:
-            warnings.warn('''Using settings.DEBUG leads to a memory
-            leak, never use this setting in production environments!''')

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -131,7 +131,6 @@ class test_DjangoWorkerFixup(FixupCase):
                 sigs.beat_embedded_init.connect.assert_called_with(
                     f.close_database,
                 )
-                sigs.worker_ready.connect.assert_called_with(f.on_worker_ready)
                 sigs.task_prerun.connect.assert_called_with(f.on_task_prerun)
                 sigs.task_postrun.connect.assert_called_with(f.on_task_postrun)
                 sigs.worker_process_init.connect.assert_called_with(
@@ -255,14 +254,6 @@ class test_DjangoWorkerFixup(FixupCase):
         with self.fixup_context(self.app) as (f, _, _):
             f.close_cache()
             f._cache.close_caches.assert_called_with()
-
-    def test_on_worker_ready(self):
-        with self.fixup_context(self.app) as (f, _, _):
-            f._settings.DEBUG = False
-            f.on_worker_ready()
-            with pytest.warns(UserWarning):
-                f._settings.DEBUG = True
-                f.on_worker_ready()
 
     @pytest.mark.patched_module('django', 'django.db', 'django.core',
                                 'django.core.cache', 'django.conf',


### PR DESCRIPTION
This warning used to be correct, but is no longer relevant since Django 1.8.

See https://github.com/django/django/commit/cfcca7ccce3dc527d16757ff6dc978e50c4a2e61
for the Django-side fix.
