### PR TITLE
Support for out-of-tree worker pool implementations

### DIFF
--- a/celery/concurrency/__init__.py
+++ b/celery/concurrency/__init__.py
@@ -1,4 +1,5 @@
 """Pool implementation abstract factory, and alias definitions."""
+import os
 
 # Import from kombu directly as it's used
 # early in the import stage, where celery.utils loads
@@ -21,6 +22,20 @@ except ImportError:
     pass
 else:
     ALIASES['threads'] = 'celery.concurrency.thread:TaskPool'
+#
+# Allow for an out-of-tree worker pool implementation. This is used as follows:
+#
+#   - Set the environment variable CELERY_CUSTOM_WORKER_POOL to the name of
+#     an implementation of :class:`celery.concurrency.base.BasePool` in the
+#     standard Celery format of "package:class".
+#   - Select this pool using '--pool custom'.
+#
+try:
+    custom = os.environ.get('CELERY_CUSTOM_WORKER_POOL')
+except KeyError:
+    pass
+else:
+    ALIASES['custom'] = custom
 
 
 def get_implementation(cls):

--- a/celery/concurrency/base.py
+++ b/celery/concurrency/base.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 import time
+from typing import Dict, Any
 
 from billiard.einfo import ExceptionInfo
 from billiard.exceptions import WorkerLostError
@@ -154,7 +155,13 @@ class BasePool:
                              callbacks_propagate=self.callbacks_propagate,
                              **options)
 
-    def _get_info(self):
+    def _get_info(self) -> Dict[str, Any]:
+        """
+        Return configuration and statistics information. Subclasses should
+        augment the data as required.
+
+        :return: The returned value must be JSON-friendly.
+        """
         return {
             'max-concurrency': self.limit,
         }

--- a/celery/concurrency/base.py
+++ b/celery/concurrency/base.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 import time
-from typing import Dict, Any
+from typing import Any, Dict
 
 from billiard.einfo import ExceptionInfo
 from billiard.exceptions import WorkerLostError

--- a/celery/concurrency/base.py
+++ b/celery/concurrency/base.py
@@ -163,6 +163,7 @@ class BasePool:
         :return: The returned value must be JSON-friendly.
         """
         return {
+            'implementation': self.__class__.__module__ + ':' + self.__class__.__name__,
             'max-concurrency': self.limit,
         }
 

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -155,7 +155,8 @@ class TaskPool(BasePool):
 
     def _get_info(self):
         write_stats = getattr(self._pool, 'human_write_stats', None)
-        return {
+        info = super()._get_info()
+        info.update({
             'max-concurrency': self.limit,
             'processes': [p.pid for p in self._pool._pool],
             'max-tasks-per-child': self._pool._maxtasksperchild or 'N/A',
@@ -163,7 +164,8 @@ class TaskPool(BasePool):
             'timeouts': (self._pool.soft_timeout or 0,
                          self._pool.timeout or 0),
             'writes': write_stats() if write_stats is not None else 'N/A',
-        }
+        })
+        return info
 
     @property
     def num_processes(self):

--- a/celery/concurrency/solo.py
+++ b/celery/concurrency/solo.py
@@ -20,10 +20,12 @@ class TaskPool(BasePool):
         signals.worker_process_init.send(sender=None)
 
     def _get_info(self):
-        return {
+        info = super()._get_info()
+        info.update({
             'max-concurrency': 1,
             'processes': [os.getpid()],
             'max-tasks-per-child': None,
             'put-guarded-by-semaphore': True,
             'timeouts': (),
-        }
+        })
+        return info

--- a/celery/concurrency/thread.py
+++ b/celery/concurrency/thread.py
@@ -61,7 +61,9 @@ class TaskPool(BasePool):
         return ApplyResult(f)
 
     def _get_info(self) -> PoolInfo:
-        return {
+        info = super()._get_info()
+        info.update({
             'max-concurrency': self.limit,
             'threads': len(self.executor._threads)
-        }
+        })
+        return info

--- a/t/unit/concurrency/test_concurrency.py
+++ b/t/unit/concurrency/test_concurrency.py
@@ -167,6 +167,7 @@ class test_get_available_pool_names:
             'gevent',
             'solo',
             'processes',
+            'custom',
         )
         with patch.dict(sys.modules, {'concurrent.futures': None}):
             importlib.reload(concurrency)
@@ -180,6 +181,7 @@ class test_get_available_pool_names:
             'solo',
             'processes',
             'threads',
+            'custom',
         )
         with patch.dict(sys.modules, {'concurrent.futures': Mock()}):
             importlib.reload(concurrency)

--- a/t/unit/concurrency/test_concurrency.py
+++ b/t/unit/concurrency/test_concurrency.py
@@ -109,6 +109,7 @@ class test_BasePool:
 
     def test_interface_info(self):
         assert BasePool(10).info == {
+            'implementation': 'celery.concurrency.base:BasePool',
             'max-concurrency': 10,
         }
 

--- a/t/unit/concurrency/test_eventlet.py
+++ b/t/unit/concurrency/test_eventlet.py
@@ -129,6 +129,7 @@ class test_TaskPool(EventletCase):
         x = TaskPool(10)
         x._pool = Mock(name='_pool')
         assert x._get_info() == {
+            'implementation': 'celery.concurrency.eventlet:TaskPool',
             'max-concurrency': 10,
             'free-threads': x._pool.free(),
             'running-threads': x._pool.running(),


### PR DESCRIPTION
## Description

At the moment, Celery has a fixed notion of the worker pool types it supports. This PR introduces the the possibility of an out-of-tree worker pool implementation. Supporting commits ensure that the current worker pool implementations consistently call into `BasePool._get_info()`, and enhance it to report the work pool class in use via the "celery inspect stats" command. For example:
```
$ celery -A ... inspect stats
->  celery@freenas: OK
    {
        ...
        "pool": {
           ...
            "implementation": "celery_aio_pool.pool:AsyncIOPool",
```
It is used as follows:

- Set the environment variable CELERY_CUSTOM_WORKER_POOL to the name of
        an implementation of :class:`celery.concurrency.base.BasePool` in the
        standard Celery format of "package:class".

- Select this pool using '--pool custom'.

I've not added end-user docs as this can be considered an enabling step for #7874, but would be happy to draft something if required (and a suitable place in the docs is pointed out).