### PR TITLE
Fix `Task.handle_ignore` not wrapping exceptions properly

### DIFF
--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -214,30 +214,26 @@ class TraceInfo:
 
     def handle_failure(self, task, req, store_errors=True, call_errbacks=True):
         """Handle exception."""
-        _, _, tb = sys.exc_info()
-        try:
-            exc = self.retval
-            # make sure we only send pickleable exceptions back to parent.
-            einfo = ExceptionInfo()
-            einfo.exception.exc = get_pickleable_exception(einfo.exception.exc)
-            einfo.type = get_pickleable_etype(einfo.type)
 
-            task.backend.mark_as_failure(
-                req.id, exc, einfo.traceback,
-                request=req, store_result=store_errors,
-                call_errbacks=call_errbacks,
-            )
+        exc = get_pickleable_exception(self.retval)
+        exc_type = get_pickleable_etype(self.retval)
+        # make sure we only send pickleable exceptions back to parent.
+        einfo = ExceptionInfo(exc_info=(exc_type, exc, exc.__traceback__))
 
-            task.on_failure(exc, req.id, req.args, req.kwargs, einfo)
-            signals.task_failure.send(sender=task, task_id=req.id,
-                                      exception=exc, args=req.args,
-                                      kwargs=req.kwargs,
-                                      traceback=tb,
-                                      einfo=einfo)
-            self._log_error(task, req, einfo)
-            return einfo
-        finally:
-            del tb
+        task.backend.mark_as_failure(
+            req.id, exc, einfo.traceback,
+            request=req, store_result=store_errors,
+            call_errbacks=call_errbacks,
+        )
+
+        task.on_failure(exc, req.id, req.args, req.kwargs, einfo)
+        signals.task_failure.send(sender=task, task_id=req.id,
+                                  exception=exc, args=req.args,
+                                  kwargs=req.kwargs,
+                                  traceback=exc.__traceback__,
+                                  einfo=einfo)
+        self._log_error(task, req, einfo)
+        return einfo
 
     def _log_error(self, task, req, einfo):
         eobj = einfo.exception = get_pickled_exception(einfo.exception)

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -214,9 +214,10 @@ class TraceInfo:
 
     def handle_failure(self, task, req, store_errors=True, call_errbacks=True):
         """Handle exception."""
+        orig_exc = self.retval
 
-        exc = get_pickleable_exception(self.retval)
-        exc_type = get_pickleable_etype(self.retval)
+        exc = get_pickleable_exception(orig_exc)
+        exc_type = get_pickleable_etype(orig_exc)
         # make sure we only send pickleable exceptions back to parent.
         einfo = ExceptionInfo(exc_info=(exc_type, exc, exc.__traceback__))
 

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -217,7 +217,13 @@ class TraceInfo:
         orig_exc = self.retval
 
         exc = get_pickleable_exception(orig_exc)
+        if exc.__traceback__ is None:
+            # `get_pickleable_exception` may have created a new exception without
+            # a traceback.
+            _, _, exc.__traceback__ = sys.exc_info()
+
         exc_type = get_pickleable_etype(orig_exc)
+
         # make sure we only send pickleable exceptions back to parent.
         einfo = ExceptionInfo(exc_info=(exc_type, exc, exc.__traceback__))
 

--- a/celery/utils/serialization.py
+++ b/celery/utils/serialization.py
@@ -147,12 +147,15 @@ class UnpickleableExceptionWrapper(Exception):
 
     @classmethod
     def from_exception(cls, exc):
-        return cls(
+        res = cls(
             exc.__class__.__module__,
             exc.__class__.__name__,
             getattr(exc, 'args', []),
             safe_repr(exc)
-        ).with_traceback(exc.__traceback__)
+        )
+        if hasattr(exc, "__traceback__"):
+            res = res.with_traceback(exc.__traceback__)
+        return res
 
 
 def get_pickleable_exception(exc):

--- a/celery/utils/serialization.py
+++ b/celery/utils/serialization.py
@@ -147,10 +147,12 @@ class UnpickleableExceptionWrapper(Exception):
 
     @classmethod
     def from_exception(cls, exc):
-        return cls(exc.__class__.__module__,
-                   exc.__class__.__name__,
-                   getattr(exc, 'args', []),
-                   safe_repr(exc))
+        return cls(
+            exc.__class__.__module__,
+            exc.__class__.__name__,
+            getattr(exc, 'args', []),
+            safe_repr(exc)
+        ).with_traceback(exc.__traceback__)
 
 
 def get_pickleable_exception(exc):

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -213,7 +213,7 @@ def retry(self, return_value=None):
 
 @shared_task(bind=True, default_retry_delay=1)
 def retry_unpickleable(self, foo, bar, *, retry_kwargs):
-    # TODO: docstring
+    """Task that fails with an unpickleable exception and is retried."""
     raise self.retry(exc=UnpickleableException(foo, bar), **retry_kwargs)
 
 
@@ -347,7 +347,7 @@ def fail(*args):
 
 @shared_task()
 def fail_unpickleable(foo, bar):
-    # TODO: docstring
+    """Task that raises an unpickleable exception."""
     raise UnpickleableException(foo, bar)
 
 

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -333,7 +333,9 @@ class test_tasks:
         """Tests retrying of task."""
         # Tests when max. retries is reached
         result = retry.delay()
-        for _ in range(5):
+
+        tik = time.monotonic()
+        while time.monotonic() < tik + 5:
             status = result.status
             if status != 'PENDING':
                 break

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -568,6 +568,7 @@ class test_task_retries(TasksCase):
         assert self.retry_task_unpickleable_exc.iterations == 3
 
         exc_wrapper = exc_info.value
+        assert exc_wrapper.exc_cls_name == "UnpickleableException"
         assert exc_wrapper.exc_args == ("foo", )
 
     def test_max_retries_exceeded(self):


### PR DESCRIPTION
## Description

Fix `Task.handle_failure` not wrapping the exception correctly in case of unpicklealbe exceptions.

Other changes:
* add the traceback object too when wrapping an unpickleable exception
* added tests to ensure that `Task.handle_failure` and `Task.handle_retry` work as expected

This work is a continuation of the fixes I made in https://github.com/celery/celery/pull/8133.

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
