### PR TITLE
Add python 3.11 to supported versions in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ What do I need?
 
 Celery version 5.3.0a1 runs on,
 
-- Python (3.7, 3.8, 3.9, 3.10)
+- Python (3.7, 3.8, 3.9, 3.10, 3.11)
 - PyPy3.7 (7.3.7+)
 
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Updating README.rst to indicate python 3.11 as a supported version. Related issue: https://github.com/celery/celery/issues/8227#issuecomment-1533422732