### PR TITLE
fixed a small float value of retry_backoff

### DIFF
--- a/celery/app/autoretry.py
+++ b/celery/app/autoretry.py
@@ -18,7 +18,7 @@ def add_autoretry_behaviour(task, **options):
     retry_kwargs = options.get(
         'retry_kwargs', getattr(task, 'retry_kwargs', {})
     )
-    retry_backoff = int(
+    retry_backoff = float(
         options.get('retry_backoff',
                     getattr(task, 'retry_backoff', False))
     )
@@ -48,7 +48,7 @@ def add_autoretry_behaviour(task, **options):
                 if retry_backoff:
                     retry_kwargs['countdown'] = \
                         get_exponential_backoff_interval(
-                            factor=retry_backoff,
+                            factor=int(max(1.0, retry_backoff)),
                             retries=task.request.retries,
                             maximum=retry_backoff_max,
                             full_jitter=retry_jitter)

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1,5 +1,4 @@
 import socket
-import tempfile
 from datetime import datetime, timedelta
 from unittest.mock import ANY, MagicMock, Mock, patch, sentinel
 
@@ -14,11 +13,6 @@ from celery.contrib.testing.mocks import ContextMock
 from celery.exceptions import Ignore, ImproperlyConfigured, Retry
 from celery.result import AsyncResult, EagerResult
 from celery.utils.serialization import UnpickleableExceptionWrapper
-
-try:
-    from urllib.error import HTTPError
-except ImportError:
-    from urllib2 import HTTPError
 
 
 def return_True(*args, **kwargs):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description
I encountered an unexpected behavior: if I set retry_backoff to 0.0 < {value} < 1.0, all retries will run after default_retry_delay (180 seconds). 
I don't think it makes much sense to allow a floating retry_backoff value, so I propose just rounding the {value} up to 1.
