### PR TITLE
fix(canvas): add group index when unrolling tasks

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1704,7 +1704,7 @@ class group(Signature):
             generator: A generator for the unrolled group tasks.
                 The generator yields tuples of the form ``(task, AsyncResult, group_id)``.
         """
-        for task in tasks:
+        for index, task in enumerate(tasks):
             if isinstance(task, CallableSignature):
                 # local sigs are always of type Signature, and we
                 # clone them to make sure we don't modify the originals.
@@ -1721,7 +1721,7 @@ class group(Signature):
             else:
                 if partial_args and not task.immutable:
                     task.args = tuple(partial_args) + tuple(task.args)
-                yield task, task.freeze(group_id=group_id, root_id=root_id), group_id
+                yield task, task.freeze(group_id=group_id, root_id=root_id, group_index=index), group_id
 
     def _apply_tasks(self, tasks, producer=None, app=None, p=None,
                      add_to_parent=None, chord=None,

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1519,6 +1519,18 @@ class test_chord:
         result = c()
         assert result.get(timeout=TIMEOUT) == 4
 
+    def test_chord_order(self, manager):
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.args[0])
+
+        inputs = [i for i in range(10)]
+
+        c = chord((identity.si(i) for i in inputs), identity.s())
+        result = c()
+        assert result.get() == inputs
+
     @pytest.mark.xfail(reason="async_results aren't performed in async way")
     def test_redis_subscribed_channels_leak(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Fixes #8421.

As mentioned in the linked issue, since Celery 5.3.0, tasks results in `chord` are not received by the callback in the same order as the tasks were created. This can be seen in https://github.com/backmarket-oss/celery/pull/1 that adds a test asserting the order. The root cause seems to be the removal of an apparently useless `zip` on `results` [here](https://github.com/celery/celery/pull/7460/commits/563269a790e3b6273aa17cb7d72296b70f772109#diff-3a80ff45da16a11b96e26a63973d7d490187a68ddc1949e2dfd7fd090b208841R1254). While removing it is a good call, the `zip` actually meant that we executed [the generator](https://github.com/celery/celery/blob/2cde29d9fb6a8f8f805bec5d97b36bc930bcb52f/celery/canvas.py#L1862-L1869), effectively setting `group_index` to retrieve the results in the correct order.

Although I wasn't sure where exactly would be the best place to fix the issue, I noticed that we could also set `group_index` while unrolling the tasks in a `group`, effectively setting the correct order for the results, while keeping all tests green. This was made after an initial workaround in https://github.com/backmarket-oss/celery/pull/2 that was more a way to show the side effect that running the generator behind `results` had than a real attempt to fix the issue.

I'm still not sure at this point if this is a proper way to fix the issue, so if you have other ideas in mind, I'm all ears.