### PR TITLE
Fix cronjob that use day of month and negative UTC timezone

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -72,8 +72,8 @@ class BaseSchedule:
     def is_due(self, last_run_at):
         raise NotImplementedError()
 
-    def maybe_make_aware(self, dt):
-        return maybe_make_aware(dt, self.tz)
+    def maybe_make_aware(self, dt, naive_as_utc=True):
+        return maybe_make_aware(dt, self.tz, naive_as_utc=naive_as_utc)
 
     @property
     def app(self):
@@ -468,9 +468,8 @@ class crontab(BaseSchedule):
             return False
 
         def is_before_last_run(year, month, day):
-            return self.maybe_make_aware(datetime(year,
-                                                  month,
-                                                  day)) < last_run_at
+            return self.maybe_make_aware(datetime(year, month, day, next_hour, next_minute),
+                                         naive_as_utc=False) < last_run_at
 
         def roll_over():
             for _ in range(2000):

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -305,10 +305,11 @@ def to_utc(dt):
     return make_aware(dt, timezone.utc)
 
 
-def maybe_make_aware(dt, tz=None):
+def maybe_make_aware(dt, tz=None, naive_as_utc=True):
     """Convert dt to aware datetime, do nothing if dt is already aware."""
     if is_naive(dt):
-        dt = to_utc(dt)
+        if naive_as_utc:
+            dt = to_utc(dt)
         return localize(
             dt, timezone.utc if tz is None else timezone.tz_or_local(tz),
         )


### PR DESCRIPTION
Before this patch, the cross day schedule jumps to the future and some tasks are skipped

## Description
Fix https://github.com/celery/celery/issues/8052

When we specify day_of_month of cronjob to non-wildcard and choose a negative UTC timezone such as "America/Los_Angeles", the roll_over function mistakenly skip valid candidates. 

The roll_over function use is_before_last_run function which does not properly take timezone, next_hour and next_minute into account. 