### PR TITLE
Support preload options for shell and purge commands 

### DIFF
--- a/celery/bin/purge.py
+++ b/celery/bin/purge.py
@@ -5,7 +5,9 @@ from celery.bin.base import COMMA_SEPARATED_LIST, CeleryCommand, CeleryOption, h
 from celery.utils import text
 
 
-@click.command(cls=CeleryCommand)
+@click.command(cls=CeleryCommand, context_settings={
+    'allow_extra_args': True
+})
 @click.option('-f',
               '--force',
               cls=CeleryOption,
@@ -26,7 +28,7 @@ from celery.utils import text
               help="Comma separated list of queues names not to purge.")
 @click.pass_context
 @handle_preload_options
-def purge(ctx, force, queues, exclude_queues):
+def purge(ctx, force, queues, exclude_queues, **kwargs):
     """Erase all messages from all known task queues.
 
     Warning:

--- a/celery/bin/shell.py
+++ b/celery/bin/shell.py
@@ -79,7 +79,9 @@ def _invoke_default_shell(locals):
         _invoke_ipython_shell(locals)
 
 
-@click.command(cls=CeleryCommand)
+@click.command(cls=CeleryCommand, context_settings={
+    'allow_extra_args': True
+})
 @click.option('-I',
               '--ipython',
               is_flag=True,
@@ -117,7 +119,7 @@ def _invoke_default_shell(locals):
 @handle_preload_options
 def shell(ctx, ipython=False, bpython=False,
           python=False, without_tasks=False, eventlet=False,
-          gevent=False):
+          gevent=False, **kwargs):
     """Start shell session with convenient access to celery symbols.
 
     The following symbols will be added to the main globals:

--- a/t/unit/app/test_preload_cli.py
+++ b/t/unit/app/test_preload_cli.py
@@ -7,6 +7,14 @@ def test_preload_options(isolated_cli_runner: CliRunner):
     # Projects like Pyramid-Celery's ini option should be valid preload
     # options.
 
