### PR TITLE
Use hub.remove_writer instead of hub.remove for write fds (#4185)

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -772,7 +772,7 @@ class AsynPool(_pool.Pool):
                     None, WRITE | ERR, consolidate=True)
             else:
                 iterate_file_descriptors_safely(
-                    inactive, all_inqueues, hub_remove)
+                    inactive, all_inqueues, hub.remove_writer)
         self.on_poll_start = on_poll_start
 
         def on_inqueue_close(fd, proc):
@@ -818,7 +818,7 @@ class AsynPool(_pool.Pool):
                     # worker is already busy with another task
                     continue
                 if ready_fd not in all_inqueues:
-                    hub_remove(ready_fd)
+                    hub.remove_writer(ready_fd)
                     continue
                 try:
                     job = pop_message()
@@ -829,7 +829,7 @@ class AsynPool(_pool.Pool):
                     # this may create a spinloop where the event loop
                     # always wakes up.
                     for inqfd in diff(active_writes):
-                        hub_remove(inqfd)
+                        hub.remove_writer(inqfd)
                     break
 
                 else:
@@ -927,7 +927,7 @@ class AsynPool(_pool.Pool):
                     else:
                         errors = 0
             finally:
-                hub_remove(fd)
+                hub.remove_writer(fd)
                 write_stats[proc.index] += 1
                 # message written, so this fd is now available
                 active_writes.discard(fd)

--- a/t/unit/worker/test_loops.py
+++ b/t/unit/worker/test_loops.py
@@ -363,7 +363,7 @@ class test_asynloop:
 
     def test_poll_write_generator(self):
         x = X(self.app)
-        x.hub.remove = Mock(name='hub.remove()')
+        x.hub.remove_writer = Mock(name='hub.remove_writer()')
 
         def Gen():
             yield 1
@@ -376,7 +376,7 @@ class test_asynloop:
         with pytest.raises(socket.error):
             asynloop(*x.args)
         assert gen.gi_frame.f_lasti != -1
-        x.hub.remove.assert_not_called()
+        x.hub.remove_writer.assert_not_called()
 
     def test_poll_write_generator_stopped(self):
         x = X(self.app)
@@ -388,7 +388,7 @@ class test_asynloop:
         x.hub.add_writer(6, gen)
         x.hub.on_tick.add(x.close_then_error(Mock(name='tick'), 2))
         x.hub.poller.poll.return_value = [(6, WRITE)]
-        x.hub.remove = Mock(name='hub.remove()')
+        x.hub.remove_writer = Mock(name='hub.remove_writer()')
         with pytest.raises(socket.error):
             asynloop(*x.args)
         assert gen.gi_frame is None


### PR DESCRIPTION
- fix main process Unrecoverable error: AssertionError() when read fd is deleted
- see https://github.com/celery/celery/issues/4185#issuecomment-2139390090
- tests:
    - change hub.remove to hub.remove_writer in test_poll_write_generator and test_poll_write_generator_stopped
    - add 2 more tests for schedule_writes to assert only hub.writers is removed when hub.readers have the same fd id