### PR TITLE
New feature flag: allow_error_cb_on_chord_header - allowing setting an error callback on chord header

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -291,6 +291,7 @@ NAMESPACES = Namespace(
         ),
         store_errors_even_if_ignored=Option(False, type='bool'),
         track_started=Option(False, type='bool'),
+        allow_error_cb_on_chord_header=Option(False, type='bool'),
     ),
     worker=Namespace(
         __old__=OLD_NS_WORKER,

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1808,6 +1808,14 @@ class _chord(Signature):
         return callback
 
     def link_error(self, errback):
+        if self.app.conf.task_allow_error_cb_on_chord_header:
+            # self.tasks can be a list of the chord header workflow.
+            if isinstance(self.tasks, list):
+                for task in self.tasks:
+                    task.link_error(errback)
+            else:
+                self.tasks.link_error(errback)
+
         self.body.link_error(errback)
         return errback
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1614,7 +1614,7 @@ class _chord(Signature):
 
     def __or__(self, other):
         if (not isinstance(other, (group, _chain)) and
-            isinstance(other, Signature)):
+                isinstance(other, Signature)):
             # chord | task ->  attach to body
             sig = self.clone()
             sig.body = sig.body | other

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -167,6 +167,9 @@ The callbacks/errbacks will then be called in order, and all
 callbacks will be called with the return value of the parent task
 as a partial argument.
 
+In case of a chord, error handling may have multiple handling strategies.
+See :ref:`chord error handling <chord-errors>` for more information.
+
 .. _calling-on-message:
 
 On message

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -167,7 +167,7 @@ The callbacks/errbacks will then be called in order, and all
 callbacks will be called with the return value of the parent task
 as a partial argument.
 
-In case of a chord, error handling may have multiple handling strategies.
+In the case of a chord, we can handle errors using multiple handling strategies.
 See :ref:`chord error handling <chord-errors>` for more information.
 
 .. _calling-on-message:

--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -941,7 +941,12 @@ Chords may have callback and errback signatures linked to them, which addresses
 some of the issues with linking signatures to groups.
 Doing so will link the provided signature to the chord's body which can be
 expected to gracefully invoke callbacks just once upon completion of the body,
-or errbacks just once if any task in the chord header or body fails.
+or errbacks just once if the body fails.
+
+This behavior can be manipulated to allow error handling of the chord header
+using the :ref:`task_allow_error_cb_on_chord_header <task_allow_error_cb_on_chord_header>` flag.
+Enabling this flag will cause the chord header to invoke the errback if any of the tasks in the header fail,
+and prevent the body from being executed if any of the tasks in the header fail.
 
 .. _chord-important-notes:
 

--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -941,12 +941,10 @@ Chords may have callback and errback signatures linked to them, which addresses
 some of the issues with linking signatures to groups.
 Doing so will link the provided signature to the chord's body which can be
 expected to gracefully invoke callbacks just once upon completion of the body,
-or errbacks just once if the body fails.
+or errbacks just once if any task in the chord header or body fails.
 
-This behavior can be manipulated to allow error handling of the chord header
-using the :ref:`task_allow_error_cb_on_chord_header <task_allow_error_cb_on_chord_header>` flag.
-Enabling this flag will cause the chord header to invoke the errback if any of the tasks in the header fail,
-and prevent the body from being executed if any of the tasks in the header fail.
+This behavior can be manipulated to allow error handling of the chord header using the :ref:`task_allow_error_cb_on_chord_header <task_allow_error_cb_on_chord_header>` flag.
+Enabling this flag will cause the chord header to invoke the errback for the body (default behavior) *and* any task in the chord's header that fails.
 
 .. _chord-important-notes:
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -525,7 +525,7 @@ Default: Disabled.
 
 Enabling this flag will allow linking an error callback to a chord header,
 which by default will not link when using :code:`link_error()`, and preventing
-from the chord body to execute if the header fails.
+from the chord's body to execute if any of the tasks in the header fails.
 
 Consider the following canvas:
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -514,8 +514,6 @@ be killed and replaced with a new one when this is exceeded.
 
 .. setting:: task_allow_error_cb_on_chord_header
 
-.. _task_allow_error_cb_on_chord_header:
-
 ``task_allow_error_cb_on_chord_header``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -527,7 +525,7 @@ Enabling this flag will allow linking an error callback to a chord header,
 which by default will not link when using :code:`link_error()`, and preventing
 from the chord's body to execute if any of the tasks in the header fails.
 
-Consider the following canvas:
+Consider the following canvas with the flag disabled (default behavior):
 
 .. code-block:: python
 
@@ -536,16 +534,23 @@ Consider the following canvas:
     c = chord(header, body)
     c.link_error(error_callback_sig)
 
-If :code:`t1` or :code:`t2` will fail, by default, the chord body would still execute, and :code:`error_callback_sig` will **not** be called.
+If *any* of the header tasks failed (:code:`t1` or :code:`t2`), by default, the chord body (:code:`t3`) would **not execute**, and :code:`error_callback_sig` will be called **once** (for the body).
 
 Enabling this flag will change the above behavior by:
 
 1. :code:`error_callback_sig` will be linked to :code:`t1` and :code:`t2` (as well as :code:`t3`).
-2. If :code:`t1` or :code:`t2` failed, :code:`t3` **will not** execute.
-3. If *any* of the header tasks failed, :code:`error_callback_sig` will be called for **each** failed header task **and** the :code:`body` (even if it didn't run).
+2. If *any* of the header tasks failed, :code:`error_callback_sig` will be called **for each** failed header task **and** the :code:`body` (even if the body didn't run).
 
-Using such a workflow may allow preventing the chord body from executing if the header was not completed successfully.
-This differs from the standard behavior of the chord, which will execute the body even if the header fails.
+Consider now the following canvas with the flag enabled:
+
+.. code-block:: python
+
+    header = group([failingT1, failingT2])
+    body = t3
+    c = chord(header, body)
+    c.link_error(error_callback_sig)
+
+If *all* of the header tasks failed (:code:`failingT1` and :code:`failingT2`), then the chord body (:code:`t3`) would **not execute**, and :code:`error_callback_sig` will be called **3 times** (two times for the header and one time for the body).
 
 .. setting:: task_soft_time_limit
 

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -2764,7 +2764,7 @@ class test_chord:
                 # Double check
                 assert not redis_connection.exists(body_key), 'Chord body was called when it should have not'
 
-            with subtests.test(msg='Confirm there only one errback was called'):
+            with subtests.test(msg='Confirm only one errback was called'):
                 await_redis_echo((errback_msg,), redis_key=errback_key, timeout=10)
                 with pytest.raises(TimeoutError):
                     await_redis_echo((errback_msg,), redis_key=errback_key, timeout=10)


### PR DESCRIPTION
Added a new flag for linking an error callback to a chord header.
The purpose of the new flag is to allow a chord header failure to prevent the chord body
from executing while executing the error callback on both the header and the body (in case of failure).
This differs from the default behavior where the chord header failure DOES NOT prevent
the body from executing nor executing an error callback on the header.

* Added new flag under task namespace: allow_error_cb_on_chord_header (turned off by default)
* Added integration tests to confirm flag works: test_enabled/disabled_flag_allow_error_cb_on_chord_header()
* Added unit test to confirm flag works: test_flag_allow_error_cb_on_chord_header()
* Added documentation to task_allow_error_cb_on_chord_header flag