### PR TITLE
Override integration test config using integration-tests-config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test.db
 pip-wheel-metadata/
 .python-version
 .vscode/
+integration-tests-config.json

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -48,7 +48,7 @@ def celery_config(request):
         # The file must contain a dictionary of valid configuration name/value pairs.
         config_overrides = json.load(open(str(request.config.rootdir / "integration-tests-config.json")))
         config.update(config_overrides)
-    except IOError:
+    except OSError:
         pass
     return config
 

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -30,8 +31,8 @@ def get_active_redis_channels():
 
 
 @pytest.fixture(scope='session')
-def celery_config():
-    return {
+def celery_config(request):
+    config = {
         'broker_url': TEST_BROKER,
         'result_backend': TEST_BACKEND,
         'cassandra_servers': ['localhost'],
@@ -41,6 +42,15 @@ def celery_config():
         'cassandra_write_consistency': 'ONE',
         'result_extended': True
     }
+    try:
+        # To override the default configuration, create the integration-tests-config.json file
+        # in Celery's root directory.
+        # The file must contain a dictionary of valid configuration name/value pairs.
+        config_overrides = json.load(open(str(request.config.rootdir / "integration-tests-config.json")))
+        config.update(config_overrides)
+    except IOError:
+        pass
+    return config
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

In order to allow to run the integration tests with a different configuration than the default, we now optionally allow to override the defaults using `integration-tests-config.json`.