### PR TITLE
Remove flakeplus package

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -736,23 +736,6 @@ Installing the dependencies:
 
     $ pip install -U -r requirements/pkgutils.txt
 
-pyflakes & PEP-8
-~~~~~~~~~~~~~~~~
-
-To ensure that your changes conform to :pep:`8` and to run pyflakes
-execute:
-
-.. code-block:: console
-
-    $ make flakecheck
-
-To not return a negative exit code when this command fails, use
-the ``flakes`` target instead:
-
-.. code-block:: console
-
-    $ make flakes
-
 API reference
 ~~~~~~~~~~~~~
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ PYTEST=pytest
 GIT=git
 TOX=tox
 ICONV=iconv
-FLAKE8=flake8
 PYROMA=pyroma
 SPHINX2RST=sphinx2rst
 RST2HTML=rst2html.py
@@ -36,8 +35,6 @@ help:
 	@echo "    configcheck      - Check configuration reference coverage."
 	@echo "    readmecheck      - Check README.rst encoding."
 	@echo "    contribcheck     - Check CONTRIBUTING.rst encoding"
-	@echo "    flakes --------  - Check code for syntax and style errors."
-	@echo "      flakecheck     - Run flake8 on the source code."
 	@echo "readme               - Regenerate README.rst file."
 	@echo "contrib              - Regenerate CONTRIBUTING.rst file"
 	@echo "clean-dist --------- - Clean all distribution build artifacts."
@@ -76,19 +73,13 @@ docs: clean-docs Documentation
 clean-docs:
 	-rm -rf "$(SPHINX_BUILDDIR)" "$(DOCUMENTATION)"
 
-lint: flakecheck apicheck configcheck readmecheck
+lint: apicheck configcheck readmecheck
 
 apicheck:
 	(cd "$(SPHINX_DIR)"; $(MAKE) apicheck)
 
 configcheck:
 	(cd "$(SPHINX_DIR)"; $(MAKE) configcheck)
-
-flakecheck:
-	$(FLAKE8) "$(PROJ)" "$(TESTDIR)"
-
-flakediag:
-	-$(MAKE) flakecheck
 
 clean-readme:
 	-rm -f $(README)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ TOX=tox
 ICONV=iconv
 FLAKE8=flake8
 PYROMA=pyroma
-FLAKEPLUS=flakeplus
 SPHINX2RST=sphinx2rst
 RST2HTML=rst2html.py
 DEVNULL=/dev/null
@@ -22,7 +21,6 @@ CONTRIBUTING=CONTRIBUTING.rst
 CONTRIBUTING_SRC="docs/contributing.rst"
 SPHINX_HTMLDIR="${SPHINX_BUILDDIR}/html"
 DOCUMENTATION=Documentation
-FLAKEPLUSTARGET=2.7
 
 WORKER_GRAPH="docs/images/worker_graph_full.png"
 
@@ -40,7 +38,6 @@ help:
 	@echo "    contribcheck     - Check CONTRIBUTING.rst encoding"
 	@echo "    flakes --------  - Check code for syntax and style errors."
 	@echo "      flakecheck     - Run flake8 on the source code."
-	@echo "      flakepluscheck - Run flakeplus on the source code."
 	@echo "readme               - Regenerate README.rst file."
 	@echo "contrib              - Regenerate CONTRIBUTING.rst file"
 	@echo "clean-dist --------- - Clean all distribution build artifacts."
@@ -92,14 +89,6 @@ flakecheck:
 
 flakediag:
 	-$(MAKE) flakecheck
-
-flakepluscheck:
-	$(FLAKEPLUS) --$(FLAKEPLUSTARGET) "$(PROJ)" "$(TESTDIR)"
-
-flakeplusdiag:
-	-$(MAKE) flakepluscheck
-
-flakes: flakediag flakeplusdiag
 
 clean-readme:
 	-rm -f $(README)

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -1,7 +1,6 @@
 setuptools>=40.8.0
 wheel>=0.33.1
 flake8>=3.8.3
-flakeplus>=1.1
 flake8-docstrings~=1.5
 pydocstyle==6.1.1; python_version >= '3.0'
 tox>=3.8.4

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist =
     {3.7,3.8,3.9,3.10,pypy3}-unit
     {3.7,3.8,3.9,3.10,pypy3}-integration-{rabbitmq_redis,rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
 
-    flake8
     apicheck
     configcheck
     bandit


### PR DESCRIPTION
This PR removes the old `flakeplus` package, and all the references to flake8.

`flake8` is already running on the `pre-commit`, and in the pipeline.