### PR TITLE
Limit tox to < 4.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,7 +51,7 @@ jobs:
         cache-dependency-path: '**/setup.py'
 
     - name: Install tox
-      run: python -m pip install --upgrade pip tox tox-gh-actions
+      run: python -m pip install --upgrade pip 'tox<4.9' tox-gh-actions
     - name: >
         Run tox for
         "${{ matrix.python-version }}-unit"
@@ -107,7 +107,7 @@ jobs:
                   cache: 'pip'
                   cache-dependency-path: '**/setup.py'
           -   name: Install tox
-              run: python -m pip install --upgrade pip tox tox-gh-actions
+              run: python -m pip install --upgrade pip 'tox<4.9' tox-gh-actions
           -   name: >
                   Run tox for
                   "${{ matrix.python-version }}-integration-${{ matrix.toxenv }}"

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -506,7 +506,7 @@ class test_chain:
         assert res.get(timeout=TIMEOUT) == [8, 8]
 
     @pytest.mark.xfail(raises=TimeoutError, reason="Task is timeout")
-    def test_nested_chain_group_lone(self, manager):
+    def test_nested_chain_group_lone(self, manager):  # Fails with Redis 5.x
         """
         Test that a lone group in a chain completes.
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 requires =
+    tox<4.9
     tox-gh-actions
 envlist =
     {3.8,3.9,3.10,3.11,pypy3}-unit


### PR DESCRIPTION
Tox has [released 4.9.0](https://github.com/tox-dev/tox/releases/tag/4.9.0) which fixed a bug where non existing environments did NOT fail, so since tox 4.9.0 they now DO fail: https://github.com/tox-dev/tox/issues/2858

We are relying on the previous behavior (the bugged one) so until we can fix it, I'm limiting tox as it breaks every PR right now which is worse than the limitation itself (which is not recommended).

We need to fix this soon so we can remove this limitation @auvipy @thedrow 