### PR TITLE
Document --logfile default

### DIFF
--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -176,7 +176,8 @@ class CeleryDaemonCommand(CeleryCommand):
     def __init__(self, *args, **kwargs):
         """Initialize a Celery command with common daemon options."""
         super().__init__(*args, **kwargs)
-        self.params.append(CeleryOption(('-f', '--logfile'), help_group="Daemonization Options"))
+        self.params.append(CeleryOption(('-f', '--logfile'), help_group="Daemonization Options",
+                           help="Log destination; defaults to stderr"))
         self.params.append(CeleryOption(('--pidfile',), help_group="Daemonization Options"))
         self.params.append(CeleryOption(('--uid',), help_group="Daemonization Options"))
         self.params.append(CeleryOption(('--gid',), help_group="Daemonization Options"))


### PR DESCRIPTION
## Description

Basically what the title says - I had to dig around in the source code to confirm this, so I thought I'd save someone else the trouble.

I did not run everything in https://docs.celeryq.dev/en/latest/contributing.html#creating-pull-requests since this is just a doc change, but I _did_ run relevant things. `make configcheck` outputs warnings but nothing related to this patch.