### PR TITLE
Added a new control command `revoke_by_stamped_headers` to revoke tasks by their stamped header instead of task id

### DIFF
--- a/celery/app/control.py
+++ b/celery/app/control.py
@@ -499,6 +499,40 @@ class Control:
             'signal': signal,
         }, **kwargs)
 
+    def revoke_by_stamped_headers(self, headers, destination=None, terminate=False,
+                                  signal=TERM_SIGNAME, **kwargs):
+        """
+        Tell all (or specific) workers to revoke a task by headers.
+
+        If a task is revoked, the workers will ignore the task and
+        not execute it after all.
+
+        Arguments:
+            headers (dict[str, list]): Headers to match when revoking tasks.
+            terminate (bool): Also terminate the process currently working
+                on the task (if any).
+            signal (str): Name of signal to send to process if terminate.
+                Default is TERM.
+
+        See Also:
+            :meth:`broadcast` for supported keyword arguments.
+        """
+        result = self.broadcast('revoke_by_stamped_headers', destination=destination, arguments={
+            'headers': headers,
+            'terminate': terminate,
+            'signal': signal,
+        }, **kwargs)
+
+        task_ids = set()
+        for host in result:
+            for response in host.values():
+                task_ids.update(response['ok'])
+
+        if task_ids:
+            return self.revoke(list(task_ids), destination=destination, terminate=terminate, signal=signal, **kwargs)
+        else:
+            return result
+
     def terminate(self, task_id,
                   destination=None, signal=TERM_SIGNAME, **kwargs):
         """Tell all (or specific) workers to terminate a task by id (or list of ids).

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -505,6 +505,10 @@ class Signature(dict):
         else:
             headers["stamped_headers"] = [header for header in headers.keys() if header not in self.options]
             _merge_dictionaries(headers, self.options)
+
+        stamped_headers = set(self.options.get("stamped_headers", []))
+        stamped_headers.update(headers["stamped_headers"])
+        headers["stamped_headers"] = list(stamped_headers)
         return self.set(**headers)
 
     def _with_list_option(self, key):
@@ -1761,6 +1765,9 @@ class _chord(Signature):
         options = dict(self.options, **options) if options else self.options
         if options:
             options.pop('task_id', None)
+            stamped_headers = set(body.options.get("stamped_headers", []))
+            stamped_headers.update(options["stamped_headers"])
+            options["stamped_headers"] = list(stamped_headers)
             body.options.update(options)
 
         bodyres = body.freeze(task_id, root_id=root_id)

--- a/celery/result.py
+++ b/celery/result.py
@@ -161,6 +161,30 @@ class AsyncResult(ResultBase):
                                 terminate=terminate, signal=signal,
                                 reply=wait, timeout=timeout)
 
+    def revoke_by_stamped_headers(self, headers, connection=None, terminate=False, signal=None,
+                                  wait=True, timeout=10):
+        """Send revoke signal to all workers only for tasks with matching headers values
+
+        Any worker receiving the task, or having reserved the
+        task, *must* ignore it.
+        All header fields *must* match.
+
+        Arguments:
+            headers (dict[str, list]): Headers to match when revoking tasks.
+            terminate (bool): Also terminate the process currently working
+                on the task (if any).
+            signal (str): Name of signal to send to process if terminate.
+                Default is TERM.
+            wait (bool): Wait for replies from workers.
+                The ``timeout`` argument specifies the seconds to wait.
+                Enabled by default.
+            timeout (float): Time in seconds to wait for replies when
+                ``wait`` is enabled.
+        """
+        self.app.control.revoke_by_stamped_headers(headers, connection=connection,
+                                                   terminate=terminate, signal=signal,
+                                                   reply=wait, timeout=timeout)
+
     def get(self, timeout=None, propagate=True, interval=0.5,
             no_ack=True, follow_parents=True, callback=None, on_message=None,
             on_interval=None, disable_sync_subtasks=True,

--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -1,12 +1,13 @@
 """Worker remote control command implementations."""
 import io
 import tempfile
+import warnings
 from collections import UserDict, namedtuple
 
 from billiard.common import TERM_SIGNAME
 from kombu.utils.encoding import safe_repr
 
-from celery.exceptions import WorkerShutdown
+from celery.exceptions import CeleryWarning, WorkerShutdown
 from celery.platforms import signals as _signals
 from celery.utils.functional import maybe_list
 from celery.utils.log import get_logger
@@ -146,6 +147,58 @@ def revoke(state, task_id, terminate=False, signal=None, **kwargs):
     #     Outside of this scope that is a function.
     # supports list argument since 3.1
     task_ids, task_id = set(maybe_list(task_id) or []), None
+    task_ids = _revoke(state, task_ids, terminate, signal, **kwargs)
+    return ok(f'tasks {task_ids} flagged as revoked')
+
+
+@control_command(
+    variadic='headers',
+    signature='[key1=value1 [key2=value2 [... [keyN=valueN]]]]',
+)
+def revoke_by_stamped_headers(state, headers, terminate=False, signal=None, **kwargs):
+    """Revoke task by header (or list of headers).
+
+    Keyword Arguments:
+        terminate (bool): Also terminate the process if the task is active.
+        signal (str): Name of signal to use for terminate (e.g., ``KILL``).
+    """
+    # pylint: disable=redefined-outer-name
+    # XXX Note that this redefines `terminate`:
+    #     Outside of this scope that is a function.
+    # supports list argument since 3.1
+    if isinstance(headers, list):
+        headers = {h.split('=')[0]: h.split('=')[1] for h in headers}, None
+
+    worker_state.revoked_headers.update(headers)
+
+    if not terminate:
+        return ok(f'headers {headers} flagged as revoked')
+
+    task_ids = set()
+    requests = worker_state.active_requests.values()
+
+    # Terminate all running tasks of matching headers
+    if requests:
+        warnings.warn(
+            "Terminating tasks by headers does not scale well when worker concurrency is high",
+            CeleryWarning
+        )
+
+        for req in requests:
+            if req.stamped_headers:
+                for stamped_header_key, expected_header_value in headers.items():
+                    if stamped_header_key in req.stamped_headers and \
+                            stamped_header_key in req._message.headers['stamps']:
+                        actual_header = req._message.headers['stamps'][stamped_header_key]
+                        if expected_header_value in actual_header:
+                            task_ids.add(req.task_id)
+                            continue
+
+    task_ids = _revoke(state, task_ids, terminate, signal, **kwargs)
+    return ok(list(task_ids))
+
+
+def _revoke(state, task_ids, terminate=False, signal=None, **kwargs):
     size = len(task_ids)
     terminated = set()
 
@@ -166,7 +219,7 @@ def revoke(state, task_id, terminate=False, signal=None, **kwargs):
 
     idstr = ', '.join(task_ids)
     logger.info('Tasks flagged as revoked: %s', idstr)
-    return ok(f'tasks {idstr} flagged as revoked')
+    return task_ids
 
 
 @control_command(

--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -67,6 +67,9 @@ all_total_count = [0]
 #: the list of currently revoked tasks.  Persistent if ``statedb`` set.
 revoked = LimitedSet(maxlen=REVOKES_MAX, expires=REVOKE_EXPIRES)
 
+#: Mapping of stamped headers flagged for revoking.
+revoked_headers = {}
+
 should_stop = None
 should_terminate = None
 

--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -468,6 +468,70 @@ Note that remote control commands must be working for revokes to work.
 Remote control commands are only supported by the RabbitMQ (amqp) and Redis
 at this point.
 
+.. control:: revoke_by_stamped_header
+
+``revoke_by_stamped_header``: Revoking tasks by their stamped headers
+---------------------------------------------------------------------
+:pool support: all, terminate only supported by prefork and eventlet
+:broker support: *amqp, redis*
+:command: :program:`celery -A proj control revoke_by_stamped_header <header=value>`
+
+This command is similar to :meth:`~@control.revoke`, but instead of
+specifying the task id(s), you specify the stamped header(s) as key-value pair(s),
+and each task that has a stamped header matching the key-value pair(s) will be revoked.
+
+.. warning::
+
+    This command may perform poorly if your worker pool concurrency is high,
+    since it will have to iterate over all the runnig tasks to find the ones
+    with the specified stamped header.
+
+.. warning::
+
+    This command applies only to tasks that are in memory and are
+    being executed by a worker.
+
+**Example**
+
+.. code-block:: pycon
+
+    >>> app.control.revoke_by_stamped_header({'my_stamped_header': 'my_value'})
+
+    >>> app.control.revoke_by_stamped_header({'my_stamped_header': 'my_value'},
+    ...                                     terminate=True)
+
+    >>> app.control.revoke_by_stamped_header({'my_stamped_header': 'my_value'},
+    ...                                     terminate=True, signal='SIGKILL')
+
+
+Revoking multiple tasks by stamped headers
+------------------------------------------
+
+.. versionadded:: 5.3
+
+The ``revoke_by_stamped_header`` method also accepts a list argument, where it will revoke
+by several headers.
+
+**Example**
+
+.. code-block:: pycon
+
+    >> app.control.revoke_by_stamped_header({
+    ...    'my_stamped_header_A': 'my_value_1',
+    ...    'my_stamped_header_B': 'my_value_2',
+    ...    'my_stamped_header_C': 'my_value_3',
+    })
+
+**CLI Example**
+
+.. code-block:: console
+
+    $ celery -A proj control revoke_by_stamped_header stamped_header_key_A=stamped_header_value_1 stamped_header_key_B=stamped_header_value_2
+
+    $ celery -A proj control revoke_by_stamped_header stamped_header_key_A=stamped_header_value_1 stamped_header_key_B=stamped_header_value_2 --terminate
+
+    $ celery -A proj control revoke_by_stamped_header stamped_header_key_A=stamped_header_value_1 stamped_header_key_B=stamped_header_value_2 --terminate --signal=SIGKILL
+
 .. _worker-time-limits:
 
 Time Limits

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -151,7 +151,7 @@ class test_Signature(CanvasCase):
             assert sig_1_res._get_task_meta()["stamp2"] == ["stamp2"]
 
         with subtests.test("sig_1_res is stamped twice", stamped_headers=["stamp2", "stamp1"]):
-            assert sig_1_res._get_task_meta()["stamped_headers"] == ["stamp2", "stamp1", "groups"]
+            assert sorted(sig_1_res._get_task_meta()["stamped_headers"]) == sorted(["stamp2", "stamp1", "groups"])
 
     def test_twice_stamping(self, subtests):
         """
