### PR TITLE
Fix redis connection leak with `app.send_task`

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -101,6 +101,9 @@ class Backend:
     #: Set to true if the backend is persistent by default.
     persistent = True
 
+    #: If the backend is thread-safe
+    is_threadsafe = False
+
     retry_policy = {
         'max_retries': 20,
         'interval_start': 0,

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -202,6 +202,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
 
     supports_autoexpire = True
     supports_native_join = True
+    is_threadsafe = True
 
     #: Maximal length of string value in Redis.
     #: 512 MB - https://redis.io/topics/data-types


### PR DESCRIPTION
## Description

This test shows that there is a Redis connection leak when using `app.send_task`. 
The connection leak doesn't happen if `task.delay()` is used.

Todos:
- [ ] find solution

