### PR TITLE
Update Django docs for CELERY_CACHE_BACKEND

### DIFF
--- a/docs/django/first-steps-with-django.rst
+++ b/docs/django/first-steps-with-django.rst
@@ -260,17 +260,14 @@ To use this with your project you need to follow these steps:
 
         CELERY_RESULT_BACKEND = 'django-db'
 
-    For the cache backend you can use:
+    When using the cache backend, you can specify a cache defined within
+    Django's CACHES setting.
 
     .. code-block:: python
 
-        CELERY_CACHE_BACKEND = 'django-cache'
+        CELERY_RESULT_BACKEND = 'django-cache'
 
-    We can also use the cache defined in the CACHES setting in django.
-
-    .. code-block:: python
-
-        # celery setting.
+        # pick which cache from the CACHES setting.
         CELERY_CACHE_BACKEND = 'default'
 
         # django setting.


### PR DESCRIPTION
## Description

The documentation for using [Django's ORM/Cache as a backend](https://docs.celeryq.dev/en/v5.4.0/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backend) indicates that setting `CELERY_CACHE_BACKEND = 'django-cache'` will configure Celery to use Django's cache backend. This is not correct: `CELERY_RESULT_BACKEND` must be set to `'django-cache'`, then `CELERY_CACHE_BACKEND` specifies which of Django's configured caches will be used.

I've confirmed on my machine that `CELERY_CACHE_BACKEND` must be set to `'django-cache'` to use the cache. [Issue 6047](https://github.com/celery/celery/issues/6047) tipped me off to the correct configuration.