### PR TITLE
Stamping bugfix with group/chord header errback linking

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1672,7 +1672,7 @@ class group(Signature):
         #
         # We return a concretised tuple of the signatures actually applied to
         # each child task signature, of which there might be none!
-        return tuple(child_task.link_error(sig.clone()) for child_task in self.tasks)
+        return tuple(child_task.link_error(sig.clone(immutable=True)) for child_task in self.tasks)
 
     def _prepared(self, tasks, partial_args, group_id, root_id, app,
                   CallableSignature=abstract.CallableSignature,
@@ -2273,7 +2273,7 @@ class _chord(Signature):
         """
         if self.app.conf.task_allow_error_cb_on_chord_header:
             for task in self.tasks:
-                task.link_error(errback.clone())
+                task.link_error(errback.clone(immutable=True))
         else:
             # Once this warning is removed, the whole method needs to be refactored to:
             # 1. link the error callback to each task in the header

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -2273,7 +2273,7 @@ class _chord(Signature):
         """
         if self.app.conf.task_allow_error_cb_on_chord_header:
             for task in self.tasks:
-                task.link_error(errback)
+                task.link_error(errback.clone())
         else:
             # Once this warning is removed, the whole method needs to be refactored to:
             # 1. link the error callback to each task in the header

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1672,7 +1672,7 @@ class group(Signature):
         #
         # We return a concretised tuple of the signatures actually applied to
         # each child task signature, of which there might be none!
-        return tuple(child_task.link_error(sig) for child_task in self.tasks)
+        return tuple(child_task.link_error(sig.clone()) for child_task in self.tasks)
 
     def _prepared(self, tasks, partial_args, group_id, root_id, app,
                   CallableSignature=abstract.CallableSignature,

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -860,7 +860,7 @@ class test_group(CanvasCase):
         # We expect that all group children will be given the errback to ensure
         # it gets called
         for child_sig in g1.tasks:
-            child_sig.link_error.assert_called_with(sig)
+            child_sig.link_error.assert_called_with(sig.clone(immutable=True))
 
     def test_apply_empty(self):
         x = group(app=self.app)

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1669,7 +1669,7 @@ class test_chord(CanvasCase):
             chord_sig.link_error(errback_sig)
             # header
             for child_sig in header_mock:
-                child_sig.link_error.assert_called_once_with(errback_sig)
+                child_sig.link_error.assert_called_once_with(errback_sig.clone(immutable=True))
             # body
             body.link_error.assert_has_calls([call(errback_sig), call(errback_sig)])
 

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1717,7 +1717,7 @@ class test_chord(CanvasCase):
         errback = c.link_error(err)
         assert errback == err
         for header_task in c.tasks:
-            assert header_task.options['link_error'] == [err]
+            assert header_task.options['link_error'] == [err.clone(immutable=True)]
         assert c.body.options['link_error'] == [err]
 
 

--- a/t/unit/tasks/test_stamping.py
+++ b/t/unit/tasks/test_stamping.py
@@ -1295,13 +1295,11 @@ class test_stamping_mechanism(CanvasCase):
 
         with subtests.test("group"):
             canvas = group(tasks())
-            canvas.link(s("group_link"))
             canvas.link_error(s("group_link_error"))
             canvas.stamp(CustomStampingVisitor())
 
-        with subtests.test("chain"):
+        with subtests.test("chord header"):
             self.app.conf.task_allow_error_cb_on_chord_header = True
             canvas = chord(tasks(), self.identity.si("body"))
-            canvas.link(s("group_link"))
             canvas.link_error(s("group_link_error"))
             canvas.stamp(CustomStampingVisitor())

--- a/t/unit/tasks/test_stamping.py
+++ b/t/unit/tasks/test_stamping.py
@@ -1303,3 +1303,14 @@ class test_stamping_mechanism(CanvasCase):
             canvas = chord(tasks(), self.identity.si("body"))
             canvas.link_error(s("group_link_error"))
             canvas.stamp(CustomStampingVisitor())
+
+        with subtests.test("chord body"):
+            self.app.conf.task_allow_error_cb_on_chord_header = False
+            canvas = chord(tasks(), self.identity.si("body"))
+            canvas.link_error(s("group_link_error"))
+            canvas.stamp(CustomStampingVisitor())
+
+        with subtests.test("chain"):
+            canvas = chain(tasks())
+            canvas.link_error(s("chain_link_error"))
+            canvas.stamp(CustomStampingVisitor())


### PR DESCRIPTION
When stamping a group that shares a link error, this causes all links to contain the same stamping.
This fix allows each errback to have its own stamps by using `clone()` when linking the errback signature.

This fix also takes into consideration Chords with the [allow_error_cb_on_chord_header](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-allow-error-cb-on-chord-header) flag True.