### PR TITLE
Support moto 5.0

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@ pytest-timeout==2.2.0
 pytest-click==1.1.0
 pytest-order==1.2.0
 boto3>=1.26.143
-moto>=4.1.11,<5.0.0
+moto>=4.1.11,<5.1.0
 # typing extensions
 mypy==1.8.0; platform_python_implementation=="CPython"
 pre-commit==3.5.0

--- a/t/unit/backends/test_s3.py
+++ b/t/unit/backends/test_s3.py
@@ -3,7 +3,11 @@ from unittest.mock import patch
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from moto import mock_s3
+
+try:
+    from moto import mock_aws
+except ImportError:
+    from moto import mock_s3 as mock_aws
 
 from celery import states
 from celery.backends.s3 import S3Backend
@@ -84,7 +88,7 @@ class test_S3Backend:
             's3', endpoint_url=endpoint_url)
 
     @pytest.mark.parametrize("key", ['uuid', b'uuid'])
-    @mock_s3
+    @mock_aws
     def test_set_and_get_a_key(self, key):
         self._mock_s3_resource()
 
@@ -97,7 +101,7 @@ class test_S3Backend:
 
         assert s3_backend.get(key) == 'another_status'
 
-    @mock_s3
+    @mock_aws
     def test_set_and_get_a_result(self):
         self._mock_s3_resource()
 
@@ -111,7 +115,7 @@ class test_S3Backend:
         value = s3_backend.get_result('foo')
         assert value == 'baar'
 
-    @mock_s3
+    @mock_aws
     def test_get_a_missing_key(self):
         self._mock_s3_resource()
 
@@ -141,7 +145,7 @@ class test_S3Backend:
             s3_backend.get('uuidddd')
 
     @pytest.mark.parametrize("key", ['uuid', b'uuid'])
-    @mock_s3
+    @mock_aws
     def test_delete_a_key(self, key):
         self._mock_s3_resource()
 
@@ -157,7 +161,7 @@ class test_S3Backend:
 
         assert s3_backend.get(key) is None
 
-    @mock_s3
+    @mock_aws
     def test_with_a_non_existing_bucket(self):
         self._mock_s3_resource()
 


### PR DESCRIPTION
## Description

moto 5.0 has been released, and the major change is to pull all of the seperate mock calls into one -- mock_aws. Continue to support moto 4, since it's easy to do so.