### PR TITLE
add documents for timeout settings

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -204,10 +204,10 @@ class AsyncResult(ResultBase):
 
         Arguments:
             timeout (float): How long to wait, in seconds, before the
-                operation times out. This is the setting for client and
-                is different from `timeout` parameter of `@app.task`, which
-                is the setting for worker. The task isn't terminated even if
-                timeout occurs.
+                operation times out. This is the setting for the publisher
+                (celery client) and is different from `timeout` parameter of
+                `@app.task`, which is the setting for the worker. The task
+                isn't terminated even if timeout occurs.
             propagate (bool): Re-raise exception if the task failed.
             interval (float): Time to wait (in seconds) before retrying to
                 retrieve the result.  Note that this does not have any effect

--- a/celery/result.py
+++ b/celery/result.py
@@ -204,7 +204,10 @@ class AsyncResult(ResultBase):
 
         Arguments:
             timeout (float): How long to wait, in seconds, before the
-                operation times out.
+                operation times out. This is the setting for client and
+                is different from `timeout` parameter of `@app.task`, which
+                is the setting for worker. The task isn't terminated even if
+                timeout occurs.
             propagate (bool): Re-raise exception if the task failed.
             interval (float): Time to wait (in seconds) before retrying to
                 retrieve the result.  Note that this does not have any effect

--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -573,7 +573,9 @@ time limit kills it:
             clean_up_in_a_hurry()
 
 Time limits can also be set using the :setting:`task_time_limit` /
-:setting:`task_soft_time_limit` settings.
+:setting:`task_soft_time_limit` settings. You can also specify time
+limits for client side operation using ``timeout`` argument of
+``AsyncResult.get()`` function.
 
 .. note::
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description
Thank you for the amazing library!

I added the explanations for `timeout` setting of `AsyncRsult.get()` function.
I got confused because there are `timeout` settings for task(worker) and celery client(publisher) respectively and there are less explanations for timelout of the publisher.

I'm not a native speaker so feel free to fix my english :joy:


<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
