### PR TITLE
Revert "Fix eager tasks does not populate name field"

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -788,7 +788,6 @@ class Task:
 
         request = {
             'id': task_id,
-            'task': self.name,
             'retries': retries,
             'is_eager': True,
             'logfile': logfile,
@@ -825,7 +824,7 @@ class Task:
         if isinstance(retval, Retry) and retval.sig is not None:
             return retval.sig.apply(retries=retries + 1)
         state = states.SUCCESS if ret.info is None else ret.info.state
-        return EagerResult(task_id, self.name, retval, state, traceback=tb)
+        return EagerResult(task_id, retval, state, traceback=tb)
 
     def AsyncResult(self, task_id, **kwargs):
         """Get AsyncResult instance for the specified task.

--- a/celery/result.py
+++ b/celery/result.py
@@ -983,11 +983,10 @@ class GroupResult(ResultSet):
 class EagerResult(AsyncResult):
     """Result that we know has already been executed."""
 
-    def __init__(self, id, name, ret_value, state, traceback=None):
+    def __init__(self, id, ret_value, state, traceback=None):
         # pylint: disable=super-init-not-called
         # XXX should really not be inheriting from AsyncResult
         self.id = id
-        self._name = name
         self._result = ret_value
         self._state = state
         self._traceback = traceback
@@ -1039,7 +1038,6 @@ class EagerResult(AsyncResult):
     @property
     def _cache(self):
         return {
-            'name': self._name,
             'task_id': self.id,
             'result': self._result,
             'status': self._state,

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -46,7 +46,7 @@ class TSR(GroupResult):
     def _failed_join_report(self):
         for value in self.value:
             if isinstance(value, Exception):
-                yield EagerResult('some_id', 'test-task', value, 'FAILURE')
+                yield EagerResult('some_id', value, 'FAILURE')
 
 
 class TSRNoReport(TSR):

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -136,7 +136,7 @@ class test_AsyncResult:
 
     def test_children(self):
         x = self.app.AsyncResult('1')
-        children = [EagerResult(str(i), 'test-task', i, states.SUCCESS) for i in range(3)]
+        children = [EagerResult(str(i), i, states.SUCCESS) for i in range(3)]
         x._cache = {'children': children, 'status': states.SUCCESS}
         x.backend = Mock()
         assert x.children
@@ -147,12 +147,12 @@ class test_AsyncResult:
         x.backend = Mock(name='backend')
         x.backend.get_task_meta.return_value = {}
         x.backend.wait_for_pending.return_value = 84
-        x.parent = EagerResult(uuid(), 'test-task', KeyError('foo'), states.FAILURE)
+        x.parent = EagerResult(uuid(), KeyError('foo'), states.FAILURE)
         with pytest.raises(KeyError):
             x.get(propagate=True)
         x.backend.wait_for_pending.assert_not_called()
 
-        x.parent = EagerResult(uuid(), 'test-task', 42, states.SUCCESS)
+        x.parent = EagerResult(uuid(), 42, states.SUCCESS)
         assert x.get(propagate=True) == 84
         x.backend.wait_for_pending.assert_called()
 
@@ -172,7 +172,7 @@ class test_AsyncResult:
     def test_build_graph_get_leaf_collect(self):
         x = self.app.AsyncResult('1')
         x.backend._cache['1'] = {'status': states.SUCCESS, 'result': None}
-        c = [EagerResult(str(i), 'test-task', i, states.SUCCESS) for i in range(3)]
+        c = [EagerResult(str(i), i, states.SUCCESS) for i in range(3)]
         x.iterdeps = Mock()
         x.iterdeps.return_value = (
             (None, x),
@@ -194,7 +194,7 @@ class test_AsyncResult:
 
     def test_iterdeps(self):
         x = self.app.AsyncResult('1')
-        c = [EagerResult(str(i), 'test-task', i, states.SUCCESS) for i in range(3)]
+        c = [EagerResult(str(i), i, states.SUCCESS) for i in range(3)]
         x._cache = {'status': states.SUCCESS, 'result': None, 'children': c}
         for child in c:
             child.backend = Mock()
@@ -945,13 +945,13 @@ class test_EagerResult:
         assert res.wait(propagate=False)
 
     def test_wait(self):
-        res = EagerResult('x', 'test-task', 'x', states.RETRY)
+        res = EagerResult('x', 'x', states.RETRY)
         res.wait()
         assert res.state == states.RETRY
         assert res.status == states.RETRY
 
     def test_forget(self):
-        res = EagerResult('x', 'test-task', 'x', states.RETRY)
+        res = EagerResult('x', 'x', states.RETRY)
         res.forget()
 
     def test_revoke(self):
@@ -962,7 +962,7 @@ class test_EagerResult:
     def test_get_sync_subtask_option(self, task_join_will_block):
         task_join_will_block.return_value = True
         tid = uuid()
-        res_subtask_async = EagerResult(tid, 'test-task', 'x', 'x', states.SUCCESS)
+        res_subtask_async = EagerResult(tid, 'x', 'x', states.SUCCESS)
         with pytest.raises(RuntimeError):
             res_subtask_async.get()
         res_subtask_async.get(disable_sync_subtasks=False)


### PR DESCRIPTION
Reverts celery/celery#8383

@Nusnus might be another potential one. unless we got a suitable solution or a non breaking change, we can defer this to v5.4.0