### PR TITLE
recreate_module: set __spec__ to the new module

### DIFF
--- a/celery/local.py
+++ b/celery/local.py
@@ -517,6 +517,7 @@ def recreate_module(name, compat_modules=None, by_module=None, direct=None,
     new_module.__dict__.update({
         mod: get_compat_module(new_module, mod) for mod in compat_modules
     })
+    new_module.__spec__ = old_module.__spec__
     return old_module, new_module
 
 

--- a/t/unit/utils/test_local.py
+++ b/t/unit/utils/test_local.py
@@ -1,3 +1,5 @@
+import sys
+from importlib.util import find_spec
 from unittest.mock import Mock
 
 import pytest
@@ -339,3 +341,15 @@ class test_PromiseProxy:
 
         assert maybe_evaluate(30) == 30
         assert x.__evaluated__()
+
+
+class test_celery_import:
+    def test_import_celery(self, monkeypatch):
+        monkeypatch.delitem(sys.modules, "celery", raising=False)
+        spec = find_spec("celery")
+        assert spec
+
+        import celery
+
+        assert celery.__spec__ == spec
+        assert find_spec("celery") == spec


### PR DESCRIPTION
The recreated module has `__spec__` set to `None`, due to which `find_spec` throws `ValueError`. 

Reading [PEP-451](https://peps.python.org/pep-0451/) and [Python's docs for `__spec__`](https://docs.python.org/3/reference/import.html#spec__), it seems that `__spec__` can be `None` in some cases but generally it should be set.

Here's the issue that this tries to fix:
```python
>>> from importlib.util import find_spec
>>> find_spec("celery")
ModuleSpec(name='celery', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7fadf901ea10>, origin='/home/user/projects/iterative/celery/celery/__init__.py', submodule_search_locations=['/home/user/projects/iterative/celery/celery'])
>>> import celery
>>> find_spec("celery")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Input In [4], in <cell line: 0>()
----> 1 find_spec("celery")

File <frozen importlib.util>:114, in find_spec(name, package)

ValueError: celery.__spec__ is None
```

I noticed this when investigating failure in pylint/astroid, see [PyCQA/pylint#7488](https://github.com/PyCQA/pylint/issues/7488) and [PyCQA/astroid#1802](https://github.com/PyCQA/astroid/pull/1802).