### PR TITLE
SecuritySerializer: ensure pack separator will not be conflicted with serialized fields

### DIFF
--- a/celery/security/serialization.py
+++ b/celery/security/serialization.py
@@ -55,37 +55,20 @@ class SecureSerializer:
     def _pack(self, body, content_type, content_encoding, signer, signature,
               sep=str_to_bytes('\x00\x01')):
         fields = sep.join(
-            ensure_bytes(s) for s in [signer, signature, content_type,
-                                      content_encoding, body]
+            ensure_bytes(s) for s in [b64encode(signer), b64encode(signature),
+                                      content_type, content_encoding, body]
         )
         return b64encode(fields)
 
     def _unpack(self, payload, sep=str_to_bytes('\x00\x01')):
         raw_payload = b64decode(ensure_bytes(payload))
-        first_sep = raw_payload.find(sep)
-
-        signer = raw_payload[:first_sep]
-        signer_cert = self._cert_store[signer]
-
-        # shift 3 bits right to get signature length
-        # 2048bit rsa key has a signature length of 256
-        # 4096bit rsa key has a signature length of 512
-        sig_len = signer_cert.get_pubkey().key_size >> 3
-        sep_len = len(sep)
-        signature_start_position = first_sep + sep_len
-        signature_end_position = signature_start_position + sig_len
-        signature = raw_payload[
-            signature_start_position:signature_end_position
-        ]
-
-        v = raw_payload[signature_end_position + sep_len:].split(sep)
-
+        v = raw_payload.split(sep, maxsplit=4)
         return {
-            'signer': signer,
-            'signature': signature,
-            'content_type': bytes_to_str(v[0]),
-            'content_encoding': bytes_to_str(v[1]),
-            'body': v[2],
+            'signer': b64decode(v[0]),
+            'signature': b64decode(v[1]),
+            'content_type': bytes_to_str(v[2]),
+            'content_encoding': bytes_to_str(v[3]),
+            'body': v[4],
         }
 
 

--- a/celery/security/serialization.py
+++ b/celery/security/serialization.py
@@ -11,6 +11,11 @@ from .utils import get_digest_algorithm, reraise_errors
 
 __all__ = ('SecureSerializer', 'register_auth')
 
+# Note: we guarantee that this value won't appear in the serialized data,
+# so we can use it as a separator.
+# If you change this value, make sure it's not present in the serialized data.
+DEFAULT_SEPARATOR = str_to_bytes("\x00\x01")
+
 
 class SecureSerializer:
     """Signed serializer."""
@@ -53,14 +58,14 @@ class SecureSerializer:
                      payload['content_encoding'], force=True)
 
     def _pack(self, body, content_type, content_encoding, signer, signature,
-              sep=str_to_bytes('\x00\x01')):
+              sep=DEFAULT_SEPARATOR):
         fields = sep.join(
             ensure_bytes(s) for s in [b64encode(signer), b64encode(signature),
                                       content_type, content_encoding, body]
         )
         return b64encode(fields)
 
-    def _unpack(self, payload, sep=str_to_bytes('\x00\x01')):
+    def _unpack(self, payload, sep=DEFAULT_SEPARATOR):
         raw_payload = b64decode(ensure_bytes(payload))
         v = raw_payload.split(sep, maxsplit=4)
         return {

--- a/t/unit/security/test_serialization.py
+++ b/t/unit/security/test_serialization.py
@@ -8,7 +8,7 @@ from kombu.utils.encoding import bytes_to_str
 from celery.exceptions import SecurityError
 from celery.security.certificate import Certificate, CertStore
 from celery.security.key import PrivateKey
-from celery.security.serialization import SecureSerializer, register_auth
+from celery.security.serialization import DEFAULT_SEPARATOR, SecureSerializer, register_auth
 
 from . import CERT1, CERT2, KEY1, KEY2
 from .case import SecurityCase
@@ -24,7 +24,9 @@ class test_secureserializer(SecurityCase):
             PrivateKey(key), Certificate(cert), store, serializer=serializer
         )
 
-    @pytest.mark.parametrize("data", [1, "foo", b"foo", {"foo": 1}, {"foo": "\x00\x01"}])
+    @pytest.mark.parametrize(
+        "data", [1, "foo", b"foo", {"foo": 1}, {"foo": DEFAULT_SEPARATOR}]
+    )
     @pytest.mark.parametrize("serializer", ["json", "pickle"])
     def test_serialize(self, data, serializer):
         s = self._get_s(KEY1, CERT1, [CERT1], serializer=serializer)

--- a/t/unit/security/test_serialization.py
+++ b/t/unit/security/test_serialization.py
@@ -24,7 +24,7 @@ class test_secureserializer(SecurityCase):
             PrivateKey(key), Certificate(cert), store, serializer=serializer
         )
 
-    @pytest.mark.parametrize("data", [1, "foo", b"foo", {"foo": 1}])
+    @pytest.mark.parametrize("data", [1, "foo", b"foo", {"foo": 1}, {"foo": "\x00\x01"}])
     @pytest.mark.parametrize("serializer", ["json", "pickle"])
     def test_serialize(self, data, serializer):
         s = self._get_s(KEY1, CERT1, [CERT1], serializer=serializer)


### PR DESCRIPTION

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

This PR fixes a bug in `SecuritySerializer` module, where the serialized data may contain the value of the `sep` used to distinguish between the serialized fields. In that case, the fields split will be incorrect and the signature verify will fail.
Here, I encode binary values to base64, to prevent the data will contain the  separator
