### PR TITLE
Fixed a bug in losing chain links when unchaining an inner chain with links

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -960,14 +960,17 @@ class _chain(Signature):
     def unchain_tasks(self):
         """Return a list of tasks in the chain.
 
-        The tasks list would be cloned from the chain's tasks,
-        and all of the tasks would be linked to the same error callback
+        The tasks list would be cloned from the chain's tasks.
+        All of the chain callbacks would be added to the last task in the (cloned) chain.
+        All of the tasks would be linked to the same error callback
         as the chain itself, to ensure that the correct error callback is called
         if any of the (cloned) tasks of the chain fail.
         """
         # Clone chain's tasks assigning signatures from link_error
-        # to each task
+        # to each task and adding the chain's links to the last task.
         tasks = [t.clone() for t in self.tasks]
+        for sig in self.options.get('link', []):
+            tasks[-1].link(sig)
         for sig in self.options.get('link_error', []):
             for task in tasks:
                 task.link_error(sig)


### PR DESCRIPTION
Related to Issue #5958 per being part of the same flow this issue was reporting about.
PR Includes:
1. Fix in `unchain_tasks` to include the links in the cloned tasks list.
2. Added unit test to check the `options` are structured correctly.
3. Added integration test to verify the link is indeed called.

### TL;DR regarding #5958
The bug that broke the chain `__or__` operator, also broke the linking of the `__or__`'ed chain.
[The fix](https://github.com/celery/celery/issues/7919) to Issue #5958 did not take into account this new links bug.
This then (hopefully) sums up the major bugs of the `__or__` operator in chains.