### PR TITLE
Limit moto to <5.0.0 until the breaking issues are fixed

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@ pytest-timeout==2.2.0
 pytest-click==1.1.0
 pytest-order==1.2.0
 boto3>=1.26.143
-moto>=4.1.11
+moto>=4.1.11,<5.0.0
 # typing extensions
 mypy==1.8.0; platform_python_implementation=="CPython"
 pre-commit==3.5.0


### PR DESCRIPTION
Yesterday, [v5.0.0](https://github.com/getmoto/moto/releases/tag/5.0.0) was released, which introduces an import error.
Limiting to below this version to return stability until it can receive focus for fixing.