### PR TITLE
Bugfix - a task will run multiple times when chaining chains with groups

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -974,7 +974,6 @@ class _chain(Signature):
                 tasks, other), app=self._app)
         elif isinstance(other, _chain):
             # chain | chain -> chain
-            # use type(self) for _chain subclasses
             return reduce(operator.or_, other.unchain_tasks(), self)
         elif isinstance(other, Signature):
             if self.tasks and isinstance(self.tasks[-1], group):

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -975,8 +975,8 @@ class _chain(Signature):
         elif isinstance(other, _chain):
             # chain | chain -> chain
             # use type(self) for _chain subclasses
-            return type(self)(seq_concat_seq(
-                self.unchain_tasks(), other.unchain_tasks()), app=self._app)
+            return reduce(operator.or_, seq_concat_seq(
+                self.unchain_tasks(), other.unchain_tasks()), _chain())
         elif isinstance(other, Signature):
             if self.tasks and isinstance(self.tasks[-1], group):
                 # CHAIN [last item is group] | TASK -> chord

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -975,8 +975,7 @@ class _chain(Signature):
         elif isinstance(other, _chain):
             # chain | chain -> chain
             # use type(self) for _chain subclasses
-            return reduce(operator.or_, seq_concat_seq(
-                self.unchain_tasks(), other.unchain_tasks()), _chain())
+            return reduce(operator.or_, other.unchain_tasks(), self)
         elif isinstance(other, Signature):
             if self.tasks and isinstance(self.tasks[-1], group):
                 # CHAIN [last item is group] | TASK -> chord

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1120,7 +1120,8 @@ class test_chain:
         group1 = group(redis_echo.si('a', redis_key), redis_echo.si('a', redis_key))
         group2 = group(redis_echo.si('a', redis_key), redis_echo.si('a', redis_key))
         chord1 = group1 | group2
-        chain(chord1, (redis_echo.si('a', redis_key) | redis_echo.si('b', redis_key))).apply_async().get(timeout=TIMEOUT)
+        chain1 = chain(chord1, (redis_echo.si('a', redis_key) | redis_echo.si('b', redis_key)))
+        chain1.apply_async().get(timeout=TIMEOUT)
         redis_connection = get_redis_connection()
         actual = redis_connection.lrange(redis_key, 0, -1)
         assert actual.count(b'b') == 1

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1108,6 +1108,24 @@ class test_chain:
         res = t3.apply_async()  # should not raise
         assert res.get(timeout=TIMEOUT) == 60
 
+    def test_upgrade_to_chord_inside_chains(self, manager):
+        if not manager.app.conf.result_backend.startswith("redis"):
+            raise pytest.skip("Requires redis result backend.")
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.args[0])
+
+        redis_key = str(uuid.uuid4())
+        group1 = group(redis_echo.si('a', redis_key), redis_echo.si('a', redis_key))
+        group2 = group(redis_echo.si('a', redis_key), redis_echo.si('a', redis_key))
+        chord1 = group1 | group2
+        chain(chord1, (redis_echo.si('a', redis_key) | redis_echo.si('b', redis_key))).apply_async().get(timeout=TIMEOUT)
+        redis_connection = get_redis_connection()
+        actual = redis_connection.lrange(redis_key, 0, -1)
+        assert actual.count(b'b') == 1
+        redis_connection.delete(redis_key)
+
 
 class test_result_set:
 

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -825,6 +825,16 @@ class test_chain(CanvasCase):
         t2 = chord([self.add.si(1, 1), self.add.si(1, 1)], t1)
         t2.freeze()  # should not raise
 
+    def test_upgrade_to_chord_on_chain(self):
+        group1 = group(self.add.si(10, 10), self.add.si(10, 10))
+        group2 = group(self.xsum.s(), self.xsum.s())
+        chord1 = group1 | group2
+        chain1 = (self.xsum.si([5]) | self.add.s(1))
+        final_task = chain(chord1, chain1)
+        assert len(final_task.tasks) == 1 and isinstance(final_task.tasks[0], chord)
+        assert isinstance(final_task.tasks[0].body, chord)
+        assert final_task.tasks[0].body.body == chain1
+
 
 class test_group(CanvasCase):
     def test_repr(self):


### PR DESCRIPTION
Fixes #9020 

On `_chain.__or__` there is already a logic that knows to take a group/chord, and check if it needs an upgrade to chord. The problem is that if we chain 2 chains, it skips this logic and just constructs a chain from all the tasks, without any checks for an upgrade. Therefore, in a case where the first chain ends with a group, it will not create a chord.