### PR TITLE
Add --skip-checks flag to bypass django core checks

### DIFF
--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -131,9 +131,15 @@ else:
               cls=CeleryOption,
               is_flag=True,
               help_group="Global Options")
+@click.option('--skip-checks',
+              envvar='SKIP_CHECKS',
+              cls=CeleryOption,
+              is_flag=True,
+              help_group="Global Options",
+              help="Skip Django core checks on startup.")
 @click.pass_context
 def celery(ctx, app, broker, result_backend, loader, config, workdir,
-           no_color, quiet, version):
+           no_color, quiet, version, skip_checks):
     """Celery command entrypoint."""
     if version:
         click.echo(VERSION_BANNER)
@@ -151,6 +157,8 @@ def celery(ctx, app, broker, result_backend, loader, config, workdir,
         os.environ['CELERY_RESULT_BACKEND'] = result_backend
     if config:
         os.environ['CELERY_CONFIG_MODULE'] = config
+    if skip_checks:
+        os.environ['CELERY_SKIP_CHECKS'] = skip_checks
     ctx.obj = CLIContext(app=app, no_color=no_color, workdir=workdir,
                          quiet=quiet)
 

--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -133,7 +133,8 @@ class DjangoWorkerFixup:
     def validate_models(self) -> None:
         from django.core.checks import run_checks
         self.django_setup()
-        run_checks()
+        if not os.environ.get('CELERY_SKIP_CHECKS'):
+            run_checks()
 
     def install(self) -> "DjangoWorkerFixup":
         signals.beat_embedded_init.connect(self.close_database)

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -263,9 +263,19 @@ class test_DjangoWorkerFixup(FixupCase):
         f.django_setup = Mock(name='django.setup')
         patching.modules('django.core.checks')
         from django.core.checks import run_checks
+
         f.validate_models()
         f.django_setup.assert_called_with()
         run_checks.assert_called_with()
+
+        # test --skip-checks flag
+        f.django_setup.reset_mock()
+        run_checks.reset_mock()
+
+        patching.setenv('CELERY_SKIP_CHECKS', True)
+        f.validate_models()
+        f.django_setup.assert_called_with()
+        run_checks.assert_not_called()
 
     def test_django_setup(self, patching):
         patching('celery.fixups.django.symbol_by_name')


### PR DESCRIPTION
## Description

Resolves feature request #7581
