### PR TITLE
Add mongodb dependencies to test.txt

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,3 +10,4 @@ mypy==0.982; platform_python_implementation=="CPython"
 pre-commit==2.20.0
 -r extras/yaml.txt
 -r extras/msgpack.txt
+-r extras/mongodb.txt


### PR DESCRIPTION
When creating a brand-new environment and running the test suite with `pytest`, the pymongo is missing. :eyes: 