### PR TITLE
Implement safer ArangoDB queries

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -292,3 +292,4 @@ Oleh Romanovskyi, 2022/06/09
 JoonHwan Kim, 2022/08/01
 Kaustav Banerjee, 2022/11/10
 Austin Snoeyink 2022/12/06
+Jeremy Z. Othieno 2023/07/27

--- a/celery/backends/arangodb.py
+++ b/celery/backends/arangodb.py
@@ -146,7 +146,7 @@ class ArangoDbBackend(KeyValueStoreBackend):
 
     def mget(self, keys):
         if keys is None:
-            return None
+            return
         query = self.db.AQLQuery(
             "FOR k IN @keys RETURN DOCUMENT(@@collection, k).task",
             rawResults=True,

--- a/celery/backends/arangodb.py
+++ b/celery/backends/arangodb.py
@@ -118,6 +118,8 @@ class ArangoDbBackend(KeyValueStoreBackend):
         return timedelta(seconds=self.expires)
 
     def get(self, key):
+        if key is None:
+            return None
         query = self.db.AQLQuery(
             "RETURN DOCUMENT(@@collection, @key).task",
             rawResults=True,

--- a/celery/backends/arangodb.py
+++ b/celery/backends/arangodb.py
@@ -115,7 +115,7 @@ class ArangoDbBackend(KeyValueStoreBackend):
 
     @cached_property
     def expires_delta(self):
-        return timedelta(seconds=self.expires)
+        return timedelta(seconds=0 if self.expires is None else self.expires)
 
     def get(self, key):
         if key is None:
@@ -172,7 +172,7 @@ class ArangoDbBackend(KeyValueStoreBackend):
         )
 
     def cleanup(self):
-        if self.expires_delta is None:
+        if not self.expires:
             return
         checkpoint = (self.app.now() - self.expires_delta).isoformat()
         self.db.AQLQuery(

--- a/celery/backends/arangodb.py
+++ b/celery/backends/arangodb.py
@@ -2,8 +2,6 @@
 
 # pylint: disable=W1202,W0703
 
-import json
-import logging
 from datetime import timedelta
 
 from kombu.utils.objects import cached_property

--- a/celery/backends/arangodb.py
+++ b/celery/backends/arangodb.py
@@ -163,6 +163,8 @@ class ArangoDbBackend(KeyValueStoreBackend):
                 break
 
     def delete(self, key):
+        if key is None:
+            return
         self.db.AQLQuery(
             "REMOVE {_key: @key} IN @@collection",
             bindVars={

--- a/celery/backends/arangodb.py
+++ b/celery/backends/arangodb.py
@@ -120,113 +120,69 @@ class ArangoDbBackend(KeyValueStoreBackend):
         return timedelta(seconds=self.expires)
 
     def get(self, key):
-        try:
-            logging.debug(
-                'RETURN DOCUMENT("{collection}/{key}").task'.format(
-                    collection=self.collection, key=key
-                )
-            )
-            query = self.db.AQLQuery(
-                'RETURN DOCUMENT("{collection}/{key}").task'.format(
-                    collection=self.collection, key=key
-                )
-            )
-            result = query.response["result"][0]
-            if result is None:
-                return None
-            return json.dumps(result)
-        except AQLQueryError as aql_err:
-            logging.error(aql_err)
-            return None
-        except Exception as err:
-            logging.error(err)
-            return None
+        query = self.db.AQLQuery(
+            "RETURN DOCUMENT(@@collection, @key).task",
+            rawResults=True,
+            bindVars={
+                "@collection": self.collection,
+                "key": key,
+            },
+        )
+        return next(query) if len(query) > 0 else None
 
     def set(self, key, value):
-        """Insert a doc with value into task attribute and _key as key."""
-        try:
-            logging.debug(
-                'INSERT {{ task: {task}, _key: "{key}" }} INTO {collection}'
-                .format(
-                    collection=self.collection, key=key, task=value
-                )
-            )
-            self.db.AQLQuery(
-                'INSERT {{ task: {task}, _key: "{key}" }} INTO {collection}'
-                .format(
-                    collection=self.collection, key=key, task=value
-                )
-            )
-        except AQLQueryError as aql_err:
-            logging.error(aql_err)
-        except Exception as err:
-            logging.error(err)
+        self.db.AQLQuery(
+            """
+            UPSERT {_key: @key}
+            INSERT {_key: @key, task: @value}
+            UPDATE {task: @value} IN @@collection
+            """,
+            bindVars={
+                "@collection": self.collection,
+                "key": key,
+                "value": value,
+            },
+        )
 
     def mget(self, keys):
-        try:
-            json_keys = json.dumps(keys)
-            logging.debug(
-                """
-                FOR key in {keys}
-                    RETURN DOCUMENT(CONCAT("{collection}/", key)).task
-                """.format(
-                    collection=self.collection, keys=json_keys
-                )
-            )
-            query = self.db.AQLQuery(
-                """
-                FOR key in {keys}
-                    RETURN DOCUMENT(CONCAT("{collection}/", key)).task
-                """.format(
-                    collection=self.collection, keys=json_keys
-                )
-            )
-            results = []
-            while True:
-                results.extend(query.response['result'])
+        if keys is None:
+            return None
+        query = self.db.AQLQuery(
+            "FOR k IN @keys RETURN DOCUMENT(@@collection, k).task",
+            rawResults=True,
+            bindVars={
+                "@collection": self.collection,
+                "keys": keys if isinstance(keys, list) else list(keys),
+            },
+        )
+        while True:
+            yield from query
+            try:
                 query.nextBatch()
-        except StopIteration:
-            values = [
-                result if result is None else json.dumps(result)
-                for result in results
-            ]
-            return values
-        except AQLQueryError as aql_err:
-            logging.error(aql_err)
-            return [None] * len(keys)
-        except Exception as err:
-            logging.error(err)
-            return [None] * len(keys)
+            except StopIteration:
+                break
 
     def delete(self, key):
-        try:
-            logging.debug(
-                'REMOVE {{ _key: "{key}" }} IN {collection}'.format(
-                    key=key, collection=self.collection
-                )
-            )
-            self.db.AQLQuery(
-                'REMOVE {{ _key: "{key}" }} IN {collection}'.format(
-                    key=key, collection=self.collection
-                )
-            )
-        except AQLQueryError as aql_err:
-            logging.error(aql_err)
-        except Exception as err:
-            logging.error(err)
+        self.db.AQLQuery(
+            "REMOVE {_key: @key} IN @@collection",
+            bindVars={
+                "@collection": self.collection,
+                "key": key,
+            },
+        )
 
     def cleanup(self):
-        """Delete expired meta-data."""
-        remove_before = (self.app.now() - self.expires_delta).isoformat()
-        try:
-            query = (
-                'FOR item IN {collection} '
-                'FILTER item.task.date_done < "{remove_before}" '
-                'REMOVE item IN {collection}'
-            ).format(collection=self.collection, remove_before=remove_before)
-            logging.debug(query)
-            self.db.AQLQuery(query)
-        except AQLQueryError as aql_err:
-            logging.error(aql_err)
-        except Exception as err:
-            logging.error(err)
+        if self.expires_delta is None:
+            return
+        checkpoint = (self.app.now() - self.expires_delta).isoformat()
+        self.db.AQLQuery(
+            """
+            FOR record IN @@collection
+                FILTER record.task.date_done < @checkpoint
+                REMOVE record IN @@collection
+            """,
+            bindVars={
+                "@collection": self.collection,
+                "checkpoint": checkpoint,
+            },
+        )

--- a/requirements/extras/arangodb.txt
+++ b/requirements/extras/arangodb.txt
@@ -1,1 +1,1 @@
-pyArango>=2.0.1
+pyArango>=2.0.2

--- a/t/unit/backends/test_arangodb.py
+++ b/t/unit/backends/test_arangodb.py
@@ -68,6 +68,23 @@ class test_ArangoDbBackend:
         assert self.backend.get(sentinel.task_id) == sentinel.retval
         self.backend.get.assert_called_once_with(sentinel.task_id)
 
+    def test_set(self):
+        self.backend._connection = MagicMock(spec=["__getitem__"])
+
+        assert self.backend.set(sentinel.key, sentinel.value) is None
+        self.backend.db.AQLQuery.assert_called_once_with(
+            """
+            UPSERT {_key: @key}
+            INSERT {_key: @key, task: @value}
+            UPDATE {task: @value} IN @@collection
+            """,
+            bindVars={
+                "@collection": self.backend.collection,
+                "key": sentinel.key,
+                "value": sentinel.value,
+            },
+        )
+
     def test_mget(self):
         self.backend._connection = MagicMock(spec=["__getitem__"])
 

--- a/t/unit/backends/test_arangodb.py
+++ b/t/unit/backends/test_arangodb.py
@@ -1,6 +1,6 @@
 """Tests for the ArangoDb."""
 import datetime
-from unittest.mock import Mock, MagicMock, patch, sentinel
+from unittest.mock import MagicMock, Mock, patch, sentinel
 
 import pytest
 

--- a/t/unit/backends/test_arangodb.py
+++ b/t/unit/backends/test_arangodb.py
@@ -39,6 +39,21 @@ class test_ArangoDbBackend:
         self.app.conf.arangodb_backend_settings = None
         ArangoDbBackend(app=self.app)
 
+    def test_init_url(self):
+        url = None
+        expected_database = "celery"
+        expected_collection = "celery"
+        backend = ArangoDbBackend(app=self.app, url=url)
+        assert backend.database == expected_database
+        assert backend.collection == expected_collection
+
+        url = "arangodb://localhost:27017/celery-database/celery-collection"
+        expected_database = "celery-database"
+        expected_collection = "celery-collection"
+        backend = ArangoDbBackend(app=self.app, url=url)
+        assert backend.database == expected_database
+        assert backend.collection == expected_collection
+
     def test_get_connection_connection_exists(self):
         with patch('pyArango.connection.Connection') as mock_Connection:
             self.backend._connection = sentinel.connection
@@ -47,7 +62,7 @@ class test_ArangoDbBackend:
             mock_Connection.assert_not_called()
 
             expected_connection = mock_Connection()
-            mock_Connection.reset_mock() # So the assert_called_once below is accurate.
+            mock_Connection.reset_mock()  # So the assert_called_once below is accurate.
             self.backend._connection = None
             connection = self.backend.connection
             assert connection == expected_connection

--- a/t/unit/backends/test_arangodb.py
+++ b/t/unit/backends/test_arangodb.py
@@ -65,8 +65,15 @@ class test_ArangoDbBackend:
         )
 
         self.backend.get = Mock(return_value=sentinel.retval)
-        assert self.backend.get('1f3fab') == sentinel.retval
-        self.backend.get.assert_called_once_with('1f3fab')
+        assert self.backend.get(sentinel.task_id) == sentinel.retval
+        self.backend.get.assert_called_once_with(sentinel.task_id)
+
+    def test_mget(self):
+        self.backend._connection = MagicMock(spec=["__getitem__"])
+
+        result = list(self.backend.mget(None))
+        expected_result = []
+        assert result == expected_result
 
     def test_delete(self):
         self.backend._connection = MagicMock(spec=["__getitem__"])

--- a/t/unit/backends/test_arangodb.py
+++ b/t/unit/backends/test_arangodb.py
@@ -51,10 +51,10 @@ class test_ArangoDbBackend:
     def test_get(self):
         self.backend._connection = MagicMock(spec=["__getitem__"])
 
-        assert self.backend.get(None) == None
+        assert self.backend.get(None) is None
         self.backend.db.AQLQuery.assert_not_called()
 
-        assert self.backend.get(sentinel.task_id) == None
+        assert self.backend.get(sentinel.task_id) is None
         self.backend.db.AQLQuery.assert_called_once_with(
             "RETURN DOCUMENT(@@collection, @key).task",
             rawResults=True,
@@ -69,11 +69,19 @@ class test_ArangoDbBackend:
         self.backend.get.assert_called_once_with('1f3fab')
 
     def test_delete(self):
-        self.app.conf.arangodb_backend_settings = {}
-        x = ArangoDbBackend(app=self.app)
-        x.delete = Mock()
-        x.delete.return_value = None
-        assert x.delete('1f3fab') is None
+        self.backend._connection = MagicMock(spec=["__getitem__"])
+
+        assert self.backend.delete(None) is None
+        self.backend.db.AQLQuery.assert_not_called()
+
+        assert self.backend.delete(sentinel.task_id) is None
+        self.backend.db.AQLQuery.assert_called_once_with(
+            "REMOVE {_key: @key} IN @@collection",
+            bindVars={
+                "@collection": self.backend.collection,
+                "key": sentinel.task_id,
+            },
+        )
 
     def test_config_params(self):
         self.app.conf.arangodb_backend_settings = {


### PR DESCRIPTION
The AQL queries used in the ArangoDbBackend's implementation are potentially
vulnerable to injections because no sanity checks are performed on the
arguments used to build the query strings.

This is particularly evident when using a database collection with a dash in
its name, e.g. "celery-task-results". The query string generated by the set
method is 'INSERT {task: v}, _key: "k"} INTO celery-task-results' instead of
'INSERT {task: v}, _key: "k"} INTO `celery-task-results`' (backticks
surrounding collection name). The former is evaluated as a substraction
(celery - task - results) and is therefore an illegal collection name,
while the latter is evaluated as a string.

This commit re-implements the setter and getters using bind parameters,
which performs the necessary safety checks. Furthermore, the new query used
in the set method accounts for updates to existing keys, resolving https://github.com/celery/celery/issues/7039.
