### PR TITLE
setup.py: enable include_package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ setuptools.setup(
     python_requires=">=3.8",
     tests_require=reqs('test.txt'),
     extras_require=extras_require(),
+    include_package_data=True,
     entry_points={
         'console_scripts': [
             'celery = celery.__main__:main',


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

I think https://github.com/celery/celery/pull/8248 introduced a issue with celery cli complaining about missing png assets:
```
[2023-07-18 12:19:28,552] [CRITICAL] [celery.worker] Unrecoverable error: FileNotFoundError(2, 'No such file or directory')
Traceback (most recent call last):
  File "/nix/store/fidxvxfcmr6g69c066097ldfcjxyr92f-python3.10-celery-5.3.0/lib/python3.10/site-packages/celery/worker/worker.py", line 202, in start
    self.blueprint.start(self)
  File "/nix/store/fidxvxfcmr6g69c066097ldfcjxyr92f-python3.10-celery-5.3.0/lib/python3.10/site-packages/celery/bootsteps.py", line 112, in start
    self.on_start()
  File "/nix/store/fidxvxfcmr6g69c066097ldfcjxyr92f-python3.10-celery-5.3.0/lib/python3.10/site-packages/celery/apps/worker.py", line 135, in on_start
    self.emit_banner()
  File "/nix/store/fidxvxfcmr6g69c066097ldfcjxyr92f-python3.10-celery-5.3.0/lib/python3.10/site-packages/celery/apps/worker.py", line 166, in emit_banner
    print(term.imgcat(static.logo()))
  File "/nix/store/fidxvxfcmr6g69c066097ldfcjxyr92f-python3.10-celery-5.3.0/lib/python3.10/site-packages/celery/utils/term.py", line 177, in imgcat
    _read_as_base64(path), _IMG_POST)
  File "/nix/store/fidxvxfcmr6g69c066097ldfcjxyr92f-python3.10-celery-5.3.0/lib/python3.10/site-packages/celery/utils/term.py", line 169, in _read_as_base64
    with codecs.open(path, mode='rb') as fh:
  File "/nix/store/79mn78vhybpkklj9vmgfrm5vk98jyg9q-python3-3.10.12/lib/python3.10/codecs.py", line 906, in open
    file = builtins.open(filename, mode, buffering)
FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/fidxvxfcmr6g69c066097ldfcjxyr92f-python3.10-celery-5.3.0/lib/python3.10/site-packages/celery/utils/static/celery_128.png'
```

The `MANIFEST.in` is referencing that png file. This change re-enables including data files when packaging, fixing that error.