### PR TITLE
elasticsearch.py: Replace deprecated datetime.utcnow()

### DIFF
--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -1,5 +1,5 @@
 """Elasticsearch result store backend."""
-from datetime import datetime
+from datetime import datetime, timezone
 
 from kombu.utils.encoding import bytes_to_str
 from kombu.utils.url import _parse_url
@@ -129,7 +129,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
         body = {
             'result': value,
             '@timestamp': '{}Z'.format(
-                datetime.utcnow().isoformat()[:-3]
+                datetime.now(timezone.utc).isoformat()[:-9]
             ),
         }
         try:

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -178,13 +178,13 @@ class test_ElasticsearchBackend:
         x._server.index.assert_called_once_with(
             id=sentinel.task_id,
             index=x.index,
-            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'},
+            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-9] + 'Z'},
             params={'op_type': 'create'},
         )
         x._server.update.assert_called_once_with(
             id=sentinel.task_id,
             index=x.index,
-            body={'doc': {'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'}},
+            body={'doc': {'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-9] + 'Z'}},
             params={'if_seq_no': 2, 'if_primary_term': 1}
         )
 
@@ -219,14 +219,14 @@ class test_ElasticsearchBackend:
             id=sentinel.task_id,
             index=x.index,
             doc_type=x.doc_type,
-            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'},
+            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-9] + 'Z'},
             params={'op_type': 'create'},
         )
         x._server.update.assert_called_once_with(
             id=sentinel.task_id,
             index=x.index,
             doc_type=x.doc_type,
-            body={'doc': {'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'}},
+            body={'doc': {'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-9] + 'Z'}},
             params={'if_seq_no': 2, 'if_primary_term': 1}
         )
 
@@ -260,13 +260,13 @@ class test_ElasticsearchBackend:
         x._server.index.assert_called_once_with(
             id=sentinel.task_id,
             index=x.index,
-            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'},
+            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-9] + 'Z'},
             params={'op_type': 'create'},
         )
         x._server.update.assert_called_once_with(
             id=sentinel.task_id,
             index=x.index,
-            body={'doc': {'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'}},
+            body={'doc': {'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-9] + 'Z'}},
             params={'if_seq_no': 2, 'if_primary_term': 1}
         )
 
@@ -305,13 +305,13 @@ class test_ElasticsearchBackend:
         x._server.index.assert_called_once_with(
             id=sentinel.task_id,
             index=x.index,
-            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'},
+            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-9] + 'Z'},
             params={'op_type': 'create'},
         )
         x._server.update.assert_called_once_with(
             id=sentinel.task_id,
             index=x.index,
-            body={'doc': {'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'}},
+            body={'doc': {'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-9] + 'Z'}},
             params={'if_seq_no': 2, 'if_primary_term': 1}
         )
 
@@ -347,7 +347,7 @@ class test_ElasticsearchBackend:
         x._server.index.assert_called_once_with(
             id=sentinel.task_id,
             index=x.index,
-            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'},
+            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-9] + 'Z'},
             params={'op_type': 'create'},
         )
         x._server.update.assert_not_called()
@@ -382,7 +382,7 @@ class test_ElasticsearchBackend:
         x._server.index.assert_called_once_with(
             id=sentinel.task_id,
             index=x.index,
-            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-3] + 'Z'},
+            body={'result': sentinel.result, '@timestamp': expected_dt.isoformat()[:-9] + 'Z'},
             params={'op_type': 'create'},
         )
         x._server.update.assert_not_called()
@@ -455,7 +455,7 @@ class test_ElasticsearchBackend:
                     index=x.index,
                     body={
                         'result': expected_result,
-                        '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                        '@timestamp': expected_dt.isoformat()[:-9] + 'Z'
                     },
                     params={'op_type': 'create'}
                 ),
@@ -464,7 +464,7 @@ class test_ElasticsearchBackend:
                     index=x.index,
                     body={
                         'result': expected_result,
-                        '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                        '@timestamp': expected_dt.isoformat()[:-9] + 'Z'
                     },
                     params={'op_type': 'create'}
                 ),
