### PR TITLE
fix supported versions in docs

### DIFF
--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -19,8 +19,8 @@ Using Celery with Django
 
 .. note::
 
-    Celery 5.0.x supports Django 1.11 LTS or newer versions. Please use Celery 4.4.x
-    for versions older than Django 1.11.
+    Celery 5.3.x supports Django 2.2 LTS or newer versions.
+    Please use Celery 5.2.x for versions older than Django 2.2 or Celery 4.4.x if your Django version is older than 1.11.
 
 To use Celery with your Django project you must first define
 an instance of the Celery library (called an "app")

--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -39,10 +39,10 @@ What do I need?
 ===============
 
 .. sidebar:: Version Requirements
-    :subtitle: Celery version 5.2 runs on
+    :subtitle: Celery version 5.3 runs on
 
-    - Python ❨3.7, 3.8, 3.9, 3.10❩
-    - PyPy3.7, 3.8 ❨7.3.7❩
+    - Python ❨3.8, 3.9, 3.10, 3.11❩
+    - PyPy3.8+ ❨v7.3.11+❩
 
     Celery 4.x was the last version to support Python 2.7,
     Celery 5.x requires Python 3.6 or newer.


### PR DESCRIPTION

## Description

Updated the documentation about the new versions supported.

Got the PyPy one from the README https://github.com/celery/celery/blob/main/README.rst?plain=1#L64

Django one from the release notes: https://github.com/celery/celery/releases/tag/v5.3.0 (technically between 1.11 and 2.2 in theory 5.0.x - 5.2.x range is supported but maybe its better to nudge ppl to the latest one)
