### PR TITLE
Added -vv to unit, integration and smoke tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,9 +43,9 @@ deps=
     bandit: bandit
 
 commands =
-    unit: pytest --maxfail=10 --capture=no -v --cov=celery --cov-report=xml --cov-report term {posargs}
-    integration: pytest -xsv t/integration {posargs}
-    smoke: pytest -xsv t/smoke --dist=loadscope --reruns 10 --reruns-delay 60 --rerun-except AssertionError {posargs}
+    unit: pytest -vv --maxfail=10 --capture=no -v --cov=celery --cov-report=xml --cov-report term {posargs}
+    integration: pytest -xsvv t/integration {posargs}
+    smoke: pytest -xsvv t/smoke --dist=loadscope --reruns 10 --reruns-delay 60 --rerun-except AssertionError {posargs}
 setenv =
     PIP_EXTRA_INDEX_URL=https://celery.github.io/celery-wheelhouse/repo/simple/
     BOTO_CONFIG = /dev/null


### PR DESCRIPTION
On failing tests, the assertion error message would be more readable in the CI logs