### PR TITLE
Fix git bug in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,6 +132,8 @@ RUN pyenv exec python3.8 -m pip install \
 
 WORKDIR $HOME/celery
 
+RUN git config --global --add safe.directory /home/developer/celery
+
 # Setup the entrypoint, this ensures pyenv is initialized when a container is started
 # and that any compiled files from earlier steps or from mounts are removed to avoid
 # pytest failing with an ImportMismatchError


### PR DESCRIPTION
Fixed error from docker:
```
An error has occurred: FatalError: git failed. Is it installed, and are you in a Git repository directory?
Check the log at /home/developer/.cache/pre-commit/pre-commit.log
```

Happens when trying to run tox -e lint inside a bash prompt inside the celery docker container.