### PR TITLE
Bump Kombu to v5.4.0rc1

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 billiard>=4.2.0,<5.0
-kombu>=5.3.4,<6.0
+kombu>=5.4.0rc1,<6.0
 vine>=5.1.0,<6.0
 click>=8.1.2,<9.0
 click-didyoumean>=0.3.0


### PR DESCRIPTION
This should apply the Redis fix from https://github.com/celery/kombu/pull/2007 to `main` and also generally check the [v5.4.0rc1](https://github.com/celery/kombu/releases/tag/v5.4.0rc1) is working fine with the latest celery changes