### PR TITLE
all added to routes

### DIFF
--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -20,7 +20,7 @@ except AttributeError:  # pragma: no cover
     # for support Python 3.7
     Pattern = re.Pattern
 
-__all__ = ('MapRoute', 'Router', 'prepare')
+__all__ = ('MapRoute', 'Router', 'expand_router_string', 'prepare')
 
 
 class MapRoute:


### PR DESCRIPTION

Simple fix: Adding expand_router_string to the __all__ in /celery/app/routes.py.

