### PR TITLE
Use string value for CELERY_SKIP_CHECKS envvar

### DIFF
--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -138,7 +138,6 @@ else:
               help_group="Global Options",
               help="Skip Django core checks on startup. Setting the SKIP_CHECKS environment "
                    "variable to any non-empty string will have the same effect.")
-
 @click.pass_context
 def celery(ctx, app, broker, result_backend, loader, config, workdir,
            no_color, quiet, version, skip_checks):

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -158,7 +158,7 @@ def celery(ctx, app, broker, result_backend, loader, config, workdir,
     if config:
         os.environ['CELERY_CONFIG_MODULE'] = config
     if skip_checks:
-        os.environ['CELERY_SKIP_CHECKS'] = skip_checks
+        os.environ['CELERY_SKIP_CHECKS'] = 'true'
     ctx.obj = CLIContext(app=app, no_color=no_color, workdir=workdir,
                          quiet=quiet)
 

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -136,7 +136,9 @@ else:
               cls=CeleryOption,
               is_flag=True,
               help_group="Global Options",
-              help="Skip Django core checks on startup.")
+              help="Skip Django core checks on startup. Setting the SKIP_CHECKS environment "
+                   "variable to any non-empty string will have the same effect.")
+
 @click.pass_context
 def celery(ctx, app, broker, result_backend, loader, config, workdir,
            no_color, quiet, version, skip_checks):

--- a/t/unit/bin/test_worker.py
+++ b/t/unit/bin/test_worker.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 from click.testing import CliRunner
 

--- a/t/unit/bin/test_worker.py
+++ b/t/unit/bin/test_worker.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from click.testing import CliRunner
 
@@ -18,3 +19,15 @@ def test_cli(isolated_cli_runner: CliRunner):
         catch_exceptions=False
     )
     assert res.exit_code == 1, (res, res.stdout)
+
+
+def test_cli_skip_checks(isolated_cli_runner: CliRunner):
+    Logging._setup = True  # To avoid hitting the logging sanity checks
+    assert "CELERY_SKIP_CHECKS" not in os.environ, "CELERY_SKIP_CHECKS should not be set to start"
+    res = isolated_cli_runner.invoke(
+        celery,
+        ["-A", "t.unit.bin.proj.app", "--skip-checks", "worker", "--pool", "solo"],
+        catch_exceptions=False,
+    )
+    assert res.exit_code == 1, (res, res.stdout)
+    assert os.environ["CELERY_SKIP_CHECKS"] == "true", "should set CELERY_SKIP_CHECKS"

--- a/t/unit/bin/test_worker.py
+++ b/t/unit/bin/test_worker.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -24,11 +25,11 @@ def test_cli(isolated_cli_runner: CliRunner):
 
 def test_cli_skip_checks(isolated_cli_runner: CliRunner):
     Logging._setup = True  # To avoid hitting the logging sanity checks
-    assert "CELERY_SKIP_CHECKS" not in os.environ, "CELERY_SKIP_CHECKS should not be set to start"
-    res = isolated_cli_runner.invoke(
-        celery,
-        ["-A", "t.unit.bin.proj.app", "--skip-checks", "worker", "--pool", "solo"],
-        catch_exceptions=False,
-    )
-    assert res.exit_code == 1, (res, res.stdout)
-    assert os.environ["CELERY_SKIP_CHECKS"] == "true", "should set CELERY_SKIP_CHECKS"
+    with patch.dict(os.environ, clear=True):
+        res = isolated_cli_runner.invoke(
+            celery,
+            ["-A", "t.unit.bin.proj.app", "--skip-checks", "worker", "--pool", "solo"],
+            catch_exceptions=False,
+        )
+        assert res.exit_code == 1, (res, res.stdout)
+        assert os.environ["CELERY_SKIP_CHECKS"] == "true", "should set CELERY_SKIP_CHECKS"

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -272,7 +272,7 @@ class test_DjangoWorkerFixup(FixupCase):
         f.django_setup.reset_mock()
         run_checks.reset_mock()
 
-        patching.setenv('CELERY_SKIP_CHECKS', True)
+        patching.setenv('CELERY_SKIP_CHECKS', 'true')
         f.validate_models()
         f.django_setup.assert_called_with()
         run_checks.assert_not_called()


### PR DESCRIPTION
## Description

Sets the `CELERY_SKIP_CHECKS` value to a string value (`'true'`) instead of a Boolean. Updates the existing test to patch in this string value instead of `True`

An integration test that validates that command line argument handling in `celery/bin/celery.py` matches the unit test assumptions would be a nice addition. However, since it should test more than just this option, it is far enough afield that I have not added it.

Fixes #8461.