### PR TITLE
fix(beat): debug statement should only log AsyncResult.id if it exists

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -282,7 +282,10 @@ class Scheduler:
             error('Message Error: %s\n%s',
                   exc, traceback.format_stack(), exc_info=True)
         else:
-            debug('%s sent. id->%s', entry.task, result.id)
+            if result and hasattr(result, 'id'):
+                debug('%s sent. id->%s', entry.task, result.id)
+            else:
+                debug('%s sent.', entry.task)
 
     def adjust(self, n, drift=-0.010):
         if n and n > 0:


### PR DESCRIPTION
## Description
`celery.beat.apply_entry()` assumes that `apply_async()` will return an `AsyncResult` containing an ID.  this is not always the case:  for example when Django's `transaction.on_commit()` wraps the invoked task. this proposed fix simply modifies the `debug()` logging statement to more safely handle the result that is being logged after the task is created.

Fixes https://github.com/celery/celery/issues/8372
