### PR TITLE
return list of nodes to make sphinx extension compatible with Sphinx 6.0

### DIFF
--- a/celery/contrib/sphinx.py
+++ b/celery/contrib/sphinx.py
@@ -32,6 +32,7 @@ Use ``.. autotask::`` to alternatively manually document a task.
 """
 from inspect import signature
 
+from docutils import nodes
 from sphinx.domains.python import PyFunction
 from sphinx.ext.autodoc import FunctionDocumenter
 
@@ -75,7 +76,7 @@ class TaskDirective(PyFunction):
     """Sphinx task directive."""
 
     def get_signature_prefix(self, sig):
-        return self.env.config.celery_task_prefix
+        return [nodes.Text(self.env.config.celery_task_prefix)]
 
 
 def autodoc_skip_member_handler(app, what, name, obj, skip, options):


### PR DESCRIPTION
When using `celery.contrib.sphinx` and `Sphinx==5.3.0`, sphinx emits a warning while building:

```
/home/mertl/git/mati/django-ca/.tox/docs/lib/python3.10/site-packages/sphinx/domains/python.py:516: RemovedInSphinx60Warning: Python directive method get_signature_prefix() returning a string is deprecated. It must now return a list of nodes. Return value was '(task)'.
  warnings.warn(
```

The MR fixes the issue. I tested the HTML output with Sphinx 5.3.0 and it remains identical.