### PR TITLE
chore(tests): run tests on Python 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.9', 'pypy-3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.9', 'pypy-3.8']
         os: ["ubuntu-latest", "windows-latest"]
         exclude:
             - python-version: 'pypy-3.9'
@@ -85,7 +85,7 @@ jobs:
       strategy:
           fail-fast: false
           matrix:
-              python-version: ['3.7', '3.8', '3.9', '3.10']
+              python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
               toxenv: ['redis', 'rabbitmq', 'rabbitmq_redis']
 
       services:

--- a/requirements/test-ci-default.txt
+++ b/requirements/test-ci-default.txt
@@ -21,4 +21,4 @@
 git+https://github.com/celery/kombu.git
 
 # SQS dependencies other than boto
-pycurl==7.43.0.5
+pycurl==7.45.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,15 +8,24 @@ all_files = 1
 # whenever it makes the code more readable.
 max-line-length = 117
 extend-ignore =
-    E203,  # incompatible with black https://github.com/psf/black/issues/315#issuecomment-395457972
-    D102,  # Missing docstring in public method
-    D104,  # Missing docstring in public package
-    D105,  # Missing docstring in magic method
-    D107,  # Missing docstring in __init__
-    D401,  # First line should be in imperative mood; try rephrasing
-    D412,  # No blank lines allowed between a section header and its content
-    E741,  # ambiguous variable name '...'
-    E742,  # ambiguous class definition '...'
+    # incompatible with black https://github.com/psf/black/issues/315#issuecomment-395457972
+    E203,
+    # Missing docstring in public method
+    D102,  
+    # Missing docstring in public package
+    D104,  
+    # Missing docstring in magic method
+    D105,  
+    # Missing docstring in __init__
+    D107,  
+    # First line should be in imperative mood; try rephrasing
+    D401,  
+    # No blank lines allowed between a section header and its content
+    D412,  
+    # ambiguous variable name '...'
+    E741,  
+    # ambiguous class definition '...'
+    E742,
 per-file-ignores =
    t/*,setup.py,examples/*,docs/*,extra/*:
        # docstrings

--- a/setup.py
+++ b/setup.py
@@ -194,6 +194,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Operating System :: OS Independent"

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 requires =
     tox-gh-actions
 envlist =
-    {3.7,3.8,3.9,3.10,pypy3}-unit
-    {3.7,3.8,3.9,3.10,pypy3}-integration-{rabbitmq_redis,rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
+    {3.7,3.8,3.9,3.10,3.11,pypy3}-unit
+    {3.7,3.8,3.9,3.10,3.11,pypy3}-integration-{rabbitmq_redis,rabbitmq,redis,dynamodb,azureblockblob,cache,cassandra,elasticsearch}
 
     flake8
     apicheck
@@ -17,6 +17,7 @@ python =
     3.8: 3.8-unit
     3.9: 3.9-unit
     3.10: 3.10-unit
+    3.11: 3.11-unit
     pypy-3: pypy3-unit
 
 [testenv]
@@ -29,8 +30,8 @@ deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/pkgutils.txt
 
-    3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/test-ci-default.txt
-    3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/docs.txt
+    3.7,3.8,3.9,3.10,3.11: -r{toxinidir}/requirements/test-ci-default.txt
+    3.7,3.8,3.9,3.10,3.11: -r{toxinidir}/requirements/docs.txt
     pypy3: -r{toxinidir}/requirements/test-ci-default.txt
 
     integration: -r{toxinidir}/requirements/test-integration.txt
@@ -79,6 +80,7 @@ basepython =
     3.8: python3.8
     3.9: python3.9
     3.10: python3.10
+    3.11: python3.11
     pypy3: pypy3
     mypy: python3.8
     lint,apicheck,linkcheck,configcheck,bandit: python3.9


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

This PR adds Python 3.11 to test runners (CI, tox) and updates trove classifier accordingly.