### PR TITLE
Replaces datetime.fromisoformat with the more lenient dateutil parser

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from operator import attrgetter
 
 from click.exceptions import Exit
+from dateutil.parser import isoparse
 from kombu import pools
 from kombu.clocks import LamportClock
 from kombu.common import oid_from
@@ -740,7 +741,7 @@ class Celery:
                     expires) - self.now()).total_seconds()
             elif isinstance(expires, str):
                 expires_s = (maybe_make_aware(
-                    datetime.fromisoformat(expires)) - self.now()).total_seconds()
+                    isoparse(expires)) - self.now()).total_seconds()
             else:
                 expires_s = expires
 

--- a/celery/result.py
+++ b/celery/result.py
@@ -6,6 +6,7 @@ from collections import deque
 from contextlib import contextmanager
 from weakref import proxy
 
+from dateutil.parser import isoparse
 from kombu.utils.objects import cached_property
 from vine import Thenable, barrier, promise
 
@@ -532,7 +533,7 @@ class AsyncResult(ResultBase):
         """UTC date and time."""
         date_done = self._get_task_meta().get('date_done')
         if date_done and not isinstance(date_done, datetime.datetime):
-            return datetime.datetime.fromisoformat(date_done)
+            return isoparse(date_done)
         return date_done
 
     @property

--- a/celery/utils/iso8601.py
+++ b/celery/utils/iso8601.py
@@ -52,7 +52,7 @@ TIMEZONE_REGEX = re.compile(
 
 def parse_iso8601(datestring):
     """Parse and convert ISO-8601 string to datetime."""
-    warn("parse_iso8601", "v5.3", "v6", "datetime.datetime.fromisoformat")
+    warn("parse_iso8601", "v5.3", "v6", "datetime.datetime.fromisoformat or dateutil.parser.isoparse")
     m = ISO8601_REGEX.match(datestring)
     if not m:
         raise ValueError('unable to parse date string %r' % datestring)

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -14,6 +14,7 @@ from types import ModuleType
 from typing import Any, Callable
 
 from dateutil import tz as dateutil_tz
+from dateutil.parser import isoparse
 from kombu.utils.functional import reprcall
 from kombu.utils.objects import cached_property
 
@@ -288,7 +289,7 @@ def maybe_iso8601(dt: datetime | str | None) -> None | datetime:
         return
     if isinstance(dt, datetime):
         return dt
-    return datetime.fromisoformat(dt)
+    return isoparse(dt)
 
 
 def is_naive(dt: datetime) -> bool:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fixes #8499.  The `isoparse` from dateutil is more correct about what it supports, handling the 'Z' timezone as well, which earlier versions of Python didn't support.  

I'm not 100% sure where the user is providing the eta as a string to, since apply_async notes it to be a datetime.  If someone can point me to that and a simple test case, I'll add some additional date strings there to catch this in the future.
