### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ in such a way that the client enqueues an URL to be requested by a worker.
 What do I need?
 ===============
 
-Celery version 5.3.1 runs on,
+Celery version 5.3.1 runs on:
 
 - Python (3.8, 3.9, 3.10, 3.11)
 - PyPy3.8+ (v7.3.11+)


### PR DESCRIPTION
Updated the grammatical error
As the sentence is having bullet points as other sentences , there should be a semicolon not a comma for better readability and Punctuation.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description
As the sentence is having bullet points as other sentences , there should be a semicolon not a comma for better readability and Punctuation.

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
