### PR TITLE
Add option to S3 backend to partition by date

### DIFF
--- a/celery/backends/s3.py
+++ b/celery/backends/s3.py
@@ -1,5 +1,7 @@
 """s3 result store backend."""
 
+from datetime import datetime
+
 from kombu.utils.encoding import bytes_to_str
 
 from celery.exceptions import ImproperlyConfigured
@@ -48,9 +50,13 @@ class S3Backend(KeyValueStoreBackend):
 
         self.base_path = conf.get('s3_base_path', None)
 
+        self.partition_by_date = conf.get('s3_partition_by_date', False)
+
         self._s3_resource = self._connect_to_s3()
 
     def _get_s3_object(self, key):
+        if self.partition_by_date:
+            key = "date=" + str(datetime.utcnow().date()) + "/" + key
         key_bucket_path = self.base_path + key if self.base_path else key
         return self._s3_resource.Object(self.bucket_name, key_bucket_path)
 


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Adds a new configuration parameter to the S3 backend to enable partitioning by date, which is useful for my application. Can be enabled with `app.conf.s3_partition_by_date = True`.
