### PR TITLE
Add clarifying information to completed_count documentation

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -651,8 +651,11 @@ class ResultSet(ResultBase):
     def completed_count(self):
         """Task completion count.
 
+        Note that `complete` means `successful` in this context. In other words, the
+        return value of this method is the number of successful tasks.
+
         Returns:
-            int: the number of tasks completed.
+            int: the number of complete (i.e. successful) tasks.
         """
         return sum(int(result.successful()) for result in self.results)
 

--- a/celery/result.py
+++ b/celery/result.py
@@ -652,7 +652,7 @@ class ResultSet(ResultBase):
         """Task completion count.
 
         Note that `complete` means `successful` in this context. In other words, the
-        return value of this method is the number of successful tasks.
+        return value of this method is the number of ``successful`` tasks.
 
         Returns:
             int: the number of complete (i.e. successful) tasks.

--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -797,7 +797,9 @@ It supports the following operations:
 
 * :meth:`~celery.result.GroupResult.completed_count`
 
-    Return the number of completed subtasks.
+    Return the number of completed subtasks. Note that `complete` means `successful` in
+    this context. In other words, the return value of this method is the number of
+    ``successful`` tasks.
 
 * :meth:`~celery.result.GroupResult.revoke`
 


### PR DESCRIPTION
## Description

Closes #7713

This PR adds clarifying information to documentation about the `ResultSet.completed_count` method. It clarifies that "complete" and "successful" have the same meaning.