### PR TITLE
Fix revoke by headers tests stability

### DIFF
--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -200,6 +200,13 @@ class test_tasks:
 
     def test_revoked_by_headers_simple_canvas(self, manager):
         """Testing revoking of task using a stamped header"""
+        # Try to purge the queue before we start
+        # to attempt to avoid interference from other tests
+        while True:
+            count = manager.app.control.purge()
+            if count == 0:
+                break
+
         target_monitoring_id = uuid4().hex
 
         class MonitoringIdStampingVisitor(StampingVisitor):
@@ -226,6 +233,13 @@ class test_tasks:
                 assert result.failed() is False
                 assert result.successful() is True
         worker_state.revoked_headers.clear()
+
+        # Try to purge the queue after we're done
+        # to attempt to avoid interference to other tests
+        while True:
+            count = manager.app.control.purge()
+            if count == 0:
+                break
 
     # This test leaves the environment dirty,
     # so we let it run last in the suite to avoid

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -241,11 +241,6 @@ class test_tasks:
             if count == 0:
                 break
 
-    # This test leaves the environment dirty,
-    # so we let it run last in the suite to avoid
-    # affecting other tests until we can fix it.
-    @pytest.mark.order("last")
-    @flaky
     def test_revoked_by_headers_complex_canvas(self, manager, subtests):
         """Testing revoking of task using a stamped header"""
         try:
@@ -298,6 +293,13 @@ class test_tasks:
                     assert result.failed() is False
                     assert result.successful() is False
             worker_state.revoked_headers.clear()
+
+        # Try to purge the queue after we're done
+        # to attempt to avoid interference to other tests
+        while True:
+            count = manager.app.control.purge()
+            if count == 0:
+                break
 
     @flaky
     def test_wrong_arguments(self, manager):


### PR DESCRIPTION
`test_revoked_by_headers_simple_canvas()` and `test_revoked_by_headers_complex_canvas()` are still randomly failing.
This attempt to fix relies on cleanups instead of retries/ordering. 