### PR TITLE
Clarify wording in Redis priority docs

### DIFF
--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -304,8 +304,8 @@ The config above will give you these queue names:
 
 
 That said, note that this will never be as good as priorities implemented at the
-server level, and may be approximate at best. But it may still be good enough
-for your application.
+broker server level, and may be approximate at best. But it may still be good
+enough for your application.
 
 
 AMQP Primer


### PR DESCRIPTION
## Description

What exactly "server" referred to in this context was confusing a coworker of mine (I think he was thinking about where Celery Python code actually runs), so it seemed worth clarifying.