### PR TITLE
fix doc rendering issues, part I

### DIFF
--- a/docs/getting-started/next-steps.rst
+++ b/docs/getting-started/next-steps.rst
@@ -127,7 +127,7 @@ and prioritization, all described in the :ref:`Routing Guide
 <guide-routing>`.
 
 You can get a complete list of command-line arguments
-by passing in the :option:`--help <celery --help>` flag:
+by passing in the :option:`!--help` flag:
 
 .. code-block:: console
 

--- a/docs/history/changelog-2.2.rst
+++ b/docs/history/changelog-2.2.rst
@@ -20,8 +20,8 @@ Security Fixes
 --------------
 
 * [Security: `CELERYSA-0001`_] Daemons would set effective id's rather than
-  real id's when the :option:`--uid <celery --uid>`/
-  :option:`--gid <celery --gid>` arguments to :program:`celery multi`,
+  real id's when the :option:`!--uid`/
+  :option:`!--gid` arguments to :program:`celery multi`,
   :program:`celeryd_detach`, :program:`celery beat` and
   :program:`celery events` were used.
 
@@ -47,7 +47,7 @@ Security Fixes
 
 * Redis result backend now works with Redis 2.4.4.
 
-* multi: The :option:`--gid <celery --gid>` option now works correctly.
+* multi: The :option:`!--gid` option now works correctly.
 
 * worker: Retry wrongfully used the repr of the traceback instead
   of the string representation.
@@ -1026,6 +1026,3 @@ Experimental
     def my_view(request):
         with pool.acquire() as publisher:
             add.apply_async((2, 2), publisher=publisher, retry=True)
-
-
-

--- a/docs/history/changelog-2.3.rst
+++ b/docs/history/changelog-2.3.rst
@@ -20,8 +20,8 @@ Security Fixes
 --------------
 
 * [Security: `CELERYSA-0001`_] Daemons would set effective id's rather than
-  real id's when the :option:`--uid <celery --uid>`/
-  :option:`--gid <celery --gid>` arguments to :program:`celery multi`,
+  real id's when the :option:`!--uid`/
+  :option:`!--gid` arguments to :program:`celery multi`,
   :program:`celeryd_detach`, :program:`celery beat` and
   :program:`celery events` were used.
 
@@ -368,4 +368,3 @@ Fixes
 
 * Remote control command ``add_consumer`` now does nothing if the
   queue is already being consumed from.
-

--- a/docs/history/changelog-2.4.rst
+++ b/docs/history/changelog-2.4.rst
@@ -37,8 +37,8 @@ Security Fixes
 --------------
 
 * [Security: `CELERYSA-0001`_] Daemons would set effective id's rather than
-  real id's when the :option:`--uid <celery --uid>`/
-  :option:`--gid <celery --gid>` arguments to
+  real id's when the :option:`!--uid`/
+  :option:`!--gid` arguments to
   :program:`celery multi`, :program:`celeryd_detach`,
   :program:`celery beat` and :program:`celery events` were used.
 

