### PR TITLE
Propagates more ImportErrors during autodiscovery

### DIFF
--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -270,7 +270,7 @@ def find_related_module(package, related_name):
         return importlib.import_module(module_name)
     except ModuleNotFoundError as e:
         import_exc_name = getattr(e, 'name', module_name)
-        # If sibling does not exist return None.
+        # If candidate does not exist, then return None.
         if import_exc_name == module_name:
             return
 

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -253,10 +253,12 @@ def find_related_module(package, related_name):
     # Django 1.7 allows for specifying a class name in INSTALLED_APPS.
     # (Issue #2248).
     try:
+        # Return package itself when no related_name.
         module = importlib.import_module(package)
         if not related_name and module:
             return module
-    except ImportError:
+    except ModuleNotFoundError:
+        # On import error, try to walk package up one level.
         package, _, _ = package.rpartition('.')
         if not package:
             raise
@@ -264,9 +266,13 @@ def find_related_module(package, related_name):
     module_name = f'{package}.{related_name}'
 
     try:
+        # Try to find related_name under package.
         return importlib.import_module(module_name)
-    except ImportError as e:
+    except ModuleNotFoundError as e:
         import_exc_name = getattr(e, 'name', module_name)
-        if import_exc_name is not None and import_exc_name != module_name:
-            raise e
-        return
+        # If sibling does not exist return None.
+        if import_exc_name == module_name:
+            return
+
+        # Otherwise, raise because error probably originated from a nested import.
+        raise e

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -269,9 +269,9 @@ def find_related_module(package, related_name):
         # Try to find related_name under package.
         return importlib.import_module(module_name)
     except ModuleNotFoundError as e:
-        import_exc_name = getattr(e, 'name', module_name)
+        import_exc_name = getattr(e, 'name', None)
         # If candidate does not exist, then return None.
-        if module_name.startswith(import_exc_name):
+        if import_exc_name and module_name.startswith(import_exc_name):
             return
 
         # Otherwise, raise because error probably originated from a nested import.

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -271,7 +271,7 @@ def find_related_module(package, related_name):
     except ModuleNotFoundError as e:
         import_exc_name = getattr(e, 'name', module_name)
         # If candidate does not exist, then return None.
-        if import_exc_name == module_name:
+        if module_name.startswith(import_exc_name):
             return
 
         # Otherwise, raise because error probably originated from a nested import.

--- a/t/integration/test_loader.py
+++ b/t/integration/test_loader.py
@@ -1,0 +1,22 @@
+from celery import shared_task
+
+
+@shared_task()
+def dummy_task(x, y):
+    return x + y
+
+
+class test_loader:
+    def test_autodiscovery(self, manager):
+        # Arrange
+        expected_package_name, _, module_name = __name__.rpartition('.')
+        unexpected_package_name = 'nonexistent.package.name'
+
+        # Act
+        manager.app.autodiscover_tasks([expected_package_name, unexpected_package_name], module_name, force=True)
+
+        # Assert
+        assert f'{expected_package_name}.{module_name}.dummy_task' in manager.app.tasks
+        assert not any(
+            task.startswith(unexpected_package_name) for task in manager.app.tasks
+        )

--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -274,7 +274,7 @@ class test_autodiscovery:
             imp.assert_any_call('foo')
             imp.assert_any_call('foo.tasks')
 
-    def test_find_related_module__when_neither_package_nor_related_name_exists(self):
+    def test_find_related_module__when_existent_package_parent_but_not_related_name(self):
         with patch('importlib.import_module') as imp:
             first_import = ModuleNotFoundError(name='foo.bar')
             second_import = ModuleNotFoundError(name='foo.tasks')

--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -274,7 +274,7 @@ class test_autodiscovery:
             imp.assert_any_call('foo')
             imp.assert_any_call('foo.tasks')
 
-    def test_find_related_module__when_existent_package_parent_but_not_related_name(self):
+    def test_find_related_module__when_existent_package_parent_but_no_related_name(self):
         with patch('importlib.import_module') as imp:
             first_import = ModuleNotFoundError(name='foo.bar')
             second_import = ModuleNotFoundError(name='foo.tasks')

--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -240,7 +240,7 @@ class test_autodiscovery:
             imp.return_value = Mock()
             imp.return_value.__path__ = 'foo'
             assert base.find_related_module('foo', None).__path__ == 'foo'
-            imp.assert_any_call('foo')
+            imp.assert_called_once_with('foo')
 
     def test_find_related_module__when_existent_package_and_related_name(self):
         with patch('importlib.import_module') as imp:

--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -234,19 +234,74 @@ class test_autodiscovery:
             base.autodiscover_tasks(['foo'])
             frm.assert_called()
 
-    def test_find_related_module(self):
+    # Happy - get something back
+    def test_find_related_module__when_existent_package_alone(self):
         with patch('importlib.import_module') as imp:
             imp.return_value = Mock()
             imp.return_value.__path__ = 'foo'
-            assert base.find_related_module('bar', 'tasks').__path__ == 'foo'
-            imp.assert_any_call('bar')
-            imp.assert_any_call('bar.tasks')
+            assert base.find_related_module('foo', None).__path__ == 'foo'
+            imp.assert_any_call('foo')
 
