### PR TITLE
Fixed a bug where replacing a stamped task and stamping it again

### DIFF
--- a/examples/stamping/shell.py
+++ b/examples/stamping/shell.py
@@ -38,8 +38,8 @@ def prepare_workflow() -> Signature:
     to revoke the task by its stamped header.
     """
     canvas = create_canvas(n=3)
-    canvas.stamp(MonitoringIdStampingVisitor())
     canvas = canvas | wait_for_revoke.s()
+    canvas.stamp(MonitoringIdStampingVisitor())
     return canvas
 
 


### PR DESCRIPTION
Fixing the new stamping tutorial/example has found a new bug.
This fixes and keeps the change in the example as it makes more sense.