### PR TITLE
Fixing minor typo in code example in calling.rst

### DIFF
--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -234,7 +234,7 @@ a shortcut to set ETA by seconds into the future.
 
     >>> result = add.apply_async((2, 2), countdown=3)
     >>> result.get()    # this takes at least 3 seconds to return
-    20
+    4
 
 The task is guaranteed to be executed at some time *after* the
 specified date and time, but not necessarily at that exact time.


### PR DESCRIPTION
## Description

Several examples in `docs/userguide/calling.rst` add additional arguments to `sum.add((2,2), ...)` to make the result `(2+2) + 16 = 20` instead of `2 + 2 = 4`.  One example drops the additional arguments yet still returns `20`.  I have corrected this to `4`.