### PR TITLE
ChainMap observers fix

### DIFF
--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -206,7 +206,7 @@ class ChainMap(MutableMapping):
     changes = None
     defaults = None
     maps = None
-    _observers = []
+    _observers = ()
 
     def __init__(self, *maps, **kwargs):
         # type: (*Mapping, **Any) -> None
@@ -216,6 +216,7 @@ class ChainMap(MutableMapping):
             maps=maps,
             changes=maps[0],
             defaults=maps[1:],
+            _observers=[],
         )
 
     def add_defaults(self, d):

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -2,14 +2,14 @@ import pickle
 from collections.abc import Mapping
 from itertools import count
 from time import monotonic
+from unittest.mock import Mock
 
 import pytest
-from unittest.mock import Mock
 from billiard.einfo import ExceptionInfo
 
 import t.skip
-from celery.utils.collections import (AttributeDict, BufferMap, ConfigurationView, DictAttribute, LimitedSet,
-                                      Messagebuffer, ChainMap)
+from celery.utils.collections import (AttributeDict, BufferMap, ChainMap, ConfigurationView, DictAttribute,
+                                      LimitedSet, Messagebuffer)
 from celery.utils.objects import Bunch
 
 

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -4,11 +4,12 @@ from itertools import count
 from time import monotonic
 
 import pytest
+from unittest.mock import Mock
 from billiard.einfo import ExceptionInfo
 
 import t.skip
 from celery.utils.collections import (AttributeDict, BufferMap, ConfigurationView, DictAttribute, LimitedSet,
-                                      Messagebuffer)
+                                      Messagebuffer, ChainMap)
 from celery.utils.objects import Bunch
 
 
@@ -448,3 +449,16 @@ class test_BufferMap:
 
     def test_repr(self):
         assert repr(Messagebuffer(10, [1, 2, 3]))
+
+
+class test_ChainMap:
+
+    def test_observers_not_shared(self):
+        a = ChainMap()
+        b = ChainMap()
+        callback = Mock()
+        a.bind_to(callback)
+        b.update(x=1)
+        callback.assert_not_called()
+        a.update(x=1)
+        callback.assert_called_once_with(x=1)


### PR DESCRIPTION
Observers should not be shared across different instances. Aside from unwanted behavior, this can lead to object leaks (like celery app objects not being garbage collected).