### PR TITLE
Revert "store children with database backend"

### DIFF
--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -25,7 +25,6 @@ class Task(ResultModelBase):
     date_done = sa.Column(sa.DateTime, default=datetime.utcnow,
                           onupdate=datetime.utcnow, nullable=True)
     traceback = sa.Column(sa.Text, nullable=True)
-    children = sa.Column(PickleType, nullable=True)
 
     def __init__(self, task_id):
         self.task_id = task_id
@@ -37,7 +36,6 @@ class Task(ResultModelBase):
             'result': self.result,
             'traceback': self.traceback,
             'date_done': self.date_done,
-            'children': self.children,
         }
 
     def __repr__(self):

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -99,7 +99,6 @@ class test_DatabaseBackend:
         assert meta['task_id'] == 'xxx-does-not-exist-at-all'
         assert meta['result'] is None
         assert meta['traceback'] is None
-        assert meta['children'] is None
 
     def test_mark_as_done(self):
         tb = DatabaseBackend(self.uri, app=self.app)


### PR DESCRIPTION
Reverts celery/celery#8338

@Nusnus we might revert this for now and reintroduce in future with a proper migration support. for migration support I can work