### PR TITLE
Removed the mandatory requirement to include `stamped_headers` key when implementing `on_signature()`

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -501,7 +501,10 @@ class Signature(dict):
         """
         headers = headers.copy()
         if visitor is not None:
-            headers.update(visitor.on_signature(self, **headers))
+            visitor_headers = visitor.on_signature(self, **headers)
+            if "stamped_headers" not in visitor_headers:
+                visitor_headers["stamped_headers"] = list(visitor_headers.keys())
+            headers.update(visitor_headers)
         else:
             headers["stamped_headers"] = [header for header in headers.keys() if header not in self.options]
             _merge_dictionaries(headers, self.options)

--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -1232,9 +1232,22 @@ the external monitoring system.
 
     class MonitoringIdStampingVisitor(StampingVisitor):
         def on_signature(self, sig, **headers) -> dict:
-            return {'monitoring_id': uuid4(), 'stamped_headers': ['monitoring_id']}
+            return {'monitoring_id': uuid4().hex}
 
-Next, lets see how to use the ``MonitoringIdStampingVisitor`` stamping visitor.
+.. note::
+
+    The ``stamped_headers`` key returned in ``on_signature`` is used to specify the headers that will be
+    stamped on the task. If this key is not specified, the stamping visitor will assume all keys in the
+    returned dictionary are the stamped headers from the visitor.
+    This means the following code block will result in the same behavior as the previous example.
+
+.. code-block:: python
+
+    class MonitoringIdStampingVisitor(StampingVisitor):
+        def on_signature(self, sig, **headers) -> dict:
+            return {'monitoring_id': uuid4().hex, 'stamped_headers': ['monitoring_id']}
+
+Next, lets see how to use the ``MonitoringIdStampingVisitor`` example stamping visitor.
 
 .. code-block:: python
 

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -204,7 +204,7 @@ class test_tasks:
 
         class MonitoringIdStampingVisitor(StampingVisitor):
             def on_signature(self, sig, **headers) -> dict:
-                return {'monitoring_id': target_monitoring_id, 'stamped_headers': ['monitoring_id']}
+                return {'monitoring_id': target_monitoring_id}
 
         for monitoring_id in [target_monitoring_id, uuid4().hex, 4242, None]:
             stamped_task = add.si(1, 1)


### PR DESCRIPTION
The `Signature.stamp()` method will now implicitly populate the "stamping_header" key if it was not manually set.