### PR TITLE
feat(typecheck): allow changing type check behavior on the app level;

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -458,6 +458,9 @@ class Celery:
                     sum([len(args), len(opts)])))
         return inner_create_task_cls(**opts)
 
+    def type_checker(self, fun, bound=False):
+        return staticmethod(head_from_fun(fun, bound=bound))
+
     def _task_from_fun(self, fun, name=None, base=None, bind=False, **options):
         if not self.finalized and not self.autofinalize:
             raise RuntimeError('Contract breach: app not finalized')
@@ -474,7 +477,7 @@ class Celery:
                 '__doc__': fun.__doc__,
                 '__module__': fun.__module__,
                 '__annotations__': fun.__annotations__,
-                '__header__': staticmethod(head_from_fun(fun, bound=bind)),
+                '__header__': self.type_checker(fun, bound=bind),
                 '__wrapped__': run}, **options))()
             # for some reason __qualname__ cannot be set in type()
             # so we have to set it here.


### PR DESCRIPTION
For example in case you want to implement strict type checking that relay on annotations or the dataclass object you may just set `Celery.type_checker` with valid interface.

Use case:
https://github.com/moaddib666/celery-DTO-Concept 