### PR TITLE
Revert "sqlalchemy==1.4.46 (#7995)"

### DIFF
--- a/requirements/extras/sqlalchemy.txt
+++ b/requirements/extras/sqlalchemy.txt
@@ -1,1 +1,1 @@
-sqlalchemy>=1.4.46
+sqlalchemy==1.4.45


### PR DESCRIPTION
The change `sqlalchemy==1.4.46` broke the unit tests in `main` so I'm reverting it until we find a better fix because we can't have main broken.

I'm merging this PR now as we cannot have `main` broken.
This is an issue for me because I found a bug in the `Task.replace` and I have a fix that I can't merge because it fails for issues caused from the reverted commit.

FYI @auvipy 