@@ -168,10 +168,10 @@ class test_Signature(CanvasCase):
         sig_1.apply()
 
         with subtests.test("sig_1_res is stamped twice", stamps=["stamp2", "stamp1"]):
-            assert sig_1_res._get_task_meta()["stamp"] == ["stamp2", "stamp1"]
+            assert sorted(sig_1_res._get_task_meta()["stamp"]) == sorted(["stamp2", "stamp1"])
 
         with subtests.test("sig_1_res is stamped twice", stamped_headers=["stamp2", "stamp1"]):
-            assert sig_1_res._get_task_meta()["stamped_headers"] == ["stamp", "groups"]
+            assert sorted(sig_1_res._get_task_meta()["stamped_headers"]) == sorted(["stamp", "groups"])
 
     @pytest.mark.usefixtures('depends_on_current_app')
     def test_manual_stamping(self):
@@ -188,7 +188,7 @@ class test_Signature(CanvasCase):
         sig_1.stamp(visitor=None, groups=stamps[0])
         sig_1_res = sig_1.freeze()
         sig_1.apply()
-        assert sig_1_res._get_task_meta()['groups'] == stamps
+        assert sorted(sig_1_res._get_task_meta()['groups']) == sorted(stamps)
 
     def test_getitem_property_class(self):
         assert Signature.task
