### PR TITLE
Incredibly minor spelling fix.

### DIFF
--- a/docs/getting-started/backends-and-brokers/index.rst
+++ b/docs/getting-started/backends-and-brokers/index.rst
@@ -98,6 +98,6 @@ SQLAlchemy
 
 SQLAlchemy is a backend.
 
-It allows Celery to interface with MySQL, PostgreSQL, SQlite, and more. It is a ORM, and is the way Celery can use a SQL DB as a result backend.
+It allows Celery to interface with MySQL, PostgreSQL, SQlite, and more. It is an ORM, and is the way Celery can use a SQL DB as a result backend.
 
 :ref:`See documentation for details <conf-database-result-backend>`


### PR DESCRIPTION
## Description

"A" becomes "an" when followed by a vowel sound, and whether saying "ORM" or "object relational mapping", it starts with an "oh" sound, thus "an".