### PR TITLE
Fix issue 7726: variable used in finally block may not be instantiated

### DIFF
--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -72,6 +72,7 @@ def start_worker(
     """
     test_worker_starting.send(sender=app)
 
+    worker = None
     try:
         with _start_worker_thread(app,
                                   concurrency=concurrency,


### PR DESCRIPTION
Closes #7726 