### PR TITLE
Fix eager tasks does not populate name field

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -825,7 +825,7 @@ class Task:
         if isinstance(retval, Retry) and retval.sig is not None:
             return retval.sig.apply(retries=retries + 1)
         state = states.SUCCESS if ret.info is None else ret.info.state
-        return EagerResult(task_id, retval, state, traceback=tb)
+        return EagerResult(task_id, self.name, retval, state, traceback=tb)
 
     def AsyncResult(self, task_id, **kwargs):
         """Get AsyncResult instance for the specified task.

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -788,6 +788,7 @@ class Task:
 
         request = {
             'id': task_id,
+            'task': self.name,
             'retries': retries,
             'is_eager': True,
             'logfile': logfile,

--- a/celery/result.py
+++ b/celery/result.py
@@ -983,10 +983,11 @@ class GroupResult(ResultSet):
 class EagerResult(AsyncResult):
     """Result that we know has already been executed."""
 
-    def __init__(self, id, ret_value, state, traceback=None):
+    def __init__(self, id, name, ret_value, state, traceback=None):
         # pylint: disable=super-init-not-called
         # XXX should really not be inheriting from AsyncResult
         self.id = id
+        self._name = name
         self._result = ret_value
         self._state = state
         self._traceback = traceback
@@ -1038,6 +1039,7 @@ class EagerResult(AsyncResult):
     @property
     def _cache(self):
         return {
+            'name': self._name,
             'task_id': self.id,
             'result': self._result,
             'status': self._state,

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -46,7 +46,7 @@ class TSR(GroupResult):
     def _failed_join_report(self):
         for value in self.value:
             if isinstance(value, Exception):
-                yield EagerResult('some_id', value, 'FAILURE')
+                yield EagerResult('some_id', 'test-task', value, 'FAILURE')
 
 
 class TSRNoReport(TSR):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Multiple issues were reported both here (https://github.com/celery/celery/issues/7715) and in django-celery-results (https://github.com/celery/django-celery-results/issues/289 & https://github.com/celery/django-celery-results/issues/362) that when running in eager mode name of the tasks are not populated. After my investigation it seems to me that this field was just missed as it's not critical in terms of functionality. I added it and it seems to work.

Let me know what do you think.

Fixes #7715 