### PR TITLE
Support sqlalchemy 2.0 in tests

### DIFF
--- a/requirements/extras/sqlalchemy.txt
+++ b/requirements/extras/sqlalchemy.txt
@@ -1,1 +1,1 @@
-sqlalchemy>=1.4.48,<2.0
+sqlalchemy>=1.4.48

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -408,7 +408,12 @@ class test_SessionManager:
         from sqlalchemy.dialects.sqlite import dialect
         from sqlalchemy.exc import DatabaseError
 
-        sqlite = dialect.dbapi()
+        if hasattr(dialect, 'dbapi'):
+            # Method name in SQLAlchemy < 2.0
+            sqlite = dialect.dbapi()
+        else:
+            # Newer method name in SQLAlchemy 2.0
+            sqlite = dialect.import_dbapi()
         manager = SessionManager()
         engine = manager.get_engine('dburi')
 


### PR DESCRIPTION
## Description

This patch updates the call to [sqlalchemy.engine.Dialect.dbapi](https://docs.sqlalchemy.org/en/20/core/internals.html#sqlalchemy.engine.Dialect.dbapi) to work with the latest sqlalchemy (2.0). The change is made to be compatible with older version of sqlalchemy so it should work with older versions too.