### PR TITLE
even if it is cached no_ack should affect to the get function

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -215,7 +215,7 @@ class AsyncResult(ResultBase):
         if on_interval:
             _on_interval.then(on_interval)
 
-        if self._cache:
+        if self._cache and not no_ack:
             if propagate:
                 self.maybe_throw(callback=callback)
             return self.result


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

I'm beginer of celery. I'm trying to ampq as broker and backend.

in tutorial, result is not removed by get() function

for example,


case1
```
result = add.delay(4, 4)
result.ready()
result.get()
```

case2
```
result = add.delay(4, 4)
result.get()
```

when I was trying to case 1,  not removed from result queue.
but case 2 does.

so I add 1 line in get function.

I'm  not good at programming, If you have a another solution. plz tell me.

thanks.

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
