### PR TITLE
feat(daemon): allows daemonization options to be fetched from app settings

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3680,7 +3680,7 @@ An optional user ID to use when beat :program:`celery beat` drops its privileges
 
 Default: :const:`None`
 
-An optionnal group ID to use when :program:`celery beat` daemon drops its privileges (default to no GID change).
+An optional group ID to use when :program:`celery beat` daemon drops its privileges (defaults to no GID change).
 
 .. setting:: beat_umask
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3662,7 +3662,7 @@ An optionnal file path for :program:`celery beat` to log into (default to `stdou
 
 Default: :const:`None`
 
-An optionnal file path for :program:`celery beat` to create/store it PID file (default to no PID file created).
+An optional file path for :program:`celery beat` to create/store it PID file (defaults to no PID file created).
 
 .. setting:: beat_uid
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3689,7 +3689,7 @@ An optional group ID to use when :program:`celery beat` daemon drops its privile
 
 Default: :const:`None`
 
-An optionnal `umask` to use when :program:`celery beat` creates files (log, pid...) when daemonizing.
+An optional `umask` to use when :program:`celery beat` creates files (log, pid...) when daemonizing.
 
 .. setting:: beat_executable
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3214,7 +3214,7 @@ An optional user ID to use when events :program:`celery events` drops its privil
 
 Default: :const:`None`
 
-An optionnal group ID to use when :program:`celery events` daemon drops its privileges (default to no GID change).
+An optional group ID to use when :program:`celery events` daemon drops its privileges (defaults to no GID change).
 
 .. setting:: events_umask
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3205,7 +3205,7 @@ An optional file path for :program:`celery events` to create/store its PID file 
 
 Default: :const:`None`
 
-An optionnal user ID to use when events :program:`celery events` drops its privileges (default to no UID change).
+An optional user ID to use when events :program:`celery events` drops its privileges (defaults to no UID change).
 
 .. setting:: events_gid
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3180,6 +3180,61 @@ Message serialization format used when sending event messages.
     :ref:`calling-serializers`.
 
 
+.. setting:: events_logfile
+
+``events_logfile``
+~~~~~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal file path for :program:`celery events` to log into (default to `stdout`).
+
+.. setting:: events_pidfile
+
+``events_pidfile``
+~~~~~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal file path for :program:`celery events` to create/store it PID file (default to no PID file created).
+
+.. setting:: events_uid
+
+``events_uid``
+~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal user ID to use when events :program:`celery events` drops its privileges (default to no UID change).
+
+.. setting:: events_gid
+
+``events_gid``
+~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal group ID to use when :program:`celery events` daemon drops its privileges (default to no GID change).
+
+.. setting:: events_umask
+
+``events_umask``
+~~~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal `umask` to use when :program:`celery events` creates files (log, pid...) when daemonizing.
+
+.. setting:: events_executable
+
+``events_executable``
+~~~~~~~~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal `python` executable path for :program:`celery events` to use when deaemonizing (default to :data:`sys.executable`).
+
+
 .. _conf-control:
 
 Remote Control Commands
@@ -3448,6 +3503,62 @@ Default: ``"kombu.asynchronous.hub.timer:Timer"``.
 Name of the ETA scheduler class used by the worker.
 Default is or set by the pool implementation.
 
+.. setting:: worker_logfile
+
+``worker_logfile``
+~~~~~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal file path for :program:`celery worker` to log into (default to `stdout`).
+
+.. setting:: worker_pidfile
+
+``worker_pidfile``
+~~~~~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal file path for :program:`celery worker` to create/store it PID file (default to no PID file created).
+
+.. setting:: worker_uid
+
+``worker_uid``
+~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal user ID to use when :program:`celery worker` daemon drops its privileges (default to no UID change).
+
+.. setting:: worker_gid
+
+``worker_gid``
+~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal group ID to use when :program:`celery worker` daemon drops its privileges (default to no GID change).
+
+.. setting:: worker_umask
+
+``worker_umask``
+~~~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal `umask` to use when :program:`celery worker` creates files (log, pid...) when daemonizing.
+
+.. setting:: worker_executable
+
+``worker_executable``
+~~~~~~~~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal `python` executable path for :program:`celery worker` to use when deaemonizing (default to :data:`sys.executable`).
+
+
+
 .. _conf-celerybeat:
 
 Beat Settings (:program:`celery beat`)
@@ -3534,3 +3645,57 @@ Default: None.
 When using cron, the number of seconds :mod:`~celery.bin.beat` can look back
 when deciding whether a cron schedule is due. When set to `None`, cronjobs that
 are past due will always run immediately.
+
+.. setting:: beat_logfile
+
+``beat_logfile``
+~~~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal file path for :program:`celery beat` to log into (default to `stdout`).
+
+.. setting:: beat_pidfile
+
+``beat_pidfile``
+~~~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal file path for :program:`celery beat` to create/store it PID file (default to no PID file created).
+
+.. setting:: beat_uid
+
+``beat_uid``
+~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal user ID to use when beat :program:`celery beat` drops its privileges (default to no UID change).
+
+.. setting:: beat_gid
+
+``beat_gid``
+~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal group ID to use when :program:`celery beat` daemon drops its privileges (default to no GID change).
+
+.. setting:: beat_umask
+
+``beat_umask``
+~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal `umask` to use when :program:`celery beat` creates files (log, pid...) when daemonizing.
+
+.. setting:: beat_executable
+
+``beat_executable``
+~~~~~~~~~~~~~~~~~~~
+
+Default: :const:`None`
+
+An optionnal `python` executable path for :program:`celery beat` to use when deaemonizing (default to :data:`sys.executable`).

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3223,7 +3223,7 @@ An optional group ID to use when :program:`celery events` daemon drops its privi
 
 Default: :const:`None`
 
-An optionnal `umask` to use when :program:`celery events` creates files (log, pid...) when daemonizing.
+An optional `umask` to use when :program:`celery events` creates files (log, pid...) when daemonizing.
 
 .. setting:: events_executable
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3189,6 +3189,8 @@ Default: :const:`None`
 
 An optional file path for :program:`celery events` to log into (defaults to `stdout`).
 
+.. versionadded:: 5.4
+
 .. setting:: events_pidfile
 
 ``events_pidfile``
@@ -3197,6 +3199,8 @@ An optional file path for :program:`celery events` to log into (defaults to `std
 Default: :const:`None`
 
 An optional file path for :program:`celery events` to create/store its PID file (default to no PID file created).
+
+.. versionadded:: 5.4
 
 .. setting:: events_uid
 
@@ -3207,6 +3211,8 @@ Default: :const:`None`
 
 An optional user ID to use when events :program:`celery events` drops its privileges (defaults to no UID change).
 
+.. versionadded:: 5.4
+
 .. setting:: events_gid
 
 ``events_gid``
@@ -3216,6 +3222,8 @@ Default: :const:`None`
 
 An optional group ID to use when :program:`celery events` daemon drops its privileges (defaults to no GID change).
 
+.. versionadded:: 5.4
+
 .. setting:: events_umask
 
 ``events_umask``
@@ -3224,6 +3232,8 @@ An optional group ID to use when :program:`celery events` daemon drops its privi
 Default: :const:`None`
 
 An optional `umask` to use when :program:`celery events` creates files (log, pid...) when daemonizing.
+
+.. versionadded:: 5.4
 
 .. setting:: events_executable
 
@@ -3512,6 +3522,8 @@ Default: :const:`None`
 
 An optional file path for :program:`celery worker` to log into (defaults to `stdout`).
 
+.. versionadded:: 5.4
+
 .. setting:: worker_pidfile
 
 ``worker_pidfile``
@@ -3520,6 +3532,8 @@ An optional file path for :program:`celery worker` to log into (defaults to `std
 Default: :const:`None`
 
 An optional file path for :program:`celery worker` to create/store its PID file (defaults to no PID file created).
+
+.. versionadded:: 5.4
 
 .. setting:: worker_uid
 
@@ -3530,6 +3544,8 @@ Default: :const:`None`
 
 An optional user ID to use when :program:`celery worker` daemon drops its privileges (defaults to no UID change).
 
+.. versionadded:: 5.4
+
 .. setting:: worker_gid
 
 ``worker_gid``
@@ -3538,6 +3554,8 @@ An optional user ID to use when :program:`celery worker` daemon drops its privil
 Default: :const:`None`
 
 An optional group ID to use when :program:`celery worker` daemon drops its privileges (defaults to no GID change).
+
+.. versionadded:: 5.4
 
 .. setting:: worker_umask
 
@@ -3548,6 +3566,8 @@ Default: :const:`None`
 
 An optional `umask` to use when :program:`celery worker` creates files (log, pid...) when daemonizing.
 
+.. versionadded:: 5.4
+
 .. setting:: worker_executable
 
 ``worker_executable``
@@ -3556,6 +3576,8 @@ An optional `umask` to use when :program:`celery worker` creates files (log, pid
 Default: :const:`None`
 
 An optional `python` executable path for :program:`celery worker` to use when deaemonizing (defaults to :data:`sys.executable`).
+
+.. versionadded:: 5.4
 
 
 
@@ -3655,6 +3677,8 @@ Default: :const:`None`
 
 An optional file path for :program:`celery beat` to log into (defaults to `stdout`).
 
+.. versionadded:: 5.4
+
 .. setting:: beat_pidfile
 
 ``beat_pidfile``
@@ -3663,6 +3687,8 @@ An optional file path for :program:`celery beat` to log into (defaults to `stdou
 Default: :const:`None`
 
 An optional file path for :program:`celery beat` to create/store it PID file (defaults to no PID file created).
+
+.. versionadded:: 5.4
 
 .. setting:: beat_uid
 
@@ -3673,6 +3699,8 @@ Default: :const:`None`
 
 An optional user ID to use when beat :program:`celery beat` drops its privileges (defaults to no UID change).
 
+.. versionadded:: 5.4
+
 .. setting:: beat_gid
 
 ``beat_gid``
@@ -3681,6 +3709,8 @@ An optional user ID to use when beat :program:`celery beat` drops its privileges
 Default: :const:`None`
 
 An optional group ID to use when :program:`celery beat` daemon drops its privileges (defaults to no GID change).
+
+.. versionadded:: 5.4
 
 .. setting:: beat_umask
 
@@ -3691,6 +3721,8 @@ Default: :const:`None`
 
 An optional `umask` to use when :program:`celery beat` creates files (log, pid...) when daemonizing.
 
+.. versionadded:: 5.4
+
 .. setting:: beat_executable
 
 ``beat_executable``
@@ -3699,3 +3731,5 @@ An optional `umask` to use when :program:`celery beat` creates files (log, pid..
 Default: :const:`None`
 
 An optional `python` executable path for :program:`celery beat` to use when deaemonizing (defaults to :data:`sys.executable`).
+
+.. versionadded:: 5.4

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3196,7 +3196,7 @@ An optionnal file path for :program:`celery events` to log into (default to `std
 
 Default: :const:`None`
 
-An optionnal file path for :program:`celery events` to create/store it PID file (default to no PID file created).
+An optional file path for :program:`celery events` to create/store its PID file (default to no PID file created).
 
 .. setting:: events_uid
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3232,7 +3232,7 @@ An optional `umask` to use when :program:`celery events` creates files (log, pid
 
 Default: :const:`None`
 
-An optionnal `python` executable path for :program:`celery events` to use when deaemonizing (default to :data:`sys.executable`).
+An optional `python` executable path for :program:`celery events` to use when deaemonizing (defaults to :data:`sys.executable`).
 
 
 .. _conf-control:
@@ -3510,7 +3510,7 @@ Default is or set by the pool implementation.
 
 Default: :const:`None`
 
-An optionnal file path for :program:`celery worker` to log into (default to `stdout`).
+An optional file path for :program:`celery worker` to log into (defaults to `stdout`).
 
 .. setting:: worker_pidfile
 
@@ -3519,7 +3519,7 @@ An optionnal file path for :program:`celery worker` to log into (default to `std
 
 Default: :const:`None`
 
-An optionnal file path for :program:`celery worker` to create/store it PID file (default to no PID file created).
+An optional file path for :program:`celery worker` to create/store its PID file (defaults to no PID file created).
 
 .. setting:: worker_uid
 
@@ -3528,7 +3528,7 @@ An optionnal file path for :program:`celery worker` to create/store it PID file 
 
 Default: :const:`None`
 
-An optionnal user ID to use when :program:`celery worker` daemon drops its privileges (default to no UID change).
+An optional user ID to use when :program:`celery worker` daemon drops its privileges (defaults to no UID change).
 
 .. setting:: worker_gid
 
@@ -3537,7 +3537,7 @@ An optionnal user ID to use when :program:`celery worker` daemon drops its privi
 
 Default: :const:`None`
 
-An optionnal group ID to use when :program:`celery worker` daemon drops its privileges (default to no GID change).
+An optional group ID to use when :program:`celery worker` daemon drops its privileges (defaults to no GID change).
 
 .. setting:: worker_umask
 
@@ -3546,7 +3546,7 @@ An optionnal group ID to use when :program:`celery worker` daemon drops its priv
 
 Default: :const:`None`
 
-An optionnal `umask` to use when :program:`celery worker` creates files (log, pid...) when daemonizing.
+An optional `umask` to use when :program:`celery worker` creates files (log, pid...) when daemonizing.
 
 .. setting:: worker_executable
 
@@ -3555,7 +3555,7 @@ An optionnal `umask` to use when :program:`celery worker` creates files (log, pi
 
 Default: :const:`None`
 
-An optionnal `python` executable path for :program:`celery worker` to use when deaemonizing (default to :data:`sys.executable`).
+An optional `python` executable path for :program:`celery worker` to use when deaemonizing (defaults to :data:`sys.executable`).
 
 
 
@@ -3653,7 +3653,7 @@ are past due will always run immediately.
 
 Default: :const:`None`
 
-An optionnal file path for :program:`celery beat` to log into (default to `stdout`).
+An optional file path for :program:`celery beat` to log into (defaults to `stdout`).
 
 .. setting:: beat_pidfile
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3698,4 +3698,4 @@ An optional `umask` to use when :program:`celery beat` creates files (log, pid..
 
 Default: :const:`None`
 
-An optionnal `python` executable path for :program:`celery beat` to use when deaemonizing (default to :data:`sys.executable`).
+An optional `python` executable path for :program:`celery beat` to use when deaemonizing (defaults to :data:`sys.executable`).

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3187,7 +3187,7 @@ Message serialization format used when sending event messages.
 
 Default: :const:`None`
 
-An optionnal file path for :program:`celery events` to log into (default to `stdout`).
+An optional file path for :program:`celery events` to log into (defaults to `stdout`).
 
 .. setting:: events_pidfile
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3671,7 +3671,7 @@ An optional file path for :program:`celery beat` to create/store it PID file (de
 
 Default: :const:`None`
 
-An optionnal user ID to use when beat :program:`celery beat` drops its privileges (default to no UID change).
+An optional user ID to use when beat :program:`celery beat` drops its privileges (defaults to no UID change).
 
 .. setting:: beat_gid
 

--- a/t/unit/bin/proj/daemon.py
+++ b/t/unit/bin/proj/daemon.py
@@ -1,0 +1,4 @@
+from celery import Celery
+
+app = Celery(set_as_current=False)
+app.config_from_object("t.unit.bin.proj.daemon_config")

--- a/t/unit/bin/proj/daemon_config.py
+++ b/t/unit/bin/proj/daemon_config.py
@@ -1,0 +1,22 @@
+# Test config for t/unit/bin/test_deamonization.py
+
+beat_pidfile = "/tmp/beat.test.pid"
+beat_logfile = "/tmp/beat.test.log"
+beat_uid = 42
+beat_gid = 4242
+beat_umask = 0o777
+beat_executable = "/beat/bin/python"
+
+events_pidfile = "/tmp/events.test.pid"
+events_logfile = "/tmp/events.test.log"
+events_uid = 42
+events_gid = 4242
+events_umask = 0o777
+events_executable = "/events/bin/python"
+
+worker_pidfile = "/tmp/worker.test.pid"
+worker_logfile = "/tmp/worker.test.log"
+worker_uid = 42
+worker_gid = 4242
+worker_umask = 0o777
+worker_executable = "/worker/bin/python"

--- a/t/unit/bin/test_daemonization.py
+++ b/t/unit/bin/test_daemonization.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from celery.bin.celery import celery
+
+from .proj import daemon_config as config
+
+
+@pytest.mark.usefixtures('depends_on_current_app')
+@pytest.mark.parametrize("daemon", ["worker", "beat", "events"])
+def test_daemon_options_from_config(daemon: str, cli_runner: CliRunner):
+
+    with patch(f"celery.bin.{daemon}.{daemon}.callback") as mock:
+        cli_runner.invoke(celery, f"-A t.unit.bin.proj.daemon {daemon}")
+
+    mock.assert_called_once()
+    for param in "logfile", "pidfile", "uid", "gid", "umask", "executable":
+        assert mock.call_args.kwargs[param] == getattr(config, f"{daemon}_{param}")


### PR DESCRIPTION
## Description

This pull-requests allows to provide daemonization settings (`--logfile`, `--pidfile`, `--uid`, `--gid`, `--umask` and `--executable`) from your config file with the following new settings:
- `beat_logfile`
- `beat_pidfile`
- `beat_uid`
- `beat_gid`
- `beat_umask`
- `beat_executable`
- `worker_logfile`
- `worker_pidfile`
- `worker_uid`
- `worker_gid`
- `worker_umask`
- `worker_executable`
- `events_logfile`
- `events_pidfile`
- `events_uid`
- `events_gid`
- `events_umask`
- `events_executable`

This PR is backward compatible, tested and documented. Missing CLI documentation for daemonization settings have been added in the process.