### PR TITLE
Remove dependency on `python-dateutil` by shifting to using our own ambiguous datetime detection

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -8,4 +8,3 @@ click-plugins>=1.1.1
 importlib-metadata>=3.6; python_version < '3.8'
 backports.zoneinfo>=0.2.1; python_version < '3.9'
 tzdata>=2022.7
-python-dateutil>=2.8.2


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
