### PR TITLE
store children with database backend

### DIFF
--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -25,6 +25,7 @@ class Task(ResultModelBase):
     date_done = sa.Column(sa.DateTime, default=datetime.utcnow,
                           onupdate=datetime.utcnow, nullable=True)
     traceback = sa.Column(sa.Text, nullable=True)
+    children = sa.Column(PickleType, nullable=True)
 
     def __init__(self, task_id):
         self.task_id = task_id
@@ -36,6 +37,7 @@ class Task(ResultModelBase):
             'result': self.result,
             'traceback': self.traceback,
             'date_done': self.date_done,
+            'children': self.children,
         }
 
     def __repr__(self):

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -99,6 +99,7 @@ class test_DatabaseBackend:
         assert meta['task_id'] == 'xxx-does-not-exist-at-all'
         assert meta['result'] is None
         assert meta['traceback'] is None
+        assert meta['children'] is None
 
     def test_mark_as_done(self):
         tb = DatabaseBackend(self.uri, app=self.app)


### PR DESCRIPTION
Attempt to fix #8336. The test passes with `assert meta['children'] is None`, but need to test further with a task that actually has children.