### PR TITLE
Added integration test_chord_header_id_duplicated_on_rabbitmq_msg_duplication()

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -83,7 +83,7 @@ jobs:
           fail-fast: false
           matrix:
               python-version: ['3.7', '3.8', '3.9', '3.10']
-              toxenv: ['redis', 'rabbitmq']
+              toxenv: ['redis', 'rabbitmq', 'rabbitmq_redis']
 
       services:
           redis:

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -605,7 +605,7 @@ class Signature(dict):
 
     def __deepcopy__(self, memo):
         memo[id(self)] = self
-        return dict(self)
+        return dict(self)  # TODO: Potential bug of being a shallow copy
 
     def __invert__(self):
         return self.apply_async().get()
@@ -1687,7 +1687,7 @@ class _chord(Signature):
         body = body.clone(**options)
         app = self._get_app(body)
         tasks = (self.tasks.clone() if isinstance(self.tasks, group)
-                 else group(self.tasks, app=app))
+                 else group(self.tasks, app=app, task_id=self.options.get('task_id', uuid())))
         if app.conf.task_always_eager:
             with allow_join_result():
                 return self.apply(args, kwargs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ addopts = "--strict-markers"
 testpaths = "t/unit/"
 python_classes = "test_*"
 xfail_strict=true
-markers = ["sleepdeprived_patched_module", "masked_modules", "patched_environ", "patched_module"]
+markers = ["sleepdeprived_patched_module", "masked_modules", "patched_environ", "patched_module", "flaky", "timeout"]
 
 [tool.mypy]
 warn_unused_configs = true

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,3 +3,4 @@ git+https://github.com/celery/py-amqp.git
 git+https://github.com/celery/kombu.git
 git+https://github.com/celery/billiard.git
 vine>=5.0.0
+isort~=5.10.1

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -241,6 +241,12 @@ def redis_echo(message, redis_key="redis-echo"):
     redis_connection.rpush(redis_key, message)
 
 
+@shared_task(bind=True)
+def redis_echo_group_id(self, _, redis_key="redis-group-ids"):
+    redis_connection = get_redis_connection()
+    redis_connection.rpush(redis_key, self.request.group)
+
+
 @shared_task
 def redis_count(redis_key="redis-count"):
     """Task that increments a specified or well-known redis key."""

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox-gh-actions
 envlist =
     {3.7,3.8,3.9,3.10,pypy3}-unit
-    {3.7,3.8,3.9,3.10,pypy3}-integration-{rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
+    {3.7,3.8,3.9,3.10,pypy3}-integration-{rabbitmq_redis,rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
 
     flake8
     apicheck
@@ -63,6 +63,9 @@ setenv =
 
     redis: TEST_BROKER=redis://
     redis: TEST_BACKEND=redis://
+
+    rabbitmq_redis: TEST_BROKER=pyamqp://
+    rabbitmq_redis: TEST_BACKEND=redis://
 
     dynamodb: TEST_BROKER=redis://
     dynamodb: TEST_BACKEND=dynamodb://@localhost:8000


### PR DESCRIPTION
When a task that predates a chord in a chain was duplicated by Rabbitmq (for whatever reason), the chord header id was not duplicated. This caused the chord header to have a different id. This test ensures that the chord header's id preserves itself in face of such an edge case.