### PR TITLE
Fix readthedocs build failure

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+    - method: pip
+      path: .
+    - requirements: requirements/docs.txt

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 pytz>=2021.3
 billiard>=4.0.2,<5.0
-kombu>=5.3.0b1,<6.0
+kombu>=5.3.0b2,<6.0
 vine>=5.0.0,<6.0
 click>=8.1.2,<9.0
 click-didyoumean>=0.3.0


### PR DESCRIPTION
Closes https://github.com/celery/celery/issues/7783 https://github.com/celery/celery/pull/7834 https://github.com/celery/celery/pull/7833

Fix doc build failure:

* `kombu>=5.3.0b2`
* make sure readthedocs builds with the proper dependencies