### PR TITLE
Reference Gopher Celery in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ to high availability and horizontal scaling.
 
 Celery is written in Python, but the protocol can be implemented in any
 language. In addition to Python there's node-celery_ for Node.js,
-a `PHP client`_, `gocelery`_ for golang, and rusty-celery_ for Rust.
+a `PHP client`_, `gocelery`_, gopher-celery_ for Go, and rusty-celery_ for Rust.
 
 Language interoperability can also be achieved by using webhooks
 in such a way that the client enqueues an URL to be requested by a worker.
@@ -52,6 +52,7 @@ in such a way that the client enqueues an URL to be requested by a worker.
 .. _node-celery: https://github.com/mher/node-celery
 .. _`PHP client`: https://github.com/gjedeer/celery-php
 .. _`gocelery`: https://github.com/gocelery/gocelery
+.. _gopher-celery: https://github.com/marselester/gopher-celery
 .. _rusty-celery: https://github.com/rusty-celery/rusty-celery
 
 What do I need?


### PR DESCRIPTION
## Description

Please consider adding https://github.com/marselester/gopher-celery to a list of protocol implementations.