### PR TITLE
Deprecate parse_iso8601 in favor of fromisoformat

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -14,7 +14,6 @@ from ._state import _set_task_join_will_block, task_join_will_block
 from .app import app_or_default
 from .exceptions import ImproperlyConfigured, IncompleteStream, TimeoutError
 from .utils.graph import DependencyGraph, GraphFormatter
-from .utils.iso8601 import parse_iso8601
 
 try:
     import tblib
@@ -530,7 +529,7 @@ class AsyncResult(ResultBase):
         """UTC date and time."""
         date_done = self._get_task_meta().get('date_done')
         if date_done and not isinstance(date_done, datetime.datetime):
-            return parse_iso8601(date_done)
+            return datetime.datetime.fromisoformat(date_done)
         return date_done
 
     @property

--- a/celery/utils/iso8601.py
+++ b/celery/utils/iso8601.py
@@ -37,6 +37,8 @@ from datetime import datetime
 
 from pytz import FixedOffset
 
+from celery.utils.deprecated import warn
+
 __all__ = ('parse_iso8601',)
 
 # Adapted from http://delete.me.uk/2005/03/iso8601.html
@@ -53,6 +55,7 @@ TIMEZONE_REGEX = re.compile(
 
 def parse_iso8601(datestring):
     """Parse and convert ISO-8601 string to datetime."""
+    warn("parse_iso8601", "v5.3", "v6", "datetime.datetime.fromisoformat")
     m = ISO8601_REGEX.match(datestring)
     if not m:
         raise ValueError('unable to parse date string %r' % datestring)

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -13,7 +13,6 @@ from pytz import timezone as _timezone
 from pytz import utc
 
 from .functional import dictfilter
-from .iso8601 import parse_iso8601
 from .text import pluralize
 
 __all__ = (
@@ -257,7 +256,7 @@ def maybe_iso8601(dt):
         return
     if isinstance(dt, datetime):
         return dt
-    return parse_iso8601(dt)
+    return datetime.fromisoformat(dt)
 
 
 def is_naive(dt):

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -13,7 +13,6 @@ from celery.canvas import StampingVisitor, signature
 from celery.contrib.testing.mocks import ContextMock
 from celery.exceptions import Ignore, ImproperlyConfigured, Retry
 from celery.result import AsyncResult, EagerResult
-from celery.utils.time import parse_iso8601
 
 try:
     from urllib.error import HTTPError
@@ -889,11 +888,11 @@ class test_tasks(TasksCase):
         assert task_headers['task'] == task_name
         if test_eta:
             assert isinstance(task_headers.get('eta'), str)
-            to_datetime = parse_iso8601(task_headers.get('eta'))
+            to_datetime = datetime.fromisoformat(task_headers.get('eta'))
             assert isinstance(to_datetime, datetime)
         if test_expires:
             assert isinstance(task_headers.get('expires'), str)
-            to_datetime = parse_iso8601(task_headers.get('expires'))
+            to_datetime = datetime.fromisoformat(task_headers.get('expires'))
             assert isinstance(to_datetime, datetime)
         properties = properties or {}
         for arg_name, arg_value in properties.items():


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fixes #8080.  As suggested there, marks as deprecated for v5.3 with removal planned in v6
