### PR TITLE
Update README to Include FastAPI in Framework Integration Section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,8 @@ integration packages:
     +--------------------+------------------------+
     | `Tornado`_         | `tornado-celery`_      |
     +--------------------+------------------------+
+    | `FastAPI`_         | not needed             |
+    +--------------------+------------------------+
 
 The integration packages aren't strictly necessary, but they can make
 development easier, and sometimes they add important hooks like closing
@@ -217,6 +219,7 @@ database connections at ``fork``.
 .. _`web2py-celery`: https://code.google.com/p/web2py-celery/
 .. _`Tornado`: https://www.tornadoweb.org/
 .. _`tornado-celery`: https://github.com/mher/tornado-celery/
+.. _`FastAPI`: https://fastapi.tiangolo.com/
 
 .. _celery-documentation:
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description
This Pull Request updates the "Framework Integration" section of the README to include [FastAPI](https://fastapi.tiangolo.com/), a popular (> 70.9k ⭐) and fast-growing asynchronous web framework. This addition reflects Celery's compatibility with FastAPI and indicates to users that no special integration package is needed to use Celery with FastAPI.

#### Changes Made:
Added a new row in the integration table for FastAPI, marked as "not needed" for any special integration package. This aligns with the entries for other frameworks like Django and Flask where no specific Celery integration package is required.

--
This update ensures the README remains current and informative, particularly for developers exploring asynchronous frameworks compatible with Celery. By explicitly listing FastAPI, we aim to assist in clearer framework choices for Celery users, especially given FastAPI's growing popularity and frequent use in modern web applications.

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