@@ -476,7 +476,7 @@ class test_ElasticsearchBackend:
                     body={
                         'doc': {
                             'result': expected_result,
-                            '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                            '@timestamp': expected_dt.isoformat()[:-9] + 'Z'
                         }
                     },
                     params={'if_seq_no': 2, 'if_primary_term': 1}
@@ -487,7 +487,7 @@ class test_ElasticsearchBackend:
                     body={
                         'doc': {
                             'result': expected_result,
-                            '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                            '@timestamp': expected_dt.isoformat()[:-9] + 'Z'
                         }
                     },
                     params={'if_seq_no': 3, 'if_primary_term': 1}
@@ -550,7 +550,7 @@ class test_ElasticsearchBackend:
                     index=x.index,
                     body={
                         'result': expected_result,
-                        '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                        '@timestamp': expected_dt.isoformat()[:-9] + 'Z'
                     },
                     params={'op_type': 'create'}
                 ),
@@ -559,7 +559,7 @@ class test_ElasticsearchBackend:
                     index=x.index,
                     body={
                         'result': expected_result,
-                        '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                        '@timestamp': expected_dt.isoformat()[:-9] + 'Z'
                     },
                     params={'op_type': 'create'}
                 ),
@@ -618,7 +618,7 @@ class test_ElasticsearchBackend:
                     index=x.index,
                     body={
                         'result': expected_result,
-                        '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                        '@timestamp': expected_dt.isoformat()[:-9] + 'Z'
                     },
                     params={'op_type': 'create'}
                 ),
@@ -627,7 +627,7 @@ class test_ElasticsearchBackend:
                     index=x.index,
                     body={
                         'result': expected_result,
-                        '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                        '@timestamp': expected_dt.isoformat()[:-9] + 'Z'
                     },
                     params={'op_type': 'create'}
                 ),
@@ -685,7 +685,7 @@ class test_ElasticsearchBackend:
             index=x.index,
             body={
                 'result': expected_result,
-                '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                '@timestamp': expected_dt.isoformat()[:-9] + 'Z'
             },
             params={'op_type': 'create'}
         )
@@ -695,7 +695,7 @@ class test_ElasticsearchBackend:
             body={
                 'doc': {
                     'result': expected_result,
-                    '@timestamp': expected_dt.isoformat()[:-3] + 'Z'
+                    '@timestamp': expected_dt.isoformat()[:-9] + 'Z'
                 }
             },
             params={'if_primary_term': 1, 'if_seq_no': 2}

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -151,7 +151,7 @@ class test_ElasticsearchBackend:
     @patch('celery.backends.elasticsearch.datetime')
     def test_index_conflict(self, datetime_mock):
         expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
-        datetime_mock.utcnow.return_value = expected_dt
+        datetime_mock.now.return_value = expected_dt
 
         x = ElasticsearchBackend(app=self.app)
         x._server = Mock()
@@ -191,7 +191,7 @@ class test_ElasticsearchBackend:
     @patch('celery.backends.elasticsearch.datetime')
     def test_index_conflict_with_doctype(self, datetime_mock):
         expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
-        datetime_mock.utcnow.return_value = expected_dt
+        datetime_mock.now.return_value = expected_dt
 
         x = ElasticsearchBackend(app=self.app)
         x._server = Mock()
@@ -233,7 +233,7 @@ class test_ElasticsearchBackend:
     @patch('celery.backends.elasticsearch.datetime')
     def test_index_conflict_without_state(self, datetime_mock):
         expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
-        datetime_mock.utcnow.return_value = expected_dt
+        datetime_mock.now.return_value = expected_dt
 
         x = ElasticsearchBackend(app=self.app)
         x._server = Mock()
