### PR TITLE
chore(build): clean `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,6 @@ setuptools.setup(
     tests_require=reqs('test.txt'),
     extras_require=extras_require(),
     include_package_data=True,
-    zip_safe=False,
     entry_points={
         'console_scripts': [
             'celery = celery.__main__:main',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 import codecs
 import os
 import re
-import sys
 
 import setuptools
 import setuptools.command.test
@@ -132,22 +131,6 @@ def long_description():
     except OSError:
         return 'Long description error: Missing README.rst file'
 
-# -*- Command: setup.py test -*-
-
-
-class pytest(setuptools.command.test.test):
-    user_options = [('pytest-args=', 'a', 'Arguments to pass to pytest')]
-
-    def initialize_options(self):
-        super().initialize_options()
-        self.pytest_args = []
-
-    def run_tests(self):
-        import pytest as _pytest
-        sys.exit(_pytest.main(self.pytest_args))
-
-# -*- %%% -*-
-
 
 meta = parse_dist_meta()
 setuptools.setup(
@@ -166,7 +149,6 @@ setuptools.setup(
     python_requires=">=3.7",
     tests_require=reqs('test.txt'),
     extras_require=extras_require(),
-    cmdclass={'test': pytest},
     include_package_data=True,
     zip_safe=False,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,6 @@ setuptools.setup(
     python_requires=">=3.7",
     tests_require=reqs('test.txt'),
     extras_require=extras_require(),
-    include_package_data=True,
     entry_points={
         'console_scripts': [
             'celery = celery.__main__:main',


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Cleaning before https://github.com/celery/celery/pull/8238.

This PR:
- removes `zip_safe` parameter as this is considered deprecated and used for egg distribution format, cf. https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html.
- removes `cmdclass` as it seems unused, cf. https://setuptools.pypa.io/en/latest/userguide/extension.html for more context.
- removes `include_package_data` parameter as this is not used, cf. https://setuptools.pypa.io/en/latest/userguide/datafiles.html.

