### PR TITLE
Added signal triggered before fork

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -38,6 +38,7 @@ from vine import promise
 
 from celery.utils.functional import noop
 from celery.utils.log import get_logger
+from celery.signals import worker_before_create_process
 from celery.worker import state as worker_state
 
 # pylint: disable=redefined-outer-name
@@ -476,6 +477,7 @@ class AsynPool(_pool.Pool):
         )
 
     def _create_worker_process(self, i):
+        worker_before_create_process.send(sender=self)
         gc.collect()  # Issue #2927
         return super()._create_worker_process(i)
 

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -36,9 +36,9 @@ from kombu.utils.eventio import SELECT_BAD_FD
 from kombu.utils.functional import fxrange
 from vine import promise
 
+from celery.signals import worker_before_create_process
 from celery.utils.functional import noop
 from celery.utils.log import get_logger
-from celery.signals import worker_before_create_process
 from celery.worker import state as worker_state
 
 # pylint: disable=redefined-outer-name

--- a/celery/signals.py
+++ b/celery/signals.py
@@ -18,12 +18,13 @@ __all__ = (
     'task_prerun', 'task_postrun', 'task_success',
     'task_received', 'task_rejected', 'task_unknown',
     'task_retry', 'task_failure', 'task_revoked', 'celeryd_init',
-    'celeryd_after_setup', 'worker_init', 'worker_process_init',
-    'worker_process_shutdown', 'worker_ready', 'worker_shutdown',
-    'worker_shutting_down', 'setup_logging', 'after_setup_logger',
-    'after_setup_task_logger', 'beat_init', 'beat_embedded_init',
-    'heartbeat_sent', 'eventlet_pool_started', 'eventlet_pool_preshutdown',
-    'eventlet_pool_postshutdown', 'eventlet_pool_apply',
+    'celeryd_after_setup', 'worker_init', 'worker_before_create_process',
+    'worker_process_init', 'worker_process_shutdown', 'worker_ready',
+    'worker_shutdown', 'worker_shutting_down', 'setup_logging',
+    'after_setup_logger', 'after_setup_task_logger', 'beat_init',
+    'beat_embedded_init', 'heartbeat_sent', 'eventlet_pool_started',
+    'eventlet_pool_preshutdown', 'eventlet_pool_postshutdown',
+    'eventlet_pool_apply',
 )
 
 # - Task
@@ -105,6 +106,7 @@ celeryd_after_setup = Signal(
 # - Worker
 import_modules = Signal(name='import_modules')
 worker_init = Signal(name='worker_init')
+worker_before_create_process = Signal(name="worker_before_create_process")
 worker_process_init = Signal(name='worker_process_init')
 worker_process_shutdown = Signal(name='worker_process_shutdown')
 worker_ready = Signal(name='worker_ready')

--- a/docs/userguide/signals.rst
+++ b/docs/userguide/signals.rst
@@ -543,6 +543,13 @@ Provides arguments:
 
 Dispatched before the worker is started.
 
+.. signal:: worker_before_create_process
+
+``worker_before_create_process``
+~~~~~~~~~~~~~~~
+
+Dispatched before new child process is created.
+
 .. signal:: worker_ready
 
 ``worker_ready``

--- a/docs/userguide/signals.rst
+++ b/docs/userguide/signals.rst
@@ -546,7 +546,7 @@ Dispatched before the worker is started.
 .. signal:: worker_before_create_process
 
 ``worker_before_create_process``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Dispatched in the parent process, just before new child process is created in the prefork pool.
 It can be used to clean up instances that don't behave well when forking.

--- a/docs/userguide/signals.rst
+++ b/docs/userguide/signals.rst
@@ -548,7 +548,14 @@ Dispatched before the worker is started.
 ``worker_before_create_process``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Dispatched before new child process is created.
+Dispatched in the parent process, just before new child process is created in the prefork pool.
+It can be used to clean up instances that don't behave well when forking.
+
+.. code-block:: python
+
+    @signals.worker_before_create_process.connect
+    def clean_channels(**kwargs):
+        grpc_singleton.clean_channel()
 
 .. signal:: worker_ready
 

--- a/docs/userguide/signals.rst
+++ b/docs/userguide/signals.rst
@@ -546,7 +546,7 @@ Dispatched before the worker is started.
 .. signal:: worker_before_create_process
 
 ``worker_before_create_process``
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Dispatched before new child process is created.
 

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -365,6 +365,18 @@ class test_AsynPool:
         pool.register_with_event_loop(hub)
         hub.on_tick.add.assert_called_once()
 
+    @patch('billiard.pool.Pool._create_worker_process')
+    def test_before_create_process_signal(self, create_process):
+        from celery import signals
+        on_worker_before_create_process = Mock()
+        signals.worker_before_create_process.connect(on_worker_before_create_process)
+        pool = asynpool.AsynPool(processes=1, threads=False)
+        create_process.assert_called_once_with(0)
+        on_worker_before_create_process.assert_any_call(
+            signal=signals.worker_before_create_process,
+            sender=pool,
+        )
+
 
 @t.skip.if_win32
 class test_ResultHandler:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Created signal emitted just before creating new child process.
I need to clean some classes which use grpc channels and ssl connections.

In our case GCP secretmanager using grpc channel cause many "Timed out waiting for UP message" due to stuck on command:
![Zrzut ekranu z 2023-03-23 17-07-15](https://user-images.githubusercontent.com/78016744/229564191-7aa5d2d1-c687-44a9-b8aa-2960f51dbacb.png)



