### PR TITLE
Add annotations to minimise differences with celery-aio-pool's tracer.py.

### DIFF
--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -8,6 +8,7 @@ import os
 import sys
 import time
 from collections import namedtuple
+from typing import Any, Callable, Dict, FrozenSet, Optional, Sequence, Tuple, Type, Union
 from warnings import warn
 
 from billiard.einfo import ExceptionInfo
@@ -16,6 +17,8 @@ from kombu.serialization import loads as loads_message
 from kombu.serialization import prepare_accept_content
 from kombu.utils.encoding import safe_repr, safe_str
 
+import celery
+import celery.loaders.app
 from celery import current_app, group, signals, states
 from celery._state import _task_stack
 from celery.app.task import Context
@@ -286,10 +289,20 @@ def traceback_clear(exc=None):
         tb = tb.tb_next
 
 
-def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
-                 Info=TraceInfo, eager=False, propagate=False, app=None,
-                 monotonic=time.monotonic, trace_ok_t=trace_ok_t,
-                 IGNORE_STATES=IGNORE_STATES):
+def build_tracer(
+        name: str,
+        task: Union[celery.Task, celery.local.PromiseProxy],
+        loader: Optional[celery.loaders.app.AppLoader] = None,
+        hostname: Optional[str] = None,
+        store_errors: bool = True,
+        Info: Type[TraceInfo] = TraceInfo,
+        eager: bool = False,
+        propagate: bool = False,
+        app: Optional[celery.Celery] = None,
+        monotonic: Callable[[], int] = time.monotonic,
+        trace_ok_t: Type[trace_ok_t] = trace_ok_t,
+        IGNORE_STATES: FrozenSet[str] = IGNORE_STATES) -> \
+        Callable[[str, Tuple[Any, ...], Dict[str, Any], Any], trace_ok_t]:
     """Return a function that traces task execution.
 
     Catches all exceptions and updates result backend with the
@@ -369,7 +382,12 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
     from celery import canvas
     signature = canvas.maybe_signature  # maybe_ does not clone if already
 
-    def on_error(request, exc, state=FAILURE, call_errbacks=True):
+    def on_error(
+            request: celery.app.task.Context,
+            exc: Union[Exception, Type[Exception]],
+            state: str = FAILURE,
+            call_errbacks: bool = True) -> Tuple[Info, Any, Any, Any]:
+        """Handle any errors raised by a `Task`'s execution."""
         if propagate:
             raise
         I = Info(state, exc)
@@ -378,7 +396,13 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
         )
         return I, R, I.state, I.retval
 
-    def trace_task(uuid, args, kwargs, request=None):
+    def trace_task(
+            uuid: str,
+            args: Sequence[Any],
+            kwargs: Dict[str, Any],
+            request: Optional[Dict[str, Any]] = None) -> trace_ok_t:
+        """Execute and trace a `Task`."""
+
         # R      - is the possibly prepared return value.
         # I      - is the Info object.
         # T      - runtime


### PR DESCRIPTION
## Description

As per #7874, add annotations to trace.py to improve it's documentation, and make it easier to compare with celery-aio-pool's tracer.py. See also #the-wondersmith/celery-aio-pool/pull/4.

(Note: unit tests are currently badly broken)
