### PR TITLE
Fix code indentation for route_task() example

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2349,8 +2349,8 @@ Where ``myapp.tasks.route_task`` could be:
 .. code-block:: python
 
     def route_task(self, name, args, kwargs, options, task=None, **kw):
-            if task == 'celery.ping':
-                return {'queue': 'default'}
+        if task == 'celery.ping':
+            return {'queue': 'default'}
 
 ``route_task`` may return a string or a dict. A string then means
 it's a queue name in :setting:`task_queues`, a dict means it's a custom route.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

I corrected the indentation for the code snippet for the `route_task()` function in the configuration docs [here](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-routes).