### PR TITLE
importlib_metadata remove deprecated entry point interfaces

### DIFF
--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -1,6 +1,7 @@
 """Celery Command Line Interface."""
 import os
 import pathlib
+import sys
 import traceback
 
 try:
@@ -75,7 +76,16 @@ class App(ParamType):
 APP = App()
 
 
-@with_plugins(entry_points().get('celery.commands', []))
+if sys.version_info >= (3, 10):
+    _PLUGINS = entry_points(group='celery.commands')
+else:
+    try:
+        _PLUGINS = entry_points().get('celery.commands', [])
+    except AttributeError:
+        _PLUGINS = entry_points().select(group='celery.commands')
+
+
+@with_plugins(_PLUGINS)
 @click.group(cls=DYMGroup, invoke_without_command=True)
 @click.option('-A',
               '--app',

--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -141,7 +141,14 @@ def gen_task_name(app, name, module_name):
 
 
 def load_extension_class_names(namespace):
-    for ep in entry_points().get(namespace, []):
+    if sys.version_info >= (3, 10):
+        _entry_points = entry_points(group=namespace)
+    else:
+        try:
+            _entry_points = entry_points().get(namespace, [])
+        except AttributeError:
+            _entry_points = entry_points().select(group=namespace)
+    for ep in _entry_points:
         yield ep.name, ep.value
 
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,4 +6,4 @@ click>=8.1.2,<9.0
 click-didyoumean>=0.3.0
 click-repl>=0.2.0
 click-plugins>=1.1.1
-importlib-metadata>=1.4.0; python_version < '3.8'
+importlib-metadata>=3.6; python_version < '3.8'


### PR DESCRIPTION
Closes #7783

See https://github.com/python/importlib_metadata/pull/405