### PR TITLE
Re-raise ModuleNotFoundError unless for guessed task

### DIFF
--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -271,7 +271,7 @@ def find_related_module(package, related_name):
     except ModuleNotFoundError as e:
         import_exc_name = getattr(e, 'name', None)
         # If candidate does not exist, then return None.
-        if import_exc_name and module_name.startswith(import_exc_name):
+        if import_exc_name and module_name == import_exc_name:
             return
 
         # Otherwise, raise because error probably originated from a nested import.

--- a/t/integration/test_loader.py
+++ b/t/integration/test_loader.py
@@ -12,7 +12,6 @@ class test_loader:
     def test_autodiscovery__when_packages_exist(self, manager):
         # Arrange
         expected_package_name, _, module_name = __name__.rpartition('.')
-        # Expect built-in to neither have test_loader.py module nor define a Celery task.
         unexpected_package_name = 'datetime.datetime'
 
         # Act
@@ -22,7 +21,7 @@ class test_loader:
         assert f'{expected_package_name}.{module_name}.dummy_task' in manager.app.tasks
         assert not any(
             task.startswith(unexpected_package_name) for task in manager.app.tasks
-        )
+        ), 'Expected datetime.datetime to neither have test_loader module nor define a Celery task.'
 
     def test_autodiscovery__when_packages_do_not_exist(self, manager):
         # Arrange

--- a/t/integration/test_loader.py
+++ b/t/integration/test_loader.py
@@ -26,11 +26,14 @@ class test_loader:
 
     def test_autodiscovery__when_packages_do_not_exist(self, manager):
         # Arrange
+        existent_package_name, _, module_name = __name__.rpartition('.')
         nonexistent_package_name = 'nonexistent.package.name'
 
         # Act
         with pytest.raises(ModuleNotFoundError) as exc:
-            manager.app.autodiscover_tasks([nonexistent_package_name], force=True)
+            manager.app.autodiscover_tasks(
+                [existent_package_name, nonexistent_package_name], module_name, force=True
+            )
 
         # Assert
-        assert nonexistent_package_name.startswith(exc.value.name), "Expected to fail on importing 'nonexistent'"
+        assert nonexistent_package_name.startswith(exc.value.name), 'Expected to fail on importing "nonexistent"'


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
We just merged #8632, which should propagate import-errors that originate outside of the `importlib.import_module` call. After reading through the code again today, I realized my change may swallow some other import errors that should fail.

I've updated the integration test with clearer cases, and modified `celery.loaders.base.find_related_module` so that it only returns none if the exact task-module being guessed is what caused the `ModuleNotFoundError`.