### PR TITLE
fix: bump eventlet to support more python version

### DIFF
--- a/requirements/extras/eventlet.txt
+++ b/requirements/extras/eventlet.txt
@@ -1,1 +1,1 @@
-eventlet>=0.34
+eventlet>=0.36.1

--- a/requirements/extras/eventlet.txt
+++ b/requirements/extras/eventlet.txt
@@ -1,1 +1,1 @@
-eventlet>=0.32.0; python_version<"3.10"
+eventlet>=0.34.0

--- a/requirements/extras/eventlet.txt
+++ b/requirements/extras/eventlet.txt
@@ -1,1 +1,1 @@
-eventlet>=0.34.0
+eventlet>=0.34

--- a/requirements/extras/eventlet.txt
+++ b/requirements/extras/eventlet.txt
@@ -1,1 +1,1 @@
-eventlet>=0.36.1
+eventlet>=0.36.1; python_version<"3.10"


### PR DESCRIPTION
Hi :wave:

I submit a PR to bump the extra `eventlet` requirement.

It's seems that the `python_version<"3.10"` condition where added in https://github.com/celery/celery/pull/6807, with the commit https://github.com/celery/celery/pull/6807/commits/914c6cd470d5057e6519521671cb5171f116c65c, 3 years ago.

The message of the commit was `"Currently, eventlet is not supported by 3.10."`.

So now, the `eventlet` package support python from 3.7 to 3.12 (ref: https://github.com/eventlet/eventlet/tree/v0.34.0?tab=readme-ov-file#supported-python-versions).