### PR TITLE
Fix command for starting flower with specified broker URL

### DIFF
--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -299,9 +299,9 @@ Broker URL can also be passed through the
 
 .. code-block:: console
 
-    $ celery flower --broker=amqp://guest:guest@localhost:5672//
+    $ celery --broker=amqp://guest:guest@localhost:5672// flower
     or
-    $ celery flower --broker=redis://guest:guest@localhost:6379/0
+    $ celery --broker=redis://guest:guest@localhost:6379/0 flower
 
 Then, you can visit flower in your web browser :
 


### PR DESCRIPTION
The documentation specifies the command to start flower as

```
celery flower --broker="redis://localhost:6379/0"
```

Flower now gives a warning and ignores the `--broker` argument.

```
You have incorrectly specified the following celery arguments after flower command: ['--broker']. Please specify them after celery command instead following this template: celery [celery args] flower [flower args].
```

This is because `--broker` is an argument for Celery not Flower.

## Description

This PR fixes the aforementioned issue in the documentation by moving the `--broker` argument to the correct place.