### PR TITLE
Fix errors on code blocks rendering in docs

### DIFF
--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -1201,6 +1201,7 @@ For example, the following example ``InGroupVisitor`` will label
 tasks that are in side of some group by lable ``in_group``.
 
 .. code-block:: python
+
     class InGroupVisitor(StampingVisitor):
         def __init__(self):
             self.in_group = False


### PR DESCRIPTION
Signed-off-by: Oleg Hoefling <oleg.hoefling@gmail.com>

## Description

This simple PR fixes a small issue with the code block not being rendered in docs [here](https://docs.celeryq.dev/en/latest/userguide/canvas.html#custom-stamping):

<img width="588" alt="image" src="https://user-images.githubusercontent.com/4455652/182033916-280a995a-eda9-4894-8e4c-17bc2d2cd6d7.png">