### PR TITLE
Docfix: pip install celery[sqs] -> pip install "celery[sqs]"

### DIFF
--- a/docs/getting-started/backends-and-brokers/sqs.rst
+++ b/docs/getting-started/backends-and-brokers/sqs.rst
@@ -15,7 +15,7 @@ the ``celery[sqs]`` :ref:`bundle <bundles>`:
 
 .. code-block:: console
 
-    $ pip install celery[sqs]
+    $ pip install "celery[sqs]"
 
 .. _broker-sqs-configuration:
 


### PR DESCRIPTION
Fixes #8809