### PR TITLE
Trying to clarify CERT_REQUIRED

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1230,8 +1230,9 @@ Use the ``rediss://`` protocol to connect to redis over TLS::
     result_backend = 'rediss://username:password@host:port/db?ssl_cert_reqs=required'
 
 Note that the ``ssl_cert_reqs`` string should be one of ``required``,
-``optional``, or ``none`` (though, for backwards compatibility, the string
-may also be one of ``CERT_REQUIRED``, ``CERT_OPTIONAL``, ``CERT_NONE``).
+``optional``, or ``none`` (though, for backwards compatibility with older Celery versions, the string
+may also be one of ``CERT_REQUIRED``, ``CERT_OPTIONAL``, ``CERT_NONE``, but those values
+only work for Celery, not for Redis directly).
 
 If a Unix socket connection should be used, the URL needs to be in the format:::
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

I spent a while trying to understand why my URL was causing a runtime error in Redis, and that's when I realized that ssl_cert_reqs=CERT_REQUIRED only works for Celery, not for Redis directly. Re-reading the docs, I see how that is implied, but I didn't understand that "backward compatibility" meant "backward compatibility with older Celery versions". I've attempted to re-word it so that others don't make the mistake I did. Suggestions welcome. 