### PR TITLE
Document need for CELERY_ prefix on CLI env vars

### DIFF
--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -2,6 +2,9 @@
  Command Line Interface
 =======================
 
+.. NOTE:: The prefix `CELERY_` must be added to the names of the environment
+   variables described below. E.g., `APP` becomes `CELERY_APP`.
+
 .. click:: celery.bin.celery:celery
    :prog: celery
    :nested: full


### PR DESCRIPTION
## Description

This adds a "note" annotation at the top of `cli.rst` to point out the need for a `CELERY_` prefix to any of the environment vars listed there. I'm not thrilled with the resulting presentation - it's awfully emphatic. However, the only alternative I see is to bury the note at the very end of a long autogenerated page where it might as well not be there.

Really, need a fix to https://github.com/click-contrib/sphinx-click/issues/119 to clean this up.