### PR TITLE
Fix potential AttributeError on 'stamps'

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -491,7 +491,7 @@ class Backend:
                     if hasattr(request, 'delivery_info') and
                     request.delivery_info else None,
                 }
-                if getattr(request, 'stamps'):
+                if getattr(request, 'stamps', None):
                     request_meta['stamped_headers'] = request.stamped_headers
                     request_meta.update(request.stamps)
 

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -125,6 +125,18 @@ class test_Backend_interface:
         assert meta['kwargs'] == kwargs
         assert meta['queue'] == 'celery'
 
+    def test_get_result_meta_stamps_attribute_error(self):
+        class Request:
+            pass
+        self.app.conf.result_extended = True
+        b1 = BaseBackend(self.app)
+        meta = b1._get_result_meta(result={'fizz': 'buzz'},
+                                   state=states.SUCCESS, traceback=None,
+                                   request=Request())
+        assert meta['status'] == states.SUCCESS
+        assert meta['result'] == {'fizz': 'buzz'}
+        assert meta['traceback'] is None
+
     def test_get_result_meta_encoded(self):
         self.app.conf.result_extended = True
         b1 = BaseBackend(self.app)


### PR DESCRIPTION
## Description

The current check will fail if the attribute doesn't exists on the `request` instance.

Stack trace of the error:

```
AttributeError: 'Bunch' object has no attribute 'stamps'
  File "celery/worker/worker.py", line 202, in start
    self.blueprint.start(self)
  File "celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "celery/bootsteps.py", line 365, in start
    return self.obj.start()
  File "celery/worker/consumer/consumer.py", line 336, in start
    blueprint.start(self)
  File "celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "celery/worker/consumer/consumer.py", line 726, in start
    c.loop(*c.loop_args())
  File "celery/worker/loops.py", line 130, in synloop
    connection.drain_events(timeout=2.0)
  File "kombu/connection.py", line 331, in drain_events
    return self.transport.drain_events(self.connection, **kwargs)
  File "kombu/transport/virtual/base.py", line 983, in drain_events
    get(self._deliver, timeout=timeout)
  File "kombu/transport/redis.py", line 588, in get
    ret = self.handle_event(fileno, event)
  File "kombu/transport/redis.py", line 570, in handle_event
    return self.on_readable(fileno), self
  File "kombu/transport/redis.py", line 566, in on_readable
    chan.handlers[type]()
  File "kombu/transport/redis.py", line 971, in _brpop_read
    self.connection._deliver(loads(bytes_to_str(item)), dest)
  File "kombu/transport/virtual/base.py", line 1003, in _deliver
    callback(message)
  File "kombu/transport/virtual/base.py", line 630, in _callback
    return callback(message)
  File "kombu/messaging.py", line 642, in _receive_callback
    return on_m(message) if on_m else self.receive(decoded, message)
  File "celery/worker/consumer/consumer.py", line 644, in on_task_received
    return on_unknown_task(None, message, exc)
  File "celery/worker/consumer/consumer.py", line 591, in on_unknown_task
    self.app.backend.mark_as_failure(
  File "celery/backends/base.py", line 167, in mark_as_failure
    self.store_result(task_id, exc, state,
  File "celery/backends/base.py", line 526, in store_result
    self._store_result(task_id, result, state, traceback,
  File "celery/backends/base.py", line 963, in _store_result
    meta = self._get_result_meta(result=result, state=state,
  File "celery/backends/base.py", line 494, in _get_result_meta
    if getattr(request, 'stamps'):
```
