### PR TITLE
Fix backend.get_task_meta ignores the result_extended config parameter in mongodb backend

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -197,6 +197,21 @@ class MongoBackend(BaseBackend):
         """Get task meta-data for a task by id."""
         obj = self.collection.find_one({'_id': task_id})
         if obj:
+            if self.app.conf.find_value_for_key('extended', 'result'):
+                return self.meta_from_decoded({
+                'name': obj['name'],
+                'args': obj['args'],
+                'task_id': obj['_id'],
+                'queue': obj['queue'],
+                'kwargs': obj['kwargs'],
+                'status': obj['status'],
+                'worker': obj['worker'],
+                'retries': obj['retries'],
+                'children': obj['children'],
+                'date_done': obj['date_done'],
+                'traceback': obj['traceback'],
+                'result': self.decode(obj['result']),
+            })
             return self.meta_from_decoded({
                 'task_id': obj['_id'],
                 'status': obj['status'],

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -211,7 +211,7 @@ class MongoBackend(BaseBackend):
                     'date_done': obj['date_done'],
                     'traceback': obj['traceback'],
                     'result': self.decode(obj['result']),
-            })
+                })
             return self.meta_from_decoded({
                 'task_id': obj['_id'],
                 'status': obj['status'],

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -199,18 +199,18 @@ class MongoBackend(BaseBackend):
         if obj:
             if self.app.conf.find_value_for_key('extended', 'result'):
                 return self.meta_from_decoded({
-                'name': obj['name'],
-                'args': obj['args'],
-                'task_id': obj['_id'],
-                'queue': obj['queue'],
-                'kwargs': obj['kwargs'],
-                'status': obj['status'],
-                'worker': obj['worker'],
-                'retries': obj['retries'],
-                'children': obj['children'],
-                'date_done': obj['date_done'],
-                'traceback': obj['traceback'],
-                'result': self.decode(obj['result']),
+                    'name': obj['name'],
+                    'args': obj['args'],
+                    'task_id': obj['_id'],
+                    'queue': obj['queue'],
+                    'kwargs': obj['kwargs'],
+                    'status': obj['status'],
+                    'worker': obj['worker'],
+                    'retries': obj['retries'],
+                    'children': obj['children'],
+                    'date_done': obj['date_done'],
+                    'traceback': obj['traceback'],
+                    'result': self.decode(obj['result']),
             })
             return self.meta_from_decoded({
                 'task_id': obj['_id'],

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -429,6 +429,28 @@ class test_MongoBackend:
         ])) == list(sorted(ret_val.keys()))
 
     @patch('celery.backends.mongodb.MongoBackend._get_database')
+    def test_get_task_meta_for_result_extended(self, mock_get_database):
+        self.backend.taskmeta_collection = MONGODB_COLLECTION
+
+        mock_database = MagicMock(spec=['__getitem__', '__setitem__'])
+        mock_collection = Mock()
+        mock_collection.find_one.return_value = MagicMock()
+
+        mock_get_database.return_value = mock_database
+        mock_database.__getitem__.return_value = mock_collection
+
+        self.app.conf.result_extended = True
+        ret_val = self.backend._get_task_meta_for(sentinel.task_id)
+
+        mock_get_database.assert_called_once_with()
+        mock_database.__getitem__.assert_called_once_with(MONGODB_COLLECTION)
+        assert list(sorted([
+            'status', 'task_id', 'date_done',
+            'traceback', 'result', 'children',
+            'name', 'args', 'queue', 'kwargs', 'worker', 'retries',
+        ])) == list(sorted(ret_val.keys()))
+
+    @patch('celery.backends.mongodb.MongoBackend._get_database')
     def test_get_task_meta_for_no_result(self, mock_get_database):
         self.backend.taskmeta_collection = MONGODB_COLLECTION
 


### PR DESCRIPTION
Fix for bug report: #8387.

backend.get_task_meta ignores the result_extended config parameter in mongodb backend

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
