### PR TITLE
Skipping test_tasks::test_task_accepted

### DIFF
--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -418,7 +418,8 @@ class test_tasks:
 
         assert result.status == 'FAILURE'
 
-    @flaky
+    # Requires investigation why it randomly succeeds/fails
+    @pytest.mark.skip(reason="Randomly fails")
     def test_task_accepted(self, manager, sleep=1):
         r1 = sleeping.delay(sleep)
         sleeping.delay(sleep)


### PR DESCRIPTION
The CI needs to be stable.
It appears this test is failing randomly and it’s not clear why nor additional reruns help.

I am skipping it to allow us to maintain a fully 100% deterministic passing CI. It’s not the best option, but we need to trust the CI.