### PR TITLE
Ensure argument for `map` is JSON serializable

### DIFF
--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -1037,7 +1037,7 @@ For example using ``map``:
 
     >>> from proj.tasks import add
 
-    >>> ~tsum.map([range(10), range(100)])
+    >>> ~tsum.map([list(range(10)), list(range(100))])
     [45, 4950]
 
 is the same as having a task doing:


### PR DESCRIPTION
This is just a small correction in the documentation.

The original example doesn't work because `range` is not serializable by default. The correction turns the ranges into JSON serializable lists.