### PR TITLE
Update & simplify GHA pip caching

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -103,6 +103,8 @@ jobs:
               uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
+                  cache: 'pip'
+                  cache-dependency-path: '**/setup.py'
           -   name: Install tox
               run: python -m pip install --upgrade pip tox tox-gh-actions
           -   name: >

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,19 +46,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: Cache
-      uses: actions/cache@v3.0.2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key:
-          ${{ matrix.python-version }}-${{matrix.os}}-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ matrix.python-version }}-${{matrix.os}}
+        cache: 'pip'
+        cache-dependency-path: '**/setup.py'
 
     - name: Install tox
       run: python -m pip install --upgrade pip tox tox-gh-actions
@@ -114,11 +103,6 @@ jobs:
               uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
-
-          -   name: Get pip cache dir
-              id: pip-cache
-              run: |
-                  echo "::set-output name=dir::$(pip cache dir)"
           -   name: Install tox
               run: python -m pip install --upgrade pip tox tox-gh-actions
           -   name: >


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

This PR accomplishes two things for the workflow.  

One, it will resolve the niggling warnings about using `set-output`, which is deprecated and going to be removed eventually.

Two (and this is the large one), it changes the action to utilize the `pip` caching from `actions/setup-python`.  This frees the project from needing to maintain caching and get any benefits from the upstream's improvements to the caching.  The cache key will already include the OS, OS version, Python version and has been updated to include the `setup.py` as the previous code did.  This could also extend to the requirement text files easily, if desired.

You can compare the timing of the [first run](https://github.com/stumpylog/celery/actions/runs/4547884225) without caching to a [second run](https://github.com/stumpylog/celery/actions/runs/4548157700) where the cache keys were hit.  38m 36s down to 31m 17s isn't a huge decrease, but it's a little better.

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
