### PR TITLE
Bump Kombu to v5.4.0

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 billiard>=4.2.0,<5.0
-kombu>=5.4.0rc3,<6.0
+kombu>=5.4.0,<6.0
 vine>=5.1.0,<6.0
 click>=8.1.2,<9.0
 click-didyoumean>=0.3.0


### PR DESCRIPTION
[v5.4.0](https://github.com/celery/kombu/releases/tag/v5.4.0) is officially released