### PR TITLE
Fix typos and grammar

### DIFF
--- a/.github/ISSUE_TEMPLATE/Enhancement.md
+++ b/.github/ISSUE_TEMPLATE/Enhancement.md
@@ -22,7 +22,7 @@ To check an item on the list replace [ ] with [x].
 - [ ] I have checked the [pull requests list](https://github.com/celery/celery/pulls?q=is%3Apr+label%3A%22Issue+Type%3A+Enhancement%22+-label%3A%22Category%3A+Documentation%22)
   for existing proposed enhancements.
 - [ ] I have checked the [commit log](https://github.com/celery/celery/commits/main)
-  to find out if the if the same enhancement was already implemented in the
+  to find out if the same enhancement was already implemented in the
   main branch.
 - [ ] I have included all related issues and possible duplicate issues in this issue
       (If there are none, check this box anyway).

--- a/celery/backends/filesystem.py
+++ b/celery/backends/filesystem.py
@@ -50,7 +50,7 @@ class FilesystemBackend(KeyValueStoreBackend):
         self.open = open
         self.unlink = unlink
 
-        # Lets verify that we've everything setup right
+        # Let's verify that we've everything setup right
         self._do_directory_test(b'.fs-backend-' + uuid().encode(encoding))
 
     def __reduce__(self, args=(), kwargs=None):

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -222,7 +222,7 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
 
     def on_out_of_band_result(self, task_id, message):
         # Callback called when a reply for a task is received,
-        # but we have no idea what do do with it.
+        # but we have no idea what to do with it.
         # Since the result is not pending, we put it in a separate
         # buffer: probably it will become pending later.
         if self.result_consumer:

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -396,7 +396,7 @@ class Signature(dict):
         else:
             args, kwargs, options = self.args, self.kwargs, self.options
         # pylint: disable=too-many-function-args
-        #   Borks on this, as it's a property
+        #   Works on this, as it's a property
         return _apply(args, kwargs, **options)
 
     def _merge(self, args=None, kwargs=None, options=None, force=False):
@@ -515,7 +515,7 @@ class Signature(dict):
         if group_index is not None:
             opts['group_index'] = group_index
         # pylint: disable=too-many-function-args
-        #   Borks on this, as it's a property.
+        #   Works on this, as it's a property.
         return self.AsyncResult(tid)
 
     _freeze = freeze

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -194,7 +194,7 @@ def iterate_file_descriptors_safely(fds_iter, source_data,
     or possibly other reasons, so safely manage our lists of FDs.
     :param fds_iter: the file descriptors to iterate and apply hub_method
     :param source_data: data source to remove FD if it renders OSError
-    :param hub_method: the method to call with with each fd and kwargs
+    :param hub_method: the method to call with each fd and kwargs
     :*args to pass through to the hub_method;
     with a special syntax string '*fd*' represents a substitution
     for the current fd object in the iteration (for some callers).

--- a/t/unit/app/test_backends.py
+++ b/t/unit/app/test_backends.py
@@ -48,7 +48,7 @@ def embed_worker(app,
     Helper embedded worker for testing.
 
     It's based on a :func:`celery.contrib.testing.worker.start_worker`,
-    but doesn't modifies logging settings and additionally shutdown
+    but doesn't modify logging settings and additionally shutdown
     worker pool.
     """
     # prepare application for worker

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -1171,7 +1171,7 @@ class test_RedisBackend_chords_complex(basetest_RedisBackend):
         self.b.client.lrange.assert_not_called()
         # Confirm that the `GroupResult.restore` mock was called
         complex_header_result.assert_called_once_with(request.group)
-        # Confirm the the callback was called with the `join()`ed group result
+        # Confirm that the callback was called with the `join()`ed group result
         if supports_native_join:
             expected_join = mock_result_obj.join_native
         else:

--- a/t/unit/conftest.py
+++ b/t/unit/conftest.py
@@ -106,7 +106,7 @@ def reset_cache_backend_state(celery_app):
 
 @contextmanager
 def assert_signal_called(signal, **expected):
-    """Context that verifes signal is called before exiting."""
+    """Context that verifies signal is called before exiting."""
     handler = Mock()
 
     def on_call(**kwargs):

--- a/t/unit/contrib/test_worker.py
+++ b/t/unit/contrib/test_worker.py
@@ -28,7 +28,7 @@ class test_worker:
         })
 
         # to avoid changing the root logger level to ERROR,
-        # we have we have to set both app.log.loglevel start_worker arg to 0
+        # we have to set both app.log.loglevel start_worker arg to 0
         # (see celery.app.log.setup_logging_subsystem)
         self.app.log.loglevel = 0
 


### PR DESCRIPTION
## Description

I found some typos and also a couple of grammar errors in the documentation and code comments.
