### PR TITLE
Fix test warnings

### DIFF
--- a/celery/concurrency/__init__.py
+++ b/celery/concurrency/__init__.py
@@ -1,4 +1,5 @@
 """Pool implementation abstract factory, and alias definitions."""
+import os
 
 # Import from kombu directly as it's used
 # early in the import stage, where celery.utils loads
@@ -21,6 +22,20 @@ except ImportError:
     pass
 else:
     ALIASES['threads'] = 'celery.concurrency.thread:TaskPool'
+#
+# Allow for an out-of-tree worker pool implementation. This is used as follows:
+#
+#   - Set the environment variable CELERY_CUSTOM_WORKER_POOL to the name of
+#     an implementation of :class:`celery.concurrency.base.BasePool` in the
+#     standard Celery format of "package:class".
+#   - Select this pool using '--pool custom'.
+#
+try:
+    custom = os.environ.get('CELERY_CUSTOM_WORKER_POOL')
+except KeyError:
+    pass
+else:
+    ALIASES['custom'] = custom
 
 
 def get_implementation(cls):

--- a/celery/concurrency/base.py
+++ b/celery/concurrency/base.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 import time
+from typing import Dict, Any
 
 from billiard.einfo import ExceptionInfo
 from billiard.exceptions import WorkerLostError
@@ -154,7 +155,13 @@ class BasePool:
                              callbacks_propagate=self.callbacks_propagate,
                              **options)
 
-    def _get_info(self):
+    def _get_info(self) -> Dict[str, Any]:
+        """
+        Return configuration and statistics information. Subclasses should
+        augment the data as required.
+
+        :return: The returned value must be JSON-friendly.
+        """
         return {
             'max-concurrency': self.limit,
         }

--- a/celery/concurrency/base.py
+++ b/celery/concurrency/base.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 import time
-from typing import Dict, Any
+from typing import Any, Dict
 
 from billiard.einfo import ExceptionInfo
 from billiard.exceptions import WorkerLostError

