### PR TITLE
chore(build): switch to Poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,106 @@
+[tool.poetry]
+name = "celery"
+version = "5.3.0b2"
+description = "Distributed Task Queue."
+license = "BSD-3-Clause"
+authors = ["Ask Solem <auvipy@gmail.com>"]
+homepage = "https://docs.celeryq.dev/"
+keywords = ["task", "queue", "job", "async", "rabbitmq", "amqp", "redis", "python", "distributed", "actor"] 
+classifiers = []
+include = ["CONTRIBUTORS.txt", "Changelog.rst", "LICENSE", "README.rst", "TODO", "docs/**", "extra/**", "examples/*", "t/**/*.py", "t/**/*.rst", "celery/utils/static/*.png"]
+exclude = ["docs/_build/*"]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+billiard = "^4.1.0"
+kombu = "^5.3.0b3"
+vine = "^5.0.0"
+click = "^8.1.2"
+click-didyoumean = "^0.3.0"
+click-repl = "^0.2.0"
+click-plugins = "^1.1.1"
+importlib-metadata = { version = "^3.6", python = "<3.8" }
+backports = { version = "^0.2.1", python = "<3.9" }
+tzdata = ">=2022.7"
+
+pyArango = { version = "^2.0.1", optional = true }
+cryptography = { version = "40.0.1", optional = true }
+azure-storage-blob = { version = "40.0.1", optional = true }
+cassandra-driver = { version = "^3.25.0", optional = true }
+python-consul2 = { version = "0.1.5", optional = true }
+pydocumentdb = { version = "2.3.5", optional = true }
+Django = { version = ">=2.2.28", optional = true }
+elasticsearch = { version = "<8.0", optional = true }
+eventlet = { version = ">=0.32.0", python = "<3.10", optional = true }
+gevent = { version = ">=1.5.0", optional = true }
+librabbitmq = { version = ">=1.5.0", optional = true }
+pylibmc = { version = "1.6.3", markers = "platform_system != 'Windows'", optional = true }
+pymongo = { version = ">=4.0.2", extras = ["srv"], optional = true }
+msgpack = { version = "1.0.5", optional = true }
+python-memcached = { version = "1.59", optional = true }
+pyro5 = { version = "*", optional = true }
+pytest-celery = { version = "0.0.0", optional = true }
+redis = { version = "^4.3.6", optional = true }
+boto3 = { version = "1.26.110", optional = true }
+softlayer_messaging = { version = ">1.0.3", optional = true }
+ephem = { version = "4.1.4", markers = "platform_python_implementation != 'PyPy'", optional = true }
+sqlalchemy = { version = "^1.4.47", optional = true }
+zstandard = { version = "0.20.0", optional = true }
+kazoo = { version = ">=1.3.1", optional = true }
+PyYAML = { version = ">=3.10", optional = true }
+pycouchdb = { version = "1.14.2", optional = true }
+
+[tool.poetry.group.test.dependencies]
+pytest = "7.3.1"
+pytest-celery = "0.0.0"
+pytest-subtests = "0.10.0"
+pytest-timeout = "2.1.0"
+pytest-click = "1.1.0"
+pytest-order = "1.1.0"
+boto3 = "^1.26.114"
+moto = "^4.1.7"
+mypy = { version = "1.2.0", markers = "platform_python_implementation == 'CPython'" }
+pre-commit = "2.21.0"
+PyYAML = "^3.10"
+pymongo = { version = "^4.0.2", extras = ["srv"]}
+msgpack = "1.0.5"
+
+[tool.poetry.extras]
+arangodb = ["pyArango"]
+auth = ["cryptography"]
+azureblockblob = ["azure-storage-blob"]
+brotli = [] 
+cassandra = ["cassandra-driver"]
+consul = ["python-consul2"]
+cosmosdbsql = ["pydocumentdb"]
+couchbase = []
+couchdb = ["pycouchdb"]
+django = ["Django"]
+dynamodb = ["boto3"]
+elasticsearch = ["elasticsearch"]
+eventlet = ["eventlet"]
+gevent = ["gevent"]
+librabbitmq = ["librabbitmq"]
+memcache = ["pylibmc"]
+mongodb = ["pymongo"]
+msgpack = ["msgpack"]
+pymemcache = ["python-memcached"]
+pyro = ["pyro5"]
+pytest = ["pytest-celery"]
+redis = ["redis"]
+s3 = ["boto3"]
+slmq = ["softlayer_messaging"]
+solar = ["ephem"]
+sqlalchemy = ["sqlalchemy"]
+sqs = ["kombu"]
+tblib = []
+yaml = ["PyYAML"]
+zookeeper = ["kazoo"]
+zstd = ["zstandard"]
+
+[tool.poetry.scripts]
+celery = "celery.__main__:main"
+
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
 testpaths = "t/unit/"
@@ -49,3 +152,7 @@ omit = [
     "*celery/contrib/testing/*",
     "*celery/contrib/pytest.py"
 ]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/setup.py
+++ b/setup.py
@@ -166,9 +166,9 @@ setuptools.setup(
     python_requires=">=3.7",
     tests_require=reqs('test.txt'),
     extras_require=extras_require(),
-    cmdclass={'test': pytest},
-    include_package_data=True,
-    zip_safe=False,
+    cmdclass={'test': pytest},  # python setup.py test ? TODO: check where this is used
+    include_package_data=True,  # https://setuptools.pypa.io/en/latest/userguide/datafiles.html
+    zip_safe=False,  # https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html
     entry_points={
         'console_scripts': [
             'celery = celery.__main__:main',


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

WIP

This is a proposal about switching from scattered build and requirements files to PEP-517 build system using `poetry` and `poetry-core` with `pyproject.toml`.
The work is not done yet, I'd like to get some feedback about the idea first before moving forward.

TODO

- [ ] Check that we have no regression in wheel content
- [ ] Check that dependencies version and extras are the same as before
- [ ] Update GH actions accordingly 