### PR TITLE
Fix exc_type being exception instance rather than type

### DIFF
--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -222,7 +222,7 @@ class TraceInfo:
             # a traceback.
             _, _, exc.__traceback__ = sys.exc_info()
 
-        exc_type = get_pickleable_etype(orig_exc)
+        exc_type = get_pickleable_etype(type(orig_exc))
 
         # make sure we only send pickleable exceptions back to parent.
         einfo = ExceptionInfo(exc_info=(exc_type, exc, exc.__traceback__))


### PR DESCRIPTION
This PR https://github.com/celery/celery/pull/8149 introduced a regression which will cause some log handlers to crash. In my particular case, it is `structlog` with `ConsoleRenderer` (which uses `rich` under the hood). The reason for that I believe is https://github.com/celery/celery/commit/3ce5b85806104e14f75a377fadc4de3e50038396#diff-fb194522c454315cd87ccb1cf4a2a53aafa49124c85abc01dcca4310cf19d6d3R225 which passes the exception instance rather than the exception type. Some handlers will inspect and expect there to be a type and that will lead to crashes.