-            imp.reset_mock()
-            assert base.find_related_module('bar', None).__path__ == 'foo'
-            imp.assert_called_once_with('bar')
+    def test_find_related_module__when_existent_package_and_related_name(self):
+        with patch('importlib.import_module') as imp:
+            first_import = Mock()
+            first_import.__path__ = 'foo'
+            second_import = Mock()
+            second_import.__path__ = 'foo/tasks'
+            imp.side_effect = [first_import, second_import]
+            assert base.find_related_module('foo', 'tasks').__path__ == 'foo/tasks'
+            imp.assert_any_call('foo')
+            imp.assert_any_call('foo.tasks')
 
-            imp.side_effect = ImportError()
-            with pytest.raises(ImportError):
-                base.find_related_module('bar', 'tasks')
-            assert base.find_related_module('bar.foo', 'tasks') is None
+    def test_find_related_module__when_existent_package_parent_and_related_name(self):
+        with patch('importlib.import_module') as imp:
+            first_import = ModuleNotFoundError(name='foo.BarApp')  # Ref issue #2248
+            second_import = Mock()
+            second_import.__path__ = 'foo/tasks'
+            imp.side_effect = [first_import, second_import]
+            assert base.find_related_module('foo.BarApp', 'tasks').__path__ == 'foo/tasks'
+            imp.assert_any_call('foo.BarApp')
+            imp.assert_any_call('foo.tasks')
+
+    # Sad - nothing returned
+    def test_find_related_module__when_package_exists_but_related_name_does_not(self):
+        with patch('importlib.import_module') as imp:
+            first_import = Mock()
+            first_import.__path__ = 'foo'
+            second_import = ModuleNotFoundError(name='foo.tasks')
+            imp.side_effect = [first_import, second_import]
+            assert base.find_related_module('foo', 'tasks') is None
+            imp.assert_any_call('foo')
+            imp.assert_any_call('foo.tasks')
+
+    def test_find_related_module__when_neither_package_nor_related_name_exists(self):
+        with patch('importlib.import_module') as imp:
+            first_import = ModuleNotFoundError(name='foo.bar')
+            second_import = ModuleNotFoundError(name='foo.tasks')
+            imp.side_effect = [first_import, second_import]
+            assert base.find_related_module('foo.bar', 'tasks') is None
+            imp.assert_any_call('foo.bar')
+            imp.assert_any_call('foo.tasks')
+
+    # Sad - errors
+    def test_find_related_module__when_no_package_parent(self):
+        with patch('importlib.import_module') as imp:
+            non_existent_import = ModuleNotFoundError(name='foo')
+            imp.side_effect = non_existent_import
+            with pytest.raises(ImportError) as exc:
+                base.find_related_module('foo', 'tasks')
+
+            assert exc.value.name == 'foo'
+            imp.assert_called_once_with('foo')
+
+    def test_find_related_module__when_nested_import_missing(self):
+        expected_error = 'nested import error - e.g. missing library'
+        with patch('importlib.import_module') as imp:
+            first_import = Mock()
+            first_import.__path__ = 'foo'
+            second_import = ImportError(expected_error)
+            imp.side_effect = [first_import, second_import]
+            with pytest.raises(ImportError) as exc:
+                base.find_related_module('foo', 'tasks')
+
+            assert exc.value.msg == expected_error

--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -288,20 +288,20 @@ class test_autodiscovery:
         with patch('importlib.import_module') as imp:
             non_existent_import = ModuleNotFoundError(name='foo')
             imp.side_effect = non_existent_import
-            with pytest.raises(ImportError) as exc:
+            with pytest.raises(ModuleNotFoundError) as exc:
                 base.find_related_module('foo', 'tasks')
 
             assert exc.value.name == 'foo'
             imp.assert_called_once_with('foo')
 
     def test_find_related_module__when_nested_import_missing(self):
-        expected_error = 'nested import error - e.g. missing library'
+        expected_error = 'dummy import error - e.g. missing nested package'
         with patch('importlib.import_module') as imp:
             first_import = Mock()
             first_import.__path__ = 'foo'
-            second_import = ImportError(expected_error)
+            second_import = ModuleNotFoundError(expected_error)
             imp.side_effect = [first_import, second_import]
-            with pytest.raises(ImportError) as exc:
+            with pytest.raises(ModuleNotFoundError) as exc:
                 base.find_related_module('foo', 'tasks')
 
             assert exc.value.msg == expected_error


### PR DESCRIPTION
# Problem

The gist of the problem is that the current implementation of autodiscovering tasks will hide `ImportErrors` that originate outside of `importlib.import_module`.

For details see discussion in https://github.com/celery/celery/discussions/8620.

# Solution

Narrow the caught-exceptions to ones that:
1. Are `ModuleNotFoundError` (which is a subclass of `ImportError` that `importlib` seems to raise these days), and
2. Have a `name` attribute that matches the task being "guessed" (previously the code would default to the task's name if the exception lacked a `name` attribute).

Also, refactored the tests into what seem like the specific edge cases `find_related_module` is trying to handle.