### PR TITLE
Fix #8431: Set format_date to False when calling _get_result_meta on mongo backend

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -182,7 +182,8 @@ class MongoBackend(BaseBackend):
                       traceback=None, request=None, **kwargs):
         """Store return value and state of an executed task."""
         meta = self._get_result_meta(result=self.encode(result), state=state,
-                                     traceback=traceback, request=request)
+                                     traceback=traceback, request=request,
+                                     format_date=False)
         # Add the _id for mongodb
         meta['_id'] = task_id
 

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -187,7 +187,7 @@ class test_Backend_interface:
         meta = b1._get_result_meta(result={'fizz': 'buzz'},
                                    state=states.SUCCESS, traceback=None,
                                    request=request, format_date=True)
-        assert type(meta['date_done']) == str
+        assert isinstance(meta['date_done'], str)
 
         self.app.conf.result_extended = True
         b2 = BaseBackend(self.app)
@@ -198,7 +198,7 @@ class test_Backend_interface:
         meta = b2._get_result_meta(result={'fizz': 'buzz'},
                                    state=states.SUCCESS, traceback=None,
                                    request=request, format_date=False)
-        assert type(meta['date_done']) == datetime.datetime
+        assert isinstance(meta['date_done'], datetime.datetime)
 
 
 class test_BaseBackend_interface:

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -176,6 +176,30 @@ class test_Backend_interface:
         assert meta['kwargs'] == kwargs
         assert meta['queue'] == 'celery'
 
+    def test_get_result_meta_format_date(self):
+        import datetime
+        self.app.conf.result_extended = True
+        b1 = BaseBackend(self.app)
+        args = ['a', 'b']
+        kwargs = {'foo': 'bar'}
+
+        request = Context(args=args, kwargs=kwargs)
+        meta = b1._get_result_meta(result={'fizz': 'buzz'},
+                                   state=states.SUCCESS, traceback=None,
+                                   request=request, format_date=True)
+        assert type(meta['date_done']) == str
+
+        self.app.conf.result_extended = True
+        b2 = BaseBackend(self.app)
+        args = ['a', 'b']
+        kwargs = {'foo': 'bar'}
+
+        request = Context(args=args, kwargs=kwargs)
+        meta = b2._get_result_meta(result={'fizz': 'buzz'},
+                                   state=states.SUCCESS, traceback=None,
+                                   request=request, format_date=False)
+        assert type(meta['date_done']) == datetime.datetime
+
 
 class test_BaseBackend_interface:
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

This PR sets `format_date` argument to `False` when calling `self.get_result_meta` in `MongoBackend._strore_result` to fix task_result collection never been cleaned up when task_expires configuration is set.

Fixes #8431 

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
