### PR TITLE
fix: share redis connection as it's thread-safe

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -955,6 +955,22 @@ class Celery:
         backend, url = backends.by_url(
             self.backend_cls or self.conf.result_backend,
             self.loader)
+
+        from celery.backends.redis import RedisBackend
+
+        if backend == RedisBackend:
+            # redis-py is thread safe, so we can share one backend to avoid creating too many open connections
+            # (especially in regard to gevent)
+            return self.redis_backend
+
+        return backend(app=self, url=url)
+
+    @cached_property
+    def redis_backend(self):
+        backend, url = backends.by_url(
+            self.backend_cls or self.conf.result_backend,
+            self.loader)
+
         return backend(app=self, url=url)
 
     def _finalize_pending_conf(self):


### PR DESCRIPTION
## Description
- attempt to fix https://github.com/celery/celery/issues/6819

## Notes
- Celery shared Redis connections between threads and not between geventlets before [this PR](https://github.com/celery/celery/pull/6416/files)
- The linked PR then changed it to have a connection per thread which probably ([due to gevents monkeypatching](https://www.gevent.org/api/gevent.monkey.html)) translates to one connection per geventlet
- The PR tries to revert the changes for redis as `redis-py` is thread-safe

## Open questions
- Is `threading.local` cleaning up properly? (especially after `gevent` monkeypatching)?