### PR TITLE
Switch between thread & global for app.backend

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -1257,19 +1257,18 @@ class Celery:
             self._green = is_green
 
     def _cached_or_create(self, name, factory, thread_safe):
-        """Thread or process store
-        
+        """Thread or process store.
+
         :param: thread_safe: func(created) => True/False
         """
         cached = (getattr(self._local, name, None)
-                or getattr(self._global, name, None))
+                 or getattr(self._global, name, None))
         if cached is not None:
             return cached
-        
+
         created = factory()
         use_global = self._green or thread_safe(created)
-        setattr(self._global if use_global else self._local,
-            name, created)
+        setattr(self._global if use_global else self._local, name, created)
         return created
 
     @property

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -1,10 +1,10 @@
 """Actual App instance implementation."""
 import inspect
+import multiprocessing
 import os
 import sys
 import threading
 import warnings
-import multiprocessing
 from collections import UserDict, defaultdict, deque
 from datetime import datetime
 from operator import attrgetter

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -1,6 +1,5 @@
 """Actual App instance implementation."""
 import inspect
-import multiprocessing
 import os
 import sys
 import threading
@@ -9,6 +8,7 @@ from collections import UserDict, defaultdict, deque
 from datetime import datetime
 from operator import attrgetter
 
+from billiard.process import current_process
 from click.exceptions import Exit
 from kombu import pools
 from kombu.clocks import LamportClock
@@ -230,7 +230,7 @@ class Celery:
                  **kwargs):
 
         self._local = threading.local()
-        self._global = multiprocessing.current_process()
+        self._global = current_process()
         self._green = False
 
         self.clock = LamportClock()

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -1261,8 +1261,7 @@ class Celery:
 
         :param: thread_safe: func(created) => True/False
         """
-        cached = (getattr(self._local, name, None)
-                 or getattr(self._global, name, None))
+        cached = getattr(self._local, name, None) or getattr(self._global, name, None)
         if cached is not None:
             return cached
 

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -101,6 +101,9 @@ class Backend:
     #: Set to true if the backend is persistent by default.
     persistent = True
 
+    #: Set to true if backend lib is thread-safe
+    thread_safe = False
+
     retry_policy = {
         'max_retries': 20,
         'interval_start': 0,

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -191,6 +191,8 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
     GET, MGET, DEL, INCRBY, EXPIRE, SET, SETEX
     """
 
+    thread_safe = True
+
     ResultConsumer = ResultConsumer
 
     #: :pypi:`redis` client module.

--- a/celery/worker/worker.py
+++ b/celery/worker/worker.py
@@ -127,6 +127,8 @@ class WorkController:
 
         # Initialize bootsteps
         self.pool_cls = _concurrency.get_implementation(self.pool_cls)
+        self.app.inform_green(self.pool_cls.is_green)
+
         self.steps = []
         self.on_init_blueprint()
         self.blueprint = self.Blueprint(

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,15 +8,24 @@ all_files = 1
 # whenever it makes the code more readable.
 max-line-length = 117
 extend-ignore =
-    E203,  # incompatible with black https://github.com/psf/black/issues/315#issuecomment-395457972
-    D102,  # Missing docstring in public method
-    D104,  # Missing docstring in public package
-    D105,  # Missing docstring in magic method
-    D107,  # Missing docstring in __init__
-    D401,  # First line should be in imperative mood; try rephrasing
-    D412,  # No blank lines allowed between a section header and its content
-    E741,  # ambiguous variable name '...'
-    E742,  # ambiguous class definition '...'
+    # incompatible with black https://github.com/psf/black/issues/315#issuecomment-395457972
+    E203,
+    # Missing docstring in public method
+    D102,
+    # Missing docstring in public package
+    D104,
+    # Missing docstring in magic method
+    D105,
+    # Missing docstring in __init__
+    D107,
+    # First line should be in imperative mood; try rephrasing
+    D401,
+    # No blank lines allowed between a section header and its content
+    D412,
+    # ambiguous variable name '...'
+    E741,
+    # ambiguous class definition '...'
+    E742,
 per-file-ignores =
    t/*,setup.py,examples/*,docs/*,extra/*:
        # docstrings


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

For app.backend, switch between self._local and self._global as cache, depending
on whether the environment is fully thread-safe (eg. eventlet), and whether the
backend is thread-safe (eg. Redis)

Fixes:
- #7960 
- #6819
