### PR TITLE
Another fix for `link_error` signatures being `dict`s instead of `Signature`s

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -722,7 +722,7 @@ class Signature(dict):
         """
         return self.append_to_list_option('link', callback)
 
-    def link_error(self, errback):
+    (self, errback):
         """Add callback task to be applied on error in task execution.
 
         Returns:
@@ -1674,7 +1674,7 @@ class group(Signature):
         # We return a concretised tuple of the signatures actually applied to
         # each child task signature, of which there might be none!
         sig = maybe_signature(sig)
-        
+
         return tuple(child_task.link_error(sig.clone(immutable=True)) for child_task in self.tasks)
 
     def _prepared(self, tasks, partial_args, group_id, root_id, app,

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1673,6 +1673,8 @@ class group(Signature):
         #
         # We return a concretised tuple of the signatures actually applied to
         # each child task signature, of which there might be none!
+        sig = maybe_signature(sig)
+        
         return tuple(child_task.link_error(sig.clone(immutable=True)) for child_task in self.tasks)
 
     def _prepared(self, tasks, partial_args, group_id, root_id, app,

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -722,7 +722,7 @@ class Signature(dict):
         """
         return self.append_to_list_option('link', callback)
 
-    (self, errback):
+    def link_error(self, errback):
         """Add callback task to be applied on error in task execution.
 
         Returns:

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -873,7 +873,7 @@ class test_group(CanvasCase):
         g1 = group(Mock(name='t1'), Mock(name='t2'), app=self.app)
         errback = signature('tcb')
         errback_dict = dict(errback)
-        x.link_error(errback_dict)
+        g1.link_error(errback_dict)
         # We expect that all group children will be given the errback to ensure
         # it gets called
         for child_sig in g1.tasks:

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -869,6 +869,16 @@ class test_group(CanvasCase):
         for child_sig in g1.tasks:
             child_sig.link_error.assert_called_with(sig.clone(immutable=True))
 
+    def test_link_error_with_dict_sig(self):
+        g1 = group(Mock(name='t1'), Mock(name='t2'), app=self.app)
+        errback = signature('tcb')
+        errback_dict = dict(errback)
+        x.link_error(errback_dict)
+        # We expect that all group children will be given the errback to ensure
+        # it gets called
+        for child_sig in g1.tasks:
+            child_sig.link_error.assert_called_with(errback.clone(immutable=True))
+
     def test_apply_empty(self):
         x = group(app=self.app)
         x.apply()


### PR DESCRIPTION
Related to https://github.com/celery/celery/issues/8678

Fix for https://github.com/celery/celery/issues/8840

## Description

The most recent release ([v5.4.0rc1](https://github.com/celery/celery/releases/tag/v5.4.0rc1)) includes https://github.com/celery/celery/pull/8702, which fixes an issue where the signature can be a `dict` in the case of a `chord.link_error()`. I don't know enough about Celery to know what the causes the different code paths, but the fix is almost exactly the same as the earlier PR, just for `group.link_error()`.