### PR TITLE
result_backend_thread_safe config shares backend across threads

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -131,6 +131,7 @@ class Backend:
         self.max_sleep_between_retries_ms = conf.get('result_backend_max_sleep_between_retries_ms', 10000)
         self.base_sleep_between_retries_ms = conf.get('result_backend_base_sleep_between_retries_ms', 10)
         self.max_retries = conf.get('result_backend_max_retries', float("inf"))
+        self.thread_safe = conf.get('result_backend_thread_safe', False)
 
         self._pending_results = pending_results_t({}, WeakValueDictionary())
         self._pending_messages = BufferMap(MESSAGE_BUFFER_MAX)

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -792,6 +792,18 @@ Default: Inf
 This is the maximum of retries in case of recoverable exceptions.
 
 
+.. setting:: result_backend_thread_safe
+
+``result_backend_thread_safe``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: False
+
+If True, then the backend object is shared across threads.
+This may be useful for using a shared connection pool instead of creating
+a connection for every thread.
+
+
 .. setting:: result_backend_transport_options
 
 ``result_backend_transport_options``

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1052,6 +1052,21 @@ class test_App:
         uuid.UUID(thread_oid)
         assert main_oid != thread_oid
 
+    def test_thread_backend_thread_safe(self):
+        # Should share the backend object across threads
+        from concurrent.futures import ThreadPoolExecutor
+
+        with self.Celery() as app:
+            app.conf.update(result_backend_thread_safe=True)
+            main_backend = app.backend
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(lambda: app.backend)
+
+            thread_backend = future.result()
+            assert isinstance(main_backend, Backend)
+            assert isinstance(thread_backend, Backend)
+            assert main_backend is thread_backend
+
 
 class test_defaults:
 

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -1219,3 +1219,15 @@ class test_backend_retries:
         finally:
             self.app.conf.result_backend_always_retry = prev
             self.app.conf.result_backend_max_retries = prev_max_retries
+
+    def test_result_backend_thread_safe(self):
+        # Should identify the backend as thread safe
+        self.app.conf.result_backend_thread_safe = True
+        b = BaseBackend(app=self.app)
+        assert b.thread_safe is True
+
+    def test_result_backend_not_thread_safe(self):
+        # Should identify the backend as not being thread safe
+        self.app.conf.result_backend_thread_safe = False
+        b = BaseBackend(app=self.app)
+        assert b.thread_safe is False


### PR DESCRIPTION
## Description
Addresses https://github.com/celery/celery/issues/6819

This aims to allow users to opt-in to sharing the backend object across threads if the backend is thread safe. Other attempts have been made to do this such as https://github.com/celery/celery/pull/7961. However, there seemed to be uncertainty with whether to move forward with those or not. I figure allowing this be a configuration lets users switch back if they notice issues.
