### PR TITLE
Added missing import in examples for Django

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -298,3 +298,4 @@ Jeremy Z. Othieno 2023/07/27
 Tomer Nosrati, 2022/17/07
 Andy Zickler, 2024/01/18
 Johannes Faigle, 2024/06/18
+Giovanni Giampauli, 2024/06/26

--- a/examples/django/proj/celery.py
+++ b/examples/django/proj/celery.py
@@ -1,6 +1,7 @@
 import os
 
 from celery import Celery
+from django.conf import settings
 
 # Set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings')

--- a/examples/django/proj/celery.py
+++ b/examples/django/proj/celery.py
@@ -13,7 +13,7 @@ app = Celery('proj')
 # the configuration object to child processes.
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
-app.config_from_object('django.conf:settings', namespace='CELERY')
+app.config_from_object(f'django.conf:{settings.__name__}', namespace='CELERY')
 
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()

--- a/examples/django/proj/celery.py
+++ b/examples/django/proj/celery.py
@@ -1,7 +1,8 @@
 import os
 
-from celery import Celery
 from django.conf import settings
+
+from celery import Celery
 
 # Set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings')


### PR DESCRIPTION
**Fixes #9098**

## Description

The code snippet provided in the documentation needs an additional import to function correctly. Without this import, the code does not raise any errors, but it fails to discover `@shared_task`s in other files. This PR adds the necessary import statement.

**Link to Documentation:** [First steps with Django](https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html)