@@ -804,10 +804,10 @@ class test_group(CanvasCase):
             assert sig_2_res._get_task_meta()['stamp'] == ["stamp"]
 
         with subtests.test("sig_1_res has stamped_headers", stamped_headers=["stamp", 'groups']):
-            assert sig_1_res._get_task_meta()['stamped_headers'] == ['stamp', 'groups']
+            assert sorted(sig_1_res._get_task_meta()['stamped_headers']) == sorted(['stamp', 'groups'])
 
         with subtests.test("sig_2_res has stamped_headers", stamped_headers=["stamp"]):
-            assert sig_2_res._get_task_meta()['stamped_headers'] == ['stamp', 'groups']
+            assert sorted(sig_2_res._get_task_meta()['stamped_headers']) == sorted(['stamp', 'groups'])
 
     def test_group_stamping_two_levels(self, subtests):
         """
@@ -854,11 +854,11 @@ class test_group(CanvasCase):
         with subtests.test("sig_2_res is stamped", groups=[g1_res.id]):
             assert sig_2_res._get_task_meta()['groups'] == [g1_res.id]
         with subtests.test("first_nested_sig_res is stamped", groups=[g1_res.id, g2_res.id]):
-            assert first_nested_sig_res._get_task_meta()['groups'] == \
-                [g1_res.id, g2_res.id]
+            assert sorted(first_nested_sig_res._get_task_meta()['groups']) == \
+                sorted([g1_res.id, g2_res.id])
         with subtests.test("second_nested_sig_res is stamped", groups=[g1_res.id, g2_res.id]):
-            assert second_nested_sig_res._get_task_meta()['groups'] == \
-                [g1_res.id, g2_res.id]
+            assert sorted(second_nested_sig_res._get_task_meta()['groups']) == \
+                sorted([g1_res.id, g2_res.id])
 
     def test_group_stamping_with_replace(self, subtests):
         """
