### PR TITLE
Disabled couchbase tests due to broken package breaking main

### DIFF
--- a/requirements/test-ci-default.txt
+++ b/requirements/test-ci-default.txt
@@ -12,7 +12,7 @@
 -r extras/thread.txt
 -r extras/elasticsearch.txt
 -r extras/couchdb.txt
--r extras/couchbase.txt
+# -r extras/couchbase.txt
 -r extras/arangodb.txt
 -r extras/consul.txt
 -r extras/cosmosdbsql.txt


### PR DESCRIPTION
The `couchbase` package stopped working and causes the following error in Github Actions:
```
terminate called after throwing an instance of 'std::bad_cast'
    what():  std::bad_cast
  Fatal Python error: Aborted
```

Possible related issue from Stack Overflow:
https://stackoverflow.com/questions/76706020/stdbad-cast-error-while-using-python-sdk-for-couchbase/76713522