### PR TITLE
pin importlib-metadata>=1.4.0,<5.0

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,4 +6,4 @@ click>=8.1.2,<9.0
 click-didyoumean>=0.3.0
 click-repl>=0.2.0
 click-plugins>=1.1.1
-importlib-metadata>=1.4.0; python_version < '3.8'
+importlib-metadata>=1.4.0,<5.0; python_version < '3.8'


### PR DESCRIPTION
## Description

* Since importlib-metadata has released version 5.0.0 [1] and breaks a backward compatible with throwing error as below,

  ``` ImportError: cannot import name 'Celery' from 'celery' (/usr/local/lib/python3.7/site-packages/celery/__init__.py) ```

---
[1] https://pypi.org/project/importlib-metadata/5.0.0