### PR TITLE
[enhance feature] Crontab schedule: allow using month names

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -15,7 +15,7 @@ from celery import Celery
 from . import current_app
 from .utils.collections import AttributeDict
 from .utils.time import (ffwd, humanize_seconds, localize, maybe_make_aware, maybe_timedelta, remaining, timezone,
-                         weekday)
+                         weekday, yearmonth)
 
 __all__ = (
     'ParseException', 'schedule', 'crontab', 'crontab_parser',
@@ -300,9 +300,12 @@ class crontab_parser:
             i = int(s)
         except ValueError:
             try:
-                i = weekday(s)
+                i = yearmonth(s)
             except KeyError:
-                raise ValueError(f'Invalid weekday literal {s!r}.')
+                try:
+                    i = weekday(s)
+                except KeyError:
+                    raise ValueError(f'Invalid weekday literal {s!r}.')
 
         max_val = self.min_ + self.max_ - 1
         if i > max_val:

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -41,6 +41,9 @@ C_REMDEBUG = os.environ.get('C_REMDEBUG', False)
 DAYNAMES = 'sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'
 WEEKDAYS = dict(zip(DAYNAMES, range(7)))
 
+MONTHNAMES = 'jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'
+YEARMONTHS = dict(zip(MONTHNAMES, range(1, 13)))
+
 RATE_MODIFIER_MAP = {
     's': lambda n: n,
     'm': lambda n: n / 60.0,
@@ -253,6 +256,21 @@ def weekday(name: str) -> int:
     abbreviation = name[0:3].lower()
     try:
         return WEEKDAYS[abbreviation]
+    except KeyError:
+        # Show original day name in exception, instead of abbr.
+        raise KeyError(name)
+
+
+def yearmonth(name: str) -> int:
+    """Return the position of a month: 1 - 12, where 1 is January.
+
+    Example:
+        >>> yearmonth('january'), yearmonth('jan'), yearmonth('may')
+        (1, 1, 5)
+    """
+    abbreviation = name[0:3].lower()
+    try:
+        return YEARMONTHS[abbreviation]
     except KeyError:
         # Show original day name in exception, instead of abbr.
         raise KeyError(name)

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -307,6 +307,20 @@ class test_crontab_remaining_estimate:
             datetime(2010, 9, 11, 14, 30, 15),
         )
         assert next == datetime(2010, 9, 13, 0, 5)
+    
+    def test_monthyear(self):
+        next = self.next_occurrence(
+            self.crontab(minute=30, hour=14, month_of_year='oct', day_of_month=18),
+            datetime(2010, 9, 11, 14, 30, 15),
+        )
+        assert next == datetime(2010, 10, 18, 14, 30)
+
+    def test_not_monthyear(self):
+        next = self.next_occurrence(
+            self.crontab(minute=[5, 42], month_of_year='nov-dec', day_of_month=13),
+            datetime(2010, 9, 11, 14, 30, 15),
+        )
+        assert next == datetime(2010, 11, 13, 0, 5)
 
     def test_monthday(self):
         next = self.next_occurrence(
@@ -607,6 +621,11 @@ class test_crontab_is_due:
     @pytest.mark.parametrize('month_of_year,expected', [
         (1, {1}),
         ('1', {1}),
+        ('feb', {2}),
+        ('Mar', {3}),
+        ('april', {4}),
+        ('may,jun,jul', {5, 6, 7}),
+        ('aug-oct', {8, 9, 10}),
         ('2,4,6', {2, 4, 6}),
         ('*/2', {1, 3, 5, 7, 9, 11}),
         ('2-12/2', {2, 4, 6, 8, 10, 12}),
@@ -615,7 +634,7 @@ class test_crontab_is_due:
         c = self.crontab(month_of_year=month_of_year)
         assert c.month_of_year == expected
 
-    @pytest.mark.parametrize('month_of_year', [0, '0-5', 13, '12,13'])
+    @pytest.mark.parametrize('month_of_year', [0, '0-5', 13, '12,13', 'jaan', 'sebtember'])
     def test_crontab_spec_invalid_moy(self, month_of_year):
         with pytest.raises(ValueError):
             self.crontab(month_of_year=month_of_year)

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -307,7 +307,7 @@ class test_crontab_remaining_estimate:
             datetime(2010, 9, 11, 14, 30, 15),
         )
         assert next == datetime(2010, 9, 13, 0, 5)
-    
+
     def test_monthyear(self):
         next = self.next_occurrence(
             self.crontab(minute=30, hour=14, month_of_year='oct', day_of_month=18),


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Title explains everything, this allows creating crons using the month name similar to how week days currently work
so for example:
```python
from celery.schedules import crontab

crontab(month_of_year='mar')

# <crontab: * * * mar * (m/h/dM/MY/d)>

crontab(month_of_year='apr') 

#<crontab: * * * apr * (m/h/dM/MY/d)>

crontab(month_of_year='December') 

#<crontab: * * * December * (m/h/dM/MY/d)>
```
