### PR TITLE
Fix DeprecationWarning: datetime.datetime.utcnow()

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -6,6 +6,7 @@ import threading
 import warnings
 from collections import UserDict, defaultdict, deque
 from datetime import datetime
+from datetime import timezone as datetime_timezone
 from operator import attrgetter
 
 from click.exceptions import Exit
@@ -937,7 +938,7 @@ class Celery:
 
     def now(self):
         """Return the current time and date as a datetime."""
-        now_in_utc = to_utc(datetime.utcnow())
+        now_in_utc = to_utc(datetime.now(datetime_timezone.utc))
         return now_in_utc.astimezone(self.timezone)
 
     def select_queues(self, queues=None):

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -1,5 +1,5 @@
 """MongoDB result store backend."""
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from kombu.exceptions import EncodeError
 from kombu.utils.objects import cached_property
@@ -228,7 +228,7 @@ class MongoBackend(BaseBackend):
         meta = {
             '_id': group_id,
             'result': self.encode([i.id for i in result]),
-            'date_done': datetime.utcnow(),
+            'date_done': datetime.now(timezone.utc),
         }
         self.group_collection.replace_one({'_id': group_id}, meta, upsert=True)
         return result

--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -2,7 +2,7 @@
 import os
 import sys
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib import import_module
 from typing import IO, TYPE_CHECKING, Any, List, Optional, cast
 
@@ -100,7 +100,7 @@ class DjangoFixup:
         self.worker_fixup.install()
 
     def now(self, utc: bool = False) -> datetime:
-        return datetime.utcnow() if utc else self._now()
+        return datetime.now(timezone.utc) if utc else self._now()
 
     def autodiscover_tasks(self) -> List[str]:
         from django.apps import apps

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -3,7 +3,7 @@ import importlib
 import os
 import re
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 from kombu.utils import json
 from kombu.utils.objects import cached_property
@@ -62,7 +62,7 @@ class BaseLoader:
 
     def now(self, utc=True):
         if utc:
-            return datetime.utcnow()
+            return datetime.now(timezone.utc)
         return datetime.now()
 
     def on_task_init(self, task_id, task):

--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -43,7 +43,7 @@ class Certificate:
 
     def has_expired(self) -> bool:
         """Check if the certificate has expired."""
