### PR TITLE
Issue 3426. Adding myself to the contributors.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -220,6 +220,7 @@ Adriano Martins de Jesus, 2016/06/22
 Kevin Richardson, 2016/06/29
 Andrew Stewart, 2016/07/04
 Xin Li, 2016/08/03
+Samuel Giffard, 2016/09/08
 Alli Witheford, 2016/09/29
 Alan Justino da Silva, 2016/10/14
 Marat Sharafutdinov, 2016/11/04


### PR DESCRIPTION
This is a long due edit. This comes from contributions 938407f.

The initial commits that initially made this CONTRIBUTORS change were 9146290 and b7bbeeb. They were part of PR #3433, but this line never made it to the cherry-pick.

Note: I was looking for my GitHub profile image in the Celery contributors list, because I knew I contributed long ago, and noticed I didn't add myself back then. This was an error on my part 😬.

Never late than never, they say. :)
Please forgive my 7 years delay 🙇 