### PR TITLE
[Smoke Tests only] Using pytest-xdist config: --dist=loadscope

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,6 +11,7 @@ on:
         - '**.txt'
         - '.github/workflows/python-package.yml'
         - '**.toml'
+        - "tox.ini"
   pull_request:
     branches: [ 'main', 'smoke_tests' ]
     paths:
@@ -18,6 +19,7 @@ on:
         - '**.txt'
         - '**.toml'
         - '.github/workflows/python-package.yml'
+        - "tox.ini"
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps=
 commands =
     unit: pytest --maxfail=10 --capture=no -v --cov=celery --cov-report=xml --cov-report term {posargs}
     integration: pytest -xsv t/integration {posargs}
-    smoke: pytest -xsv t/smoke --reruns 10 --reruns-delay 60 --rerun-except AssertionError {posargs}
+    smoke: pytest -xsv t/smoke --dist=loadscope --reruns 10 --reruns-delay 60 --rerun-except AssertionError {posargs}
 setenv =
     PIP_EXTRA_INDEX_URL=https://celery.github.io/celery-wheelhouse/repo/simple/
     BOTO_CONFIG = /dev/null


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-xdist/blob/master/CHANGELOG.rst#pytest-xdist-350-2023-11-21
> pytest-xdist 3.5.0 (2023-11-21)
> 
> Features
> 
> https://github.com/pytest-dev/pytest-xdist/issues/632: --dist=loadscope now sorts scopes by number of tests to assign largest scopes early -- in many cases this should improve overall test session running time, as there is less chance of a large scope being left to be processed near the end of the session, leaving other workers idle.