### PR TITLE
Don't add a separator to global_keyprefix if it already has one

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -833,9 +833,11 @@ class BaseKeyValueStoreBackend(Backend):
         """
         global_keyprefix = self.app.conf.get('result_backend_transport_options', {}).get("global_keyprefix", None)
         if global_keyprefix:
-            self.task_keyprefix = f"{global_keyprefix}_{self.task_keyprefix}"
-            self.group_keyprefix = f"{global_keyprefix}_{self.group_keyprefix}"
-            self.chord_keyprefix = f"{global_keyprefix}_{self.chord_keyprefix}"
+            if global_keyprefix[-1] not in ':_-.':
+                global_keyprefix += '_'
+            self.task_keyprefix = f"{global_keyprefix}{self.task_keyprefix}"
+            self.group_keyprefix = f"{global_keyprefix}{self.group_keyprefix}"
+            self.chord_keyprefix = f"{global_keyprefix}{self.chord_keyprefix}"
 
     def _encode_prefixes(self):
         self.task_keyprefix = self.key_t(self.task_keyprefix)

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -760,7 +760,7 @@ class test_KeyValueStoreBackend:
         assert self.b._strip_prefix('x1b34') == 'x1b34'
 
     def test_global_keyprefix(self):
-        global_keyprefix = "test_global_keyprefix_"
+        global_keyprefix = "test_global_keyprefix"
         app = copy.deepcopy(self.app)
         app.conf.get('result_backend_transport_options', {}).update({"global_keyprefix": global_keyprefix})
         b = KVBackend(app=app)
@@ -768,6 +768,24 @@ class test_KeyValueStoreBackend:
         assert bytes_to_str(b.get_key_for_task(tid)) == f"{global_keyprefix}_celery-task-meta-{tid}"
         assert bytes_to_str(b.get_key_for_group(tid)) == f"{global_keyprefix}_celery-taskset-meta-{tid}"
         assert bytes_to_str(b.get_key_for_chord(tid)) == f"{global_keyprefix}_chord-unlock-{tid}"
+
+        global_keyprefix = "test_global_keyprefix_"
+        app = copy.deepcopy(self.app)
+        app.conf.get('result_backend_transport_options', {}).update({"global_keyprefix": global_keyprefix})
+        b = KVBackend(app=app)
+        tid = uuid()
+        assert bytes_to_str(b.get_key_for_task(tid)) == f"{global_keyprefix}celery-task-meta-{tid}"
+        assert bytes_to_str(b.get_key_for_group(tid)) == f"{global_keyprefix}celery-taskset-meta-{tid}"
+        assert bytes_to_str(b.get_key_for_chord(tid)) == f"{global_keyprefix}chord-unlock-{tid}"
+
+        global_keyprefix = "test_global_keyprefix:"
+        app = copy.deepcopy(self.app)
+        app.conf.get('result_backend_transport_options', {}).update({"global_keyprefix": global_keyprefix})
+        b = KVBackend(app=app)
+        tid = uuid()
+        assert bytes_to_str(b.get_key_for_task(tid)) == f"{global_keyprefix}celery-task-meta-{tid}"
+        assert bytes_to_str(b.get_key_for_group(tid)) == f"{global_keyprefix}celery-taskset-meta-{tid}"
+        assert bytes_to_str(b.get_key_for_chord(tid)) == f"{global_keyprefix}chord-unlock-{tid}"
 
     def test_global_keyprefix_missing(self):
         tid = uuid()


### PR DESCRIPTION
## Description

Fixes: https://github.com/celery/celery/issues/9066

Currently an underscore is appended to `result_backend_transport_options['global_keyprefix']`. This has at least two downsides:
1. the user cannot choose a separator, e.g. they may want to use `:` instead of `_` (which is common in redis, for example)
2. this doesn't match [documentation](https://github.com/celery/celery/blob/main/docs/getting-started/backends-and-brokers/redis.rst#global-keyprefix), which indirectly implies that a user needs to include their preferred separator:

```python
app.conf.result_backend_transport_options = {
    'global_keyprefix': 'my_prefix_'
}
```

Changes:
- if the prefix ends with a separator (one of `:_-.`), use the prefix as is, otherwise append a `_` separator for backward compatibility,
- add tests for new behavior.