### PR TITLE
chore(style): switch to Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,4 @@
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.2
-    hooks:
-      - id: pyupgrade
-        args: ["--py37-plus"]
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
-    hooks:
-      - id: yesqa
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -23,13 +7,13 @@ repos:
       - id: check-yaml
       - id: mixed-line-ending
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.2.0
     hooks:
     -   id: mypy
         pass_filenames: false
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.265"
+    hooks:
+      - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,40 @@ omit = [
     "*celery/contrib/testing/*",
     "*celery/contrib/pytest.py"
 ]
+
+[tool.ruff]
+select = ["E", "F", "D", "I", "UP", "RUF100", "S"]
+ignore = ["S110", "S101", "S102", "S301", "S311", "S603", "S606", "I001", "UP024", "UP030", "D101", "D102", "D103", "D104", "D105", "D107", "D202", "D203", "D204", "D205", "D208", "D209", "D211", "D212", "D213", "D214", "D301", "D400", "D401", "D403", "D404", "D414", "D406", "D405", "D407", "D410","D411", "D412","D413","D415", "D416","D417", "E741", "E742"]
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+line-length = 117
+target-version = "py37"
+
+[tool.ruff.per-file-ignores]
+"setup.py" = ["D"]
+"t/*" = ["D", "S"]
+"docs/*" = ["D"]
+"examples/*" = ["D", "S"]
+"extra/*" = ["D"]
+


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

This PR aims at showcasing switching from multiple pre-commit tools (flake8, isort, yesqa, pyupgrade and bandit) to [Ruff](https://beta.ruff.rs/docs/). More precisely, it:
- adds ruff to pre-commit configuration
- adds ruff section in `pyproject.toml`

This is left as a draft for now as I want to get feedback on whether we want to go for this switch or not, if the idea is accepted, I'll describe in further details the changes and split the work in multiple commits/PRs.

Advantages:
- Ruff is way quicker than former tools ([numbers speak for themselves](https://beta.ruff.rs/docs/)) .
- We can leverage even more `pyproject.toml` configuration and maybe at some point get rid of `setup.cfg` file.