### PR TITLE
Remove tox version limit

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,7 +51,7 @@ jobs:
         cache-dependency-path: '**/setup.py'
 
     - name: Install tox
-      run: python -m pip install --upgrade pip 'tox<4.9' tox-gh-actions
+      run: python -m pip install --upgrade pip 'tox' tox-gh-actions
     - name: >
         Run tox for
         "${{ matrix.python-version }}-unit"
@@ -107,7 +107,7 @@ jobs:
                   cache: 'pip'
                   cache-dependency-path: '**/setup.py'
           -   name: Install tox
-              run: python -m pip install --upgrade pip 'tox<4.9' tox-gh-actions
+              run: python -m pip install --upgrade pip 'tox' tox-gh-actions
           -   name: >
                   Run tox for
                   "${{ matrix.python-version }}-integration-${{ matrix.toxenv }}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 requires =
-    tox<4.9
     tox-gh-actions
 envlist =
     {3.8,3.9,3.10,3.11,pypy3}-unit


### PR DESCRIPTION
This reverts #8443.
tox v4.11 now works normally.
We're potentially now dependent on 4.11> but I'll leave it without restrictions for now.