### PR TITLE
[Draft/Not-Completed] Allow consuming from multiple brokers

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -222,15 +222,12 @@ class Worker(WorkController):
         if not self.task_events:
             events = 'OFF (enable -E to monitor tasks in this worker)'
 
-        consumers = self.consumers
-        delimiter = app.conf.broker_concurrent_readers_delimiter
-        conninfo = delimiter.join(c.url or c.app.connection().as_uri() for c in consumers)
         banner = BANNER.format(
             app=appr,
             hostname=safe_str(self.hostname),
             timestamp=datetime.now().replace(microsecond=0),
             version=VERSION_BANNER,
-            conninfo=conninfo,
+            conninfo='|'.join(c.read_write_url or c.app.connection().as_uri() for c in self.consumers),
             results=self.app.backend.as_uri(),
             concurrency=concurrency,
             platform=safe_str(_platform.platform()),

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -222,12 +222,15 @@ class Worker(WorkController):
         if not self.task_events:
             events = 'OFF (enable -E to monitor tasks in this worker)'
 
+        consumers = self.consumers
+        delimiter = app.conf.broker_concurrent_readers_delimiter
+        conninfo = delimiter.join(c.url or c.app.connection().as_uri() for c in consumers)
         banner = BANNER.format(
             app=appr,
             hostname=safe_str(self.hostname),
             timestamp=datetime.now().replace(microsecond=0),
             version=VERSION_BANNER,
-            conninfo=self.app.connection().as_uri(),
+            conninfo=conninfo,
             results=self.app.backend.as_uri(),
             concurrency=concurrency,
             platform=safe_str(_platform.platform()),

--- a/celery/worker/components.py
+++ b/celery/worker/components.py
@@ -166,7 +166,7 @@ class Pool(bootsteps.StartStopStep):
         max_restarts = None
         if w.app.conf.worker_pool in GREEN_POOLS:  # pragma: no cover
             warnings.warn(UserWarning(W_POOL_SETTING))
-        threaded = not w.use_eventloop or IS_WINDOWS
+        threaded = not w.use_eventloop or IS_WINDOWS or w.app.conf.concurrent_readers > 1
         procs = w.min_concurrency
         w.process_task = w._process_task
         if not threaded:

--- a/celery/worker/components.py
+++ b/celery/worker/components.py
@@ -60,8 +60,16 @@ class Hub(bootsteps.StartStopStep):
     requires = (Timer,)
 
     def __init__(self, w, **kwargs):
+        w.concurrent_readers_delimiter = '|'
+
+        if self._is_concurrency_needed(w):
+            w.concurrent_readers = len(w.app.conf.broker_url.split(w.concurrent_readers_delimiter))
+        else:
+            w.concurrent_readers = 1
+
+        w.hubs = []
+
         super().__init__(w, **kwargs)
-        self._init_event_loop_per_broker(w)
 
     def include_if(self, w):
         return w.use_eventloop
@@ -78,11 +86,8 @@ class Hub(bootsteps.StartStopStep):
         pass
 
     def stop(self, w):
-        if self._is_concurrency_needed(w):
-            for hub in w.hubs:
-                hub.close()
-        else:
-            w.hub.close()
+        for hub in w.hubs:
+            hub.close()
 
     def terminate(self, w):
         self.stop(w)
@@ -99,30 +104,20 @@ class Hub(bootsteps.StartStopStep):
             pool.Lock = DummyLock
 
     def _is_concurrency_needed(self, w):
-        return w.app.conf.broker_concurrent_readers_delimiter in w.app.conf.broker_url
-
-    def _init_event_loop_per_broker(self, w):
-        if self._is_concurrency_needed(w):
-            broker_url = w.app.conf.broker_url
-            concurrency_delimiter = w.app.conf.broker_concurrent_readers_delimiter
-            concurrent_readers = len(broker_url.split(concurrency_delimiter))
-            w.app.conf.broker_concurrent_readers = concurrent_readers
-            w.hubs = [None]
-        else:
-            w.hub = None
+        if isinstance(w.app.conf.broker_url, str):
+            return w.concurrent_readers_delimiter in w.app.conf.broker_url
+        return False
 
     def _create_concurrent_hubs(self, w):
-        w.hubs.clear()
-        concurrent_readers = w.app.conf.broker_concurrent_readers
-        for _ in range(concurrent_readers):
+        for _ in range(w.concurrent_readers):
             w.hubs.append(_Hub(w.timer))
         set_event_loop(None)  # Avoid using the global loop
 
     def _create_global_hub(self, w):
-        w.hub = get_event_loop()
-        if w.hub is None:
+        w.hubs.append(get_event_loop())
+        if w.hubs[0] is None:
             required_hub = getattr(w._conninfo, "requires_hub", None)
-            w.hub = set_event_loop((required_hub if required_hub else _Hub)(w.timer))
+            w.hubs[0] = set_event_loop((required_hub if required_hub else _Hub)(w.timer))
 
 
 class Pool(bootsteps.StartStopStep):
@@ -167,7 +162,7 @@ class Pool(bootsteps.StartStopStep):
         max_restarts = None
         if w.app.conf.worker_pool in GREEN_POOLS:  # pragma: no cover
             warnings.warn(UserWarning(W_POOL_SETTING))
-        threaded = not w.use_eventloop or IS_WINDOWS or w.app.conf.broker_concurrent_readers > 1
+        threaded = not w.use_eventloop or IS_WINDOWS or w.concurrent_readers > 1
         procs = w.min_concurrency
         w.process_task = w._process_task
         if not threaded:
@@ -257,7 +252,7 @@ class Consumer(bootsteps.StartStopStep):
             w,
             concurrency=prefetch_count / w.prefetch_multiplier,
             prefetch_multiplier=w.prefetch_multiplier,
-            consumers_count=w.app.conf.broker_concurrent_readers,
+            consumers_count=w.concurrent_readers,
         )
         return w.consumers
 
@@ -280,6 +275,9 @@ class Consumer(bootsteps.StartStopStep):
         for consumer in self.obj:
             stopped_consumers.append(consumer.stop())
         return stopped_consumers
+
+    def terminate(self, parent):
+        return self.stop(parent)
 
     def distribute_prefetch(
         self,
@@ -338,8 +336,8 @@ class Consumer(bootsteps.StartStopStep):
             prefetch_multiplier=prefetch_multiplier,
             consumers_count=consumers_count,
         )
-        hubs = w.hubs if consumers_count > 1 else [w.hub]
-        urls = w.app.conf.broker_url.split(w.app.conf.broker_concurrent_readers_delimiter)
+        hubs = w.hubs or [None]
+        urls = w.app.conf.broker_url.split(w.concurrent_readers_delimiter)
 
         if len(urls) != consumers_count:
             raise ValueError(
@@ -348,8 +346,14 @@ class Consumer(bootsteps.StartStopStep):
 
         for dist, hub, url in zip(distribution, hubs, urls):
             dist = int(dist)
-            multiplier = 1 if consumers_count > 1 else prefetch_multiplier
-            url = url if consumers_count > 1 else None
+            if consumers_count > 1:
+                multiplier = 1
+                allocated_processes = dist
+            else:
+                multiplier = prefetch_multiplier
+                allocated_processes = None
+                url = None
+
             c = self.instantiate(
                 w.consumer_cls,
                 w.process_task,
@@ -366,7 +370,7 @@ class Consumer(bootsteps.StartStopStep):
                 disable_rate_limits=w.disable_rate_limits,
                 prefetch_multiplier=multiplier,
                 connection_url=url,
-                allocated_processes=dist,
+                allocated_processes=allocated_processes,
             )
             consumers.append(c)
         return consumers

--- a/examples/app/myapp.py
+++ b/examples/app/myapp.py
@@ -28,7 +28,7 @@ from celery import Celery
 
 app = Celery(
     'myapp',
-    broker='amqp://guest@localhost//',
+    broker='redis:///0|redis:///1',
     # ## add result backend here if needed.
     # backend='rpc'
     task_acks_late=True

--- a/t/smoke/tests/test_POC.py
+++ b/t/smoke/tests/test_POC.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import pytest
+from pytest_celery import (RABBITMQ_CONTAINER_TIMEOUT, RABBITMQ_PORTS, RESULT_TIMEOUT, WORKER_DEBUGPY_PORTS,
+                           CeleryBackendCluster, CeleryBrokerCluster, CeleryTestSetup, MemcachedTestBackend,
+                           RabbitMQContainer, RabbitMQTestBroker)
+from pytest_celery import sleep as sleeping
+from pytest_docker_tools import build, container, fxtr
+
+from celery import Celery
+from celery.canvas import Signature, group
+from celery.result import AsyncResult
+from t.integration.tasks import identity
+from t.smoke.workers.dev import SmokeWorkerContainer
+
+###############################################################################
+# Broker
+###############################################################################
+
+
+class RabbitMQManagementTestBroker(RabbitMQTestBroker):
+    def get_management_url(self) -> str:
+        """Opening this link during debugging allows you to see the
+        RabbitMQ management UI in your browser.
+        """
+        ports = self.container.attrs["NetworkSettings"]["Ports"]
+        ip = ports["15672/tcp"][0]["HostIp"]
+        port = ports["15672/tcp"][0]["HostPort"]
+        return f"http://{ip}:{port}"
+
+
+@pytest.fixture
+def default_rabbitmq_broker_image() -> str:
+    return "rabbitmq:management"
+
+
+@pytest.fixture
+def default_rabbitmq_broker_ports() -> dict:
+    # Expose the management UI port
+    ports = RABBITMQ_PORTS.copy()
+    ports.update({"15672/tcp": None})
+    return ports
+
+
+@pytest.fixture
+def broker1(
+    default_rabbitmq_broker: RabbitMQContainer,
+) -> RabbitMQManagementTestBroker:
+    broker = RabbitMQManagementTestBroker(default_rabbitmq_broker)
+    yield broker
+    broker.teardown()
+
+
+failover_broker = container(
+    image="{default_rabbitmq_broker_image}",
+    ports=fxtr("default_rabbitmq_broker_ports"),
+    environment=fxtr("default_rabbitmq_broker_env"),
+    network="{default_pytest_celery_network.name}",
+    wrapper_class=RabbitMQContainer,
+    timeout=RABBITMQ_CONTAINER_TIMEOUT,
+)
+
+
+@pytest.fixture
+def broker2(failover_broker: RabbitMQContainer) -> RabbitMQManagementTestBroker:
+    broker = RabbitMQManagementTestBroker(failover_broker)
+    yield broker
+    broker.teardown()
+
+
+other_failover_broker = container(
+    image="{default_rabbitmq_broker_image}",
+    ports=fxtr("default_rabbitmq_broker_ports"),
+    environment=fxtr("default_rabbitmq_broker_env"),
+    network="{default_pytest_celery_network.name}",
+    wrapper_class=RabbitMQContainer,
+    timeout=RABBITMQ_CONTAINER_TIMEOUT,
+)
+
+
+@pytest.fixture
+def broker3(other_failover_broker: RabbitMQContainer) -> RabbitMQManagementTestBroker:
+    broker = RabbitMQManagementTestBroker(other_failover_broker)
+    yield broker
+    broker.teardown()
+
+
+@pytest.fixture
+def celery_broker_cluster(
+    broker1: RabbitMQManagementTestBroker,
+    broker2: RabbitMQManagementTestBroker,
+    broker3: RabbitMQManagementTestBroker,
+) -> CeleryBrokerCluster:
+    cluster = CeleryBrokerCluster(broker1, broker2, broker3)
+    yield cluster
+    cluster.teardown()
+
+
+###############################################################################
+# Result Backend
+###############################################################################
+
+
+@pytest.fixture
+def celery_backend_cluster(
+    celery_memcached_backend: MemcachedTestBackend,
+) -> CeleryBackendCluster:
+    cluster = CeleryBackendCluster(celery_memcached_backend)
+    yield cluster
+    cluster.teardown()
+
+
+###############################################################################
+# Worker
+###############################################################################
+
+
+class WorkerContainer(SmokeWorkerContainer):
+    @classmethod
+    def log_level(cls) -> str:
+        return "INFO"
+
+    @classmethod
+    def worker_queue(cls) -> str:
+        return "celery"
+
+    @classmethod
+    def command(cls, *args: str, **kwargs: dict) -> list[str]:
+        return super().command(
+            "-Ofair",
+            "--without-gossip",
+            "--without-mingle",
+            "--without-heartbeat",
+            # "-P",
+            # "gevent",
+            debugpy=True,
+            wait_for_client=False,
+        )
+
+    @classmethod
+    def ports(cls) -> dict | None:
+        return WORKER_DEBUGPY_PORTS
+
+    @classmethod
+    def initial_env(
+        cls, celery_worker_cluster_config: dict, initial: dict | None = None
+    ) -> dict:
+        initial_env = super().initial_env(
+            celery_worker_cluster_config,
+            # {
+            #     "GEVENT_SUPPORT": True,
+            #     "PYDEVD_DISABLE_FILE_VALIDATION": 1,
+            # },
+        )
+        initial_env['CELERY_BROKER_URL'] = initial_env['CELERY_BROKER_URL'].replace(";", "|")
+        # replace back only one | into ;
+        # initial_env['CELERY_BROKER_URL'] = initial_env['CELERY_BROKER_URL'].replace("|", ";", 1)
+        return initial_env
+
+
+@pytest.fixture
+def default_worker_container_cls() -> type[SmokeWorkerContainer]:
+    return WorkerContainer
+
+
+@pytest.fixture(scope="session")
+def default_worker_container_session_cls() -> type[SmokeWorkerContainer]:
+    return WorkerContainer
+
+
+celery_dev_worker_image = build(
+    path=".",
+    dockerfile="t/smoke/workers/docker/dev",
+    tag="t/smoke/worker:dev",
+    buildargs=WorkerContainer.buildargs(),
+)
+
+
+@pytest.fixture
+def default_worker_app(default_worker_app: Celery) -> Celery:
+    app = default_worker_app
+    app.conf.update(
+        broker_use_ssl=False,
+        broker_transport_options={"confirm_publish": True},
+        worker_prefetch_multiplier=1,
+        task_acks_late=True,
+        task_reject_on_worker_lost=True,
+        task_result_expires=60 * 60 * 24,  # 24 hours
+        task_default_delivery_mode=1,
+        worker_enable_remote_control=False,
+        worker_cancel_long_running_tasks_on_connection_loss=True,
+    )
+
+    return app
+
+
+###############################################################################
+# Publisher Side
+###############################################################################
+
+
+@pytest.fixture
+def publish_to_broker():
+    def _publish_to_broker(
+        broker: RabbitMQManagementTestBroker,
+        sig: Signature,
+    ) -> AsyncResult:
+        app = Celery(sig.app.main)
+        app.conf = sig.app.conf
+        app.conf["broker_url"] = broker.config()["host_url"]
+        sig._app = app
+        if isinstance(sig, group):
+            for t in sig.tasks:
+                t._app = app
+        return sig.apply_async()
+
+    return _publish_to_broker
+
+
+def test_publish_to_multiple_brokers(
+    celery_setup: CeleryTestSetup,
+    broker1: RabbitMQManagementTestBroker,
+    broker2: RabbitMQManagementTestBroker,
+    broker3: RabbitMQManagementTestBroker,
+    publish_to_broker,
+    subtests,
+):
+    with subtests.test(msg="Publish to broker1"):
+        res: AsyncResult = publish_to_broker(broker1, identity.si("broker1"))
+
+    with subtests.test(msg="Assert get() == 'broker1'"):
+        assert res.get(timeout=RESULT_TIMEOUT) == "broker1"
+
+    with subtests.test(msg="Publish to broker2"):
+        res: AsyncResult = publish_to_broker(broker2, identity.si("broker2"))
+
+    with subtests.test(msg="Assert get() == 'broker2'"):
+        assert res.get(timeout=RESULT_TIMEOUT) == "broker2"
+
+    with subtests.test(msg="Publish to broker3"):
+        res: AsyncResult = publish_to_broker(broker3, identity.si("broker3"))
+
+    with subtests.test(msg="Assert get() == 'broker3'"):
+        assert res.get(timeout=RESULT_TIMEOUT) == "broker3"
+
+    print("Done\n" + celery_setup.worker.logs())
+
+
+def test_publish_large_traffic(
+    celery_setup: CeleryTestSetup,
+    broker1: RabbitMQManagementTestBroker,
+    broker2: RabbitMQManagementTestBroker,
+    broker3: RabbitMQManagementTestBroker,
+    publish_to_broker,
+    subtests,
+):
+    RESULT_TIMEOUT = 60 * 3
+    count = 30
+    brokers = 3
+    # sig = group([identity.si(i) for i in range(count)])
+    sleep_sig = group([sleeping.si(0.1) for i in range(count)])
+    sig = sleep_sig
+
+    with subtests.test(msg="Publish large traffic to broker1"):
+        res: AsyncResult = publish_to_broker(broker1, sig)
+
+    with subtests.test(msg="Assert get() == list(range(count))"):
+        # assert res.get(timeout=RESULT_TIMEOUT) == list(range(count))
+        assert all(res.get(timeout=RESULT_TIMEOUT))
+
+    with subtests.test(msg="Publish large traffic to broker2"):
+        res: AsyncResult = publish_to_broker(broker2, sig)
+
+    with subtests.test(msg="Assert get() == list(range(count))"):
+        # assert res.get(timeout=RESULT_TIMEOUT) == list(range(count))
+        assert all(res.get(timeout=RESULT_TIMEOUT))
+
+    with subtests.test(msg="Publish large traffic to broker3"):
+        res: AsyncResult = publish_to_broker(broker3, sig)
+
+    with subtests.test(msg="Assert get() == list(range(count))"):
+        # assert res.get(timeout=RESULT_TIMEOUT) == list(range(count))
+        assert all(res.get(timeout=RESULT_TIMEOUT))
+
+    with subtests.test(msg="Publish to both brokers"):
+        sig1 = group(identity.si(i) for i in range(count // brokers))
+        sig2 = group(identity.si(i) for i in range(count // brokers, count))
+        sig3 = group(identity.si(i) for i in range(count // brokers * 2, count))
+        res1: AsyncResult = publish_to_broker(broker1, sig1)
+        res2: AsyncResult = publish_to_broker(broker2, sig2)
+        res3: AsyncResult = publish_to_broker(broker3, sig3)
+
+    with subtests.test(msg="Assert get() == list(range(count // brokers))"):
+        assert res1.get(timeout=RESULT_TIMEOUT) == list(range(count // brokers))
+
+    with subtests.test(msg="Assert get() == list(range(count // brokers, count))"):
+        assert res2.get(timeout=RESULT_TIMEOUT) == list(range(count // brokers, count))
+
+    with subtests.test(msg="Assert get() == list(range(count // brokers * 2, count))"):
+        assert res3.get(timeout=RESULT_TIMEOUT) == list(range(count // brokers * 2, count))
+
+    print("Done\n" + celery_setup.worker.logs())
+
+
+def test_kill_broker1(
+    celery_setup: CeleryTestSetup,
+    broker1: RabbitMQManagementTestBroker,
+    broker2: RabbitMQManagementTestBroker,
+    broker3: RabbitMQManagementTestBroker,
+    publish_to_broker,
+    subtests,
+):
+    count = 10
+    sig = group([identity.si(i) for i in range(count)])
+
+    with subtests.test(msg="Kill broker1"):
+        broker1.kill()
+
+    with subtests.test(msg="Publish large traffic to broker2"):
+        res: AsyncResult = publish_to_broker(broker2, sig)
+
+    with subtests.test(msg="Assert get() == list(range(count))"):
+        assert res.get(timeout=RESULT_TIMEOUT) == list(range(count))
+
+    with subtests.test(msg="Publish large traffic to broker3"):
+        res: AsyncResult = publish_to_broker(broker3, sig)
+
+    with subtests.test(msg="Assert get() == list(range(count))"):
+        assert res.get(timeout=RESULT_TIMEOUT) == list(range(count))
+
+    print("Done\n" + celery_setup.worker.logs())

--- a/t/unit/worker/test_components.py
+++ b/t/unit/worker/test_components.py
@@ -1,10 +1,11 @@
+import re
 from unittest.mock import Mock, patch
 
 import pytest
 
 import t.skip
 from celery.exceptions import ImproperlyConfigured
-from celery.worker.components import Beat, Hub, Pool, Timer
+from celery.worker.components import Beat, Consumer, Hub, Pool, Timer
 
 # some of these are tested in test_worker, so I've only written tests
 # here to complete coverage.  Should move everything to this module at some
@@ -25,7 +26,11 @@ class test_Hub:
     def setup_method(self):
         self.w = Mock(name='w')
         self.hub = Hub(self.w)
-        self.w.hub = Mock(name='w.hub')
+        self.w.hubs = [Mock(name='w.hub')]
+
+    def test_init(self):
+        assert self.w.concurrent_readers_delimiter == '|'
+        assert self.w.concurrent_readers == 1
 
     @patch('celery.worker.components.set_event_loop')
     @patch('celery.worker.components.get_event_loop')
@@ -39,11 +44,32 @@ class test_Hub:
 
     def test_stop(self):
         self.hub.stop(self.w)
-        self.w.hub.close.assert_called_with()
+        self.w.hubs[0].close.assert_called_with()
 
     def test_terminate(self):
         self.hub.terminate(self.w)
-        self.w.hub.close.assert_called_with()
+        self.w.hubs[0].close.assert_called_with()
+
+    def test_is_concurrency_needed(self):
+        assert self.hub._is_concurrency_needed(self.w) is False
+
+
+class test_Hubs:
+
+    def setup_method(self):
+        self.w = Mock(name='w')
+        self.w.app.conf.broker_url = 'amqp://|amqp://'
+        self.hub = Hub(self.w)
+
+    def test_init(self):
+        assert self.w.concurrent_readers == 2
+
+    def test_create(self):
+        self.hub.create(self.w)
+        assert len(self.w.hubs) == 2
+
+    def test_is_concurrency_needed(self):
+        assert self.hub._is_concurrency_needed(self.w) is True
 
 
 class test_Pool:
@@ -65,6 +91,7 @@ class test_Pool:
     def test_create_when_eventloop(self):
         w = Mock()
         w.use_eventloop = w.pool_putlocks = w.pool_cls.uses_semaphore = True
+        w.concurrent_readers = 1
         comp = Pool(w)
         w.pool = Mock()
         comp.create(w)
@@ -73,6 +100,7 @@ class test_Pool:
     def test_create_calls_instantiate_with_max_memory(self):
         w = Mock()
         w.use_eventloop = w.pool_putlocks = w.pool_cls.uses_semaphore = True
+        w.concurrent_readers = 1
         comp = Pool(w)
         comp.instantiate = Mock()
         w.max_memory_per_child = 32
@@ -80,6 +108,14 @@ class test_Pool:
         comp.create(w)
 
         assert comp.instantiate.call_args[1]['max_memory_per_child'] == 32
+
+    def test_threaded_enabled_with_concurrent_readers(self):
+        w = Mock()
+        w.concurrent_readers = 2
+        comp = Pool(w)
+        w.pool = Mock()
+        comp.create(w)
+        assert w.process_task is not w._process_task_sem
 
 
 class test_Beat:
@@ -89,3 +125,112 @@ class test_Beat:
         w.pool_cls.__module__ = 'foo_gevent'
         with pytest.raises(ImproperlyConfigured):
             Beat(w).create(w)
+
+
+class test_Consumers:
+
+    def setup_method(self):
+        self.w = Mock(name='w')
+        self.w.app.conf.broker_url = 'amqp://|amqp://|amqp://'
+        self.w.concurrent_readers_delimiter = '|'
+        self.hub = Hub(self.w)
+        self.hub.create(self.w)
+        self.consumer = Consumer(self.w)
+
+    def test_create_consumers(self):
+        consumers = self.consumer._create_consumers(
+            self.w,
+            concurrency=2,
+            prefetch_multiplier=2,
+            consumers_count=3,
+        )
+        assert len(consumers) == 3
+
+    @patch('threading.Thread.start', autospec=True)
+    def test_start(self, mock_thread_start):
+        consumers = self.consumer._create_consumers(
+            self.w,
+            concurrency=2,
+            prefetch_multiplier=2,
+            consumers_count=3,
+        )
+        self.consumer.obj = consumers
+        returned_threads = self.consumer.start(self.w)
+        assert mock_thread_start.call_count == len(consumers)
+        assert len(returned_threads) == len(consumers)
+
+    @patch('celery.worker.consumer.Consumer.stop', autospec=True)
+    def test_stop(self, mock_consumer_stop):
+        consumers = self.consumer._create_consumers(
+            self.w,
+            concurrency=2,
+            prefetch_multiplier=2,
+            consumers_count=3,
+        )
+        self.consumer.obj = consumers
+        returned_stopped = self.consumer.stop(self.w)
+        assert len(returned_stopped) == len(consumers)
+
+    def test_create_consumers_without_matching_broker_url(self):
+        consumers_count = 2
+        length = len(self.w.app.conf.broker_url.split(self.w.concurrent_readers_delimiter))
+        assert length != consumers_count, "Test setup error"
+        error_msg = f"Number of consumers ({consumers_count}) does not match the number of brokers ({length})."
+        with pytest.raises(ValueError, match=re.escape(error_msg)):
+            self.consumer._create_consumers(
+                self.w,
+                concurrency=2,
+                prefetch_multiplier=2,
+                consumers_count=consumers_count,
+            )
+
+    def test_distribute_prefetch_no_concurrency(self):
+        with pytest.raises(ValueError):
+            self.consumer.distribute_prefetch(
+                concurrency=0,
+                prefetch_multiplier=1,
+                consumers_count=1,
+            )
+
+    def test_distribute_prefetch_no_prefetch_multiplier(self):
+        with pytest.raises(ValueError):
+            self.consumer.distribute_prefetch(
+                concurrency=1,
+                prefetch_multiplier=0,
+                consumers_count=1,
+            )
+
+    def test_distribute_prefetch_no_consumers_count(self):
+        with pytest.raises(ValueError):
+            self.consumer.distribute_prefetch(
+                concurrency=1,
+                prefetch_multiplier=1,
+                consumers_count=0,
+            )
+
+    @pytest.mark.parametrize('concurrency, prefetch_multiplier, consumers_count, expected', [
+        (1, 1, 1, [1]),
+        (1, 1, 2, [1, 1]),
+        (1, 2, 1, [2]),
+        (1, 2, 2, [1, 1]),
+        (2, 1, 1, [2]),
+        (2, 1, 2, [1, 1]),
+        (2, 1, 3, [1, 1, 1]),
+        (3, 4, 1, [12]),
+        (3, 4, 2, [6, 6]),
+        (3, 4, 3, [4, 4, 4]),
+        (3, 4, 4, [3, 3, 3, 3]),
+        (3, 4, 5, [3, 3, 2, 2, 2]),
+        (3, 4, 6, [2, 2, 2, 2, 2, 2]),
+        (3, 4, 7, [2, 2, 2, 2, 2, 1, 1]),
+        (3, 4, 8, [2, 2, 2, 2, 1, 1, 1, 1]),
+        (3, 4, 9, [2, 2, 2, 1, 1, 1, 1, 1, 1]),
+        (3, 4, 10, [2, 2, 1, 1, 1, 1, 1, 1, 1, 1]),
+        (3, 4, 11, [2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+        (3, 4, 12, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+        (3, 4, 13, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+        (3, 4, 14, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    ])
+    def test_distribute_prefetch(self, concurrency, prefetch_multiplier, consumers_count, expected):
+        result = self.consumer.distribute_prefetch(concurrency, prefetch_multiplier, consumers_count)
+        assert result == expected

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -464,6 +464,21 @@ class test_Consumer(ConsumerTestCase):
                 with pytest.raises(ConnectionError):
                     c.ensure_connected(conn)
 
+    def test_connection_url(self):
+        c = self.get_consumer()
+        assert c.read_write_url is None
+        c = self.get_consumer(connection_url='123')
+        assert c.read_write_url == '123'
+
+    def test_num_processes(self):
+        c = self.get_consumer()
+        assert not hasattr(c, 'available_processes')
+        assert c.num_processes == 2
+        c = self.get_consumer(allocated_processes=4)
+        assert c.pool.num_processes == 2, 'Pool processes should be ignored when using allocated_processes'
+        assert c.available_processes == 4
+        assert c.num_processes == 4
+
 
 @pytest.mark.parametrize(
     "broker_connection_retry_on_startup,is_connection_loss_on_startup",

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -695,13 +695,13 @@ class test_ControlPanel:
     def test_pool_restart(self):
         consumer = Consumer(self.app)
         consumer.controller = _WC(app=self.app)
-        consumer.controller.consumer = consumer
+        consumer.controller.consumers = [consumer]
         consumer.controller.pool.restart = Mock()
         consumer.reset_rate_limits = Mock(name='reset_rate_limits()')
         consumer.update_strategies = Mock(name='update_strategies()')
         consumer.event_dispatcher = Mock(name='evd')
         panel = self.create_panel(consumer=consumer)
-        assert panel.state.consumer.controller.consumer is consumer
+        assert panel.state.consumer.controller.consumers[0] is consumer
         panel.app = self.app
         _import = panel.app.loader.import_from_cwd = Mock()
         _reload = Mock()
@@ -725,13 +725,13 @@ class test_ControlPanel:
     def test_pool_restart_import_modules(self, _debug):
         consumer = Consumer(self.app)
         consumer.controller = _WC(app=self.app)
-        consumer.controller.consumer = consumer
+        consumer.controller.consumers = [consumer]
         consumer.controller.pool.restart = Mock()
         consumer.reset_rate_limits = Mock(name='reset_rate_limits()')
         consumer.update_strategies = Mock(name='update_strategies()')
         panel = self.create_panel(consumer=consumer)
         panel.app = self.app
-        assert panel.state.consumer.controller.consumer is consumer
+        assert panel.state.consumer.controller.consumers[0] is consumer
         _import = consumer.controller.app.loader.import_from_cwd = Mock()
         _reload = Mock()
 


### PR DESCRIPTION
Add support to consume from multiple brokers.
To use, just set the `broker_url` to a list separated by `|` of broker urls, e.g, `redis:///0|redis:///1|redis:///2`