### PR TITLE
Update ETA example to include timezone

### DIFF
--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -250,9 +250,9 @@ and timezone information):
 
 .. code-block:: pycon
 
-    >>> from datetime import datetime, timedelta
+    >>> from datetime import datetime, timedelta, timezone
 
-    >>> tomorrow = datetime.utcnow() + timedelta(days=1)
+    >>> tomorrow = datetime.now(timezone.utc) + timedelta(days=1)
     >>> add.apply_async((2, 2), eta=tomorrow)
 
 .. warning::
@@ -313,9 +313,9 @@ either as seconds after task publish, or a specific date and time using
     >>> add.apply_async((10, 10), expires=60)
 
     >>> # Also supports datetime
-    >>> from datetime import datetime, timedelta
+    >>> from datetime import datetime, timedelta, timezone
     >>> add.apply_async((10, 10), kwargs,
-    ...                 expires=datetime.now() + timedelta(days=1))
+    ...                 expires=datetime.now(timezone.utc) + timedelta(days=1))
 
 
 When a worker receives an expired task it will mark


### PR DESCRIPTION
The behavior when using timezone unaware datetime objects can be incorrect.

For a Redis broker running on the same machine as my Celery queue, I got incorrect scheduling when using naive datetime objects. Setting the timezone explicitly fixed the issue.