--- a/celery/concurrency/base.py
+++ b/celery/concurrency/base.py
@@ -163,6 +163,7 @@ class BasePool:
         :return: The returned value must be JSON-friendly.
         """
         return {
+            'implementation': self.__class__.__module__ + ':' + self.__class__.__name__,
             'max-concurrency': self.limit,
         }
 

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -155,7 +155,8 @@ class TaskPool(BasePool):
 
     def _get_info(self):
         write_stats = getattr(self._pool, 'human_write_stats', None)
-        return {
+        info = super()._get_info()
+        info.update({
             'max-concurrency': self.limit,
             'processes': [p.pid for p in self._pool._pool],
             'max-tasks-per-child': self._pool._maxtasksperchild or 'N/A',
@@ -163,7 +164,8 @@ class TaskPool(BasePool):
             'timeouts': (self._pool.soft_timeout or 0,
                          self._pool.timeout or 0),
             'writes': write_stats() if write_stats is not None else 'N/A',
-        }
+        })
+        return info
 
     @property
     def num_processes(self):

--- a/celery/concurrency/solo.py
+++ b/celery/concurrency/solo.py
@@ -20,10 +20,12 @@ class TaskPool(BasePool):
         signals.worker_process_init.send(sender=None)
 
     def _get_info(self):
-        return {
+        info = super()._get_info()
+        info.update({
             'max-concurrency': 1,
             'processes': [os.getpid()],
             'max-tasks-per-child': None,
             'put-guarded-by-semaphore': True,
             'timeouts': (),
-        }
+        })
+        return info

--- a/celery/concurrency/thread.py
+++ b/celery/concurrency/thread.py
@@ -61,7 +61,9 @@ class TaskPool(BasePool):
         return ApplyResult(f)
 
     def _get_info(self) -> PoolInfo:
-        return {
+        info = super()._get_info()
+        info.update({
             'max-concurrency': self.limit,
             'threads': len(self.executor._threads)
-        }
+        })
+        return info

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -206,7 +206,7 @@ class test_AMQP_proto1:
 
 
 class test_AMQP_Base:
-    def setup(self):
+    def setup_method(self):
         self.simple_message = self.app.amqp.as_task_v2(
             uuid(), 'foo', create_sent_event=True,
         )

--- a/t/unit/app/test_annotations.py
+++ b/t/unit/app/test_annotations.py
@@ -8,7 +8,7 @@ class MyAnnotation:
 
 class AnnotationCase:
 
-    def setup(self):
+    def setup_method(self):
         @self.app.task(shared=False)
         def add(x, y):
             return x + y

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -71,7 +71,7 @@ class test_task_join_will_block:
 
 class test_App:
 
-    def setup(self):
+    def setup_method(self):
         self.app.add_defaults(deepcopy(self.CELERY_TEST_CONFIG))
 
     def test_now(self):

--- a/t/unit/app/test_builtins.py
+++ b/t/unit/app/test_builtins.py
@@ -10,7 +10,7 @@ from celery.utils.functional import pass1
 
 class BuiltinsCase:
 
-    def setup(self):
+    def setup_method(self):
         @self.app.task(shared=False)
         def xsum(x):
             return sum(x)
@@ -34,7 +34,7 @@ class test_backend_cleanup(BuiltinsCase):
 
 class test_accumulate(BuiltinsCase):
 
-    def setup(self):
+    def setup_method(self):
         self.accumulate = self.app.tasks['celery.accumulate']
 
     def test_with_index(self):
@@ -89,7 +89,7 @@ class test_chunks(BuiltinsCase):
 
 class test_group(BuiltinsCase):
 
-    def setup(self):
+    def setup_method(self):
         self.maybe_signature = self.patching('celery.canvas.maybe_signature')
         self.maybe_signature.side_effect = pass1
         self.app.producer_or_acquire = Mock()
@@ -98,7 +98,7 @@ class test_group(BuiltinsCase):
         )
         self.app.conf.task_always_eager = True
         self.task = builtins.add_group_task(self.app)
-        super().setup()
+        super().setup_method()
 
     def test_apply_async_eager(self):
         self.task.apply = Mock(name='apply')
@@ -132,8 +132,8 @@ class test_group(BuiltinsCase):
 
 class test_chain(BuiltinsCase):
 
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         self.task = builtins.add_chain_task(self.app)
 
     def test_not_implemented(self):
@@ -143,9 +143,9 @@ class test_chain(BuiltinsCase):
 
 class test_chord(BuiltinsCase):
 
-    def setup(self):
+    def setup_method(self):
         self.task = builtins.add_chord_task(self.app)
-        super().setup()
+        super().setup_method()
 
     def test_apply_async(self):
         x = chord([self.add.s(i, i) for i in range(10)], body=self.xsum.s())

--- a/t/unit/app/test_control.py
+++ b/t/unit/app/test_control.py
@@ -52,7 +52,7 @@ class test_flatten_reply:
 
 class test_inspect:
 
-    def setup(self):
+    def setup_method(self):
         self.app.control.broadcast = Mock(name='broadcast')
         self.app.control.broadcast.return_value = {}
         self.inspect = self.app.control.inspect()
@@ -207,7 +207,7 @@ class test_inspect:
 
 class test_Control_broadcast:
 
-    def setup(self):
+    def setup_method(self):
         self.app.control.mailbox = Mock(name='mailbox')
 
     def test_broadcast(self):
@@ -231,7 +231,7 @@ class test_Control_broadcast:
 
 class test_Control:
 
-    def setup(self):
+    def setup_method(self):
         self.app.control.broadcast = Mock(name='broadcast')
         self.app.control.broadcast.return_value = {}
 

--- a/t/unit/app/test_defaults.py
+++ b/t/unit/app/test_defaults.py
@@ -7,10 +7,10 @@ from celery.app.defaults import (_OLD_DEFAULTS, _OLD_SETTING_KEYS, _TO_NEW_KEY, 
 
 class test_defaults:
 
-    def setup(self):
+    def setup_method(self):
         self._prev = sys.modules.pop('celery.app.defaults', None)
 
-    def teardown(self):
+    def teardown_method(self):
         if self._prev:
             sys.modules['celery.app.defaults'] = self._prev
 

--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -35,7 +35,7 @@ class test_LoaderBase:
                       'password': 'qwerty',
                       'timeout': 3}
 
-    def setup(self):
+    def setup_method(self):
         self.loader = DummyLoader(app=self.app)
 
     def test_handlers_pass(self):
@@ -212,7 +212,7 @@ class test_DefaultLoader:
 
 class test_AppLoader:
 
-    def setup(self):
+    def setup_method(self):
         self.loader = AppLoader(app=self.app)
 
     def test_on_worker_init(self):

--- a/t/unit/app/test_log.py
+++ b/t/unit/app/test_log.py
@@ -150,7 +150,7 @@ class test_default_logger:
 
         return logging.root
 
-    def setup(self):
+    def setup_method(self):
         self.get_logger = lambda n=None: get_logger(n) if n else logging.root
         signals.setup_logging.receivers[:] = []
         self.app.log.already_setup = False
@@ -312,7 +312,7 @@ class test_default_logger:
 
 class test_task_logger(test_default_logger):
 
-    def setup(self):
+    def setup_method(self):
         logger = self.logger = get_logger('celery.task')
         logger.handlers = []
         logging.root.manager.loggerDict.pop(logger.name, None)
@@ -326,7 +326,7 @@ class test_task_logger(test_default_logger):
         from celery._state import _task_stack
         _task_stack.push(test_task)
 
-    def teardown(self):
+    def teardown_method(self):
         from celery._state import _task_stack
         _task_stack.pop()
 

--- a/t/unit/app/test_registry.py
+++ b/t/unit/app/test_registry.py
@@ -23,7 +23,7 @@ class test_unpickle_task:
 
 class test_TaskRegistry:
 
-    def setup(self):
+    def setup_method(self):
         self.mytask = self.app.task(name='A', shared=False)(returns)
         self.missing_name_task = self.app.task(
             name=None, shared=False)(returns)

--- a/t/unit/app/test_routes.py
+++ b/t/unit/app/test_routes.py
@@ -27,7 +27,7 @@ def set_queues(app, **queues):
 
 class RouteCase:
 
-    def setup(self):
+    def setup_method(self):
         self.a_queue = {
             'exchange': 'fooexchange',
             'exchange_type': 'fanout',

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -25,7 +25,7 @@ def patch_crontab_nowfun(cls, retval):
 
 class test_solar:
 
-    def setup(self):
+    def setup_method(self):
         pytest.importorskip('ephem')
         self.s = solar('sunrise', 60, 30, app=self.app)
 
@@ -475,7 +475,7 @@ class test_crontab_remaining_estimate:
 
 class test_crontab_is_due:
 
-    def setup(self):
+    def setup_method(self):
         self.now = self.app.now()
         self.next_minute = 60 - self.now.second - 1e-6 * self.now.microsecond
         self.every_minute = self.crontab()

--- a/t/unit/apps/test_multi.py
+++ b/t/unit/apps/test_multi.py
@@ -172,7 +172,7 @@ class test_multi_args:
 
 class test_Node:
 
-    def setup(self):
+    def setup_method(self):
         self.p = Mock(name='p')
         self.p.options = {
             '--executable': 'python',
@@ -308,7 +308,7 @@ class test_Node:
 
 class test_Cluster:
 
-    def setup(self):
+    def setup_method(self):
         self.Popen = self.patching('celery.apps.multi.Popen')
         self.kill = self.patching('os.kill')
         self.gethostname = self.patching('celery.apps.multi.gethostname')

--- a/t/unit/backends/test_arangodb.py
+++ b/t/unit/backends/test_arangodb.py
@@ -19,7 +19,7 @@ pytest.importorskip('pyArango')
 
 class test_ArangoDbBackend:
 
-    def setup(self):
+    def setup_method(self):
         self.backend = ArangoDbBackend(app=self.app)
 
     def test_init_no_arangodb(self):

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -14,7 +14,7 @@ pytest.importorskip('azure.core.exceptions')
 
 
 class test_AzureBlockBlobBackend:
-    def setup(self):
+    def setup_method(self):
         self.url = (
             "azureblockblob://"
             "DefaultEndpointsProtocol=protocol;"
@@ -168,7 +168,7 @@ class test_AzureBlockBlobBackend:
 
 
 class test_as_uri:
-    def setup(self):
+    def setup_method(self):
         self.url = (
             "azureblockblob://"
             "DefaultEndpointsProtocol=protocol;"

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -69,7 +69,7 @@ class test_serialization:
 
 class test_Backend_interface:
 
-    def setup(self):
+    def setup_method(self):
         self.app.conf.accept_content = ['json']
 
     def test_accept_precedence(self):
@@ -167,7 +167,7 @@ class test_Backend_interface:
 
 class test_BaseBackend_interface:
 
-    def setup(self):
+    def setup_method(self):
         self.b = BaseBackend(self.app)
 
         @self.app.task(shared=False)
@@ -261,7 +261,7 @@ class test_exception_pickle:
 
 class test_prepare_exception:
 
-    def setup(self):
+    def setup_method(self):
         self.b = BaseBackend(self.app)
 
     def test_unpickleable(self):
@@ -359,7 +359,7 @@ class DictBackend(BaseBackend):
 
 class test_BaseBackend_dict:
 
-    def setup(self):
+    def setup_method(self):
         self.b = DictBackend(app=self.app)
 
         @self.app.task(shared=False, bind=True)
@@ -650,7 +650,7 @@ class test_BaseBackend_dict:
 
 class test_KeyValueStoreBackend:
 
-    def setup(self):
+    def setup_method(self):
         self.b = KVBackend(app=self.app)
 
     def test_on_chord_part_return(self):
@@ -1031,7 +1031,7 @@ class test_DisabledBackend:
 
 class test_as_uri:
 
-    def setup(self):
+    def setup_method(self):
         self.b = BaseBackend(
             app=self.app,
             url='sch://uuuu:pwpw@hostname.dom'

--- a/t/unit/backends/test_cache.py
+++ b/t/unit/backends/test_cache.py
@@ -20,14 +20,14 @@ class SomeClass:
 
 class test_CacheBackend:
 
-    def setup(self):
+    def setup_method(self):
         self.app.conf.result_serializer = 'pickle'
         self.tb = CacheBackend(backend='memory://', app=self.app)
         self.tid = uuid()
         self.old_get_best_memcached = backends['memcache']
         backends['memcache'] = lambda: (DummyClient, ensure_bytes)
 
-    def teardown(self):
+    def teardown_method(self):
         backends['memcache'] = self.old_get_best_memcached
 
     def test_no_backend(self):

--- a/t/unit/backends/test_cassandra.py
+++ b/t/unit/backends/test_cassandra.py
@@ -18,7 +18,7 @@ CASSANDRA_MODULES = [
 
 class test_CassandraBackend:
 
-    def setup(self):
+    def setup_method(self):
         self.app.conf.update(
             cassandra_servers=['example.com'],
             cassandra_keyspace='celery',

--- a/t/unit/backends/test_consul.py
+++ b/t/unit/backends/test_consul.py
@@ -9,7 +9,7 @@ pytest.importorskip('consul')
 
 class test_ConsulBackend:
 
-    def setup(self):
+    def setup_method(self):
         self.backend = ConsulBackend(
             app=self.app, url='consul://localhost:800')
 

--- a/t/unit/backends/test_cosmosdbsql.py
+++ b/t/unit/backends/test_cosmosdbsql.py
@@ -13,7 +13,7 @@ pytest.importorskip('pydocumentdb')
 
 
 class test_DocumentDBBackend:
-    def setup(self):
+    def setup_method(self):
         self.url = "cosmosdbsql://:key@endpoint"
         self.backend = CosmosDBSQLBackend(app=self.app, url=self.url)
 

--- a/t/unit/backends/test_couchbase.py
+++ b/t/unit/backends/test_couchbase.py
@@ -22,7 +22,7 @@ pytest.importorskip('couchbase')
 
 class test_CouchbaseBackend:
 
-    def setup(self):
+    def setup_method(self):
         self.backend = CouchbaseBackend(app=self.app)
 
     def test_init_no_couchbase(self):

--- a/t/unit/backends/test_couchdb.py
+++ b/t/unit/backends/test_couchdb.py
@@ -20,7 +20,7 @@ pytest.importorskip('pycouchdb')
 
 class test_CouchBackend:
 
-    def setup(self):
+    def setup_method(self):
         self.Server = self.patching('pycouchdb.Server')
         self.backend = CouchBackend(app=self.app)
 

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -45,7 +45,7 @@ class test_session_cleanup:
 @skip.if_pypy
 class test_DatabaseBackend:
 
-    def setup(self):
+    def setup_method(self):
         self.uri = 'sqlite:///test.db'
         self.app.conf.result_serializer = 'pickle'
 
@@ -219,7 +219,7 @@ class test_DatabaseBackend:
 
 @skip.if_pypy
 class test_DatabaseBackend_result_extended():
-    def setup(self):
+    def setup_method(self):
         self.uri = 'sqlite:///test.db'
         self.app.conf.result_serializer = 'pickle'
         self.app.conf.result_extended = True

--- a/t/unit/backends/test_dynamodb.py
+++ b/t/unit/backends/test_dynamodb.py
@@ -12,7 +12,7 @@ pytest.importorskip('boto3')
 
 
 class test_DynamoDBBackend:
-    def setup(self):
+    def setup_method(self):
         self._static_timestamp = Decimal(1483425566.52)
         self.app.conf.result_backend = 'dynamodb://'
 

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -31,7 +31,7 @@ pytest.importorskip('elasticsearch')
 
 class test_ElasticsearchBackend:
 
-    def setup(self):
+    def setup_method(self):
         self.backend = ElasticsearchBackend(app=self.app)
 
     def test_init_no_elasticsearch(self):

--- a/t/unit/backends/test_filesystem.py
+++ b/t/unit/backends/test_filesystem.py
@@ -17,7 +17,7 @@ from celery.exceptions import ImproperlyConfigured
 @t.skip.if_win32
 class test_FilesystemBackend:
 
-    def setup(self):
+    def setup_method(self):
         self.directory = tempfile.mkdtemp()
         self.url = 'file://' + self.directory
         self.path = self.directory.encode('ascii')

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -77,7 +77,7 @@ class test_MongoBackend:
         'hostname.dom/database?replicaSet=rs'
     )
 
-    def setup(self):
+    def setup_method(self):
         self.patching('celery.backends.mongodb.MongoBackend.encode')
         self.patching('celery.backends.mongodb.MongoBackend.decode')
         self.patching('celery.backends.mongodb.Binary')

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -358,7 +358,7 @@ class basetest_RedisBackend:
             callback.delay = Mock(name='callback.delay')
             yield tasks, request, callback
 
-    def setup(self):
+    def setup_method(self):
         self.Backend = self.get_backend()
         self.E_LOST = self.get_E_LOST()
         self.b = self.Backend(app=self.app)
@@ -1193,7 +1193,7 @@ class test_SentinelBackend:
         from celery.backends.redis import E_LOST
         return E_LOST
 
-    def setup(self):
+    def setup_method(self):
         self.Backend = self.get_backend()
         self.E_LOST = self.get_E_LOST()
         self.b = self.Backend(app=self.app)

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -23,7 +23,7 @@ class test_RPCResultConsumer:
 
 class test_RPCBackend:
 
-    def setup(self):
+    def setup_method(self):
         self.b = RPCBackend(app=self.app)
 
     def test_oid(self):

--- a/t/unit/concurrency/test_concurrency.py
+++ b/t/unit/concurrency/test_concurrency.py
@@ -167,6 +167,7 @@ class test_get_available_pool_names:
             'gevent',
             'solo',
             'processes',
+            'custom',
         )
         with patch.dict(sys.modules, {'concurrent.futures': None}):
             importlib.reload(concurrency)
@@ -180,6 +181,7 @@ class test_get_available_pool_names:
             'solo',
             'processes',
             'threads',
+            'custom',
         )
         with patch.dict(sys.modules, {'concurrent.futures': Mock()}):
             importlib.reload(concurrency)

--- a/t/unit/concurrency/test_concurrency.py
+++ b/t/unit/concurrency/test_concurrency.py
@@ -109,6 +109,7 @@ class test_BasePool:
 
     def test_interface_info(self):
         assert BasePool(10).info == {
+            'implementation': 'celery.concurrency.base:BasePool',
             'max-concurrency': 10,
         }
 

--- a/t/unit/concurrency/test_eventlet.py
+++ b/t/unit/concurrency/test_eventlet.py
@@ -129,6 +129,7 @@ class test_TaskPool(EventletCase):
         x = TaskPool(10)
         x._pool = Mock(name='_pool')
         assert x._get_info() == {
+            'implementation': 'celery.concurrency.eventlet:TaskPool',
             'max-concurrency': 10,
             'free-threads': x._pool.free(),
             'running-threads': x._pool.running(),

--- a/t/unit/concurrency/test_eventlet.py
+++ b/t/unit/concurrency/test_eventlet.py
@@ -22,10 +22,10 @@ eventlet_modules = (
 @t.skip.if_pypy
 class EventletCase:
 
-    def setup(self):
+    def setup_method(self):
         self.patching.modules(*eventlet_modules)
 
-    def teardown(self):
+    def teardown_method(self):
         for mod in [mod for mod in sys.modules
                     if mod.startswith('eventlet')]:
             try:

--- a/t/unit/concurrency/test_gevent.py
+++ b/t/unit/concurrency/test_gevent.py
@@ -26,7 +26,7 @@ class test_gevent_patch:
 
 class test_Timer:
 
-    def setup(self):
+    def setup_method(self):
         self.patching.modules(*gevent_modules)
         self.greenlet = self.patching('gevent.greenlet')
         self.GreenletExit = self.patching('gevent.greenlet.GreenletExit')
@@ -57,7 +57,7 @@ class test_Timer:
 
 class test_TaskPool:
 
-    def setup(self):
+    def setup_method(self):
         self.patching.modules(*gevent_modules)
         self.spawn_raw = self.patching('gevent.spawn_raw')
         self.Pool = self.patching('gevent.pool.Pool')

--- a/t/unit/concurrency/test_pool.py
+++ b/t/unit/concurrency/test_pool.py
@@ -24,7 +24,7 @@ def raise_something(i):
 
 class test_TaskPool:
 
-    def setup(self):
+    def setup_method(self):
         from celery.concurrency.prefork import TaskPool
         self.TaskPool = TaskPool
 

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -194,7 +194,7 @@ class ExeMockTaskPool(mp.TaskPool):
 @t.skip.if_win32
 class test_AsynPool:
 
-    def setup(self):
+    def setup_method(self):
         pytest.importorskip('multiprocessing')
 
     def test_gen_not_started(self):
@@ -369,7 +369,7 @@ class test_AsynPool:
 @t.skip.if_win32
 class test_ResultHandler:
 
-    def setup(self):
+    def setup_method(self):
         pytest.importorskip('multiprocessing')
 
     def test_process_result(self):

--- a/t/unit/contrib/test_abortable.py
+++ b/t/unit/contrib/test_abortable.py
@@ -3,7 +3,7 @@ from celery.contrib.abortable import AbortableAsyncResult, AbortableTask
 
 class test_AbortableTask:
 
-    def setup(self):
+    def setup_method(self):
         @self.app.task(base=AbortableTask, shared=False)
         def abortable():
             return True

--- a/t/unit/contrib/test_worker.py
+++ b/t/unit/contrib/test_worker.py
@@ -8,7 +8,7 @@ from celery.contrib.testing.worker import start_worker
 
 
 class test_worker:
-    def setup(self):
+    def setup_method(self):
         self.app = Celery('celerytest', backend='cache+memory://', broker='memory://',)
 
         @self.app.task

--- a/t/unit/events/test_cursesmon.py
+++ b/t/unit/events/test_cursesmon.py
@@ -11,7 +11,7 @@ class MockWindow:
 
 class test_CursesDisplay:
 
-    def setup(self):
+    def setup_method(self):
         from celery.events import cursesmon
         self.monitor = cursesmon.CursesMonitor(object(), app=self.app)
         self.win = MockWindow()

--- a/t/unit/events/test_snapshot.py
+++ b/t/unit/events/test_snapshot.py
@@ -19,7 +19,7 @@ timer = MockTimer()
 
 class test_Polaroid:
 
-    def setup(self):
+    def setup_method(self):
         self.state = self.app.events.State()
 
     def test_constructor(self):
@@ -101,7 +101,7 @@ class test_evcam:
         def Receiver(self, *args, **kwargs):
             return test_evcam.MockReceiver()
 
-    def setup(self):
+    def setup_method(self):
         self.app.events = self.MockEvents()
         self.app.events.app = self.app
 

--- a/t/unit/security/case.py
+++ b/t/unit/security/case.py
@@ -3,5 +3,5 @@ import pytest
 
 class SecurityCase:
 
-    def setup(self):
+    def setup_method(self):
         pytest.importorskip('cryptography')

--- a/t/unit/security/test_security.py
+++ b/t/unit/security/test_security.py
@@ -33,7 +33,7 @@ from .case import SecurityCase
 
 class test_security(SecurityCase):
 
-    def teardown(self):
+    def teardown_method(self):
         registry._disabled_content_types.clear()
         registry._set_default_serializer('json')
         try:

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -44,7 +44,7 @@ class test_maybe_unroll_group:
 
 class CanvasCase:
 
-    def setup(self):
+    def setup_method(self):
         @self.app.task(shared=False)
         def add(x, y):
             return x + y

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -20,7 +20,7 @@ class AnySignatureWithTask(Signature):
 
 class ChordCase:
 
-    def setup(self):
+    def setup_method(self):
 
         @self.app.task(shared=False)
         def add(x, y):
@@ -323,7 +323,7 @@ class test_chord(ChordCase):
 
 class test_add_to_chord:
 
-    def setup(self):
+    def setup_method(self):
 
         @self.app.task(shared=False)
         def add(x, y):

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -63,7 +63,7 @@ class _MockBackend:
 
 class test_AsyncResult:
 
-    def setup(self):
+    def setup_method(self):
         self.app.conf.result_cache_max = 100
         self.app.conf.result_serializer = 'pickle'
         self.app.conf.result_extended = True
@@ -628,7 +628,7 @@ class SimpleBackend(SyncBackendMixin):
 
 class test_GroupResult:
 
-    def setup(self):
+    def setup_method(self):
         self.size = 10
         self.ts = self.app.GroupResult(
             uuid(), make_mock_group(self.app, self.size),
@@ -882,7 +882,7 @@ class test_pending_AsyncResult:
 
 class test_failed_AsyncResult:
 
-    def setup(self):
+    def setup_method(self):
         self.size = 11
         self.app.conf.result_serializer = 'pickle'
         results = make_mock_group(self.app, 10)
@@ -907,7 +907,7 @@ class test_failed_AsyncResult:
 
 class test_pending_Group:
 
-    def setup(self):
+    def setup_method(self):
         self.ts = self.app.GroupResult(
             uuid(), [self.app.AsyncResult(uuid()),
                      self.app.AsyncResult(uuid())])
@@ -932,7 +932,7 @@ class test_pending_Group:
 
 class test_EagerResult:
 
-    def setup(self):
+    def setup_method(self):
         @self.app.task(shared=False)
         def raising(x, y):
             raise KeyError(x, y)

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -60,7 +60,7 @@ class TaskWithRetryButForTypeError(Task):
 
 class TasksCase:
 
-    def setup(self):
+    def setup_method(self):
         self.mytask = self.app.task(shared=False)(return_True)
 
         @self.app.task(bind=True, count=0, shared=False)

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -28,7 +28,7 @@ def trace(
 
 
 class TraceCase:
-    def setup(self):
+    def setup_method(self):
         @self.app.task(shared=False)
         def add(x, y):
             return x + y

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -52,7 +52,7 @@ class test_DictAttribute:
 
 class test_ConfigurationView:
 
-    def setup(self):
+    def setup_method(self):
         self.view = ConfigurationView(
             {'changed_key': 1, 'both': 2},
             [

--- a/t/unit/worker/test_autoscale.py
+++ b/t/unit/worker/test_autoscale.py
@@ -73,7 +73,7 @@ class test_WorkerComponent:
 
 class test_Autoscaler:
 
-    def setup(self):
+    def setup_method(self):
         self.pool = MockPool(3)
 
     def test_stop(self):

--- a/t/unit/worker/test_bootsteps.py
+++ b/t/unit/worker/test_bootsteps.py
@@ -56,7 +56,7 @@ class test_Step:
     class Def(bootsteps.StartStopStep):
         name = 'test_Step.Def'
 
-    def setup(self):
+    def setup_method(self):
         self.steps = []
 
     def test_blueprint_name(self, bp='test_blueprint_name'):
@@ -162,7 +162,7 @@ class test_StartStopStep:
     class Def(bootsteps.StartStopStep):
         name = 'test_StartStopStep.Def'
 
-    def setup(self):
+    def setup_method(self):
         self.steps = []
 
     def test_start__stop(self):

--- a/t/unit/worker/test_components.py
+++ b/t/unit/worker/test_components.py
@@ -22,7 +22,7 @@ class test_Timer:
 
 class test_Hub:
 
-    def setup(self):
+    def setup_method(self):
         self.w = Mock(name='w')
         self.hub = Hub(self.w)
         self.w.hub = Mock(name='w.hub')

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -41,7 +41,7 @@ class ConsumerTestCase:
 
 
 class test_Consumer(ConsumerTestCase):
-    def setup(self):
+    def setup_method(self):
         @self.app.task(shared=False)
         def add(x, y):
             return x + y

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -116,7 +116,7 @@ class test_Pidbox_green:
 
 class test_ControlPanel:
 
-    def setup(self):
+    def setup_method(self):
         self.panel = self.create_panel(consumer=Consumer(self.app))
 
         @self.app.task(name='c.unittest.mytask', rate_limit=200, shared=False)

--- a/t/unit/worker/test_loops.py
+++ b/t/unit/worker/test_loops.py
@@ -133,7 +133,7 @@ def get_task_callback(*args, **kwargs):
 
 class test_asynloop:
 
-    def setup(self):
+    def setup_method(self):
         @self.app.task(shared=False)
         def add(x, y):
             return x + y
@@ -529,7 +529,7 @@ class test_synloop:
 
 class test_quick_drain:
 
-    def setup(self):
+    def setup_method(self):
         self.connection = Mock(name='connection')
 
     def test_drain(self):

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -26,7 +26,7 @@ from celery.worker.state import revoked
 
 class RequestCase:
 
-    def setup(self):
+    def setup_method(self):
         self.app.conf.result_serializer = 'pickle'
 
         @self.app.task(shared=False)
@@ -1173,11 +1173,11 @@ class test_Request(RequestCase):
 
 class test_create_request_class(RequestCase):
 
-    def setup(self):
+    def setup_method(self):
         self.task = Mock(name='task')
         self.pool = Mock(name='pool')
         self.eventer = Mock(name='eventer')
-        super().setup()
+        super().setup_method()
 
     def create_request_cls(self, **kwargs):
         return create_request_cls(

--- a/t/unit/worker/test_state.py
+++ b/t/unit/worker/test_state.py
@@ -45,7 +45,7 @@ class MyPersistent(state.Persistent):
 
 class test_maybe_shutdown:
 
-    def teardown(self):
+    def teardown_method(self):
         state.should_stop = None
         state.should_terminate = None
 

--- a/t/unit/worker/test_strategy.py
+++ b/t/unit/worker/test_strategy.py
@@ -18,7 +18,7 @@ from celery.worker.strategy import hybrid_to_proto2, proto1_to_proto2
 
 class test_proto1_to_proto2:
 
-    def setup(self):
+    def setup_method(self):
         self.message = Mock(name='message')
         self.body = {
             'args': (1,),
@@ -58,7 +58,7 @@ class test_proto1_to_proto2:
 
 class test_default_strategy_proto2:
 
-    def setup(self):
+    def setup_method(self):
         @self.app.task(shared=False)
         def add(x, y):
             return x + y
@@ -301,7 +301,7 @@ class test_custom_request_for_default_strategy(test_default_strategy_proto2):
 
 class test_hybrid_to_proto2:
 
-    def setup(self):
+    def setup_method(self):
         self.message = Mock(name='message', headers={"custom": "header"})
         self.body = {
             'args': (1,),

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -77,7 +77,7 @@ class ConsumerCase:
 
 class test_Consumer(ConsumerCase):
 
-    def setup(self):
+    def setup_method(self):
         self.buffer = FastQueue()
         self.timer = Timer()
 
@@ -86,7 +86,7 @@ class test_Consumer(ConsumerCase):
             return x * y * z
         self.foo_task = foo_task
 
-    def teardown(self):
+    def teardown_method(self):
         self.timer.stop()
 
     def LoopConsumer(self, buffer=None, controller=None, timer=None, app=None,
@@ -697,7 +697,7 @@ class test_Consumer(ConsumerCase):
 
 class test_WorkController(ConsumerCase):
 
-    def setup(self):
+    def setup_method(self):
         self.worker = self.create_worker()
         self._logger = worker_module.logger
         self._comp_logger = components.logger
@@ -709,7 +709,7 @@ class test_WorkController(ConsumerCase):
             return x * y * z
         self.foo_task = foo_task
 
-    def teardown(self):
+    def teardown_method(self):
         worker_module.logger = self._logger
         components.logger = self._comp_logger
 


### PR DESCRIPTION
## Description

On my system, running "make test" results in the following:
```
=========================== short test summary info ============================
FAILED t/unit/backends/test_mongodb.py::test_MongoBackend::test_init_mongodb_dnspython2_pymongo4_seedlist
= 1 failed, 2587 passed, 44 skipped, 3 xfailed, 1674 warnings, 126 subtests passed in 60.17s (0:01:00) =
```
About 1629 of the warnings are to do with using deprecated `nose` test methods. This patch fixes those warnings, thereby making the test results much easier to follow. Here are the results after these fixes:
```
=========================== short test summary info ============================
FAILED t/unit/backends/test_mongodb.py::test_MongoBackend::test_init_mongodb_dnspython2_pymongo4_seedlist
= 1 failed, 2587 passed, 44 skipped, 3 xfailed, 45 warnings, 126 subtests passed in 61.20s (0:01:01) =
```
For clarification, the first 5 commits (ending with 404f2e9) are from a rebase.