### PR TITLE
Update contributing guide to use ssh upstream url

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -423,7 +423,7 @@ to upstream changes:
 .. code-block:: console
 
     $ cd celery
-    $ git remote add upstream git://github.com/celery/celery.git
+    $ git remote add upstream git@github.com:celery/celery.git
     $ git fetch upstream
 
 If you need to pull in new changes from upstream you should


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

This commit updates the Contributing section to use the ssh url for the upstream repository rather than git. From my experience, using the git url results in an `Operation timed out` error while the ssh url works without issue.
