### PR TITLE
Fix non-zero exit code when receiving remote shutdown

### DIFF
--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -580,7 +580,7 @@ def autoscale(state, max=None, min=None):
 def shutdown(state, msg='Got shutdown from remote', **kwargs):
     """Shutdown worker(s)."""
     logger.warning(msg)
-    raise WorkerShutdown(msg)
+    raise WorkerShutdown(0)
 
 
 # -- Queues


### PR DESCRIPTION
## Description

Possibly fixes #8540.

This issue likely surfaced with https://github.com/celery/celery/pull/7544. Since `WorkerShutdown` inherits from `SystemExit`, providing a non-integer value [results in an exit code of 1](https://docs.python.org/3/library/exceptions.html#SystemExit). This exception is then propagated to
https://github.com/celery/celery/blob/bad275039fac8bdf66e8d03928028227aef0f782/celery/worker/worker.py#L209
which causes a non-zero exit code upon a graceful shutdown request of the worker.

