### PR TITLE
Remove `isatty` wrapper function

### DIFF
--- a/celery/app/log.py
+++ b/celery/app/log.py
@@ -18,7 +18,6 @@ from celery import signals
 from celery._state import get_current_task
 from celery.exceptions import CDeprecationWarning, CPendingDeprecationWarning
 from celery.local import class_property
-from celery.platforms import isatty
 from celery.utils.log import (ColorFormatter, LoggingProxy, get_logger, get_multiprocessing_logger, mlevel,
                               reset_multiprocessing_logger)
 from celery.utils.nodenames import node_format
@@ -204,7 +203,7 @@ class Logging:
         if colorize or colorize is None:
             # Only use color if there's no active log file
             # and stderr is an actual terminal.
-            return logfile is None and isatty(sys.stderr)
+            return logfile is None and sys.stderr.isatty()
         return colorize
 
     def colored(self, logfile=None, enabled=None):

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -20,7 +20,7 @@ from kombu.utils.encoding import safe_str
 from celery import VERSION_BANNER, platforms, signals
 from celery.app import trace
 from celery.loaders.app import AppLoader
-from celery.platforms import EX_FAILURE, EX_OK, check_privileges, isatty
+from celery.platforms import EX_FAILURE, EX_OK, check_privileges
 from celery.utils import static, term
 from celery.utils.debug import cry
 from celery.utils.imports import qualname
@@ -106,7 +106,7 @@ class Worker(WorkController):
         super().setup_defaults(**kwargs)
         self.purge = purge
         self.no_color = no_color
-        self._isatty = isatty(sys.stdout)
+        self._isatty = sys.stdout.isatty()
         self.colored = self.app.log.colored(
             self.logfile,
             enabled=not no_color if no_color is not None else no_color

--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -43,7 +43,7 @@ __all__ = (
     'DaemonContext', 'detached', 'parse_uid', 'parse_gid', 'setgroups',
     'initgroups', 'setgid', 'setuid', 'maybe_drop_privileges', 'signals',
     'signal_name', 'set_process_title', 'set_mp_process_title',
-    'get_errno_name', 'ignore_errno', 'fd_by_path', 'isatty',
+    'get_errno_name', 'ignore_errno', 'fd_by_path',
 )
 
 # exitcodes
@@ -96,14 +96,6 @@ SIGNAMES = {
     if sig.startswith('SIG') and '_' not in sig
 }
 SIGMAP = {getattr(_signal, name): name for name in SIGNAMES}
-
-
-def isatty(fh):
-    """Return true if the process has a controlling terminal."""
-    try:
-        return fh.isatty()
-    except AttributeError:
-        pass
 
 
 def pyimplementation():

--- a/celery/utils/term.py
+++ b/celery/utils/term.py
@@ -6,8 +6,6 @@ import platform
 import sys
 from functools import reduce
 
-from celery.platforms import isatty
-
 __all__ = ('colored',)
 
 BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
@@ -164,7 +162,7 @@ class colored:
 
 
 def supports_images():
-    return isatty(sys.stdin) and ITERM_PROFILE
+    return sys.stdin.isatty() and ITERM_PROFILE
 
 
 def _read_as_base64(path):

--- a/t/unit/utils/test_platforms.py
+++ b/t/unit/utils/test_platforms.py
@@ -13,9 +13,9 @@ from celery import _find_option_with_arg, platforms
 from celery.exceptions import SecurityError, SecurityWarning
 from celery.platforms import (ASSUMING_ROOT, ROOT_DISALLOWED, ROOT_DISCOURAGED, DaemonContext, LockFailed, Pidfile,
                               _setgroups_hack, check_privileges, close_open_fds, create_pidlock, detached,
-                              fd_by_path, get_fdmax, ignore_errno, initgroups, isatty, maybe_drop_privileges,
-                              parse_gid, parse_uid, set_mp_process_title, set_pdeathsig, set_process_title, setgid,
-                              setgroups, setuid, signals)
+                              fd_by_path, get_fdmax, ignore_errno, initgroups, maybe_drop_privileges, parse_gid,
+                              parse_uid, set_mp_process_title, set_pdeathsig, set_process_title, setgid, setgroups,
+                              setuid, signals)
 from celery.utils.text import WhateverIO
 from t.unit import conftest
 
@@ -23,13 +23,6 @@ try:
     import resource
 except ImportError:  # pragma: no cover
     resource = None
-
-
-def test_isatty():
-    fh = Mock(name='fh')
-    assert isatty(fh) is fh.isatty()
-    fh.isatty.side_effect = AttributeError()
-    assert not isatty(fh)
 
 
 class test_find_option_with_arg:


### PR DESCRIPTION
This function was added 11 years ago to avoid an issue with Python 2.6.

References: 
- https://groups.google.com/g/celery-users/c/E4wwZJYizYw?hl=en_US
- https://github.com/celery/celery/issues/477