### PR TITLE
Avoid librabbitmq problem in python 3.11

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -260,9 +260,9 @@ separating them by commas.
 ::
 
 
-    $ pip install "celery[amqp]"
+    $ pip install "celery[gevent]"
 
-    $ pip install "celery[amqp,redis,auth,msgpack]"
+    $ pip install "celery[gevent,redis,auth,msgpack]"
 
 The following bundles are available:
 
@@ -290,7 +290,7 @@ Concurrency
 Transports and Backends
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-:``celery[amqp]``:
+:``celery``:
     for using the RabbitMQ amqp python library.
 
 :``celery[redis]``:

--- a/requirements/extras/librabbitmq.txt
+++ b/requirements/extras/librabbitmq.txt
@@ -1,1 +1,1 @@
-librabbitmq>=2.0.0
+librabbitmq>=2.0.0; python_version < '3.11'


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

1. It seems `librabbitmq` is no longer maintained, and the `librabbitmq` package has 
bugs in python 3.11, as stated in https://github.com/celery/librabbitmq/issues/167.
If install requires with `celery[librabbitmq]` of some other packages or system migrating
to 3.11 will lead to errors. As `librabbitmq` is not suggested, we can restricted
install require python versions for bakcward compatibility and further 3.11.
```
librabbitmq>=2.0.0; python_version < '3.11'
```
2. The bundle `celery[amqp]` in readme does not exist actually. There's a warning
`WARNING: celery 5.*.* does not provide the extra 'amqp'` when installing with it.
This might be confusing. Shall we use some others to show as an example 

@auvipy 

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
4.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
