### PR TITLE
fix: fix worker asyncloop

### DIFF
--- a/celery/worker/loops.py
+++ b/celery/worker/loops.py
@@ -96,7 +96,7 @@ def asynloop(obj, connection, consumer, blueprint, hub, qos,
             try:
                 next(loop)
             except StopIteration:
-                loop = hub.create_loop()
+                break
     finally:
         try:
             hub.reset()


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Fix for 
```
Traceback (most recent call last):
  File "/srv/dotcom/lib/python3.7/site-packages/celery/worker/worker.py", line 203, in start
    self.blueprint.start(self)
  File "/srv/dotcom/lib/python3.7/site-packages/celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "/srv/dotcom/lib/python3.7/site-packages/celery/bootsteps.py", line 365, in start
    return self.obj.start()
  File "/srv/dotcom/lib/python3.7/site-packages/celery/worker/consumer/consumer.py", line 326, in start
    blueprint.start(self)
  File "/srv/dotcom/lib/python3.7/site-packages/celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "/srv/dotcom/lib/python3.7/site-packages/celery/worker/consumer/consumer.py", line 618, in start
    c.loop(*c.loop_args())
  File "/srv/dotcom/lib/python3.7/site-packages/celery/worker/loops.py", line 81, in asynloop
    next(loop)
  File "/srv/dotcom/lib/python3.7/site-packages/kombu/asynchronous/hub.py", line 301, in create_loop
    poll_timeout = fire_timers(propagate=propagate) if scheduled else 1
  File "/srv/dotcom/lib/python3.7/site-packages/kombu/asynchronous/hub.py", line 143, in fire_timers
    entry()
  File "/srv/dotcom/lib/python3.7/site-packages/kombu/asynchronous/timer.py", line 64, in __call__
    return self.fun(*self.args, **self.kwargs)
  File "/srv/dotcom/lib/python3.7/site-packages/celery/concurrency/asynpool.py", line 610, in verify_process_alive
    assert proc.outqR_fd in hub.readers
AssertionError
```

As mentioned in the comment in the asyncloop function:
```
    # FIXME: Use loop.run_forever

    # Tried and works, but no time to test properly before release.
    hub.propagate_errors = errors
    loop = hub.create_loop()

    try:
        while blueprint.state == RUN and obj.connection:
            state.maybe_shutdown()
            if heartbeat_error[0] is not None:
                raise heartbeat_error[0]

            # We only update QoS when there's no more messages to read.
            # This groups together qos calls, and makes sure that remote
            # control commands will be prioritized over task messages.
            if qos.prev != qos.value:
                update_qos()

            try:
                next(loop)
            except StopIteration:
                loop = hub.create_loop()
    finally:
        try:
            hub.reset()
        except Exception as exc:  # pylint: disable=broad-except
            logger.exception(
                'Error cleaning up after event loop: %r', exc)
```