@@ -988,17 +988,17 @@ class test_group(CanvasCase):
         with subtests.test("sig_in_g1_2_res is stamped", groups=[g1_res.id]):
             assert sig_in_g1_2_res._get_task_meta()['groups'] == [g1_res.id]
         with subtests.test("sig_in_g2_res is stamped", groups=[g1_res.id, g2_res.id]):
-            assert sig_in_g2_res._get_task_meta()['groups'] == \
-                [g1_res.id, g2_res.id]
+            assert sorted(sig_in_g2_res._get_task_meta()['groups']) == \
+                sorted([g1_res.id, g2_res.id])
         with subtests.test("sig_in_g2_chain_res is stamped", groups=[g1_res.id, g2_res.id]):
-            assert sig_in_g2_chain_res._get_task_meta()['groups'] == \
-                [g1_res.id, g2_res.id]
+            assert sorted(sig_in_g2_chain_res._get_task_meta()['groups']) == \
+                sorted([g1_res.id, g2_res.id])
         with subtests.test("sig_in_g3_1_res is stamped", groups=[g1_res.id, g2_res.id, g3_res.id]):
-            assert sig_in_g3_1_res._get_task_meta()['groups'] == \
-                [g1_res.id, g2_res.id, g3_res.id]
+            assert sorted(sig_in_g3_1_res._get_task_meta()['groups']) == \
+                sorted([g1_res.id, g2_res.id, g3_res.id])
         with subtests.test("sig_in_g3_2_res is stamped", groups=[g1_res.id, g2_res.id, g3_res.id]):