@@ -278,7 +278,7 @@ class test_ElasticsearchBackend:
         As a result, server.update will be called no matter what.
         """
         expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
-        datetime_mock.utcnow.return_value = expected_dt
+        datetime_mock.now.return_value = expected_dt
 
         x = ElasticsearchBackend(app=self.app)
         x._server = Mock()
@@ -318,7 +318,7 @@ class test_ElasticsearchBackend:
     @patch('celery.backends.elasticsearch.datetime')
     def test_index_conflict_with_existing_success(self, datetime_mock):
         expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
-        datetime_mock.utcnow.return_value = expected_dt
+        datetime_mock.now.return_value = expected_dt
 
         x = ElasticsearchBackend(app=self.app)
         x._server = Mock()
@@ -355,7 +355,7 @@ class test_ElasticsearchBackend:
     @patch('celery.backends.elasticsearch.datetime')
     def test_index_conflict_with_existing_ready_state(self, datetime_mock):
         expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
-        datetime_mock.utcnow.return_value = expected_dt
+        datetime_mock.now.return_value = expected_dt
 
         x = ElasticsearchBackend(app=self.app)
         x._server = Mock()
@@ -391,10 +391,10 @@ class test_ElasticsearchBackend:
     @patch('celery.backends.base.datetime')
     def test_backend_concurrent_update(self, base_datetime_mock, es_datetime_mock):
         expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
-        es_datetime_mock.utcnow.return_value = expected_dt
+        es_datetime_mock.now.return_value = expected_dt
 
         expected_done_dt = datetime.datetime(2020, 6, 1, 18, 45, 34, 654321, None)
-        base_datetime_mock.utcnow.return_value = expected_done_dt
+        base_datetime_mock.now.return_value = expected_done_dt
 
         self.app.conf.result_backend_always_retry, prev = True, self.app.conf.result_backend_always_retry
         x_server_get_side_effect = [
@@ -502,10 +502,10 @@ class test_ElasticsearchBackend:
     @patch('celery.backends.base.datetime')
     def test_backend_index_conflicting_document_removed(self, base_datetime_mock, es_datetime_mock):
         expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
-        es_datetime_mock.utcnow.return_value = expected_dt
+        es_datetime_mock.now.return_value = expected_dt
 
         expected_done_dt = datetime.datetime(2020, 6, 1, 18, 45, 34, 654321, None)
-        base_datetime_mock.utcnow.return_value = expected_done_dt
+        base_datetime_mock.now.return_value = expected_done_dt
 
         self.app.conf.result_backend_always_retry, prev = True, self.app.conf.result_backend_always_retry
         try:
@@ -573,10 +573,10 @@ class test_ElasticsearchBackend:
     @patch('celery.backends.base.datetime')
     def test_backend_index_conflicting_document_removed_not_throwing(self, base_datetime_mock, es_datetime_mock):
         expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
-        es_datetime_mock.utcnow.return_value = expected_dt
+        es_datetime_mock.now.return_value = expected_dt
 
         expected_done_dt = datetime.datetime(2020, 6, 1, 18, 45, 34, 654321, None)
-        base_datetime_mock.utcnow.return_value = expected_done_dt
+        base_datetime_mock.now.return_value = expected_done_dt
 
         self.app.conf.result_backend_always_retry, prev = True, self.app.conf.result_backend_always_retry
         try:
@@ -641,10 +641,10 @@ class test_ElasticsearchBackend:
     @patch('celery.backends.base.datetime')
     def test_backend_index_corrupted_conflicting_document(self, base_datetime_mock, es_datetime_mock):
         expected_dt = datetime.datetime(2020, 6, 1, 18, 43, 24, 123456, None)
-        es_datetime_mock.utcnow.return_value = expected_dt
+        es_datetime_mock.now.return_value = expected_dt
 
         expected_done_dt = datetime.datetime(2020, 6, 1, 18, 45, 34, 654321, None)
-        base_datetime_mock.utcnow.return_value = expected_done_dt
+        base_datetime_mock.now.return_value = expected_done_dt
 
         # self.app.conf.result_backend_always_retry, prev = True, self.app.conf.result_backend_always_retry
         # try:


### PR DESCRIPTION
A continuation of #8726
* #8726

% `python3.12`
```
>>> from datetime import datetime, timezone
>>> datetime.now(timezone.utc).isoformat()[:-9], datetime.utcnow().isoformat()[:-3]
<stdin>:1: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal
  in a future version.
    Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
('2023-12-19T21:15:19.935', '2023-12-19T21:15:19.935')
```