### PR TITLE
 Fix a typo to display the help message in first-steps-with-django

### DIFF
--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -308,7 +308,7 @@ use the help command:
 
 .. code-block:: console
 
-    $ celery help
+    $ celery --help
 
 Where to go from here
 =====================


### PR DESCRIPTION
With celery 5.4.0 `$ celery help` yields:

```
Usage: celery [OPTIONS] COMMAND [ARGS]...
Try 'celery --help' for help.

Error: No such command 'help'.

Did you mean one of these?
    shell
```   

The right command to display the help message seems to be : ` $ celery --help`