### PR TITLE
Remove `new` adjective in docs

### DIFF
--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -50,7 +50,7 @@ schedule manually.
 
 .. admonition:: Django Users
 
-    Celery recommends and is compatible with the new ``USE_TZ`` setting introduced
+    Celery recommends and is compatible with the ``USE_TZ`` setting introduced
     in Django 1.4.
 
     For Django users the time zone specified in the ``TIME_ZONE`` setting


### PR DESCRIPTION
Django 1.4 is not that _new_ nowadays.

Would be also nice to add Django docs inventory to intersphinx mapping so that these settings can be referenced?