### PR TITLE
Update ambiguous acks_late doc

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -252,7 +252,7 @@ class Task:
     track_started = None
 
     #: When enabled messages for this task will be acknowledged **after**
-    #: the task has been executed, and not *just before* (the
+    #: the task has been executed, and not *right before* (the
     #: default behavior).
     #:
     #: Please note that this means the task may be executed twice if the

--- a/docs/history/changelog-1.0.rst
+++ b/docs/history/changelog-1.0.rst
@@ -164,7 +164,7 @@ News
 * New task option: `Task.acks_late` (default: :setting:`CELERY_ACKS_LATE`)
 
     Late ack means the task messages will be acknowledged **after** the task
-    has been executed, not *just before*, which is the default behavior.
+    has been executed, not *right before*, which is the default behavior.
 
     .. note::
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -584,7 +584,7 @@ clean up before the hard time limit comes:
 Default: Disabled.
 
 Late ack means the task messages will be acknowledged **after** the task
-has been executed, not *just before* (the default behavior).
+has been executed, not *right before* (the default behavior).
 
 .. seealso::
 


### PR DESCRIPTION
## Description
- Update documentation about `acks_late`

As a non native English speaker, I found "and not just before" kinda ambiguous in the context. When I first read the doc, I misinterpreted it as "and not **only** before". 

Hopefully this change would help reducing ambiguity for others as well.  

The other option is to remove 'just' completely. 