-            assert sig_in_g3_2_res._get_task_meta()['groups'] == \
-                [g1_res.id, g2_res.id, g3_res.id]
+            assert sorted(sig_in_g3_2_res._get_task_meta()['groups']) == \
+                sorted([g1_res.id, g2_res.id, g3_res.id])
 
     def test_group_stamping_parallel_groups(self, subtests):
         """
@@ -1067,14 +1067,14 @@ class test_group(CanvasCase):
 
         with subtests.test("sig_in_g2_1 is stamped", groups=[g1_res.id, g2_res.id]):
             assert sig_in_g2_1_res.id == 'sig_in_g2_1'
-            assert sig_in_g2_1_res._get_task_meta()['groups'] == \
-                [g1_res.id, g2_res.id]
+            assert sorted(sig_in_g2_1_res._get_task_meta()['groups']) == \
+                sorted([g1_res.id, g2_res.id])
 
         with subtests.test("sig_in_g2_2 is stamped",
                            groups=[g1_res.id, g2_res.id]):
             assert sig_in_g2_2_res.id == 'sig_in_g2_2'
-            assert sig_in_g2_2_res._get_task_meta()['groups'] == \
-                [g1_res.id, g2_res.id]
+            assert sorted(sig_in_g2_2_res._get_task_meta()['groups']) == \
+                sorted([g1_res.id, g2_res.id])
 
         with subtests.test("sig_in_g3_chain is stamped",
                            groups=[g1_res.id]):
@@ -1085,13 +1085,13 @@ class test_group(CanvasCase):
         with subtests.test("sig_in_g3_1 is stamped",
                            groups=[g1_res.id, g3_res.id]):
             assert sig_in_g3_1_res.id == 'sig_in_g3_1'
-            assert sig_in_g3_1_res._get_task_meta()['groups'] == \
-                [g1_res.id, g3_res.id]
+            assert sorted(sig_in_g3_1_res._get_task_meta()['groups']) == \
+                sorted([g1_res.id, g3_res.id])
 
         with subtests.test("sig_in_g3_2 is stamped",
                            groups=[g1_res.id, g3_res.id]):
-            assert sig_in_g3_2_res._get_task_meta()['groups'] == \
-                [g1_res.id, g3_res.id]
+            assert sorted(sig_in_g3_2_res._get_task_meta()['groups']) == \
+                sorted([g1_res.id, g3_res.id])
 
     def test_repr(self):
         x = group([self.add.s(2, 2), self.add.s(4, 4)])
@@ -1520,10 +1520,10 @@ class test_chord(CanvasCase):
             assert sig_2_res._get_task_meta()['stamp'] == ["stamp"]
 
         with subtests.test("sig_1_res has stamped_headers", stamped_headers=["stamp", 'groups']):
-            assert sig_1_res._get_task_meta()['stamped_headers'] == ['stamp', 'groups']
+            assert sorted(sig_1_res._get_task_meta()['stamped_headers']) == sorted(['stamp', 'groups'])
 
         with subtests.test("sig_2_res has stamped_headers", stamped_headers=["stamp", 'groups']):
-            assert sig_2_res._get_task_meta()['stamped_headers'] == ['stamp', 'groups']
+            assert sorted(sig_2_res._get_task_meta()['stamped_headers']) == sorted(['stamp', 'groups'])
 
     def test_chord_stamping_two_levels(self, subtests):
         """
@@ -1565,11 +1565,11 @@ class test_chord(CanvasCase):
         with subtests.test("sig_2_res body is stamped", groups=[g1.id]):
             assert sig_2_res._get_task_meta()['groups'] == [g1.id]
         with subtests.test("first_nested_sig_res body is stamped", groups=[g1.id, g2_res.id]):
-            assert first_nested_sig_res._get_task_meta()['groups'] == \
-                [g1.id, g2_res.id]
+            assert sorted(first_nested_sig_res._get_task_meta()['groups']) == \
+                sorted([g1.id, g2_res.id])
         with subtests.test("second_nested_sig_res body is stamped", groups=[g1.id, g2_res.id]):
-            assert second_nested_sig_res._get_task_meta()['groups'] == \
-                [g1.id, g2_res.id]
+            assert sorted(second_nested_sig_res._get_task_meta()['groups']) == \
+                sorted([g1.id, g2_res.id])
 
     def test_chord_stamping_body_group(self, subtests):
         """


### PR DESCRIPTION
New documentation is added as part of this.