### PR TITLE
Remove setuptools deprecated test command from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import os
 import re
 
 import setuptools
-import setuptools.command.test
 
 NAME = 'celery'
 


### PR DESCRIPTION
## Description
Fix #9157

Setuptools has deprecated and now removed the `setuptools.command.test` package.

Since this import statement was no longer in `setup.py` since 1baca0ca90b5bd7f38e3d2ae2d513f24cc0613ea this is a simple cleanup.
