### PR TITLE
fix typos in optional tests

### DIFF
--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -26,7 +26,7 @@ def patch_crontab_nowfun(cls, retval):
 class test_solar:
 
     def setup(self):
-        pytest.importorskip('ephem0')
+        pytest.importorskip('ephem')
         self.s = solar('sunrise', 60, 30, app=self.app)
 
     def test_reduce(self):

--- a/t/unit/backends/test_cache.py
+++ b/t/unit/backends/test_cache.py
@@ -143,7 +143,7 @@ class test_CacheBackend:
         assert b.as_uri() == backend
 
     def test_regression_worker_startup_info(self):
-        pytest.importorskip('memcached')
+        pytest.importorskip('memcache')
         self.app.conf.result_backend = (
             'cache+memcached://127.0.0.1:11211;127.0.0.2:11211;127.0.0.3/'
         )


### PR DESCRIPTION
had a look at some of the optional tests, i.e. tests that are skipped if the corresponding python module is not installed, and found two small glitches:  in test_schedules, a spurious 0 was appended to the module name, and in test_cache, though the python package is named memcached, the to-be-imported module is memcache
