### PR TITLE
Option to use and kill process group in prefork

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -341,6 +341,7 @@ NAMESPACES = Namespace(
         pool_putlocks=Option(True, type='bool'),
         pool_restarts=Option(False, type='bool'),
         proc_alive_timeout=Option(4.0, type='float'),
+        proc_use_process_group=Option(False, type='bool'),
         prefetch_multiplier=Option(4, type='int'),
         eta_task_limit=Option(None, type='int'),
         enable_prefetch_count_reduction=Option(True, type='bool'),

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -425,7 +425,7 @@ class AsynPool(_pool.Pool):
 
     def __init__(self, processes=None, synack=False,
                  sched_strategy=None, proc_alive_timeout=None,
-                 *args, **kwargs):
+                 proc_use_process_group=None, *args, **kwargs):
         self.sched_strategy = SCHED_STRATEGIES.get(sched_strategy,
                                                    sched_strategy)
         processes = self.cpu_count() if processes is None else processes
@@ -449,6 +449,10 @@ class AsynPool(_pool.Pool):
         self._proc_alive_timeout = (
             PROC_ALIVE_TIMEOUT if proc_alive_timeout is None
             else proc_alive_timeout
+        )
+        self._proc_use_process_group = (
+            proc_use_process_group if proc_use_process_group is not None
+            else False
         )
         self._waiting_to_start = set()
 
@@ -619,7 +623,7 @@ class AsynPool(_pool.Pool):
         process_flush_queues = self.process_flush_queues
         waiting_to_start = self._waiting_to_start
 
-        def verify_process_alive(proc):
+        def verify_process_alive(proc, kill_pg):
             proc = proc()  # is a weakref
             if (proc is not None and proc._is_alive() and
                     proc in waiting_to_start):
@@ -627,7 +631,10 @@ class AsynPool(_pool.Pool):
                 assert fileno_to_outq[proc.outqR_fd] is proc
                 assert proc.outqR_fd in hub.readers
                 error('Timed out waiting for UP message from %r', proc)
-                os.kill(proc.pid, 9)
+                if kill_pg:
+                    os.killpg(os.getpgid(proc.pid), 9)
+                else:
+                    os.kill(proc.pid, 9)
 
         def on_process_up(proc):
             """Called when a process has started."""
@@ -654,7 +661,10 @@ class AsynPool(_pool.Pool):
 
             waiting_to_start.add(proc)
             hub.call_later(
-                self._proc_alive_timeout, verify_process_alive, ref(proc),
+                self._proc_alive_timeout,
+                verify_process_alive,
+                ref(proc),
+                self._proc_use_process_group,
             )
 
         self.on_process_up = on_process_up

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -632,7 +632,12 @@ class AsynPool(_pool.Pool):
                 assert proc.outqR_fd in hub.readers
                 error('Timed out waiting for UP message from %r', proc)
                 if kill_pg:
-                    os.killpg(os.getpgid(proc.pid), 9)
+                    # Only attempt to use killpg/getpgid if available (not on Windows)
+                    if hasattr(os, "killpg") and hasattr(os, "getpgid"):
+                        os.killpg(os.getpgid(proc.pid), 9)
+                    else:
+                        # Fallback: kill the process directly if process groups are not supported
+                        os.kill(proc.pid, 9)
                 else:
                     os.kill(proc.pid, 9)
 

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -53,7 +53,8 @@ def process_initializer(app, hostname):
     app.loader.init_worker()
     app.loader.init_worker_process()
     if app.conf.worker_proc_use_process_group:
-        os.setpgrp()
+        if hasattr(os, "setpgrp"):
+            os.setpgrp()
     logfile = os.environ.get('CELERY_LOG_FILE') or None
     if logfile and '%i' in logfile.lower():
         # logfile path will differ so need to set up logging again.

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3407,7 +3407,7 @@ The timeout in seconds (int/float) when waiting for a new worker process to star
 .. setting:: worker_proc_use_process_group
 
 ``worker_proc_use_process_group``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Default: Disabled by default.
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3404,6 +3404,16 @@ Default: 4.0.
 
 The timeout in seconds (int/float) when waiting for a new worker process to start up.
 
+.. setting:: worker_proc_use_process_group
+
+``worker_proc_use_process_group``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: Disabled by default.
+
+Use a fresh process group for each new worker process. If the worker process fails to start up,
+send a kill signal to its process group instead of the worker process only.
+
 .. setting:: worker_cancel_long_running_tasks_on_connection_loss
 
 ``worker_cancel_long_running_tasks_on_connection_loss``


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

I have a project where I launch background subprocesses during `worker_process_init` signal and kill them during `worker_process_shutdown`. Sometimes, `worker_process_init`  takes more time than allowed by `worker_proc_alive_timeout`, and the problematic worker process is then killed by celery.
The background subprocesses are not killed when this happens, only the main worker process.

This PR adds a new option to create a new process group when starting a prefork pool process, and use `kill_pg` when killing processes that exceed the deadline. This at least solve my use case, but **please let me know if this is a good idea or not.**

Still missing ATM:
- [ ] Handle windows case (no support for `kill_pg`)
- [ ] Add some tests (maybe hard to test properly)

### MWE
You can change `worker_proc_use_process_group` to `False` to see that fork are not killed by default.
Also, you need to send a hello task, because `worker_proc_alive_timeout` it's not enforced the first time.
(I don't know if it's a bug or not).

```python
from celery import Celery, signals
from time import sleep
import os
import sys

class Config:
    worker_proc_alive_timeout=1.5
    worker_max_tasks_per_child=1
    worker_proc_use_process_group=True

app = Celery('hello', broker='redis://localhost')
app.config_from_object(Config())

@signals.worker_process_init.connect()
def init_worker_process(**kwargs):
    pid = os.fork()
    if pid == 0:
        for i in range(5):
            sleep(1)
            print(i)
        sys.exit(0)
    sleep(2)

@app.task
def hello():
    return 'hello world'
```