### PR TITLE
Correct some mypy errors

### DIFF
--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -3,7 +3,7 @@ import logging
 import os
 import threading
 from contextlib import contextmanager
-from typing import Any, Iterable, Union  # noqa
+from typing import Any, Iterable, Optional, Union  # noqa
 
 import celery.worker.consumer  # noqa
 from celery import Celery, worker  # noqa
@@ -131,16 +131,15 @@ def start_worker(
 
 
 @contextmanager
-def _start_worker_thread(app,
-                         concurrency=1,
-                         pool='solo',
-                         loglevel=WORKER_LOGLEVEL,
-                         logfile=None,
-                         WorkController=TestWorkController,
-                         perform_ping_check=True,
-                         shutdown_timeout=10.0,
-                         **kwargs):
-    # type: (Celery, int, str, Union[str, int], str, Any, **Any) -> Iterable
+def _start_worker_thread(app: Celery,
+                         concurrency: int = 1,
+                         pool: str = 'solo',
+                         loglevel: Union[str, int] = WORKER_LOGLEVEL,
+                         logfile: Optional[str] = None,
+                         WorkController: Any = TestWorkController,
+                         perform_ping_check: bool = True,
+                         shutdown_timeout: float = 10.0,
+                         **kwargs) -> Iterable[worker.WorkController]:
     """Start Celery worker in a thread.
 
     Yields:
@@ -211,8 +210,7 @@ def _start_worker_process(app,
         cluster.stopwait()
 
 
-def setup_app_for_worker(app, loglevel, logfile) -> None:
-    # type: (Celery, Union[str, int], str) -> None
+def setup_app_for_worker(app: Celery, loglevel: Union[str, int], logfile: str) -> None:
     """Setup the app to be used for starting an embedded worker."""
     app.finalize()
     app.set_current()

--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -3,10 +3,10 @@ import logging
 import os
 import threading
 from contextlib import contextmanager
-from typing import Any, Iterable, Optional, Union  # noqa
+from typing import Any, Iterable, Optional, Union
 
 import celery.worker.consumer  # noqa
-from celery import Celery, worker  # noqa
+from celery import Celery, worker
 from celery.result import _set_task_join_will_block, allow_join_result
 from celery.utils.dispatch import Signal
 from celery.utils.nodenames import anon_nodename

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -595,8 +595,7 @@ class LimitedSet:
                     break  # oldest item hasn't expired yet
                 self.pop()
 
-    def pop(self, default=None) -> Any:
-        # type: (Any) -> Any
+    def pop(self, default: Any = None) -> Any:
         """Remove and return the oldest item, or :const:`None` when empty."""
         while self._heap:
             _, item = heappop(self._heap)

--- a/celery/utils/saferepr.py
+++ b/celery/utils/saferepr.py
@@ -15,7 +15,7 @@ from decimal import Decimal
 from itertools import chain
 from numbers import Number
 from pprint import _recursion
-from typing import Any, AnyStr, Callable, Dict, Iterator, List, Sequence, Set, Tuple  # noqa
+from typing import Any, AnyStr, Callable, Dict, Iterator, List, Optional, Sequence, Set, Tuple  # noqa
 
 from .text import truncate
 
@@ -194,9 +194,12 @@ def _reprseq(val, lit_start, lit_end, builtin_type, chainer):
     )
 
 
-def reprstream(stack, seen=None, maxlevels=3, level=0, isinstance=isinstance):
+def reprstream(stack: deque,
+               seen: Optional[Set] = None,
+               maxlevels: int = 3,
+               level: int = 0,
+               isinstance: Callable = isinstance) -> Iterator[Any]:
     """Streaming repr, yielding tokens."""
-    # type: (deque, Set, int, int, Callable) -> Iterator[Any]
     seen = seen or set()
     append = stack.append
     popleft = stack.popleft


### PR DESCRIPTION
## Description

Attempting to use Celery in a mypy enabled project we found that errors in Celery's type annotations prevent mypy running against our code. Basically this https://stackoverflow.com/questions/68114378/mypy-crashes-due-to-syntax-error-in-underlying-modules situation 

This branch doesn't attempt to fully overhaul the annotations; it just makes it possible to 

```
from celery import Celery
from celery.schedules import crontab
```
successfully.