### PR TITLE
Bugfix: Worker not consuming tasks after Redis broker restart

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -122,7 +122,7 @@ jobs:
                   tox --verbose --verbose -e
                   "${{ matrix.python-version }}-integration-${{ matrix.toxenv }}" -vv
 
-  failover:
+  Smoke-failover:
     needs:
     - Integration
     if: needs.Integration.result == 'success'
@@ -160,7 +160,7 @@ jobs:
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k failover
 
-  stamping:
+  Smoke-stamping:
     needs:
     - Integration
     if: needs.Integration.result == 'success'
@@ -198,7 +198,7 @@ jobs:
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k stamping
 
-  canvas:
+  Smoke-canvas:
     needs:
     - Integration
     if: needs.Integration.result == 'success'
@@ -236,7 +236,7 @@ jobs:
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_canvas.py
 
-  consumer:
+  Smoke-consumer:
     needs:
     - Integration
     if: needs.Integration.result == 'success'
@@ -274,7 +274,7 @@ jobs:
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_consumer.py
 
-  control:
+  Smoke-control:
     needs:
     - Integration
     if: needs.Integration.result == 'success'
@@ -312,7 +312,7 @@ jobs:
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_control.py
 
-  signals:
+  Smoke-signals:
     needs:
     - Integration
     if: needs.Integration.result == 'success'
@@ -350,7 +350,7 @@ jobs:
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_signals.py
 
-  tasks:
+  Smoke-tasks:
     needs:
     - Integration
     if: needs.Integration.result == 'success'
@@ -388,7 +388,7 @@ jobs:
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_tasks.py
 
-  thread_safe:
+  Smoke-thread_safe:
     needs:
     - Integration
     if: needs.Integration.result == 'success'
@@ -426,7 +426,7 @@ jobs:
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_thread_safe.py
 
-  worker:
+  Smoke-worker:
     needs:
     - Integration
     if: needs.Integration.result == 'success'


### PR DESCRIPTION
## TL;DR
Between Celery v5.3.0b1 -> v5.3.0b2, a commit was pushed that made a change that caused the infamous Redis bug. This PR reverts the change and adds automatic smoke tests that verify the bug is fixed. This test fails 100% (consistently) before reverting the change and passes 100% (consistently) after reverting the change.

Potentially fixes: #7276, #8091, #8030, #8384
Reverted change: #7925

## Long Story
So, from the community perspective, “somewhere” after v5.2.x Redis reconnection caused the celery worker to stop consuming messages until the worker itself was restarted. This caused a huge headache, and as we lacked the required effort to fix the issue, it remained unhandled so far.
There were quite a few discussions about this bug, many offering attempts to diagnose the issue, others offering their setup where it happened, and possible workarounds. Unfortunately, I lacked the experience to fully understand all of the proposals, etc., but the information was still **very** useful, so I took a different approach to solving this problem.

