### PR TITLE
doc update from #7651

### DIFF
--- a/docs/getting-started/backends-and-brokers/redis.rst
+++ b/docs/getting-started/backends-and-brokers/redis.rst
@@ -164,12 +164,14 @@ a more distant future, database-backed periodic task might be a better choice.
 Periodic tasks won't be affected by the visibility timeout,
 as this is a concept separate from ETA/countdown.
 
-You can increase this timeout by configuring a transport option
+You can increase this timeout by configuring several options
 with the same name:
 
 .. code-block:: python
 
     app.conf.broker_transport_options = {'visibility_timeout': 43200}
+    app.conf.result_backend_transport_options = {'visibility_timeout': 43200}
+    app.conf.visibility_timeout = 43200
 
 The value must be an int describing the number of seconds.
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description
from #7651:

>After a lot of testing I found that in order changes in visibility_timeout value to take effect, one must set it in all, celery config, result backend & transport options, as follows :
visibility_timeout = 600
result_backend_transport_options = broker_transport_options = { 'visibility_timeout': 600 }
So the reported behavior might not be a product defect per se, just lack of proper documentation

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
