### PR TITLE
Fix detection of custom task set as class attribute with Django

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -240,7 +240,12 @@ class Celery:
         self.loader_cls = loader or self._get_default_loader()
         self.log_cls = log or self.log_cls
         self.control_cls = control or self.control_cls
-        self._custom_task_cls_used = bool(task_cls)
+        self._custom_task_cls_used = (
+            # Custom task class provided as argument
+            bool(task_cls)
+            # subclass of Celery with a task_cls attribute
+            or self.__class__ is not Celery and hasattr(self.__class__, 'task_cls')
+        )
         self.task_cls = task_cls or self.task_cls
         self.set_as_current = set_as_current
         self.registry_cls = symbol_by_name(self.registry_cls)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Fix for feature added in 

- https://github.com/celery/celery/pull/8491

As reported in [a comment on the pull request
](https://github.com/celery/celery/pull/8491#issuecomment-2119191201), this feature breaks in case the user customised their task via a class attribute, and have Django installed:

```python
class CeleryApp(Celery):
    registry_cls = 'tenant_schemas_celery.registry:TenantTaskRegistry'
    task_cls = 'tenant_schemas_celery.task:TenantTask'
```

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

- [x] Add a test to cover this use case
- [x] When such task is defined, don't use the built-in `DjangoTask`