### PR TITLE
don't kill if pid same as file (#8997) (#8998)

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -188,6 +188,7 @@ class Pidfile:
             return True
         if pid == os.getpid():
             # this can be common in k8s pod with PID of 1 - don't kill
+            self.remove()
             return True
 
         try:

--- a/t/unit/utils/test_platforms.py
+++ b/t/unit/utils/test_platforms.py
@@ -696,7 +696,7 @@ class test_Pidfile:
         p.remove = Mock()
 
         assert p.remove_if_stale()
-        p.remove.assert_not_called()
+        p.remove.assert_called_with()
 
     @patch('os.fsync')
     @patch('os.getpid')


### PR DESCRIPTION
The pid file needs to be deleted.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
