### PR TITLE
Freezing flake8 to version 5.0.4

### DIFF
--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -1,6 +1,6 @@
 setuptools>=40.8.0
 wheel>=0.33.1
-flake8>=3.8.3
+flake8==5.0.4
 flakeplus>=1.1
 flake8-docstrings~=1.5
 pydocstyle==6.1.1; python_version >= '3.0'


### PR DESCRIPTION
I suspect the [new version](https://pypi.org/project/flake8/#history) of flake8 (v6.0.0) is what broke our linter, trying to see if this PR can stabilize it for now.