### PR TITLE
Sync kombu versions in requirements and setup.cfg

### DIFF
--- a/requirements/extras/sqs.txt
+++ b/requirements/extras/sqs.txt
@@ -1,4 +1,4 @@
 boto3>=1.26.143
 pycurl>=7.43.0.5; sys_platform != 'win32' and platform_python_implementation=="CPython"
 urllib3>=1.26.16
-kombu[sqs]>=5.3.0
+kombu[sqs]>=5.3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ per-file-ignores =
 requires = backports.zoneinfo>=0.2.1;python_version<'3.9'
            tzdata>=2022.7
            billiard >=4.1.0,<5.0
-           kombu >= 5.3.2,<6.0.0
+           kombu >= 5.3.4,<6.0.0
 
 [bdist_wheel]
 universal = 0


### PR DESCRIPTION
## Description

```
% pip check
celery 5.3.6 has requirement kombu<6.0,>=5.3.4, but you have kombu 5.3.2.
```
Arch Linux currently ships `kombu 5.3.2` and I believe that's because the version in `setup.cfg` was not updated when it [was updated in requirements](https://github.com/celery/celery/pull/8646).

I also took the liberty to update the version in `sqs.txt` because it kind of makes sense that `sqs.txt` needs it if the fix was for SQS. But I'm not familiar with how these dependencies are structured, so might be wrong on that.

This could've been just a bug report, but if I can fix it right away, that's even better. Feel free to close/edit the PR if I do something terribly wrong here 🙂