### PR TITLE
Revert "Pinned requests to v2.31.0 due to docker-py bug #3256"

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,3 @@
-# Temporary fix until requests is fixed - to be reverted afterwards:
-# https://github.com/docker/docker-py/issues/3256
-requests==2.31.0
 pytest==8.2.0
 pytest-celery[all]>=1.0.0
 pytest-rerunfailures==14.0


### PR DESCRIPTION
Reverts celery/celery#9039