### PR TITLE
Fix integration test

### DIFF
--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -355,7 +355,7 @@ class test_tasks:
             status = result.status
             if status != 'PENDING':
                 break
-            sleep(1)
+            sleep(0.1)
         else:
             raise AssertionError("Timeout while waiting for the task to be retried")
         assert status == 'RETRY'

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -355,7 +355,7 @@ class test_tasks:
             status = result.status
             if status != 'PENDING':
                 break
-            sleep(0.1)
+            sleep(1)
         else:
             raise AssertionError("Timeout while waiting for the task to be retried")
         assert status == 'RETRY'

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -351,7 +351,7 @@ class test_tasks:
         result = retry.delay(return_value='bar')
 
         tik = time.monotonic()
-        while time.monotonic() < tik + 50:
+        while time.monotonic() < tik + 5:
             status = result.status
             if status != 'PENDING':
                 break

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -351,7 +351,7 @@ class test_tasks:
         result = retry.delay(return_value='bar')
 
         tik = time.monotonic()
-        while time.monotonic() < tik + 5:
+        while time.monotonic() < tik + 50:
             status = result.status
             if status != 'PENDING':
                 break

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -11,7 +11,7 @@ from celery.canvas import StampingVisitor
 from celery.utils.serialization import UnpickleableExceptionWrapper
 from celery.worker import state as worker_state
 
-from .conftest import get_active_redis_channels
+from .conftest import TEST_BACKEND, get_active_redis_channels
 from .tasks import (ClassBasedAutoRetryTask, ExpectedException, add, add_ignore_result, add_not_typed, fail,
                     fail_unpickleable, print_unicode, retry, retry_once, retry_once_headers, retry_once_priority,
                     retry_unpickleable, return_properties, sleeping)
@@ -329,6 +329,11 @@ class test_tasks:
             result.get(timeout=5)
         assert result.status == 'FAILURE'
 
+    @pytest.mark.xfail(
+        condition=TEST_BACKEND == "rpc",
+        reason="Retry failed on rpc backend",
+        strict=False,
+    )
     def test_retry(self, manager):
         """Tests retrying of task."""
         # Tests when max. retries is reached

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -349,11 +349,15 @@ class test_tasks:
 
         # Tests when task is retried but after returns correct result
         result = retry.delay(return_value='bar')
-        for _ in range(5):
+
+        tik = time.monotonic()
+        while time.monotonic() < tik + 5:
             status = result.status
             if status != 'PENDING':
                 break
-            sleep(1)
+            sleep(0.1)
+        else:
+            raise AssertionError("Timeout while waiting for the task to be retried")
         assert status == 'RETRY'
         assert result.get() == 'bar'
         assert result.status == 'SUCCESS'


### PR DESCRIPTION
Fix regression introduced in https://github.com/celery/celery/pull/8149 after disabling the `xfail` marker