### PR TITLE
Fixed RecursionError caused by giving `config_from_object` nested mod…

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -975,7 +975,14 @@ class Celery:
             This is used by PendingConfiguration:
                 as soon as you access a key the configuration is read.
         """
-        conf = self._conf = self._load_config()
+        try:
+            conf = self._conf = self._load_config()
+        except AttributeError as e:
+            # AttributeError is not propagated, it is "handled" by
+            # PendingConfiguration parent class. This causes
+            # confusing RecursionError.
+            raise ModuleNotFoundError(*e.args)
+
         return conf
 
     def _load_config(self):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -977,11 +977,11 @@ class Celery:
         """
         try:
             conf = self._conf = self._load_config()
-        except AttributeError as e:
+        except AttributeError as err:
             # AttributeError is not propagated, it is "handled" by
             # PendingConfiguration parent class. This causes
             # confusing RecursionError.
-            raise ModuleNotFoundError(*e.args)
+            raise ModuleNotFoundError(*err.args) from err
 
         return conf
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -696,6 +696,13 @@ class test_App:
             assert exc.args[0].startswith('task_default_delivery_mode')
             assert 'CELERY_DEFAULT_DELIVERY_MODE' in exc.args[0]
 
+    def test_config_form_object__module_attr_does_not_exist(self):
+        with pytest.raises(ModuleNotFoundError) as exc:
+            self.app.config_from_object(f'{__name__}.bar')
+            # the module must exist, but it should not have the config attr
+            assert self.app.conf.broker_url is None
+            assert f'{__name__}.bar' in exc.args[0]
+
     def test_config_from_cmdline(self):
         cmdline = ['task_always_eager=no',
                    'result_backend=/dev/null',

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -697,11 +697,16 @@ class test_App:
             assert 'CELERY_DEFAULT_DELIVERY_MODE' in exc.args[0]
 
     def test_config_form_object__module_attr_does_not_exist(self):
+        module_name = __name__
+        attr_name = 'bar'
+        # the module must exist, but it should not have the config attr
+        self.app.config_from_object(f'{module_name}.{attr_name}')
+
         with pytest.raises(ModuleNotFoundError) as exc:
-            self.app.config_from_object(f'{__name__}.bar')
-            # the module must exist, but it should not have the config attr
             assert self.app.conf.broker_url is None
-            assert f'{__name__}.bar' in exc.args[0]
+
+        assert module_name in exc.value.args[0]
+        assert attr_name in exc.value.args[0]
 
     def test_config_from_cmdline(self):
         cmdline = ['task_always_eager=no',


### PR DESCRIPTION
Fixed RecursionError caused by giving `config_from_object` nested module that does not exist (#8517)


## Description

The problem is described by new unit test: t/unit/app/test_app.py::test_config_form_object__module_attr_does_not_exist

When you provide a string with valid module name but invalid submodule (attr) to `app.config_from_object` the 3rd party util `kombu.utils.imports.symbol_by_name` would raise `AttributeError` which would be "handled" by `PendingConfiguration(UserDict)` and would cause infinite recursion. This happens during the "lazy initialization" of the `app.conf` when `app.conf` attr is accessed.

The fix is to catch `AttributeError` and raise `ModuleNotFoundError` which would be propagated correctly and would provide the real error message to the end user.

I don't feel very good re: this fix, I am new to this project, so your criticism is highly desired.