-        return datetime.datetime.utcnow() >= self._cert.not_valid_after
+        return datetime.datetime.now(datetime.timezone.utc) >= self._cert.not_valid_after
 
     def get_pubkey(self) -> (
         DSAPublicKey | EllipticCurvePublicKey | Ed448PublicKey | Ed25519PublicKey | RSAPublicKey

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -217,7 +217,7 @@ def remaining(
     Returns:
         ~datetime.timedelta: Remaining time.
     """
-    now = now or datetime.utcnow()
+    now = now or datetime.now(datetime_timezone.utc)
     if str(
             start.tzinfo) == str(
             now.tzinfo) and now.utcoffset() != start.utcoffset():

--- a/celery/worker/worker.py
+++ b/celery/worker/worker.py
@@ -14,7 +14,7 @@ The worker consists of several components, all managed by bootsteps
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 from billiard import cpu_count
 from kombu.utils.compat import detect_environment
@@ -89,7 +89,7 @@ class WorkController:
     def __init__(self, app=None, hostname=None, **kwargs):
         self.app = app or self.app
         self.hostname = default_nodename(hostname)
-        self.startup_time = datetime.utcnow()
+        self.startup_time = datetime.now(timezone.utc)
         self.app.loader.init_worker()
         self.on_before_init(**kwargs)
         self.setup_defaults(**kwargs)
@@ -293,7 +293,7 @@ class WorkController:
             return reload_from_cwd(sys.modules[module], reloader)
 
     def info(self):
-        uptime = datetime.utcnow() - self.startup_time
+        uptime = datetime.now(timezone.utc) - self.startup_time
         return {'total': self.state.total_count,
                 'pid': os.getpid(),
                 'clock': str(self.app.clock),

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -2,7 +2,7 @@ import collections
 import re
 import tempfile
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from time import monotonic, sleep
 
 import pytest
@@ -366,7 +366,7 @@ class test_chain:
         except NotImplementedError as e:
             raise pytest.skip(e.args[0])
 
-        eta = datetime.utcnow() + timedelta(seconds=10)
+        eta = datetime.now(timezone.utc) + timedelta(seconds=10)
         c = chain(
             group(
                 add.s(1, 2),

--- a/t/integration/test_inspect.py
+++ b/t/integration/test_inspect.py
@@ -1,6 +1,6 @@
 import os
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from time import sleep
 from unittest.mock import ANY
 
@@ -126,7 +126,7 @@ class test_Inspect:
     @flaky
     def test_scheduled(self, inspect):
         """Tests listing scheduled tasks"""
-        exec_time = datetime.utcnow() + timedelta(seconds=5)
+        exec_time = datetime.now(timezone.utc) + timedelta(seconds=5)
         res = add.apply_async([1, 2], {'z': 3}, eta=exec_time)
         ret = inspect.scheduled()
         assert len(ret) == 1

--- a/t/integration/test_security.py
+++ b/t/integration/test_security.py
@@ -74,7 +74,7 @@ class test_security:
     def gen_certificate(self, key, common_name, issuer=None, sign_key=None):
         """generate a certificate with cryptography"""
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         certificate = x509.CertificateBuilder().subject_name(
             x509.Name([

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from time import perf_counter, sleep
 from uuid import uuid4
 
@@ -138,7 +138,7 @@ class test_tasks:
         for _ in range(4):
             sleeping.delay(2)
         # Execute task with expiration at now + 1 sec
-        result = add.apply_async((1, 1), expires=datetime.utcnow() + timedelta(seconds=1))
+        result = add.apply_async((1, 1), expires=datetime.now(timezone.utc) + timedelta(seconds=1))
         with pytest.raises(celery.exceptions.TaskRevokedError):
             result.get()
         assert result.status == 'REVOKED'
@@ -164,7 +164,7 @@ class test_tasks:
 
         start = perf_counter()
         # Schedule task to be executed at time now + 3 seconds
-        result = add.apply_async((2, 2), eta=datetime.utcnow() + timedelta(seconds=3))
+        result = add.apply_async((2, 2), eta=datetime.now(timezone.utc) + timedelta(seconds=3))
         sleep(1)
         assert result.status == 'PENDING'
         assert result.ready() is False

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
 import pytest
@@ -349,14 +349,14 @@ class test_as_task_v2(test_AMQP_Base):
             self.app.amqp.as_task_v2(uuid(), 'foo', kwargs=(1, 2, 3))
 
     def test_countdown_to_eta(self):
-        now = to_utc(datetime.utcnow()).astimezone(self.app.timezone)
+        now = to_utc(datetime.now(timezone.utc)).astimezone(self.app.timezone)
         m = self.app.amqp.as_task_v2(
             uuid(), 'foo', countdown=10, now=now,
         )
         assert m.headers['eta'] == (now + timedelta(seconds=10)).isoformat()
 
     def test_expires_to_datetime(self):
-        now = to_utc(datetime.utcnow()).astimezone(self.app.timezone)
+        now = to_utc(datetime.now(timezone.utc)).astimezone(self.app.timezone)
         m = self.app.amqp.as_task_v2(
             uuid(), 'foo', expires=30, now=now,
         )
@@ -364,7 +364,7 @@ class test_as_task_v2(test_AMQP_Base):
             now + timedelta(seconds=30)).isoformat()
 
     def test_eta_to_datetime(self):
-        eta = datetime.utcnow()
+        eta = datetime.now(timezone.utc)
         m = self.app.amqp.as_task_v2(
             uuid(), 'foo', eta=eta,
         )

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -6,6 +6,7 @@ import sys
 import uuid
 from copy import deepcopy
 from datetime import datetime, timedelta
+from datetime import timezone as datetime_timezone
 from pickle import dumps, loads
 from unittest.mock import Mock, patch
 
@@ -85,7 +86,7 @@ class test_App:
         tz_utc = timezone.get_timezone('UTC')
         tz_us_eastern = timezone.get_timezone(timezone_setting_value)
 
-        now = to_utc(datetime.utcnow())
+        now = to_utc(datetime.now(datetime_timezone.utc))
         app_now = self.app.now()
 
         assert app_now.tzinfo is tz_utc
@@ -101,7 +102,7 @@ class test_App:
 
         assert app_now.tzinfo == tz_us_eastern
 
-        diff = to_utc(datetime.utcnow()) - localize(app_now, tz_utc)
+        diff = to_utc(datetime.now(datetime_timezone.utc)) - localize(app_now, tz_utc)
         assert diff <= timedelta(seconds=1)
 
         # Verify that timezone setting overrides enable_utc=on setting

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -1,6 +1,6 @@
 import errno
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pickle import dumps, loads
 from unittest.mock import Mock, call, patch
 
@@ -863,17 +863,17 @@ class test_schedule:
     def test_maybe_make_aware(self):
         x = schedule(10, app=self.app)
         x.utc_enabled = True
-        d = x.maybe_make_aware(datetime.utcnow())
+        d = x.maybe_make_aware(datetime.now(timezone.utc))
         assert d.tzinfo
         x.utc_enabled = False
-        d2 = x.maybe_make_aware(datetime.utcnow())
+        d2 = x.maybe_make_aware(datetime.now(timezone.utc))
         assert d2.tzinfo
 
     def test_to_local(self):
         x = schedule(10, app=self.app)
         x.utc_enabled = True
-        d = x.to_local(datetime.utcnow())
+        d = x.to_local(datetime.utcnow())  # datetime.utcnow() is deprecated in Python 3.12
         assert d.tzinfo is None
         x.utc_enabled = False
-        d = x.to_local(datetime.utcnow())
+        d = x.to_local(datetime.now(timezone.utc))
         assert d.tzinfo

--- a/t/unit/app/test_exceptions.py
+++ b/t/unit/app/test_exceptions.py
@@ -1,5 +1,5 @@
 import pickle
-from datetime import datetime
+from datetime import datetime, timezone
 
 from celery.exceptions import Reject, Retry
 
@@ -7,11 +7,11 @@ from celery.exceptions import Reject, Retry
 class test_Retry:
 
     def test_when_datetime(self):
-        x = Retry('foo', KeyError(), when=datetime.utcnow())
+        x = Retry('foo', KeyError(), when=datetime.now(timezone.utc))
         assert x.humanize()
 
     def test_pickleable(self):
-        x = Retry('foo', KeyError(), when=datetime.utcnow())
+        x = Retry('foo', KeyError(), when=datetime.now(timezone.utc))
         y = pickle.loads(pickle.dumps(x))
         assert x.message == y.message
         assert repr(x.exc) == repr(y.exc)

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -1,7 +1,7 @@
 import sys
 import time
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pickle import dumps, loads
 from unittest import TestCase
 from unittest.mock import Mock
@@ -50,17 +50,17 @@ class test_solar:
     def test_is_due(self):
         self.s.remaining_estimate = Mock(name='rem')
         self.s.remaining_estimate.return_value = timedelta(seconds=0)
-        assert self.s.is_due(datetime.utcnow()).is_due
+        assert self.s.is_due(datetime.now(timezone.utc)).is_due
 
     def test_is_due__not_due(self):
         self.s.remaining_estimate = Mock(name='rem')
         self.s.remaining_estimate.return_value = timedelta(hours=10)
-        assert not self.s.is_due(datetime.utcnow()).is_due
+        assert not self.s.is_due(datetime.now(timezone.utc)).is_due
 
     def test_remaining_estimate(self):
         self.s.cal = Mock(name='cal')
-        self.s.cal.next_rising().datetime.return_value = datetime.utcnow()
-        self.s.remaining_estimate(datetime.utcnow())
+        self.s.cal.next_rising().datetime.return_value = datetime.now(timezone.utc)
+        self.s.remaining_estimate(datetime.now(timezone.utc))
 
     def test_coordinates(self):
         with pytest.raises(ValueError):
@@ -82,7 +82,7 @@ class test_solar:
             s.method = s._methods[ev]
             s.is_center = s._use_center_l[ev]
             try:
-                s.remaining_estimate(datetime.utcnow())
+                s.remaining_estimate(datetime.now(timezone.utc))
             except TypeError:
                 pytest.fail(
                     f"{s.method} was called with 'use_center' which is not a "
@@ -108,7 +108,7 @@ class test_schedule:
 # This is needed for test_crontab_parser because datetime.utcnow doesn't pickle
 # in python 2
 def utcnow():
-    return datetime.utcnow()
+    return datetime.now(timezone.utc)
 
 
 class test_crontab_parser:

--- a/t/unit/backends/test_arangodb.py
+++ b/t/unit/backends/test_arangodb.py
@@ -210,7 +210,7 @@ class test_ArangoDbBackend:
         self.backend.cleanup()
         self.backend.db.AQLQuery.assert_not_called()
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         self.backend.app.now = Mock(return_value=now)
         self.backend.expires = 86400
         expected_checkpoint = (now - self.backend.expires_delta).isoformat()

--- a/t/unit/security/test_certificate.py
+++ b/t/unit/security/test_certificate.py
@@ -40,7 +40,7 @@ class test_Certificate(SecurityCase):
         x = Certificate(CERT1)
 
         x._cert = Mock(name='cert')
-        time_after = datetime.datetime.utcnow() + datetime.timedelta(days=-1)
+        time_after = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=-1)
         x._cert.not_valid_after = time_after
 
         assert x.has_expired() is True
@@ -49,7 +49,7 @@ class test_Certificate(SecurityCase):
         x = Certificate(CERT1)
 
         x._cert = Mock(name='cert')
-        time_after = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        time_after = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
         x._cert.not_valid_after = time_after
 
         assert x.has_expired() is False

--- a/t/unit/utils/test_serialization.py
+++ b/t/unit/utils/test_serialization.py
@@ -1,7 +1,7 @@
 import json
 import pickle
 import sys
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from unittest.mock import Mock
 
 import pytest
@@ -67,9 +67,9 @@ class test_jsonify:
         Queue('foo'),
         ['foo', 'bar', 'baz'],
         {'foo': 'bar'},
-        datetime.utcnow(),
-        datetime.utcnow().replace(tzinfo=ZoneInfo("UTC")),
-        datetime.utcnow().replace(microsecond=0),
+        datetime.now(timezone.utc),
+        datetime.now(timezone.utc).replace(tzinfo=ZoneInfo("UTC")),
+        datetime.now(timezone.utc).replace(microsecond=0),
         date(2012, 1, 1),
         time(hour=1, minute=30),
         time(hour=1, minute=30, microsecond=3),

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -48,7 +48,7 @@ class test_LocalTimezone:
 class test_iso8601:
 
     def test_parse_with_timezone(self):
-        d = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        d = datetime.now(_timezone.utc).replace(tzinfo=ZoneInfo("UTC"))
         assert parse_iso8601(d.isoformat()) == d
         # 2013-06-07T20:12:51.775877+00:00
         iso = d.isoformat()
@@ -124,7 +124,7 @@ def test_maybe_timedelta(arg, expected):
 
 def test_remaining():
     # Relative
-    remaining(datetime.utcnow(), timedelta(hours=1), relative=True)
+    remaining(datetime.now(_timezone.utc), timedelta(hours=1), relative=True)
 
     """
     The upcoming cases check whether the next run is calculated correctly
@@ -188,38 +188,38 @@ class test_timezone:
         assert timezone.tz_or_local(timezone.utc)
 
     def test_to_local(self):
-        assert timezone.to_local(make_aware(datetime.utcnow(), timezone.utc))
-        assert timezone.to_local(datetime.utcnow())
+        assert timezone.to_local(make_aware(datetime.now(_timezone.utc), timezone.utc))
+        assert timezone.to_local(datetime.now(_timezone.utc))
 
     def test_to_local_fallback(self):
         assert timezone.to_local_fallback(
-            make_aware(datetime.utcnow(), timezone.utc))
-        assert timezone.to_local_fallback(datetime.utcnow())
+            make_aware(datetime.now(_timezone.utc), timezone.utc))
+        assert timezone.to_local_fallback(datetime.now(_timezone.utc))
 
 
 class test_make_aware:
 
     def test_standard_tz(self):
         tz = tzinfo()
-        wtz = make_aware(datetime.utcnow(), tz)
+        wtz = make_aware(datetime.now(_timezone.utc), tz)
         assert wtz.tzinfo == tz
 
     def test_tz_when_zoneinfo(self):
         tz = ZoneInfo('US/Eastern')
-        wtz = make_aware(datetime.utcnow(), tz)
+        wtz = make_aware(datetime.now(_timezone.utc), tz)
         assert wtz.tzinfo == tz
 
     def test_maybe_make_aware(self):
-        aware = datetime.utcnow().replace(tzinfo=timezone.utc)
+        aware = datetime.now(_timezone.utc).replace(tzinfo=timezone.utc)
         assert maybe_make_aware(aware)
-        naive = datetime.utcnow()
+        naive = datetime.utcnow()  # datetime.utcnow() is deprecated in Python 3.12
         assert maybe_make_aware(naive)
         assert maybe_make_aware(naive).tzinfo is ZoneInfo("UTC")
 
         tz = ZoneInfo('US/Eastern')
-        eastern = datetime.utcnow().replace(tzinfo=tz)
+        eastern = datetime.now(_timezone.utc).replace(tzinfo=tz)
         assert maybe_make_aware(eastern).tzinfo is tz
-        utcnow = datetime.utcnow()
+        utcnow = datetime.utcnow()  # datetime.utcnow() is deprecated in Python 3.12
         assert maybe_make_aware(utcnow, 'UTC').tzinfo is ZoneInfo("UTC")
 
 
@@ -232,17 +232,17 @@ class test_localize:
                 return None  # Mock no utcoffset specified
 
         tz = tzz()
-        assert localize(make_aware(datetime.utcnow(), tz), tz)
+        assert localize(make_aware(datetime.now(_timezone.utc), tz), tz)
 
     @patch('dateutil.tz.datetime_ambiguous')
     def test_when_zoneinfo(self, datetime_ambiguous_mock):
         datetime_ambiguous_mock.return_value = False
         tz = ZoneInfo("US/Eastern")
-        assert localize(make_aware(datetime.utcnow(), tz), tz)
+        assert localize(make_aware(datetime.now(_timezone.utc), tz), tz)
 
         datetime_ambiguous_mock.return_value = True
         tz2 = ZoneInfo("US/Eastern")
-        assert localize(make_aware(datetime.utcnow(), tz2), tz2)
+        assert localize(make_aware(datetime.now(_timezone.utc), tz2), tz2)
 
     @patch('dateutil.tz.datetime_ambiguous')
     def test_when_is_ambiguous(self, datetime_ambiguous_mock):
@@ -256,11 +256,11 @@ class test_localize:
 
         datetime_ambiguous_mock.return_value = False
         tz = tzz()
-        assert localize(make_aware(datetime.utcnow(), tz), tz)
+        assert localize(make_aware(datetime.now(_timezone.utc), tz), tz)
 
         datetime_ambiguous_mock.return_value = True
         tz2 = tzz()
-        assert localize(make_aware(datetime.utcnow(), tz2), tz2)
+        assert localize(make_aware(datetime.now(_timezone.utc), tz2), tz2)
 
     def test_localize_changes_utc_dt(self):
         now_utc_time = datetime.now(tz=ZoneInfo("UTC"))

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -2,7 +2,7 @@ import numbers
 import os
 import signal
 import socket
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from time import monotonic, time
 from unittest.mock import Mock, patch
 
@@ -537,7 +537,7 @@ class test_Request(RequestCase):
 
     def test_revoked_expires_expired(self):
         job = self.get_request(self.mytask.s(1, f='x').set(
-            expires=datetime.utcnow() - timedelta(days=1)
+            expires=datetime.now(timezone.utc) - timedelta(days=1)
         ))
         with self.assert_signal_called(
                 task_revoked, sender=job.task, request=job._context,
@@ -549,7 +549,7 @@ class test_Request(RequestCase):
 
     def test_revoked_expires_not_expired(self):
         job = self.xRequest(
-            expires=datetime.utcnow() + timedelta(days=1),
+            expires=datetime.now(timezone.utc) + timedelta(days=1),
         )
         job.revoked()
         assert job.id not in revoked
@@ -558,7 +558,7 @@ class test_Request(RequestCase):
     def test_revoked_expires_ignore_result(self):
         self.mytask.ignore_result = True
         job = self.xRequest(
-            expires=datetime.utcnow() - timedelta(days=1),
+            expires=datetime.now(timezone.utc) - timedelta(days=1),
         )
         job.revoked()
         assert job.id in revoked


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
### Fix DeprecationWarning: datetime.datetime.utcnow() on Python 3.12
```
lib/python3.12/site-packages/celery/app/base.py:940: DeprecationWarning: datetime.datetime.utcnow()
  is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent
  datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now_in_utc = to_utc(datetime.utcnow())
```
https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow