### PR TITLE
Marked flaky tests

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -2499,6 +2499,7 @@ class test_chord:
             await_redis_echo({errback_msg, }, redis_key=redis_key)
         redis_connection.delete(redis_key)
 
+    @flaky
     @pytest.mark.parametrize(
         "errback_task", [errback_old_style, errback_new_style, ],
     )

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -511,6 +511,7 @@ class test_task_redis_result_backend:
         new_channels = [channel for channel in get_active_redis_channels() if channel not in channels_before_test]
         assert new_channels == []
 
+    @flaky
     def test_asyncresult_forget_cancels_subscription(self, manager):
         channels_before_test = get_active_redis_channels()
 


### PR DESCRIPTION
Added `@flaky` to:
- test_mutable_errback_called_by_chord_from_group
- test_asyncresult_forget_cancels_subscription