### PR TITLE
[documentation] broker_connection_max_retries of 0 does not mean "retry forever"

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2817,7 +2817,7 @@ Default: 100.
 Maximum number of retries before we give up re-establishing a connection
 to the AMQP broker.
 
-If this is set to :const:`0` or :const:`None`, we'll retry forever.
+If this is set to :const:`None`, we'll retry forever.
 
 ``broker_channel_error_retry``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR updates the documentation regarding `broker_connection_max_retries`. As I learned the hard way, a value of `0` does not mean "retry forever".

Reasoning:
* the value of `broker_connection_max_retries` is used here when establishing a connection to the broker: https://github.com/celery/celery/blob/4e888810f3780f927bc0f23404448769e60bc028/celery/worker/consumer/consumer.py#L527C43-L527C72
* it gets passed into kombu's `Connection._ensure_connection` and then to `kombu.utils.functional.retry_over_time`
* there it is used in this line https://github.com/celery/kombu/blob/75650c511b7491f47263818ce36ba52f76a8fd1f/kombu/utils/functional.py#L320 A value of `0` will raise on any error instead of retrying. 

