### PR TITLE
Update cryptography dependency to 41.0.7

### DIFF
--- a/requirements/extras/auth.txt
+++ b/requirements/extras/auth.txt
@@ -1,1 +1,1 @@
-cryptography==41.0.5
+cryptography==41.0.7


### PR DESCRIPTION
For CVE-2023-49083

https://nvd.nist.gov/vuln/detail/CVE-2023-49083

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
