### PR TITLE
Tox lint upgrade from Python 3.9 to Python 3.11

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ basepython =
     3.11: python3.11
     pypy3: pypy3
     mypy: python3.8
-    lint,apicheck,linkcheck,configcheck,bandit: python3.9
+    lint,apicheck,linkcheck,configcheck,bandit: python3.11
 usedevelop = True
 
 [testenv:mypy]


### PR DESCRIPTION
Changed the base python version for tox linting affecting `lint,apicheck,linkcheck,configcheck,bandit`