### PR TITLE
Ignore coverage on `except ImportError`

### DIFF
--- a/celery/backends/cassandra.py
+++ b/celery/backends/cassandra.py
@@ -12,7 +12,7 @@ try:  # pragma: no cover
     import cassandra.auth
     import cassandra.cluster
     import cassandra.query
-except ImportError:  # pragma: no cover
+except ImportError:
     cassandra = None
 
 

--- a/celery/backends/cosmosdbsql.py
+++ b/celery/backends/cosmosdbsql.py
@@ -14,7 +14,7 @@ try:
     from pydocumentdb.documents import ConnectionPolicy, ConsistencyLevel, PartitionKind
     from pydocumentdb.errors import HTTPFailure
     from pydocumentdb.retry_options import RetryOptions
-except ImportError:  # pragma: no cover
+except ImportError:
     pydocumentdb = DocumentClient = ConsistencyLevel = PartitionKind = \
         HTTPFailure = ConnectionPolicy = RetryOptions = None
 

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -15,7 +15,7 @@ from .session import SessionManager
 try:
     from sqlalchemy.exc import DatabaseError, InvalidRequestError
     from sqlalchemy.orm.exc import StaleDataError
-except ImportError:  # pragma: no cover
+except ImportError:
     raise ImproperlyConfigured(
         'The database result backend requires SQLAlchemy to be installed.'
         'See https://pypi.org/project/SQLAlchemy/')

--- a/celery/backends/dynamodb.py
+++ b/celery/backends/dynamodb.py
@@ -12,7 +12,7 @@ from .base import KeyValueStoreBackend
 try:
     import boto3
     from botocore.exceptions import ClientError
-except ImportError:  # pragma: no cover
+except ImportError:
     boto3 = ClientError = None
 
 __all__ = ('DynamoDBBackend',)

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -11,7 +11,7 @@ from .base import KeyValueStoreBackend
 
 try:
     import elasticsearch
-except ImportError:  # pragma: no cover
+except ImportError:
     elasticsearch = None
 
 __all__ = ('ElasticsearchBackend',)

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -12,13 +12,13 @@ from .base import BaseBackend
 
 try:
     import pymongo
-except ImportError:  # pragma: no cover
+except ImportError:
     pymongo = None
 
 if pymongo:
     try:
         from bson.binary import Binary
-    except ImportError:                     # pragma: no cover
+    except ImportError:
         from pymongo.binary import Binary
     from pymongo.errors import InvalidDocument
 else:                                       # pragma: no cover

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -24,7 +24,7 @@ from .base import BaseKeyValueStoreBackend
 try:
     import redis.connection
     from kombu.transport.redis import get_redis_error_classes
-except ImportError:  # pragma: no cover
+except ImportError:
     redis = None
     get_redis_error_classes = None
 

--- a/celery/bootsteps.py
+++ b/celery/bootsteps.py
@@ -13,7 +13,7 @@ from .utils.log import get_logger
 
 try:
     from greenlet import GreenletExit
-except ImportError:  # pragma: no cover
+except ImportError:
     IGNORE_ERRORS = ()
 else:
     IGNORE_ERRORS = (GreenletExit,)

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -47,7 +47,7 @@ try:
     from _billiard import read as __read__
     readcanbuf = True
 
-except ImportError:  # pragma: no cover
+except ImportError:
 
     def __read__(fd, buf, size, read=os.read):
         chunk = read(fd, size)

--- a/celery/concurrency/gevent.py
+++ b/celery/concurrency/gevent.py
@@ -7,7 +7,7 @@ from . import base
 
 try:
     from gevent import Timeout
-except ImportError:  # pragma: no cover
+except ImportError:
     Timeout = None
 
 __all__ = ('TaskPool',)

--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -27,7 +27,7 @@ from .local import try_import
 
 try:
     from billiard.process import current_process
-except ImportError:  # pragma: no cover
+except ImportError:
     current_process = None
 
 _setproctitle = try_import('setproctitle')

--- a/celery/utils/log.py
+++ b/celery/utils/log.py
@@ -264,7 +264,7 @@ def get_multiprocessing_logger():
     """Return the multiprocessing logger."""
     try:
         from billiard import util
-    except ImportError:  # pragma: no cover
+    except ImportError:
         pass
     else:
         return util.get_logger()
@@ -274,7 +274,7 @@ def reset_multiprocessing_logger():
     """Reset multiprocessing logging setup."""
     try:
         from billiard import util
-    except ImportError:  # pragma: no cover
+    except ImportError:
         pass
     else:
         if hasattr(util, '_logger'):  # pragma: no cover
@@ -284,7 +284,7 @@ def reset_multiprocessing_logger():
 def current_process():
     try:
         from billiard import process
-    except ImportError:  # pragma: no cover
+    except ImportError:
         pass
     else:
         return process.current_process()

--- a/celery/utils/threads.py
+++ b/celery/utils/threads.py
@@ -11,13 +11,13 @@ from celery.local import Proxy
 
 try:
     from greenlet import getcurrent as get_ident
-except ImportError:  # pragma: no cover
+except ImportError:
     try:
         from _thread import get_ident
     except ImportError:
         try:
             from thread import get_ident
-        except ImportError:  # pragma: no cover
+        except ImportError:
             try:
                 from _dummy_thread import get_ident
             except ImportError:

--- a/celery/worker/components.py
+++ b/celery/worker/components.py
@@ -89,7 +89,7 @@ class Hub(bootsteps.StartStopStep):
         # multiprocessing's ApplyResult uses this lock.
         try:
             from billiard import pool
-        except ImportError:  # pragma: no cover
+        except ImportError:
             pass
         else:
             pool.Lock = DummyLock

--- a/celery/worker/worker.py
+++ b/celery/worker/worker.py
@@ -36,7 +36,7 @@ from . import state
 
 try:
     import resource
-except ImportError:  # pragma: no cover
+except ImportError:
     resource = None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,6 @@ files = [
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
-    "if TYPE_CHECKING:"
+    "if TYPE_CHECKING:",
+    "except ImportError:"
 ]

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -16,7 +16,7 @@ from celery.utils.time import parse_iso8601
 
 try:
     from urllib.error import HTTPError
-except ImportError:  # pragma: no cover
+except ImportError:
     from urllib2 import HTTPError
 
 

--- a/t/unit/utils/test_platforms.py
+++ b/t/unit/utils/test_platforms.py
@@ -21,7 +21,7 @@ from t.unit import conftest
 
 try:
     import resource
-except ImportError:  # pragma: no cover
+except ImportError:
     resource = None
 
 


### PR DESCRIPTION
There are a lot of `except ImportError` in code. Adding it to the coverage ignore list, we make sure that all of them are ignored by `coverage`.