### PR TITLE
Fix grammar typos on the whole project

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -50,7 +50,7 @@ an overview of what's new in Celery 5.2.
 - fix #7200 uid and gid.
 - Remove exception-throwing from the signal handler.
 - Add mypy to the pipeline (#7383).
-- Expose more debugging information when receiving unkown tasks. (#7405)
+- Expose more debugging information when receiving unknown tasks. (#7405)
 - Avoid importing buf_t from billiard's compat module as it was removed.
 - Avoid negating a constant in a loop. (#7443)
 - Ensure expiration is of float type when migrating tasks (#7385).

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -293,7 +293,7 @@ class Scheduler:
         return entry.is_due()
 
     def _when(self, entry, next_time_to_run, mktime=timegm):
-        """Return a utc timestamp, make sure heapq in currect order."""
+        """Return a utc timestamp, make sure heapq in correct order."""
         adjust = self.adjust
 
         as_now = maybe_make_aware(entry.default_now())

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -230,7 +230,7 @@ class Signature(dict):
             >>> add.s(1, kw=2)
 
     - the ``.s()`` shortcut does not allow you to specify execution options
-      but there's a chaning `.set` method that returns the signature:
+      but there's a chaining `.set` method that returns the signature:
 
         .. code-block:: pycon
 

--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -186,7 +186,7 @@ class Pidfile:
     def remove_if_stale(self):
         """Remove the lock if the process isn't running.
 
-        I.e. process does not respons to signal.
+        I.e. process does not respond to signal.
         """
         try:
             pid = self.read_pid()

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -440,7 +440,7 @@ class crontab(BaseSchedule):
         else:
             raise TypeError(CRON_INVALID_TYPE.format(type=type(cronspec)))
 
-        # assure the result does not preceed the min or exceed the max
+        # assure the result does not precede the min or exceed the max
         for number in result:
             if number >= max_ + min_ or number < min_:
                 raise ValueError(CRON_PATTERN_INVALID.format(

--- a/docs/history/whatsnew-4.0.rst
+++ b/docs/history/whatsnew-4.0.rst
@@ -280,7 +280,7 @@ Features removed for simplicity
     This was an experimental feature, so not covered by our deprecation
     timeline guarantee.
 
-    You can copy and pase the existing batches code for use within your projects:
+    You can copy and pass the existing batches code for use within your projects:
     https://github.com/celery/celery/blob/3.1/celery/contrib/batches.py
 
 Features removed for lack of funding
@@ -1395,7 +1395,7 @@ New Elasticsearch result backend introduced
 
 See :ref:`conf-elasticsearch-result-backend` for more information.
 
-To depend on Celery with Elasticsearch as the result bakend use:
+To depend on Celery with Elasticsearch as the result backend use:
 
 .. code-block:: console
 

--- a/extra/WindowsCMD-AzureWebJob/Celery/run.cmd
+++ b/extra/WindowsCMD-AzureWebJob/Celery/run.cmd
@@ -21,7 +21,7 @@ set CELERYD_PID_FILE=%PATH_TO_PROJECT%\log\celery.pid
 set CELERYD_LOG_FILE=%PATH_TO_PROJECT%\log\celery.log
 set CELERYD_LOG_LEVEL=INFO
 
-rem You might need to change th path of the Python runing
+rem You might need to change th path of the Python running
 set PYTHONPATH=%PYTHONPATH%;%PATH_TO_PROJECT%;
 
 cd %PATH_TO_PROJECT%

--- a/extra/WindowsCMD-AzureWebJob/CeleryBeat/run.cmd
+++ b/extra/WindowsCMD-AzureWebJob/CeleryBeat/run.cmd
@@ -25,11 +25,11 @@ set CELERYD_PID_FILE=%PATH_TO_PROJECT%\log\celerybeat.pid
 set CELERYD_LOG_FILE=%PATH_TO_PROJECT%\log\celerybeat.log
 set CELERYD_LOG_LEVEL=INFO
 
-rem CONFIG RELATED TO THE BEAT 
+rem CONFIG RELATED TO THE BEAT
 set CELERYD_DATABASE=django
 set CELERYD_SCHEDULER=django_celery_beat.schedulers:DatabaseScheduler
 
-rem You might need to change th path of the Python runing
+rem You might need to change th path of the Python running
 set PYTHONPATH=%PYTHONPATH%;%PATH_TO_PROJECT%;
 
 cd %PATH_TO_PROJECT%

--- a/extra/supervisord/supervisord.conf
+++ b/extra/supervisord/supervisord.conf
@@ -18,7 +18,7 @@ childlogdir=/var/log/supervisord/            ; where child log files will live
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///tmp/supervisor.sock ; use unix:// schem for a unix sockets.
+serverurl=unix:///tmp/supervisor.sock ; use unix:// scheme for a unix sockets.
 
 
 [include]

--- a/t/integration/test_inspect.py
+++ b/t/integration/test_inspect.py
@@ -26,7 +26,7 @@ def inspect(manager):
 
 
 class test_Inspect:
-    """Integration tests fo app.control.inspect() API"""
+    """Integration tests to app.control.inspect() API"""
 
     @flaky
     def test_ping(self, inspect):

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1023,7 +1023,7 @@ class test_App:
         assert oid1 == oid2
 
     def test_backend(self):
-        # Test that app.bakend returns the same backend in single thread
+        # Test that app.backend returns the same backend in single thread
         backend1 = self.app.backend
         backend2 = self.app.backend
         assert isinstance(backend1, Backend)
@@ -1031,7 +1031,7 @@ class test_App:
         assert backend1 is backend2
 
     def test_thread_backend(self):
-        # Test that app.bakend returns the new backend for each thread
+        # Test that app.backend returns the new backend for each thread
         main_backend = self.app.backend
         from concurrent.futures import ThreadPoolExecutor
         with ThreadPoolExecutor(max_workers=1) as executor:

--- a/t/unit/events/test_state.py
+++ b/t/unit/events/test_state.py
@@ -126,7 +126,7 @@ class ev_logical_clock_ordering(replay):
             QTEV('succeeded', tB, 'w2', name='tB', clock=offset + 9),
             QTEV('started', tC, 'w2', name='tC', clock=offset + 10),
             QTEV('received', tA, 'w3', name='tA', clock=offset + 13),
-            QTEV('succeded', tC, 'w2', name='tC', clock=offset + 12),
+            QTEV('succeeded', tC, 'w2', name='tC', clock=offset + 12),
             QTEV('started', tA, 'w3', name='tA', clock=offset + 14),
             QTEV('succeeded', tA, 'w3', name='TA', clock=offset + 16),
         ]


### PR DESCRIPTION
Based on the pipeline... https://github.com/Kludex/celery/actions/runs/3260825146/jobs/5354731620

Why do we even have bandit in the pipeline if it fails anyway? :thinking:

Why does the pipeline has this `|| true` on all commands?