As the main maintainer of the upcoming pytest-celery plugin [release](https://github.com/celery/pytest-celery/releases/tag/v1.0.0b1), I’ve taken “my baby” for a ride and started looking for the breaking commit, assuming somewhere along the git history, there should be a location where commit X has the bug and X-1 does not.

So I wrote a test that reproduces the bug for every celery version from v5.1.0-Latest
```python
from __future__ import annotations

from time import sleep
from typing import Any

import pytest
import requests
from packaging.version import parse as parse_version
from pytest_celery import CeleryBrokerCluster, CeleryTestSetup, RedisTestBroker, default_worker_container  # noqa

from t.integration.tasks import identity
from t.smoke.workers.dev import SmokeWorkerContainer


class MyWorkerContainer(SmokeWorkerContainer):
    @classmethod
    def worker_queue(cls) -> str:
        return "celery"


@pytest.fixture(scope="session")
def default_worker_container_session_cls() -> type[SmokeWorkerContainer]:
    return MyWorkerContainer


def get_celery_versions(start_version, end_version):
    url = "https://pypi.org/pypi/celery/json"
    response = requests.get(url)
    data = response.json()
    all_versions = data["releases"].keys()

    filtered_versions = [
        v
        for v in all_versions
        if (
            parse_version(start_version)
            <= parse_version(v)
            <= parse_version(end_version)
            and not parse_version(v).is_prerelease
        )
    ]

    return sorted(filtered_versions, key=parse_version)


@pytest.fixture(scope="session", params=get_celery_versions("v5.1.0", "v5.3.6"))
def celery_version(request):
    return request.param


@pytest.fixture(scope="session")
def default_worker_celery_version(celery_version: str) -> str:
    return celery_version


@pytest.fixture
def celery_broker_cluster(celery_redis_broker: RedisTestBroker) -> CeleryBrokerCluster:
    cluster = CeleryBrokerCluster(celery_redis_broker)
    yield cluster
    cluster.teardown()


class test_which_celery_fails:
    def test_worker_consume_tasks_after_redis_broker_restart(
        self,
        celery_setup: CeleryTestSetup,
        celery_version: str,
        subtests: Any,
    ):
        with subtests.test(msg=f"Using Celery v{celery_version}"):
            msg = "Before broker restart"
            res = identity.s(msg).apply_async()
            assert res.get(timeout=10) == msg
            celery_setup.broker.kill()
            sleep(3)
            celery_setup.broker.restart()
            msg = "After broker restart"
            res = identity.s(msg).apply_async()
            assert res.get(timeout=10) == msg
```
Running it with `pytest-xdist` on a 10-CPU machine produced a very nice parallel run:
```bash
pytest -vvvv t/smoke -k test_which_celery_fails -n auto
======================================================================= test session starts =======================================================================
platform darwin -- Python 3.12.1, pytest-7.4.4, pluggy-1.3.0 -- /Users/nusnus/.pyenv/versions/3.12.1/envs/celery_py312/bin/python3.12
cachedir: .pytest_cache
rootdir: /Users/nusnus/dev/GitHub/celery
configfile: pyproject.toml
plugins: docker-tools-3.1.3, timeout-2.2.0, order-1.2.0, click-1.1.0, subtests-0.11.0, rerunfailures-13.0, celery-1.0.0b1, xdist-3.5.0
10 workers [16 items]
scheduling tests via LoadScheduling

t/smoke/tests/tomer/test_which_celery_fails.py::test_which_celery_fails::test_worker_consume_tasks_after_redis_broker_restart[5.2.1-celery_setup_worker-celery_redis_backend]
t/smoke/tests/tomer/test_which_celery_fails.py::test_which_celery_fails::test_worker_consume_tasks_after_redis_broker_restart[5.2.2-celery_setup_worker-celery_redis_backend]
t/smoke/tests/tomer/test_which_celery_fails.py::test_which_celery_fails::test_worker_consume_tasks_after_redis_broker_restart[5.2.3-celery_setup_worker-celery_redis_backend]
t/smoke/tests/tomer/test_which_celery_fails.py::test_which_celery_fails::test_worker_consume_tasks_after_redis_broker_restart[5.1.2-celery_setup_worker-celery_redis_backend]
t/smoke/tests/tomer/test_which_celery_fails.py::test_which_celery_fails::test_worker_consume_tasks_after_redis_broker_restart[5.2.0-celery_setup_worker-celery_redis_backend]
t/smoke/tests/tomer/test_which_celery_fails.py::test_which_celery_fails::test_worker_consume_tasks_after_redis_broker_restart[5.1.1-celery_setup_worker-celery_redis_backend]
t/smoke/tests/tomer/test_which_celery_fails.py::test_which_celery_fails::test_worker_consume_tasks_after_redis_broker_restart[5.2.6-celery_setup_worker-celery_redis_backend]
t/smoke/tests/tomer/test_which_celery_fails.py::test_which_celery_fails::test_worker_consume_tasks_after_redis_broker_restart[5.2.5-celery_setup_worker-celery_redis_backend]
t/smoke/tests/tomer/test_which_celery_fails.py::test_which_celery_fails::test_worker_consume_tasks_after_redis_broker_restart[5.1.0-celery_setup_worker-celery_redis_backend]
t/smoke/tests/tomer/test_which_celery_fails.py::test_which_celery_fails::test_worker_consume_tasks_after_redis_broker_restart[5.2.4-celery_setup_worker-celery_redis_backend]
...
```

This allowed me to prove the bug exists and where it starts, which is correlated with the reports in the relevant issues.
So for the next step, I’ve modified the test to search on a deeper level, reproducing the bug on every commit between the passing version (v5.2.7) and the failing version (5.3.0).

```Dockerfile
FROM python:3.10-bookworm

# Create a user to run the worker
RUN adduser --disabled-password --gecos "" test_user

# Install system dependencies
RUN apt-get update && apt-get install -y build-essential git

# Set arguments
ARG CELERY_VERSION="HEAD"
ARG CELERY_LOG_LEVEL=INFO
ARG CELERY_WORKER_NAME=my_worker
ARG CELERY_WORKER_QUEUE=celery
ENV LOG_LEVEL=$CELERY_LOG_LEVEL
ENV WORKER_NAME=$CELERY_WORKER_NAME
ENV WORKER_QUEUE=$CELERY_WORKER_QUEUE

# Install packages
WORKDIR /src

RUN pip install --no-cache-dir --upgrade pip \
    && pip install pytest-celery==1.0.0b1
RUN git clone https://github.com/celery/celery.git

WORKDIR /src/celery

RUN git reset --hard $CELERY_VERSION
RUN pip install -e .

# The workdir must be /app
WORKDIR /app

# Switch to the test_user
USER test_user

# Start the celery worker
CMD celery -A app worker --loglevel=$LOG_LEVEL -n $WORKER_NAME@%h -Q $WORKER_QUEUE
```
```python
from __future__ import annotations

import subprocess
from time import sleep
from typing import Any

import pytest
from pytest_celery import (CeleryBrokerCluster, CeleryTestSetup, CeleryTestWorker, CeleryWorkerCluster,
                           CeleryWorkerContainer, RedisTestBroker, defaults)
from pytest_docker_tools import build, container, fxtr

from celery import Celery
from t.integration.tasks import identity


def get_commit_hashes(start_tag: str, end_tag: str) -> list[str]:
    cmd = ["git", "rev-list", f"{start_tag}..{end_tag}"]
    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
    return result.stdout.strip().split("\n")


# Requires running with pytest-xdist to trigger multiple docker build and avoid cached build for all params
@pytest.fixture(scope="session", params=get_commit_hashes("v5.2.7", "v5.3.0"))
# @pytest.fixture(
#     scope="session",
#     params=[
#         "029262fabe50dc941626bfa2a1727f6619e4c31f",
#         "24ac092e07403191002d700a8fad1bf5aa498138",
#         "0233c3b674dcfc6fff79f4161ca9a818dabf28e7"  # BUG!
#     ],
# )
def celery_commit(request):
    return request.param


class DetachedHeadWorkerContainer(CeleryWorkerContainer):
    @classmethod
    def version(cls) -> str:
        return fxtr("celery_commit")


celery_detached_head_worker_image = build(
    path=".",
    dockerfile="t/smoke/tests/tomer/Dockerfile",
    buildargs=DetachedHeadWorkerContainer.buildargs(),
)


celery_detached_head_worker_container = container(
    image="{celery_detached_head_worker_image.id}",
    environment=fxtr("default_worker_env"),
    network="{default_pytest_celery_network.name}",
    volumes={"{default_worker_volume.name}": defaults.DEFAULT_WORKER_VOLUME},
    wrapper_class=DetachedHeadWorkerContainer,
    timeout=defaults.DEFAULT_WORKER_CONTAINER_TIMEOUT,
)


@pytest.fixture
def celery_detached_head_worker(
    celery_detached_head_worker_container: DetachedHeadWorkerContainer,
    celery_setup_app: Celery,
) -> CeleryTestWorker:
    worker = CeleryTestWorker(
        celery_detached_head_worker_container, app=celery_setup_app
    )
    yield worker
    worker.teardown()


@pytest.fixture
def celery_worker_cluster(
    celery_detached_head_worker: CeleryTestWorker,
) -> CeleryWorkerCluster:
    cluster = CeleryWorkerCluster(celery_detached_head_worker)
    yield cluster
    cluster.teardown()


@pytest.fixture
def celery_broker_cluster(celery_redis_broker: RedisTestBroker) -> CeleryBrokerCluster:
    cluster = CeleryBrokerCluster(celery_redis_broker)
    yield cluster
    cluster.teardown()


class test_which_commit_fail:
    def test_worker_consume_tasks_after_redis_broker_restart(
        self,
        celery_setup: CeleryTestSetup,
        celery_commit: str,
        subtests: Any,
    ):
        with subtests.test(msg=f"Using Celery commit: {celery_commit}"):
            msg = "Before broker restart"
            res = identity.s(msg).apply_async()
            assert res.get(timeout=10) == msg
            celery_setup.broker.kill()
            sleep(3)
            celery_setup.broker.restart()
            msg = "After broker restart"
            res = identity.s(msg).apply_async()
            assert res.get(timeout=10) == msg
```
```bash
pytest -vvvv t/smoke -k test_which_commit_fail -n auto
======================================================================= test session starts =======================================================================
platform darwin -- Python 3.12.1, pytest-7.4.4, pluggy-1.3.0 -- /Users/nusnus/.pyenv/versions/3.12.1/envs/celery_py312/bin/python3.12
cachedir: .pytest_cache
rootdir: /Users/nusnus/dev/GitHub/celery
configfile: pyproject.toml
plugins: docker-tools-3.1.3, timeout-2.2.0, order-1.2.0, click-1.1.0, subtests-0.11.0, rerunfailures-13.0, celery-1.0.0b1, xdist-3.5.0
10 workers [410 items]
scheduling tests via LoadScheduling

t/smoke/tests/tomer/test_which_commit_fail.py::test_which_commit_fail::test_worker_consume_tasks_after_redis_broker_restart[50d4c0b07a8aa5f079b7e3fdc5e765b77ea391fa-celery_redis_backend]
t/smoke/tests/tomer/test_which_commit_fail.py::test_which_commit_fail::test_worker_consume_tasks_after_redis_broker_restart[fe891a6c79f4eb476e6d588a39fb686f05f85ac5-celery_redis_backend]
t/smoke/tests/tomer/test_which_commit_fail.py::test_which_commit_fail::test_worker_consume_tasks_after_redis_broker_restart[631ad8e1358b79c88513c49229e757e5a624618c-celery_redis_backend]
t/smoke/tests/tomer/test_which_commit_fail.py::test_which_commit_fail::test_worker_consume_tasks_after_redis_broker_restart[1baca0ca90b5bd7f38e3d2ae2d513f24cc0613ea-celery_redis_backend]
t/smoke/tests/tomer/test_which_commit_fail.py::test_which_commit_fail::test_worker_consume_tasks_after_redis_broker_restart[0e92577eb1b5358c3bd4ebc7a5e880508481f981-celery_redis_backend]
t/smoke/tests/tomer/test_which_commit_fail.py::test_which_commit_fail::test_worker_consume_tasks_after_redis_broker_restart[525f90e4dafd153e7cd8cc0fb921c24a7f45eca0-celery_redis_backend]
t/smoke/tests/tomer/test_which_commit_fail.py::test_which_commit_fail::test_worker_consume_tasks_after_redis_broker_restart[c6b54074514b14b5b7b3d8e6a4885fc1699a3e39-celery_redis_backend]
t/smoke/tests/tomer/test_which_commit_fail.py::test_which_commit_fail::test_worker_consume_tasks_after_redis_broker_restart[ed71ebb2addd0579e2f64e15e9d44ec7a1e31434-celery_redis_backend]
t/smoke/tests/tomer/test_which_commit_fail.py::test_which_commit_fail::test_worker_consume_tasks_after_redis_broker_restart[5d3ec7c7c8420f6c07d7e280b486647a373ba208-celery_redis_backend]
t/smoke/tests/tomer/test_which_commit_fail.py::test_which_commit_fail::test_worker_consume_tasks_after_redis_broker_restart[a80da3965fefcf9c7638c0a264314cd194a71d1f-celery_redis_backend]
...
```

Of course, it took some playing around and debugging because `pytest-xdist` does not sort the runs according to the git history, but it was good enough to pinpoint the bugged commit.

I verified it again with a more specific range:
```python
@pytest.fixture(
    scope="session",
    params=[
        "029262fabe50dc941626bfa2a1727f6619e4c31f",
        "24ac092e07403191002d700a8fad1bf5aa498138",
        "0233c3b674dcfc6fff79f4161ca9a818dabf28e7"  # BUG!
    ],
)
```
Git History
```bash
* 0233c3b67 - Add annotations to minimise differences with celery-aio-pool's tracer.py. (#7925) (1 year ago) <ShaheedHaque>
* 24ac092e0 - Scheduled weekly dependency update for week 01 (#7987) (1 year ago) <pyup.io bot>
* 029262fab - [pre-commit.ci] pre-commit autoupdate (1 year, 1 month ago) <pre-commit-ci[bot]>
```

Unfortunately, I still cannot explain 100% what happened, but due to the urgency of giving an answer to the community, and due to the lack of any other proper solution, and based on a functional smoke test, I am declaring this as the current fix until proven otherwise.