### PR TITLE
Upstash's Celery example repo link fix due to deprecation of the prev…

### DIFF
--- a/docs/getting-started/backends-and-brokers/redis.rst
+++ b/docs/getting-started/backends-and-brokers/redis.rst
@@ -158,7 +158,7 @@ with an eventual consistency model and durable storage, facilitated
 through a multi-tier storage architecture.
 
 Integration with Celery is straightforward as demonstrated
-in an `example provided by Upstash <https://github.com/upstash/redis-examples/tree/master/using-celery>`_.
+in an `example provided by Upstash <https://github.com/upstash/examples/tree/main/examples/using-celery>`_.
 
 .. _redis-caveats:
 


### PR DESCRIPTION
Upstash archived the previous examples repo just before #8640 was merged.
This fixes the link to the new maintained repo.