### PR TITLE
security: SecureSerializer: support generic low-level serializers

### DIFF
--- a/celery/security/serialization.py
+++ b/celery/security/serialization.py
@@ -29,7 +29,8 @@ class SecureSerializer:
         assert self._cert is not None
         with reraise_errors('Unable to serialize: {0!r}', (Exception,)):
             content_type, content_encoding, body = dumps(
-                bytes_to_str(data), serializer=self._serializer)
+                data, serializer=self._serializer)
+
             # What we sign is the serialized body, not the body itself.
             # this way the receiver doesn't have to decode the contents
             # to verify the signature (and thus avoiding potential flaws
@@ -48,7 +49,7 @@ class SecureSerializer:
                                        payload['signer'],
                                        payload['body'])
             self._cert_store[signer].verify(body, signature, self._digest)
-        return loads(bytes_to_str(body), payload['content_type'],
+        return loads(body, payload['content_type'],
                      payload['content_encoding'], force=True)
 
     def _pack(self, body, content_type, content_encoding, signer, signature,
@@ -84,7 +85,7 @@ class SecureSerializer:
             'signature': signature,
             'content_type': bytes_to_str(v[0]),
             'content_encoding': bytes_to_str(v[1]),
-            'body': bytes_to_str(v[2]),
+            'body': v[2],
         }
 
 

--- a/t/unit/security/test_serialization.py
+++ b/t/unit/security/test_serialization.py
@@ -16,15 +16,19 @@ from .case import SecurityCase
 
 class test_secureserializer(SecurityCase):
 
-    def _get_s(self, key, cert, certs):
+    def _get_s(self, key, cert, certs, serializer="json"):
         store = CertStore()
         for c in certs:
             store.add_cert(Certificate(c))
-        return SecureSerializer(PrivateKey(key), Certificate(cert), store)
+        return SecureSerializer(
+            PrivateKey(key), Certificate(cert), store, serializer=serializer
+        )
 
-    def test_serialize(self):
-        s = self._get_s(KEY1, CERT1, [CERT1])
-        assert s.deserialize(s.serialize('foo')) == 'foo'
+    @pytest.mark.parametrize("data", [1, "foo", b"foo", {"foo": 1}])
+    @pytest.mark.parametrize("serializer", ["json", "pickle"])
+    def test_serialize(self, data, serializer):
+        s = self._get_s(KEY1, CERT1, [CERT1], serializer=serializer)
+        assert s.deserialize(s.serialize(data)) == data
 
     def test_deserialize(self):
         s = self._get_s(KEY1, CERT1, [CERT1])


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Fixes #8981

This PR adds 'data_type' as a new field to the  metadata that is saved as part of `SecuredSerializer`  serialization.
This info enable us to encode/decode the original data, in order to be fit to the expected input of our serializer, without the need to assume its type when decoding (for example, today there is assumption that if the decided value is `bytes`, then the original data was of type `string`. This assumption also breaks other serializers that outputs 'binary' format, such as `pickle`.