### PR TITLE
CLI help output: avoid text rewrapping by click

### DIFF
--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -300,8 +300,11 @@ def worker(ctx, hostname=None, pool_cls=None, app=None, uid=None, gid=None,
            **kwargs):
     """Start worker instance.
 
+    \b
     Examples
     --------
+
+    \b
     $ celery --app=proj worker -l INFO
     $ celery -A proj worker -l INFO -Q hipri,lopri
     $ celery -A proj worker --concurrency=4


### PR DESCRIPTION
Closes #8151

The command `celery worker --help` gives this

```bash
Usage: celery worker [OPTIONS]

  Start worker instance.

  Examples
  --------

  $ celery --app=proj worker -l INFO $ celery -A proj worker -l INFO -Q
  hipri,lopri $ celery -A proj worker --concurrency=4 $ celery -A proj worker
  --concurrency=1000 -P eventlet $ celery worker --autoscale=10,0
```

This PR fixes it to give this

```bash
Usage: celery worker [OPTIONS]

  Start worker instance.

  Examples
  --------

  $ celery --app=proj worker -l INFO
  $ celery -A proj worker -l INFO -Q hipri,lopri
  $ celery -A proj worker --concurrency=4
  $ celery -A proj worker --concurrency=1000 -P eventlet
  $ celery worker --autoscale=10,0
```