### PR TITLE
#8080 Deprecate iso8601 module

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -14,7 +14,7 @@ from ._state import _set_task_join_will_block, task_join_will_block
 from .app import app_or_default
 from .exceptions import ImproperlyConfigured, IncompleteStream, TimeoutError
 from .utils.graph import DependencyGraph, GraphFormatter
-from .utils.iso8601 import parse_iso8601
+from .utils.time import _fromisoformat
 
 try:
     import tblib
@@ -530,7 +530,7 @@ class AsyncResult(ResultBase):
         """UTC date and time."""
         date_done = self._get_task_meta().get('date_done')
         if date_done and not isinstance(date_done, datetime.datetime):
-            return parse_iso8601(date_done)
+            return _fromisoformat(date_done)
         return date_done
 
     @property

--- a/celery/utils/iso8601.py
+++ b/celery/utils/iso8601.py
@@ -37,6 +37,10 @@ from datetime import datetime
 
 from pytz import FixedOffset
 
+from celery.utils import deprecated
+
+deprecated.warn(description="Module celery.iso8601", deprecation="5.4", removal="6.0.0", alternative="Use datetime.datetime.fromisoformat")
+
 __all__ = ('parse_iso8601',)
 
 # Adapted from http://delete.me.uk/2005/03/iso8601.html

--- a/celery/utils/iso8601.py
+++ b/celery/utils/iso8601.py
@@ -39,7 +39,12 @@ from pytz import FixedOffset
 
 from celery.utils import deprecated
 
-deprecated.warn(description="Module celery.iso8601", deprecation="5.4", removal="6.0.0", alternative="Use datetime.datetime.fromisoformat")
+deprecated.warn(
+    description="Module celery.iso8601",
+    deprecation="5.4",
+    removal="6.0.0",
+    alternative="Use datetime.datetime.fromisoformat",
+)
 
 __all__ = ('parse_iso8601',)
 

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -1,8 +1,8 @@
 """Utilities related to dates, times, intervals, and timezones."""
 import numbers
 import os
-import sys
 import random
+import sys
 import time as _time
 from calendar import monthrange
 from datetime import date, datetime, timedelta, tzinfo

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -388,7 +388,8 @@ def get_exponential_backoff_interval(
     # Adjust according to maximum wait time and account for negative values.
     return max(0, countdown)
 
-def _fromisoformat(datestring:str) -> datetime:
+
+def _fromisoformat(datestring: str) -> datetime:
     """
     Identical to `datetime.datetime.fromisoformat` with compatibility
     to Python 3.7 - 3.10.

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -13,7 +13,7 @@ from celery.canvas import StampingVisitor, signature
 from celery.contrib.testing.mocks import ContextMock
 from celery.exceptions import Ignore, ImproperlyConfigured, Retry
 from celery.result import AsyncResult, EagerResult
-from celery.utils.time import parse_iso8601
+from celery.utils.time import _fromisoformat
 
 try:
     from urllib.error import HTTPError
@@ -889,11 +889,11 @@ class test_tasks(TasksCase):
         assert task_headers['task'] == task_name
         if test_eta:
             assert isinstance(task_headers.get('eta'), str)
-            to_datetime = parse_iso8601(task_headers.get('eta'))
+            to_datetime = _fromisoformat(task_headers.get('eta'))
             assert isinstance(to_datetime, datetime)
         if test_expires:
             assert isinstance(task_headers.get('expires'), str)
-            to_datetime = parse_iso8601(task_headers.get('expires'))
+            to_datetime = _fromisoformat(task_headers.get('expires'))
             assert isinstance(to_datetime, datetime)
         properties = properties or {}
         for arg_name, arg_value in properties.items():

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -1,15 +1,18 @@
-from datetime import datetime, timedelta, tzinfo
 # Avoid clashing with celery.utils.time.timezone
+from datetime import datetime, timedelta
 from datetime import timezone as datetime_timezone
+from datetime import tzinfo
 from unittest.mock import Mock, patch
 
 import pytest
 import pytz
 from pytz import AmbiguousTimeError
 
-from celery.utils.time import (LocalTimezone, delta_resolution, ffwd, get_exponential_backoff_interval,
-                               humanize_seconds, localize, make_aware, maybe_iso8601, maybe_make_aware,
-                               maybe_timedelta, rate, remaining, timezone, utcoffset, _fromisoformat)
+from celery.utils.time import (LocalTimezone, _fromisoformat, delta_resolution, ffwd,
+                               get_exponential_backoff_interval, humanize_seconds, localize, make_aware,
+                               maybe_iso8601, maybe_make_aware, maybe_timedelta, rate, remaining, timezone,
+                               utcoffset)
+
 
 class test_LocalTimezone:
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

- Deprecation warning for `celery.utils.iso8601` module
- New private function `_fromisoformat()` in `celery.utils.time` to replace `celery.utils.iso8601.parse_iso8601()`