### PR TITLE
Fix "rm: no operand" error in clean-pyc script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ $(CONTRIBUTING):
 contrib: clean-contrib $(CONTRIBUTING)
 
 clean-pyc:
-	-find . -type f -a \( -name "*.pyc" -o -name "*$$py.class" \) | xargs rm
-	-find . -type d -name "__pycache__" | xargs rm -r
+	-find . -type f -a \( -name "*.pyc" -o -name "*$$py.class" \) | xargs -r rm
+	-find . -type d -name "__pycache__" | xargs -r rm -r
 
 removepyc: clean-pyc
 


### PR DESCRIPTION
## Description

`make clean-pyc` fails with the following error when there are no cache files to delete. We can fix this by adding the `-r` flag to `xargs` to prevent it from running on empty input.

```
$ docker compose -f docker/docker-compose.yml run --rm celery
[+] Running 4/0
 ⠿ Container docker-azurite-1   Running                                                                                                                                                                                                         0.0s
 ⠿ Container docker-redis-1     Running                                                                                                                                                                                                         0.0s
 ⠿ Container docker-dynamodb-1  Running                                                                                                                                                                                                         0.0s
 ⠿ Container docker-rabbit-1    Running                                                                                                                                                                                                         0.0s
rm: missing operand
Try 'rm --help' for more information.
rm: missing operand
Try 'rm --help' for more information.
```

Searching around, [it looks like one other person has experienced this.](https://github.com/celery/celery/pull/7135#issuecomment-990166732)