+    # TODO: Find a way to run these separate invoke and assertions
+    # such that order does not matter. Currently, running
+    # the "t.unit.bin.proj.pyramid_celery_app" first seems
+    # to result in cache or memoization of the option.
+    # As a result, the expected exception is not raised when
+    # the invoke on "t.unit.bin.proj.app" is run as a second
+    # call.
+
     res_without_preload = isolated_cli_runner.invoke(
         celery,
         ["-A", "t.unit.bin.proj.app", "purge", "-f", "--ini", "some_ini.ini"],

--- a/t/unit/app/test_preload_cli.py
+++ b/t/unit/app/test_preload_cli.py
@@ -1,4 +1,3 @@
-import sys
 from click.testing import CliRunner
 from celery.bin.celery import celery
 

--- a/t/unit/app/test_preload_cli.py
+++ b/t/unit/app/test_preload_cli.py
@@ -1,0 +1,55 @@
+import sys
+from click.testing import CliRunner
+from celery.bin.celery import celery
+
+
+def test_preload_options(isolated_cli_runner: CliRunner):
+    # Verify commands like shell and purge can accept preload options.
+    # Projects like Pyramid-Celery's ini option should be valid preload
+    # options.
+
+    res_without_preload = isolated_cli_runner.invoke(
+        celery,
+        ["-A", "t.unit.bin.proj.app", "purge", "-f", "--ini", "some_ini.ini"],
+        catch_exceptions=True,
+    )
+
+    assert "No such option: --ini" in res_without_preload.stdout
+    assert res_without_preload.exit_code == 2
+
+    res_without_preload = isolated_cli_runner.invoke(
+        celery,
+        ["-A", "t.unit.bin.proj.app", "shell", "--ini", "some_ini.ini"],
+        catch_exceptions=True,
+    )
+
+    assert "No such option: --ini" in res_without_preload.stdout
+    assert res_without_preload.exit_code == 2
+
+    res_with_preload = isolated_cli_runner.invoke(
+        celery,
+        [
+            "-A",
+            "t.unit.bin.proj.pyramid_celery_app",
+            "purge",
+            "-f",
+            "--ini",
+            "some_ini.ini",
+        ],
+        catch_exceptions=True,
+    )
+
+    assert res_with_preload.exit_code == 0
+
+    res_with_preload = isolated_cli_runner.invoke(
+        celery,
+        [
+            "-A",
+            "t.unit.bin.proj.pyramid_celery_app",
+            "shell",
+            "--ini",
+            "some_ini.ini",
+        ],
+        catch_exceptions=True,
+    )
+    assert res_with_preload.exit_code == 0

--- a/t/unit/bin/proj/pyramid_celery_app.py
+++ b/t/unit/bin/proj/pyramid_celery_app.py
@@ -1,0 +1,51 @@
+from celery import Celery
+from click import Option
+from unittest.mock import Mock, MagicMock
+
+# This module defines a mocked Celery application to replicate
+# the behavior of Pyramid-Celery's configuration by preload options.
+# Preload options should propagate to commands like shell and purge etc.
+#
+# The Pyramid-Celery project https://github.com/sontek/pyramid_celery
+# assumes that you want to configure Celery via an ini settings file.
+# The .ini files are the standard configuration file for Pyramid
+# applications.
+# See https://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tutorial/ini.html
+#
+
+app = Celery(set_as_current=False)
+app.config_from_object("t.integration.test_worker_config")
+
+class PurgeMock:
+    def queue_purge(self, queue):
+        return 0
+
+class ConnMock:
+    default_channel = PurgeMock()
+    channel_errors = KeyError
+
+mock = Mock()
+mock.__enter__ = Mock(return_value=ConnMock())
+mock.__exit__ = Mock(return_value=False)
+
+app.connection_for_write = MagicMock(return_value=mock)
+
+# Below are taken from pyramid-celery's __init__.py
+# Ref: https://github.com/sontek/pyramid_celery/blob/cf8aa80980e42f7235ad361874d3c35e19963b60/pyramid_celery/__init__.py#L25-L36
+ini_option = Option(
+    ('--ini', '-i',),
+    help='Paste ini configuration file.'
+)
+
+ini_var_option = Option(
+    ('--ini-var',),
+    help='Comma separated list of key=value to pass to ini.'
+)
+
+app.user_options['preload'].add(
+        ini_option
+)
+app.user_options['preload'].add(
+    ini_var_option
+)
+

--- a/t/unit/bin/proj/pyramid_celery_app.py
+++ b/t/unit/bin/proj/pyramid_celery_app.py
@@ -16,13 +16,16 @@ from unittest.mock import Mock, MagicMock
 app = Celery(set_as_current=False)
 app.config_from_object("t.integration.test_worker_config")
 
+
 class PurgeMock:
     def queue_purge(self, queue):
         return 0
 
+
 class ConnMock:
     default_channel = PurgeMock()
     channel_errors = KeyError
+
 
 mock = Mock()
 mock.__enter__ = Mock(return_value=ConnMock())
@@ -31,21 +34,18 @@ mock.__exit__ = Mock(return_value=False)
 app.connection_for_write = MagicMock(return_value=mock)
 
 # Below are taken from pyramid-celery's __init__.py
-# Ref: https://github.com/sontek/pyramid_celery/blob/cf8aa80980e42f7235ad361874d3c35e19963b60/pyramid_celery/__init__.py#L25-L36
+# Ref: https://github.com/sontek/pyramid_celery/blob/cf8aa80980e42f7235ad361874d3c35e19963b60/pyramid_celery/__init__.py#L25-L36 # noqa: E501
 ini_option = Option(
-    ('--ini', '-i',),
-    help='Paste ini configuration file.'
+    (
+        "--ini",
+        "-i",
+    ),
+    help="Paste ini configuration file.",
 )
 
 ini_var_option = Option(
-    ('--ini-var',),
-    help='Comma separated list of key=value to pass to ini.'
+    ("--ini-var",), help="Comma separated list of key=value to pass to ini."
 )
 
-app.user_options['preload'].add(
-        ini_option
-)
-app.user_options['preload'].add(
-    ini_var_option
-)
-
+app.user_options["preload"].add(ini_option)
+app.user_options["preload"].add(ini_var_option)


### PR DESCRIPTION
## Description
Fixes #8259 

The [pyramid-celery](https://github.com/sontek/pyramid_celery) package adds ini and ini-var options to the standard commands. These allow the standard Pyramid ini configuration files to config Celery. With current Celery however, only the worker, beat, and events have been able to be hooked into pyramid-celery's approach. This change supports shell and purge preload options.
