### PR TITLE
Added doc to "retry_errors" newly supported field of "publish_retry_policy" of the task namespace

### DIFF
--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -356,6 +356,31 @@ and can contain the following keys:
     Maximum number of seconds (float or integer) to wait between
     retries. Default is 0.2.
 
+- `retry_errors`
+
+    `retry_errors` is a tuple of exception classes that should be retried.
+    It will be ignored if not specified. Default is None (ignored).
+
+    .. warning::
+
+        If you specify a tuple of exception classes, you must make sure
+        that you also specify the ``max_retries`` option, otherwise
+        you will get an error.
+
+    For example, if you want to retry only tasks that were timed out, you can use
+    :exc:`~kombu.exceptions.TimeoutError`:
+
+    .. code-block:: python
+
+        from kombu.exceptions import TimeoutError
+
+        add.apply_async((2, 2), retry=True, retry_policy={
+            'max_retries': 3,
+            'retry_errors': (TimeoutError, ),
+        })
+
+    .. versionadded:: 5.3
+
 For example, the default policy correlates to:
 
 .. code-block:: python
@@ -365,6 +390,7 @@ For example, the default policy correlates to:
         'interval_start': 0,
         'interval_step': 0.2,
         'interval_max': 0.2,
+        'retry_errors': None,
     })
 
 the maximum time spent retrying will be 0.4 seconds. It's set relatively


### PR DESCRIPTION
This finishes up https://github.com/celery/kombu/pull/1629