### PR TITLE
Fix non working example of using celery_worker pytest fixture

### DIFF
--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -160,7 +160,8 @@ Example:
         @celery_app.task
         def mul(x, y):
             return x * y
-
+        
+        celery_worker.reload()
         assert mul.delay(4, 4).get(timeout=10) == 16
 
 ``celery_worker`` - Embed live worker.


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
closes #7750 