--- a/docs/history/changelog-3.1.rst
+++ b/docs/history/changelog-3.1.rst
@@ -638,7 +638,7 @@ new in Celery 3.1.
 
 - **Django**: Compatibility with Django 1.7 on Windows (Issue #2126).
 
-- **Programs**: :option:`--umask <celery --umask>` argument can now be
+- **Programs**: :option:`!--umask` argument can now be
   specified in both octal (if starting with 0) or decimal.
 
 

--- a/docs/history/changelog-5.0.rst
+++ b/docs/history/changelog-5.0.rst
@@ -20,7 +20,7 @@ an overview of what's new in Celery 5.0.
 - --quiet flag now actually makes celery avoid producing logs (#6599).
 - pass_context for handle_preload_options decorator (#6583).
 - Fix --pool=threads support in command line options parsing (#6787).
-Fix the behavior of our json serialization which regressed in 5.0 (#6561).
+- Fix the behavior of our json serialization which regressed in 5.0 (#6561).
 - celery -A app events -c camera now works as expected (#6774).
 
 .. _version-5.0.5:

--- a/docs/history/changelog-5.1.rst
+++ b/docs/history/changelog-5.1.rst
@@ -1,4 +1,4 @@
-.. _changelog:
+.. _changelog-5.1:
 
 ================
  Change history

--- a/docs/history/whatsnew-5.1.rst
+++ b/docs/history/whatsnew-5.1.rst
@@ -290,10 +290,10 @@ you should import `kombu.utils.encoding` instead.
 If you were using the `celery.task` module before, you should import directly
 from the `celery` module instead.
 
-If you were using `from celery.task import Task` you should use 
+If you were using `from celery.task import Task` you should use
 `from celery import Task` instead.
 
-If you were using the `celery.task` decorator you should use 
+If you were using the `celery.task` decorator you should use
 `celery.shared_task` instead.
 
 
@@ -330,7 +330,7 @@ Support for Redis username authentication
 Previously, the username was ignored from the URI.
 Starting from Redis>=6.0, that shouldn't be the case since ACL support has landed.
 
-Please refer to the :ref:`documentation <_conf-redis-result-backend>` for details.
+Please refer to the :ref:`documentation <conf-redis-result-backend>` for details.
 
 SQS transport - support back off policy
 ----------------------------------------
@@ -339,7 +339,7 @@ SQS now supports managed visibility timeout. This lets us implement a back off
 policy (for instance, an exponential policy) which means that the time between
 task failures will dynamically change based on the number of retries.
 
-Documentation: :doc:`reference/kombu.transport.SQS.rst`
+Documentation: :doc:`kombu:reference/kombu.transport.SQS`
 
 Duplicate successful tasks
 ---------------------------
@@ -393,7 +393,7 @@ SQS - support STS authentication with AWS
 The STS token requires a refresh after a certain period of time.
 After `sts_token_timeout` is reached, a new token will be created.
 
-Documentation: :doc:`getting-started/backends-and-brokers/sqs.rst`
+Documentation: :doc:`/getting-started/backends-and-brokers/sqs`
 
 Support Redis `health_check_interval`
 -------------------------------------
@@ -416,4 +416,4 @@ Support Redis Sentinel with SSL
 -------------------------------
 
 See documentation for more info:
-:doc:`getting-started/backends-and-brokers/redis.rst`
+:doc:`/getting-started/backends-and-brokers/redis`

--- a/docs/reference/celery.bin.amqp.rst
+++ b/docs/reference/celery.bin.amqp.rst
@@ -1,0 +1,11 @@
+====================
+ ``celery.bin.amqp``
+====================
+
+.. contents::
+   :local:
+.. currentmodule:: celery.bin.amqp
+
+.. automodule:: celery.bin.amqp
+   :members:
+   :undoc-members:

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1678,7 +1678,7 @@ The name for the storage container in which to store the results.
 .. setting:: azureblockblob_base_path
 
 ``azureblockblob_base_path``
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 5.1
 
@@ -1726,7 +1726,7 @@ Timeout in seconds for establishing the azure block blob connection.
 .. setting:: azureblockblob_read_timeout
 
 ``azureblockblob_read_timeout``
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Default: 120.
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -596,7 +596,7 @@ This value is used for tasks that doesn't have a custom rate limit
 
 .. seealso::
 
-    The setting:`worker_disable_rate_limits` setting can
+    The :setting:`worker_disable_rate_limits` setting can
     disable all rate limits.
 
 .. _conf-result-backend:

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -854,9 +854,6 @@ Default: 1.0.
 
 Default interval for retrying chord tasks.
 
-.. _conf-database-result-backend:
-
-
 .. setting:: override_backends
 
 ``override_backends``
@@ -876,7 +873,7 @@ Example:
 
     override_backends = {"db": "custom_module.backend.class"}
 
-
+.. _conf-database-result-backend:
 
 Database backend settings
 -------------------------

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2179,7 +2179,9 @@ or::
 
 The backend will store results in the K/V store of Consul
 as individual keys. The backend supports auto expire of results using TTLs in
-Consul. The full syntax of the URL is::
+Consul. The full syntax of the URL is:
+
+.. code-block:: text
 
     consul://host:port[?one_client=1]
 

--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -353,7 +353,7 @@ and it includes a tool to dump events to :file:`stdout`:
 
     $ celery -A proj events --dump
 
-For a complete list of options use :option:`--help <celery --help>`:
+For a complete list of options use :option:`!--help`:
 
 .. code-block:: console
 

--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -624,7 +624,7 @@ which needs two numbers: the maximum and minimum number of pool processes:
               10 if necessary).
 
 You can also define your own rules for the autoscaler by subclassing
-:class:`~celery.worker.autoscaler.Autoscaler`.
+:class:`~celery.worker.autoscale.Autoscaler`.
 Some ideas for metrics include load average or the amount of memory available.
 You can specify a custom autoscaler with the :setting:`worker_autoscaler` setting.
 
@@ -970,7 +970,7 @@ There are two types of remote control commands:
 
 Remote control commands are registered in the control panel and
 they take a single argument: the current
-:class:`~celery.worker.control.ControlDispatch` instance.
+:class:`!celery.worker.control.ControlDispatch` instance.
 From there you have access to the active
 :class:`~celery.worker.consumer.Consumer` if needed.
 

--- a/docs/whatsnew-5.2.rst
+++ b/docs/whatsnew-5.2.rst
@@ -390,4 +390,4 @@ You can now check the validity of the CA certificate while making
 a TLS connection to ArangoDB result backend.
 
 If you'd like to do so, set the ``verify`` key in the
-:setting:`arangodb_backend_settings`` dictionary to ``True``.
+:setting:`arangodb_backend_settings` dictionary to ``True``.

--- a/docs/whatsnew-5.2.rst
+++ b/docs/whatsnew-5.2.rst
@@ -330,10 +330,10 @@ older `azure-servicebus` versions.
 
 .. _v520-news:
 
-Bug: Pymongo 3.12.1 is not compatible with Celery 5.2 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Bug: Pymongo 3.12.1 is not compatible with Celery 5.2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For now we are limiting Pymongo version, only allowing for versions between 3.3.0 and 3.12.0.  
+For now we are limiting Pymongo version, only allowing for versions between 3.3.0 and 3.12.0.
 
 This will be fixed in the next patch.
 


### PR DESCRIPTION
Signed-off-by: Oleg Hoefling <oleg.hoefling@gmail.com>

## Description

This PR fixes wrong placement of the `conf-database-backend` ref label, which prevents hyperlinks from rendering, e.g. [here](https://docs.celeryq.dev/en/latest/userguide/configuration.html#result-backend):

<img width="642" alt="image" src="https://user-images.githubusercontent.com/4455652/182035381-e43ee9b1-af15-45a2-8617-328e98e5122a.png">
