### PR TITLE
update old hard-coded URLs from celeryq.org to celeryq.dev

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -28,7 +28,7 @@ __all__ = (
 
 E_WOULDBLOCK = """\
 Never call result.get() within a task!
-See http://docs.celeryq.org/en/latest/userguide/tasks.html\
+See http://docs.celeryq.dev/en/latest/userguide/tasks.html\
 #task-synchronous-subtasks
 """
 

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -76,7 +76,7 @@ Did you remember to import the module containing this task?
 Or maybe you're using relative imports?
 
 Please see
-http://docs.celeryq.org/en/latest/internals/protocol.html
+http://docs.celeryq.dev/en/latest/internals/protocol.html
 for more information.
 
 The full contents of the message body was:
@@ -90,7 +90,7 @@ The message has been ignored and discarded.
 
 Please ensure your message conforms to the task
 message protocol as described here:
-http://docs.celeryq.org/en/latest/internals/protocol.html
+http://docs.celeryq.dev/en/latest/internals/protocol.html
 
 The full contents of the message body was:
 %s


### PR DESCRIPTION
## Description

I recently encountered the `E_WOULDBLOCK` message at runtime, and when I followed the suggested link, I was taken to a site that _does **not**_ appear to belong to the actual Celery dev org, but instead some generic programming blog that _is not_ hosting Celery docs.

```
*** RuntimeError: Never call result.get() within a task!
See http://docs.celeryq.org/en/latest/userguide/tasks.html#task-synchronous-subtasks
```

This is a simple change to update these old hard-coded URLs to use the current correct domain.

These URLs were originally added back in 2016 with cf04c93d77. I remember the domain name ownership kerfuffle that happened a year ago. Perhaps this was a casualty of that event, or perhaps whoever owned the `celeryq.org` domain decided to stop redirecting to the correct docs? 🤷 