### PR TITLE
Mark flaky: test_asyncresult_get_cancels_subscription()

### DIFF
--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -540,6 +540,7 @@ class test_task_redis_result_backend:
         new_channels = [channel for channel in get_active_redis_channels() if channel not in channels_before_test]
         assert new_channels == []
 
+    @flaky
     def test_asyncresult_get_cancels_subscription(self, manager):
         channels_before_test = get_active_redis_channels()
 


### PR DESCRIPTION
Marked flaky test to attempt improving CI stability