### PR TITLE
Updated concurrency docs page.

### DIFF
--- a/docs/userguide/concurrency/index.rst
+++ b/docs/userguide/concurrency/index.rst
@@ -7,8 +7,40 @@
 :Release: |version|
 :Date: |today|
 
+Concurrency in Celery enables the parallel execution of tasks. The default
+model, `prefork`, is well-suited for many scenarios and generally recommended
+for most users.  In fact, switching to another mode will silently disable
+certain features like `soft_timeout` and `max_tasks_per_child`.
+
+This page gives a quick overview of the available options which you can pick
+between using the `--pool` option when starting the worker.
+
+Overview of Concurrency Options
+-------------------------------
+
+- `prefork`: The default option, ideal for CPU-bound tasks and most use cases.
+  It is robust and recommended unless there's a specific need for another model.
+- `eventlet` and `gevent`: Designed for IO-bound tasks, these models use
+  greenlets for high concurrency. Note that certain features, like `soft_timeout`,
+  are not available in these modes.  These have detailed documentation pages
+  linked below.
+- `solo`: Executes tasks sequentially in the main thread.
+- `threads`: Utilizes threading for concurrency, available if the
+  `concurrent.futures` module is present.
+- `custom`: Enables specifying a custom worker pool implementation through
+  environment variables.
+
+For a detailed  look at these options, visit the [Celery Worker Pools
+Overview](https://celery.school/celery-worker-pools).
+
 .. toctree::
     :maxdepth: 2
 
     eventlet
     gevent
+
+.. note::
+    While alternative models like `eventlet` and `gevent` are available, they
+    may lack certain features and are less robust compared to `prefork`. We
+    recommend `prefork` as the starting point unless specific requirements dictate
+    otherwise.

--- a/docs/userguide/concurrency/index.rst
+++ b/docs/userguide/concurrency/index.rst
@@ -30,7 +30,7 @@ Overview of Concurrency Options
 - `custom`: Enables specifying a custom worker pool implementation through
   environment variables.
 
-For a detailed  look at these options, visit the [Celery Worker Pools
+For a detailed look at these options, there is an excellent overview at [Celery Worker Pools
 Overview](https://celery.school/celery-worker-pools).
 
 .. toctree::
@@ -41,6 +41,5 @@ Overview](https://celery.school/celery-worker-pools).
 
 .. note::
     While alternative models like `eventlet` and `gevent` are available, they
-    may lack certain features and are less robust compared to `prefork`. We
-    recommend `prefork` as the starting point unless specific requirements dictate
-    otherwise.
+    may lack certain features compared to `prefork`. We recommend `prefork` as
+    the starting point unless specific requirements dictate otherwise.

--- a/docs/userguide/concurrency/index.rst
+++ b/docs/userguide/concurrency/index.rst
@@ -30,9 +30,6 @@ Overview of Concurrency Options
 - `custom`: Enables specifying a custom worker pool implementation through
   environment variables.
 
-For a detailed look at these options, there is an excellent overview at [Celery Worker Pools
-Overview](https://celery.school/celery-worker-pools).
-
 .. toctree::
     :maxdepth: 2
 


### PR DESCRIPTION
## Description

This is a docs page I wish had existed when I started using celery a couple years ago.  The current page seems to imply your only two choices are `gevent` and `eventlet` and that led me down a path of unnecessary operational pain.

This page is far from comprehensive, but I don't think it's misleading like the current page is.  Also I suspect it's probably a good idea to tell people to stick with prefork unless they have reason not to, especially since other models lack certain features - a fact which AFAICT isn't currently documented at all.
