### PR TITLE
change _read_as_base64 (b64encode returns bytes) on celery/utils/term.py

### DIFF
--- a/celery/utils/term.py
+++ b/celery/utils/term.py
@@ -1,6 +1,5 @@
 """Terminals and colors."""
 import base64
-import codecs
 import os
 import platform
 import sys
@@ -166,9 +165,9 @@ def supports_images():
 
 
 def _read_as_base64(path):
-    with codecs.open(path, mode='rb') as fh:
+    with open(path, mode='rb') as fh:
         encoded = base64.b64encode(fh.read())
-        return encoded if isinstance(encoded, str) else encoded.decode('ascii')
+        return encoded.decode('ascii')
 
 
 def imgcat(path, inline=1, preserve_aspect_ratio=0, **kwargs):

--- a/t/unit/utils/test_term.py
+++ b/t/unit/utils/test_term.py
@@ -1,8 +1,11 @@
+from base64 import b64encode
+from tempfile import NamedTemporaryFile
+
 import pytest
 
 import t.skip
 from celery.utils import term
-from celery.utils.term import colored, fg
+from celery.utils.term import _read_as_base64, colored, fg
 
 
 @t.skip.if_win32
@@ -55,3 +58,15 @@ class test_colored:
         c2 = colored().blue('ƒƒz')
         c3 = c._add(c, c2)
         assert c3 == '\x1b[1;31m\xe5foo\x1b[0m\x1b[1;34m\u0192\u0192z\x1b[0m'
+
+    def test_read_as_base64(self):
+        test_data = b"The quick brown fox jumps over the lazy dog"
+        with NamedTemporaryFile(mode='wb') as temp_file:
+            temp_file.write(test_data)
+            temp_file.seek(0)
+            temp_file_path = temp_file.name
+
+            result = _read_as_base64(temp_file_path)
+            expected_result = b64encode(test_data).decode('ascii')
+
+            assert result == expected_result


### PR DESCRIPTION
Relates to #8755 [comment](https://github.com/celery/celery/pull/8755/files#r1443834780)
