### PR TITLE
Bugfix: Removed unecessary stamping code from _chord.run()

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -2216,9 +2216,6 @@ class _chord(Signature):
         options = dict(self.options, **options) if options else self.options
         if options:
             options.pop('task_id', None)
-            stamped_headers = set(body.options.get("stamped_headers", []))
-            stamped_headers.update(options.get("stamped_headers", []))
-            options["stamped_headers"] = list(stamped_headers)
             body.options.update(options)
 
         bodyres = body.freeze(task_id, root_id=root_id)


### PR DESCRIPTION
Stamping is for signatures, not for tasks, so it is **never** expected to receive it via `options`.