### PR TITLE
Native Delayed Delivery in RabbitMQ

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -513,6 +513,7 @@ class Celery:
                 if shared:
                     def cons(app):
                         return app._task_from_fun(fun, **opts)
+
                     cons.__name__ = fun.__name__
                     connect_on_app_finalize(cons)
                 if not lazy or self.finalized:
@@ -848,10 +849,12 @@ class Celery:
                     options['routing_key'] = routing_key
                     options['exchange'] = exchange
         elif is_native_delayed_delivery and options['queue'].exchange.type == 'direct':
-            logger.warn("Direct exchanges are not supported with native delayed delivery.\n"
-                        f"{options['queue'].exchange.name} is a direct exchange but should be a topic exchange or "
-                        f"a fanout exchange in order for native delayed delivery to work properly.\n"
-                        f"If quorum queues are used, this task may block the worker process until the ETA arrives.")
+            logger.warning(
+                'Direct exchanges are not supported with native delayed delivery.\n'
+                f'{options["queue"].exchange.name} is a direct exchange but should be a topic exchange or '
+                'a fanout exchange in order for native delayed delivery to work properly.\n'
+                'If quorum queues are used, this task may block the worker process until the ETA arrives.'
+            )
 
         if expires is not None:
             if isinstance(expires, datetime):
@@ -1013,6 +1016,7 @@ class Celery:
                 'broker_connection_timeout', connect_timeout
             ),
         )
+
     broker_connection = connection
 
     def _acquire_connection(self, pool=True):
@@ -1032,6 +1036,7 @@ class Celery:
                 will be acquired from the connection pool.
         """
         return FallbackContext(connection, self._acquire_connection, pool=pool)
+
     default_connection = connection_or_acquire  # XXX compat
 
     def producer_or_acquire(self, producer=None):
@@ -1047,6 +1052,7 @@ class Celery:
         return FallbackContext(
             producer, self.producer_pool.acquire, block=True,
         )
+
     default_producer = producer_or_acquire  # XXX compat
 
     def prepare_config(self, c):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -834,6 +834,8 @@ class Celery:
             or conf.broker_url.startswith('py-amqp://')
         ):
             if eta:
+                if isinstance(eta, str):
+                    eta = isoparse(eta)
                 countdown = (maybe_make_aware(eta) - self.now()).total_seconds()
 
             if countdown:

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -832,7 +832,7 @@ class Celery:
             options, route_name or name, args, kwargs, task_type)
 
         is_native_delayed_delivery = conf.broker_native_delayed_delivery and (
-            conf.broker_url.startswith('amqp://') or conf.broker_url.startswith('py-amqp://'))
+            self.producer_pool.connections.connection == 'amqp')
         if is_native_delayed_delivery and options['queue'].exchange.type != 'direct':
             if eta:
                 if isinstance(eta, str):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -14,7 +14,7 @@ from operator import attrgetter
 
 from click.exceptions import Exit
 from dateutil.parser import isoparse
-from kombu import Exchange, Queue, pools
+from kombu import Exchange, pools
 from kombu.clocks import LamportClock
 from kombu.common import oid_from
 from kombu.utils.compat import register_after_fork
@@ -844,18 +844,9 @@ class Celery:
                         'celery_delayed_27',
                         type='topic',
                     )
-                    options['queue'] = Queue(
-                        'celery_delayed_27',
-                        exchange=exchange,
-                        routing_key=routing_key,
-                        queue_arguments={
-                            "x-queue-type": "quorum",
-                            "x-dead-letter-strategy": "at-least-once",
-                            "x-overflow": "reject-publish",
-                            "x-message-ttl": pow(2, 27) * 1000,
-                            "x-dead-letter-exchange": 'celery_delayed_26',
-                        }
-                    )
+                    del options['queue']
+                    options['routing_key'] = routing_key
+                    options['exchange'] = exchange
         elif is_native_delayed_delivery and options['queue'].exchange.type == 'direct':
             logger.warn("Direct exchanges are not supported with native delayed delivery.\n"
                         f"{options['queue'].exchange.name} is a direct exchange but should be a topic exchange or "

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -39,6 +39,7 @@ from celery.utils.objects import FallbackContext, mro_lookup
 from celery.utils.time import maybe_make_aware, timezone, to_utc
 
 from ..utils.annotations import annotation_is_class, annotation_issubclass, get_optional_arg
+from ..utils.quorum_queues import detect_quorum_queues
 # Load all builtin tasks
 from . import backends, builtins  # noqa
 from .annotations import prepare as prepare_annotations
@@ -831,8 +832,8 @@ class Celery:
         options = router.route(
             options, route_name or name, args, kwargs, task_type)
 
-        is_native_delayed_delivery = conf.broker_native_delayed_delivery and (
-            self.producer_pool.connections.connection == 'amqp')
+        is_native_delayed_delivery = detect_quorum_queues(self,
+                                                          self.producer_pool.connections.connection.transport_cls)[0]
         if is_native_delayed_delivery and options['queue'].exchange.type != 'direct':
             if eta:
                 if isinstance(eta, str):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -856,6 +856,11 @@ class Celery:
                             "x-dead-letter-exchange": 'celery_delayed_26',
                         }
                     )
+        elif is_native_delayed_delivery and options['queue'].exchange.type == 'direct':
+            logger.warn("Direct exchanges are not supported with native delayed delivery.\n"
+                        f"{options['queue'].exchange.name} is a direct exchange but should be a topic exchange or "
+                        f"a fanout exchange in order for native delayed delivery to work properly.\n"
+                        f"If quorum queues are used, this task may block the worker process until the ETA arrives.")
 
         if expires is not None:
             if isinstance(expires, datetime):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -14,7 +14,7 @@ from operator import attrgetter
 
 from click.exceptions import Exit
 from dateutil.parser import isoparse
-from kombu import pools, Queue, Exchange
+from kombu import Exchange, Queue, pools
 from kombu.clocks import LamportClock
 from kombu.common import oid_from
 from kombu.utils.compat import register_after_fork

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -17,6 +17,7 @@ from dateutil.parser import isoparse
 from kombu import Exchange, pools
 from kombu.clocks import LamportClock
 from kombu.common import oid_from
+from kombu.transport.native_delayed_delivery import calculate_routing_key
 from kombu.utils.compat import register_after_fork
 from kombu.utils.objects import cached_property
 from kombu.utils.uuid import uuid
@@ -840,7 +841,7 @@ class Celery:
 
             if countdown:
                 if countdown > 0:
-                    routing_key = '.'.join(list(f'{int(countdown):028b}')) + f'.{options["queue"].routing_key}'
+                    routing_key = calculate_routing_key(int(countdown), options["queue"].routing_key)
                     exchange = Exchange(
                         'celery_delayed_27',
                         type='topic',

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -96,7 +96,7 @@ NAMESPACES = Namespace(
         heartbeat_checkrate=Option(3.0, type='int'),
         login_method=Option(None, type='string'),
         native_delayed_delivery=Option(False, type='bool'),
-        native_delayed_delivery_queue_type=Option(default='classic', type='string'),
+        native_delayed_delivery_queue_type=Option(default='quorum', type='string'),
         pool_limit=Option(10, type='int'),
         use_ssl=Option(False, type='bool'),
 

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -96,7 +96,6 @@ NAMESPACES = Namespace(
         heartbeat_checkrate=Option(3.0, type='int'),
         login_method=Option(None, type='string'),
         native_delayed_delivery=Option(False, type='bool'),
-        native_delayed_delivery_queue_type=Option(default='classic', type='string'),
         pool_limit=Option(10, type='int'),
         use_ssl=Option(False, type='bool'),
 

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -96,6 +96,7 @@ NAMESPACES = Namespace(
         heartbeat_checkrate=Option(3.0, type='int'),
         login_method=Option(None, type='string'),
         native_delayed_delivery=Option(False, type='bool'),
+        native_delayed_delivery_queue_type=Option(default='classic', type='string'),
         pool_limit=Option(10, type='int'),
         use_ssl=Option(False, type='bool'),
 

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -95,7 +95,6 @@ NAMESPACES = Namespace(
         heartbeat=Option(120, type='int'),
         heartbeat_checkrate=Option(3.0, type='int'),
         login_method=Option(None, type='string'),
-        native_delayed_delivery=Option(False, type='bool'),
         native_delayed_delivery_queue_type=Option(default='quorum', type='string'),
         pool_limit=Option(10, type='int'),
         use_ssl=Option(False, type='bool'),

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -95,6 +95,7 @@ NAMESPACES = Namespace(
         heartbeat=Option(120, type='int'),
         heartbeat_checkrate=Option(3.0, type='int'),
         login_method=Option(None, type='string'),
+        native_delayed_delivery=Option(False, type='bool'),
         pool_limit=Option(10, type='int'),
         use_ssl=Option(False, type='bool'),
 

--- a/celery/backends/dynamodb.py
+++ b/celery/backends/dynamodb.py
@@ -504,7 +504,7 @@ class DynamoDBBackend(KeyValueStoreBackend):
             "ExpressionAttributeValues": {
                 ":num": {"N": "1"},
             },
-            "ReturnValues" : "UPDATED_NEW",
+            "ReturnValues": "UPDATED_NEW",
         }
 
     def _item_to_dict(self, raw_response):

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -97,7 +97,7 @@ class ElasticsearchBackend(KeyValueStoreBackend):
             # N/A: Low level exception (i.e. socket exception)
             if exc.status_code in {401, 409, 500, 502, 504, 'N/A'}:
                 return True
-        if isinstance(exc , elasticsearch.exceptions.TransportError):
+        if isinstance(exc, elasticsearch.exceptions.TransportError):
             return True
         return False
 

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -173,6 +173,7 @@ class CeleryCommand(click.Command):
 
 class DaemonOption(CeleryOption):
     """Common daemonization option"""
+
     def __init__(self, *args, **kwargs):
         super().__init__(args,
                          help_group=kwargs.pop("help_group", "Daemonization Options"),

--- a/celery/utils/quorum_queues.py
+++ b/celery/utils/quorum_queues.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+
+def detect_quorum_queues(app, driver_type: str) -> tuple[bool, str]:
+    """Detect if any of the queues are quorum queues.
+
+    Returns:
+        tuple[bool, str]: A tuple containing a boolean indicating if any of the queues are quorum queues
+        and the name of the first quorum queue found or an empty string if no quorum queues were found.
+    """
+    is_rabbitmq_broker = driver_type == 'amqp'
+
+    if is_rabbitmq_broker:
+        queues = app.amqp.queues
+        for qname in queues:
+            qarguments = queues[qname].queue_arguments or {}
+            if qarguments.get("x-queue-type") == "quorum":
+                return True, qname
+
+    return False, ""

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -169,6 +169,7 @@ class Consumer:
             'celery.worker.consumer.heart:Heart',
             'celery.worker.consumer.control:Control',
             'celery.worker.consumer.tasks:Tasks',
+            'celery.worker.consumer.delayed_delivery:DelayedDelivery',
             'celery.worker.consumer.consumer:Evloop',
             'celery.worker.consumer.agent:Agent',
         ]

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -478,9 +478,9 @@ class Consumer:
         return self.ensure_connected(
             self.app.connection_for_read(heartbeat=heartbeat))
 
-    def connection_for_write(self, heartbeat=None):
+    def connection_for_write(self, url=None, heartbeat=None):
         return self.ensure_connected(
-            self.app.connection_for_write(heartbeat=heartbeat))
+            self.app.connection_for_write(url=url, heartbeat=heartbeat))
 
     def ensure_connected(self, conn):
         # Callback called for each retry while the connection

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -32,7 +32,6 @@ class DelayedDelivery(bootsteps.StartStopStep):
             next_level = self.level_name(level - 1)
 
             delayed_exchange: Exchange = Exchange(current_level, type="topic").bind(channel)
-            # delayed_exchange.delete()  # POC Code only
             delayed_exchange.declare()
 
             delayed_queue: Queue = Queue(
@@ -45,7 +44,6 @@ class DelayedDelivery(bootsteps.StartStopStep):
                     "x-dead-letter-exchange": next_level if level > 0 else self.CELERY_DELAYED_DELIVERY_EXCHANGE,
                 }
             ).bind(channel)
-            # delayed_queue.delete()  # POC Code only
             delayed_queue.declare()
             delayed_queue.bind_to(current_level, routing_key)
 
@@ -63,7 +61,6 @@ class DelayedDelivery(bootsteps.StartStopStep):
             routing_key = "*." + routing_key
 
         delivery_exchange: Exchange = Exchange(self.CELERY_DELAYED_DELIVERY_EXCHANGE, type="topic").bind(channel)
-        # delivery_exchange.delete()  # POC Code only
         delivery_exchange.declare()
         delivery_exchange.bind_to(self.level_name(0), routing_key)
 

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -11,6 +11,7 @@ logger = get_logger(__name__)
 
 
 class DelayedDelivery(bootsteps.StartStopStep):
+    """This bootstep declares native delayed delivery queues and exchanges and binds all queues to them"""
     requires = (Tasks,)
 
     def include_if(self, c):

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -41,7 +41,7 @@ class DelayedDelivery(bootsteps.StartStopStep):
             delayed_queue: Queue = Queue(
                 current_level,
                 queue_arguments={
-                    "x-queue-type": "quorum",
+                    "x-queue-type": c.app.conf.broker_native_delayed_delivery_queue_type,
                     "x-dead-letter-strategy": "at-least-once",
                     "x-overflow": "reject-publish",
                     "x-message-ttl": pow(2, level) * 1000,

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -39,7 +39,7 @@ class DelayedDelivery(bootsteps.StartStopStep):
             delayed_queue: Queue = Queue(
                 current_level,
                 queue_arguments={
-                    "x-queue-type": "quorum",
+                    "x-queue-type": c.app.conf.broker_native_delayed_delivery_queue_type,
                     "x-dead-letter-strategy": "at-least-once",
                     "x-overflow": "reject-publish",
                     "x-message-ttl": pow(2, level) * 1000,

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -1,9 +1,12 @@
 from kombu import Exchange, Queue
 
 from celery import Celery, bootsteps
+from celery.utils.log import get_logger
 from celery.worker.consumer import Consumer, Tasks
 
 __all__ = ('DelayedDelivery',)
+
+logger = get_logger(__name__)
 
 
 class DelayedDelivery(bootsteps.StartStopStep):
@@ -72,7 +75,9 @@ class DelayedDelivery(bootsteps.StartStopStep):
             exchange: Exchange = queue.exchange.bind(channel)
 
             if exchange.type == 'direct':
-                # TODO: Add warning
+                logger.warn(f"Exchange {exchange.name} is a direct exchange "
+                            f"and native delayed delivery do not support direct exchanges.\n"
+                            f"ETA tasks published to this exchange will block the worker until the ETA arrives.")
                 continue
 
             routing_key = queue.routing_key if queue.routing_key.startswith('#') else f"#.{queue.routing_key}"

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -12,6 +12,12 @@ class DelayedDelivery(bootsteps.StartStopStep):
     MAX_LEVEL = MAX_NUMBER_OF_BITS_TO_USE - 1
     CELERY_DELAYED_DELIVERY_EXCHANGE = "celery_delayed_delivery"
 
+    def include_if(self, c):
+        return c.app.conf.broker_native_delayed_delivery and (
+            c.app.conf.broker_url.startswith('amqp://')
+            or c.app.conf.broker_url.startswith('py-amqp://')
+        )
+
     def level_name(self, level: int) -> str:
         return f"celery_delayed_{level}"
 

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -26,7 +26,7 @@ class DelayedDelivery(bootsteps.StartStopStep):
             next_level = self.level_name(level - 1)
 
             delayed_exchange: Exchange = Exchange(current_level, type="topic").bind(channel)
-            delayed_exchange.delete()  # POC Code only
+            # delayed_exchange.delete()  # POC Code only
             delayed_exchange.declare()
 
             delayed_queue: Queue = Queue(
@@ -39,7 +39,7 @@ class DelayedDelivery(bootsteps.StartStopStep):
                     "x-dead-letter-exchange": next_level if level > 0 else self.CELERY_DELAYED_DELIVERY_EXCHANGE,
                 }
             ).bind(channel)
-            delayed_queue.delete()  # POC Code only
+            # delayed_queue.delete()  # POC Code only
             delayed_queue.declare()
             delayed_queue.bind_to(current_level, routing_key)
 
@@ -57,7 +57,7 @@ class DelayedDelivery(bootsteps.StartStopStep):
             routing_key = "*." + routing_key
 
         delivery_exchange: Exchange = Exchange(self.CELERY_DELAYED_DELIVERY_EXCHANGE, type="topic").bind(channel)
-        delivery_exchange.delete()  # POC Code only
+        # delivery_exchange.delete()  # POC Code only
         delivery_exchange.declare()
         delivery_exchange.bind_to(self.level_name(0), routing_key)
 

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -1,4 +1,5 @@
-from kombu import Exchange, Queue
+from kombu.transport.native_delayed_delivery import (bind_queue_to_native_delayed_delivery_exchange,
+                                                     declare_native_delayed_delivery_exchanges_and_queues)
 
 from celery import Celery, bootsteps
 from celery.utils.log import get_logger
@@ -12,76 +13,18 @@ logger = get_logger(__name__)
 class DelayedDelivery(bootsteps.StartStopStep):
     requires = (Tasks,)
 
-    MAX_NUMBER_OF_BITS_TO_USE = 28
-    MAX_LEVEL = MAX_NUMBER_OF_BITS_TO_USE - 1
-    CELERY_DELAYED_DELIVERY_EXCHANGE = "celery_delayed_delivery"
-
     def include_if(self, c):
         return (c.app.conf.broker_native_delayed_delivery
                 and c.connection_for_write().transport.driver_type == 'amqp')
 
-    def level_name(self, level: int) -> str:
-        return f"celery_delayed_{level}"
-
     def start(self, c: Consumer):
         connection = c.connection_for_write()
-        channel = connection.channel()
-
-        routing_key: str = "1.#"
-
-        for level in range(27, -1, - 1):
-            current_level = self.level_name(level)
-            next_level = self.level_name(level - 1)
-
-            delayed_exchange: Exchange = Exchange(current_level, type="topic").bind(channel)
-            delayed_exchange.declare()
-
-            queue_arguments = {
-                "x-queue-type": c.app.conf.broker_native_delayed_delivery_queue_type,
-                "x-overflow": "reject-publish",
-                "x-message-ttl": pow(2, level) * 1000,
-                "x-dead-letter-exchange": next_level if level > 0 else self.CELERY_DELAYED_DELIVERY_EXCHANGE,
-            }
-
-            if c.app.conf.broker_native_delayed_delivery_queue_type == 'quorum':
-                queue_arguments["x-dead-letter-strategy"] = "at-least-once"
-
-            delayed_queue: Queue = Queue(
-                current_level,
-                queue_arguments=queue_arguments
-            ).bind(channel)
-            delayed_queue.declare()
-            delayed_queue.bind_to(current_level, routing_key)
-
-            routing_key = "*." + routing_key
-
-        routing_key = "0.#"
-        for level in range(27, 0, - 1):
-            current_level = self.level_name(level)
-            next_level = self.level_name(level - 1)
-
-            next_level_exchange: Exchange = Exchange(next_level, type="topic").bind(channel)
-
-            next_level_exchange.bind_to(current_level, routing_key)
-
-            routing_key = "*." + routing_key
-
-        delivery_exchange: Exchange = Exchange(self.CELERY_DELAYED_DELIVERY_EXCHANGE, type="topic").bind(channel)
-        delivery_exchange.declare()
-        delivery_exchange.bind_to(self.level_name(0), routing_key)
-
         app: Celery = c.app
 
+        declare_native_delayed_delivery_exchanges_and_queues(
+            connection,
+            app.conf.broker_native_delayed_delivery_queue_type
+        )
+
         for queue in app.amqp.queues.values():
-            queue: Queue = queue.bind(channel)
-            exchange: Exchange = queue.exchange.bind(channel)
-
-            if exchange.type == 'direct':
-                logger.warn(f"Exchange {exchange.name} is a direct exchange "
-                            f"and native delayed delivery do not support direct exchanges.\n"
-                            f"ETA tasks published to this exchange will block the worker until the ETA arrives.")
-                continue
-
-            routing_key = queue.routing_key if queue.routing_key.startswith('#') else f"#.{queue.routing_key}"
-            exchange.bind_to(self.CELERY_DELAYED_DELIVERY_EXCHANGE, routing_key=routing_key)
-            queue.bind_to(exchange.name, routing_key=routing_key)
+            bind_queue_to_native_delayed_delivery_exchange(connection, queue)

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -5,6 +5,7 @@ from celery.worker.consumer import Consumer, Tasks
 
 __all__ = ('DelayedDelivery',)
 
+
 class DelayedDelivery(bootsteps.StartStopStep):
     requires = (Tasks,)
 

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -1,0 +1,76 @@
+from kombu import Exchange, Queue
+
+from celery import bootsteps, Celery
+from celery.worker.consumer import Consumer, Tasks
+
+__all__ = ('DelayedDelivery',)
+
+class DelayedDelivery(bootsteps.StartStopStep):
+    requires = (Tasks,)
+
+    MAX_NUMBER_OF_BITS_TO_USE = 28
+    MAX_LEVEL = MAX_NUMBER_OF_BITS_TO_USE - 1
+    CELERY_DELAYED_DELIVERY_EXCHANGE = "celery_delayed_delivery"
+
+    def level_name(self, level: int) -> str:
+        return f"celery_delayed_{level}"
+
+    def start(self, c: Consumer):
+        connection = c.connection_for_write()
+        channel = connection.channel()
+
+        routing_key: str = "1.#"
+
+        for level in range(27, -1, - 1):
+            current_level = self.level_name(level)
+            next_level = self.level_name(level - 1)
+
+            delayed_exchange: Exchange = Exchange(current_level, type="topic").bind(channel)
+            delayed_exchange.delete()  # POC Code only
+            delayed_exchange.declare()
+
+            delayed_queue: Queue = Queue(
+                current_level,
+                queue_arguments={
+                    "x-queue-type": "quorum",
+                    "x-dead-letter-strategy": "at-least-once",
+                    "x-overflow": "reject-publish",
+                    "x-message-ttl": pow(2, level) * 1000,
+                    "x-dead-letter-exchange": next_level if level > 0 else self.CELERY_DELAYED_DELIVERY_EXCHANGE,
+                }
+            ).bind(channel)
+            delayed_queue.delete()  # POC Code only
+            delayed_queue.declare()
+            delayed_queue.bind_to(current_level, routing_key)
+
+            routing_key = "*." + routing_key
+
+        routing_key = "0.#"
+        for level in range(27, 0, - 1):
+            current_level = self.level_name(level)
+            next_level = self.level_name(level - 1)
+
+            next_level_exchange: Exchange = Exchange(next_level, type="topic").bind(channel)
+
+            next_level_exchange.bind_to(current_level, routing_key)
+
+            routing_key = "*." + routing_key
+
+        delivery_exchange: Exchange = Exchange(self.CELERY_DELAYED_DELIVERY_EXCHANGE, type="topic").bind(channel)
+        delivery_exchange.delete()  # POC Code only
+        delivery_exchange.declare()
+        delivery_exchange.bind_to(self.level_name(0), routing_key)
+
+        app: Celery = c.app
+
+        for queue in app.amqp.queues.values():
+            queue: Queue = queue.bind(channel)
+            exchange: Exchange = queue.exchange.bind(channel)
+
+            if exchange.type == 'direct':
+                # TODO: Add warning
+                continue
+
+            routing_key = queue.routing_key if queue.routing_key.startswith('#') else f"#.{queue.routing_key}"
+            exchange.bind_to(self.CELERY_DELAYED_DELIVERY_EXCHANGE, routing_key=routing_key)
+            queue.bind_to(exchange.name, routing_key=routing_key)

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -17,10 +17,7 @@ class DelayedDelivery(bootsteps.StartStopStep):
     CELERY_DELAYED_DELIVERY_EXCHANGE = "celery_delayed_delivery"
 
     def include_if(self, c):
-        return c.app.conf.broker_native_delayed_delivery and (
-            c.app.conf.broker_url.startswith('amqp://')
-            or c.app.conf.broker_url.startswith('py-amqp://')
-        )
+        return c.app.conf.broker_native_delayed_delivery and c.connection.transport.driver_type == 'amqp'
 
     def level_name(self, level: int) -> str:
         return f"celery_delayed_{level}"

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -17,7 +17,8 @@ class DelayedDelivery(bootsteps.StartStopStep):
     CELERY_DELAYED_DELIVERY_EXCHANGE = "celery_delayed_delivery"
 
     def include_if(self, c):
-        return c.app.conf.broker_native_delayed_delivery and c.connection.transport.driver_type == 'amqp'
+        return (c.app.conf.broker_native_delayed_delivery
+                and c.connection_for_write().transport.driver_type == 'amqp')
 
     def level_name(self, level: int) -> str:
         return f"celery_delayed_{level}"

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -19,13 +19,15 @@ class DelayedDelivery(bootsteps.StartStopStep):
                 and c.connection_for_write().transport.driver_type == 'amqp')
 
     def start(self, c: Consumer):
-        connection = c.connection_for_write()
         app: Celery = c.app
 
-        declare_native_delayed_delivery_exchanges_and_queues(
-            connection,
-            app.conf.broker_native_delayed_delivery_queue_type
-        )
+        for broker_url in app.conf.broker_url.split(';'):
+            connection = c.connection_for_write(url=broker_url)
 
-        for queue in app.amqp.queues.values():
-            bind_queue_to_native_delayed_delivery_exchange(connection, queue)
+            declare_native_delayed_delivery_exchanges_and_queues(
+                connection,
+                app.conf.broker_native_delayed_delivery_queue_type
+            )
+
+            for queue in app.amqp.queues.values():
+                bind_queue_to_native_delayed_delivery_exchange(connection, queue)

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -3,6 +3,7 @@ from kombu.transport.native_delayed_delivery import (bind_queue_to_native_delaye
 
 from celery import Celery, bootsteps
 from celery.utils.log import get_logger
+from celery.utils.quorum_queues import detect_quorum_queues
 from celery.worker.consumer import Consumer, Tasks
 
 __all__ = ('DelayedDelivery',)
@@ -15,8 +16,7 @@ class DelayedDelivery(bootsteps.StartStopStep):
     requires = (Tasks,)
 
     def include_if(self, c):
-        return (c.app.conf.broker_native_delayed_delivery
-                and c.connection_for_write().transport.driver_type == 'amqp')
+        return detect_quorum_queues(c.app, c.app.connection_for_write().transport.driver_type)[0]
 
     def start(self, c: Consumer):
         app: Celery = c.app

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -41,7 +41,7 @@ class DelayedDelivery(bootsteps.StartStopStep):
             delayed_queue: Queue = Queue(
                 current_level,
                 queue_arguments={
-                    "x-queue-type": c.app.conf.broker_native_delayed_delivery_queue_type,
+                    "x-queue-type": "quorum",
                     "x-dead-letter-strategy": "at-least-once",
                     "x-overflow": "reject-publish",
                     "x-message-ttl": pow(2, level) * 1000,

--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -1,6 +1,6 @@
 from kombu import Exchange, Queue
 
-from celery import bootsteps, Celery
+from celery import Celery, bootsteps
 from celery.worker.consumer import Consumer, Tasks
 
 __all__ = ('DelayedDelivery',)

--- a/celery/worker/consumer/tasks.py
+++ b/celery/worker/consumer/tasks.py
@@ -91,9 +91,6 @@ class Tasks(bootsteps.StartStopStep):
         if c.app.conf.worker_detect_quorum_queues:
             using_quorum_queues, qname = self.detect_quorum_queues(c)
 
-            if c.app.conf.broker_native_delayed_delivery is True:
-                using_quorum_queues = True
-
             if using_quorum_queues:
                 qos_global = False
                 logger.info("Global QoS is disabled. Prefetch count in now static.")

--- a/celery/worker/consumer/tasks.py
+++ b/celery/worker/consumer/tasks.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import warnings
-
 from kombu.common import QoS, ignore_errors
 
 from celery import bootsteps
-from celery.exceptions import CeleryWarning
 from celery.utils.log import get_logger
 
 from .mingle import Mingle
@@ -16,15 +13,6 @@ __all__ = ('Tasks',)
 
 logger = get_logger(__name__)
 debug = logger.debug
-
-
-ETA_TASKS_NO_GLOBAL_QOS_WARNING = """
-Detected quorum queue "%r", disabling global QoS.
-With global QoS disabled, ETA tasks may not function as expected. Instead of adjusting
-the prefetch count dynamically, ETA tasks will occupy the prefetch buffer, potentially
-blocking other tasks from being consumed.
-Please enable native delayed delivery so that ETA tasks will not block the worker.
-"""
 
 
 class Tasks(bootsteps.StartStopStep):
@@ -94,11 +82,6 @@ class Tasks(bootsteps.StartStopStep):
             if using_quorum_queues:
                 qos_global = False
                 logger.info("Global QoS is disabled. Prefetch count in now static.")
-                # The ETA tasks mechanism requires additional work for Celery to fully support
-                # quorum queues. Warn the user that ETA tasks may not function as expected until
-                # this is done so we can at least support quorum queues partially for now.
-                if c.app.conf.broker_native_delayed_delivery is False:
-                    warnings.warn(ETA_TASKS_NO_GLOBAL_QOS_WARNING % (qname,), CeleryWarning)
 
         return qos_global
 

--- a/docs/getting-started/backends-and-brokers/rabbitmq.rst
+++ b/docs/getting-started/backends-and-brokers/rabbitmq.rst
@@ -221,3 +221,12 @@ In order to properly schedule ETA/Countdown tasks you need to enable :ref:`Nativ
 
 Native Delayed Delivery
 -----------------------
+
+Since tasks with ETA/Countdown will block the worker until they are scheduled for execution,
+we need to use RabbitMQ's native capabilities to schedule the execution of tasks.
+
+The design is borrowed from NServiceBus. If you are interested in the implementation details, refer to their `documentation`_.
+
+.. _documentation: https://docs.particular.net/transports/rabbitmq/delayed-delivery
+
+To enable Native Delayed Delivery set the :setting:`broker_native_delayed_delivery` setting to ``True``.

--- a/docs/getting-started/backends-and-brokers/rabbitmq.rst
+++ b/docs/getting-started/backends-and-brokers/rabbitmq.rst
@@ -190,6 +190,7 @@ Celery supports `Quorum Queues`_ by setting the ``x-queue-type`` header to ``quo
     from kombu import Queue
 
     task_queues = [Queue('my-queue', queue_arguments={'x-queue-type': 'quorum'})]
+    broker_transport_options = {"confirm_publish": True}
 
 If you'd like to change the type of the default queue, set the :setting:`task_default_queue_type` setting to ``quorum``.
 

--- a/docs/getting-started/backends-and-brokers/rabbitmq.rst
+++ b/docs/getting-started/backends-and-brokers/rabbitmq.rst
@@ -178,6 +178,8 @@ When the server is running, you can continue reading `Setting up RabbitMQ`_.
 Using Quorum Queues
 ===================
 
+.. versionadded:: 5.5
+
 .. warning::
 
     Quorum Queues require disabling global QoS which means some features won't work as expected.

--- a/docs/getting-started/backends-and-brokers/rabbitmq.rst
+++ b/docs/getting-started/backends-and-brokers/rabbitmq.rst
@@ -173,5 +173,7 @@ but rather use the :command:`rabbitmqctl` command:
 
 When the server is running, you can continue reading `Setting up RabbitMQ`_.
 
+.. _using-quorum-queues:
+
 Using Quorum Queues
 ===================

--- a/docs/getting-started/backends-and-brokers/rabbitmq.rst
+++ b/docs/getting-started/backends-and-brokers/rabbitmq.rst
@@ -172,3 +172,6 @@ but rather use the :command:`rabbitmqctl` command:
     $ sudo rabbitmqctl stop
 
 When the server is running, you can continue reading `Setting up RabbitMQ`_.
+
+Using Quorum Queues
+===================

--- a/docs/getting-started/backends-and-brokers/rabbitmq.rst
+++ b/docs/getting-started/backends-and-brokers/rabbitmq.rst
@@ -199,6 +199,8 @@ If you'd like to change the type of the default queue, set the :setting:`task_de
 Celery automatically detects if quorum queues are used using the :setting:`worker_detect_quorum_queues` setting.
 We recommend to keep the default behavior turned on.
 
+To migrate from classic mirrored queues to quorum queues, please refer to RabbitMQ's `documentation <https://www.rabbitmq.com/blog/2023/03/02/quorum-queues-migration>`_ on the subject.
+
 .. _`Quorum Queues`: https://www.rabbitmq.com/docs/quorum-queues
 
 .. _limitations:

--- a/docs/getting-started/backends-and-brokers/rabbitmq.rst
+++ b/docs/getting-started/backends-and-brokers/rabbitmq.rst
@@ -220,7 +220,8 @@ when Quorum Queues are detected.
 In addition, :ref:`ETA/Countdown <calling-eta>` will block the worker when received until the ETA arrives since
 we can no longer increase the prefetch count and fetch another task from the queue.
 
-In order to properly schedule ETA/Countdown tasks you need to enable :ref:`Native Delayed Delivery <native-delayed-delivery>`.
+In order to properly schedule ETA/Countdown tasks we automatically detect if quorum queues are used
+and in case they are, Celery automatically enables :ref:`Native Delayed Delivery <native-delayed-delivery>`.
 
 .. _native-delayed-delivery:
 
@@ -234,4 +235,4 @@ The design is borrowed from NServiceBus. If you are interested in the implementa
 
 .. _documentation: https://docs.particular.net/transports/rabbitmq/delayed-delivery
 
-To enable Native Delayed Delivery set the :setting:`broker_native_delayed_delivery` setting to ``True``.
+Native Delayed Delivery is automatically enabled when quorum queues are detected.

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3008,11 +3008,17 @@ Set custom amqp login method.
 .. setting:: broker_native_delayed_delivery
 
 ``broker_native_delayed_delivery``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 5.5
 
+:transports supported: ``pyamqp``
+
 Default: Disabled.
+
+When enabled, tasks with ETAs and Countdowns will use the native delayed delivery mechanism for RabbitMQ.
+
+See :ref:`using-quorum-queues` for details regarding native delayed delivery.
 
 .. setting:: broker_transport_options
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -79,7 +79,6 @@ have been moved into a new  ``task_`` prefix.
 ``BROKER_FAILOVER_STRATEGY``               :setting:`broker_failover_strategy`
 ``BROKER_HEARTBEAT``                       :setting:`broker_heartbeat`
 ``BROKER_LOGIN_METHOD``                    :setting:`broker_login_method`
-``BROKER_NATIVE_DELAYED_DELIVERY``         :setting:`broker_native_delayed_delivery`
 ``BROKER_NATIVE_DELAYED_DELIVERY_QUEUE_TYPE`` :setting:`broker_native_delayed_delivery_queue_type`
 ``BROKER_POOL_LIMIT``                      :setting:`broker_pool_limit`
 ``BROKER_USE_SSL``                         :setting:`broker_use_ssl`
@@ -2658,13 +2657,6 @@ automatically detect the queue type and disable the global QoS accordingly.
 
 .. warning::
 
-    When using quorum queues, ETA tasks may not function as expected. Instead of adjusting
-    the prefetch count dynamically, ETA tasks will occupy the prefetch buffer, potentially
-    blocking other tasks from being consumed. To mitigate this, enable the :setting:`broker_native_delayed_delivery`
-    setting.
-
-.. warning::
-
     Quorum queues require confirm publish to be enabled.
     Use :setting:`broker_transport_options` to enable confirm publish by setting:
 
@@ -3005,21 +2997,6 @@ Default: ``"AMQPLAIN"``.
 
 Set custom amqp login method.
 
-.. setting:: broker_native_delayed_delivery
-
-``broker_native_delayed_delivery``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.5
-
-:transports supported: ``pyamqp``
-
-Default: Disabled.
-
-When enabled, tasks with ETAs and Countdowns will use the native delayed delivery mechanism for RabbitMQ.
-
-See :ref:`using-quorum-queues` for details regarding native delayed delivery.
-
 .. setting:: broker_native_delayed_delivery_queue_type
 
 ``broker_native_delayed_delivery_queue_type``
@@ -3032,7 +3009,7 @@ See :ref:`using-quorum-queues` for details regarding native delayed delivery.
 Default: ``"quorum"``.
 
 This setting is used to allow changing the default queue type for the
-:setting:`broker_native_delayed_delivery` queues. The other viable option is ``"classic"`` which
+native delayed delivery queues. The other viable option is ``"classic"`` which
 is only supported by RabbitMQ and sets the queue type to ``classic`` using the ``x-queue-type``
 queue argument.
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -80,6 +80,7 @@ have been moved into a new  ``task_`` prefix.
 ``BROKER_HEARTBEAT``                       :setting:`broker_heartbeat`
 ``BROKER_LOGIN_METHOD``                    :setting:`broker_login_method`
 ``BROKER_NATIVE_DELAYED_DELIVERY``         :setting:`broker_native_delayed_delivery`
+``BROKER_NATIVE_DELAYED_DELIVERY_QUEUE_TYPE`` :setting:`broker_native_delayed_delivery_queue_type`
 ``BROKER_POOL_LIMIT``                      :setting:`broker_pool_limit`
 ``BROKER_USE_SSL``                         :setting:`broker_use_ssl`
 ``CELERY_CACHE_BACKEND``                   :setting:`cache_backend`
@@ -3018,6 +3019,22 @@ Default: Disabled.
 When enabled, tasks with ETAs and Countdowns will use the native delayed delivery mechanism for RabbitMQ.
 
 See :ref:`using-quorum-queues` for details regarding native delayed delivery.
+
+.. setting:: broker_native_delayed_delivery_queue_type
+
+``broker_native_delayed_delivery_queue_type``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.5
+
+:transports supported: ``pyamqp``
+
+Default: ``"classic"``.
+
+This setting is used to allow changing the default queue type for the
+:setting:`broker_native_delayed_delivery` queues. The other viable option is ``"quorum"`` which
+is only supported by RabbitMQ and sets the queue type to ``quorum`` using the ``x-queue-type``
+queue argument.
 
 .. setting:: broker_transport_options
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -79,6 +79,7 @@ have been moved into a new  ``task_`` prefix.
 ``BROKER_FAILOVER_STRATEGY``               :setting:`broker_failover_strategy`
 ``BROKER_HEARTBEAT``                       :setting:`broker_heartbeat`
 ``BROKER_LOGIN_METHOD``                    :setting:`broker_login_method`
+``BROKER_NATIVE_DELAYED_DELIVERY``         :setting:`broker_native_delayed_delivery`
 ``BROKER_POOL_LIMIT``                      :setting:`broker_pool_limit`
 ``BROKER_USE_SSL``                         :setting:`broker_use_ssl`
 ``CELERY_CACHE_BACKEND``                   :setting:`cache_backend`
@@ -3003,6 +3004,15 @@ Also, this option doesn't work when `broker_connection_retry` is `False`.
 Default: ``"AMQPLAIN"``.
 
 Set custom amqp login method.
+
+.. setting:: broker_native_delayed_delivery
+
+``broker_native_delayed_delivery``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.5
+
+Default: Disabled.
 
 .. setting:: broker_transport_options
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -80,7 +80,6 @@ have been moved into a new  ``task_`` prefix.
 ``BROKER_HEARTBEAT``                       :setting:`broker_heartbeat`
 ``BROKER_LOGIN_METHOD``                    :setting:`broker_login_method`
 ``BROKER_NATIVE_DELAYED_DELIVERY``         :setting:`broker_native_delayed_delivery`
-``BROKER_NATIVE_DELAYED_DELIVERY_QUEUE_TYPE`` :setting:`broker_native_delayed_delivery_queue_type`
 ``BROKER_POOL_LIMIT``                      :setting:`broker_pool_limit`
 ``BROKER_USE_SSL``                         :setting:`broker_use_ssl`
 ``CELERY_CACHE_BACKEND``                   :setting:`cache_backend`
@@ -3019,22 +3018,6 @@ Default: Disabled.
 When enabled, tasks with ETAs and Countdowns will use the native delayed delivery mechanism for RabbitMQ.
 
 See :ref:`using-quorum-queues` for details regarding native delayed delivery.
-
-.. setting:: broker_native_delayed_delivery_queue_type
-
-``broker_native_delayed_delivery_queue_type``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 5.5
-
-:transports supported: ``pyamqp``
-
-Default: ``"classic"``.
-
-This setting is used to allow changing the default queue type for the
-:setting:`broker_native_delayed_delivery` queues. The other viable option is ``"quorum"`` which
-is only supported by RabbitMQ and sets the queue type to ``quorum`` using the ``x-queue-type``
-queue argument.
 
 .. setting:: broker_transport_options
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3029,11 +3029,11 @@ See :ref:`using-quorum-queues` for details regarding native delayed delivery.
 
 :transports supported: ``pyamqp``
 
-Default: ``"classic"``.
+Default: ``"quorum"``.
 
 This setting is used to allow changing the default queue type for the
-:setting:`broker_native_delayed_delivery` queues. The other viable option is ``"quorum"`` which
-is only supported by RabbitMQ and sets the queue type to ``quorum`` using the ``x-queue-type``
+:setting:`broker_native_delayed_delivery` queues. The other viable option is ``"classic"`` which
+is only supported by RabbitMQ and sets the queue type to ``classic`` using the ``x-queue-type``
 queue argument.
 
 .. setting:: broker_transport_options

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -80,6 +80,7 @@ have been moved into a new  ``task_`` prefix.
 ``BROKER_HEARTBEAT``                       :setting:`broker_heartbeat`
 ``BROKER_LOGIN_METHOD``                    :setting:`broker_login_method`
 ``BROKER_NATIVE_DELAYED_DELIVERY``         :setting:`broker_native_delayed_delivery`
+``BROKER_NATIVE_DELAYED_DELIVERY_QUEUE_TYPE`` :setting:`broker_native_delayed_delivery_queue_type`
 ``BROKER_POOL_LIMIT``                      :setting:`broker_pool_limit`
 ``BROKER_USE_SSL``                         :setting:`broker_use_ssl`
 ``CELERY_CACHE_BACKEND``                   :setting:`cache_backend`
@@ -2659,9 +2660,8 @@ automatically detect the queue type and disable the global QoS accordingly.
 
     When using quorum queues, ETA tasks may not function as expected. Instead of adjusting
     the prefetch count dynamically, ETA tasks will occupy the prefetch buffer, potentially
-    blocking other tasks from being consumed. To mitigate this, either set a high prefetch
-    count or avoid using quorum queues until the ETA mechanism is updated to support a
-    disabled global QoS, which is required for quorum queues.
+    blocking other tasks from being consumed. To mitigate this, enable the :setting:`broker_native_delayed_delivery`
+    setting.
 
 .. warning::
 
@@ -3019,6 +3019,22 @@ Default: Disabled.
 When enabled, tasks with ETAs and Countdowns will use the native delayed delivery mechanism for RabbitMQ.
 
 See :ref:`using-quorum-queues` for details regarding native delayed delivery.
+
+.. setting:: broker_native_delayed_delivery_queue_type
+
+``broker_native_delayed_delivery_queue_type``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.5
+
+:transports supported: ``pyamqp``
+
+Default: ``"classic"``.
+
+This setting is used to allow changing the default queue type for the
+:setting:`broker_native_delayed_delivery` queues. The other viable option is ``"quorum"`` which
+is only supported by RabbitMQ and sets the queue type to ``quorum`` using the ``x-queue-type``
+queue argument.
 
 .. setting:: broker_transport_options
 

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -344,6 +344,7 @@ class ExpectedException(Exception):
 
 class UnpickleableException(Exception):
     """Exception that doesn't survive a pickling roundtrip (dump + load)."""
+
     def __init__(self, foo, bar=None):
         if bar is None:
             # We define bar with a default value in the signature so that

--- a/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
+++ b/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
@@ -12,73 +12,13 @@ from t.smoke.tasks import noop
 from t.smoke.tests.quorum_queues.conftest import RabbitMQManagementBroker
 
 
-class test_broker_configuration_quorum:
+class test_broker_configuration:
     @pytest.fixture
     def default_worker_app(self, default_worker_app: Celery) -> Celery:
         app = default_worker_app
         app.conf.broker_transport_options = {"confirm_publish": True}
         app.conf.task_default_queue_type = "quorum"
         app.conf.broker_native_delayed_delivery = True
-        app.conf.broker_native_delayed_delivery_queue_type = 'quorum'
-        app.conf.task_default_exchange_type = 'topic'
-        app.conf.task_default_routing_key = 'celery'
-
-        return app
-
-    def test_native_delayed_delivery_queue_configuration(
-        self,
-        celery_setup: CeleryTestSetup,
-        default_worker_app: Celery
-    ):
-        broker: RabbitMQManagementBroker = celery_setup.broker
-        api = broker.get_management_url() + "/api/queues"
-        response = requests.get(api, auth=HTTPBasicAuth("guest", "guest"))
-        assert response.status_code == 200
-        res = response.json()
-        assert isinstance(res, list)
-
-        res = [queue for queue in res if queue["name"].startswith('celery_delayed')]
-
-        assert len(res) == 28
-
-        for queue in res:
-            queue_level = int(queue["name"].split("_")[-1])
-
-            queue_arguments = queue["arguments"]
-            if queue_level == 0:
-                assert queue_arguments["x-dead-letter-exchange"] == "celery_delayed_delivery"
-            else:
-                assert queue_arguments["x-dead-letter-exchange"] == f"celery_delayed_{queue_level - 1}"
-
-            assert queue_arguments["x-message-ttl"] == pow(2, queue_level) * 1000
-
-            conf = default_worker_app.conf
-            assert queue_arguments["x-queue-type"] == conf.broker_native_delayed_delivery_queue_type
-
-    def test_native_delayed_delivery_exchange_configuration(self, celery_setup: CeleryTestSetup):
-        broker: RabbitMQManagementBroker = celery_setup.broker
-        api = broker.get_management_url() + "/api/exchanges"
-        response = requests.get(api, auth=HTTPBasicAuth("guest", "guest"))
-        assert response.status_code == 200
-        res = response.json()
-        assert isinstance(res, list)
-
-        res = [exchange for exchange in res if exchange["name"].startswith('celery_delayed')]
-
-        assert len(res) == 29
-
-        for exchange in res:
-            assert exchange["type"] == "topic"
-
-
-class test_broker_configuration_classic:
-    @pytest.fixture
-    def default_worker_app(self, default_worker_app: Celery) -> Celery:
-        app = default_worker_app
-        app.conf.broker_transport_options = {"confirm_publish": True}
-        app.conf.task_default_queue_type = "quorum"
-        app.conf.broker_native_delayed_delivery = True
-        app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         app.conf.task_default_exchange_type = 'topic'
         app.conf.task_default_routing_key = 'celery'
 

--- a/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
+++ b/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
@@ -18,7 +18,6 @@ class test_broker_configuration_quorum:
         app = default_worker_app
         app.conf.broker_transport_options = {"confirm_publish": True}
         app.conf.task_default_queue_type = "quorum"
-        app.conf.broker_native_delayed_delivery = True
         app.conf.broker_native_delayed_delivery_queue_type = 'quorum'
         app.conf.task_default_exchange_type = 'topic'
         app.conf.task_default_routing_key = 'celery'
@@ -77,7 +76,6 @@ class test_broker_configuration_classic:
         app = default_worker_app
         app.conf.broker_transport_options = {"confirm_publish": True}
         app.conf.task_default_queue_type = "quorum"
-        app.conf.broker_native_delayed_delivery = True
         app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         app.conf.task_default_exchange_type = 'topic'
         app.conf.task_default_routing_key = 'celery'
@@ -134,7 +132,6 @@ class test_native_delayed_delivery:
         app = default_worker_app
         app.conf.broker_transport_options = {"confirm_publish": True}
         app.conf.task_default_queue_type = "quorum"
-        app.conf.broker_native_delayed_delivery = True
         app.conf.task_default_exchange_type = 'topic'
         app.conf.task_default_routing_key = 'celery'
 

--- a/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
+++ b/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
@@ -1,0 +1,50 @@
+from datetime import timedelta
+from datetime import timezone as datetime_timezone
+
+import pytest
+from future.backports.datetime import datetime
+from pytest_celery import CeleryTestSetup
+
+from celery import Celery
+from t.smoke.tasks import noop
+
+
+class test_native_delayed_delivery:
+    @pytest.fixture
+    def default_worker_app(self, default_worker_app: Celery) -> Celery:
+        app = default_worker_app
+        app.conf.broker_transport_options = {"confirm_publish": True}
+        app.conf.task_default_queue_type = "quorum"
+        app.conf.broker_native_delayed_delivery = True
+        app.conf.task_default_exchange_type = 'topic'
+        app.conf.task_default_routing_key = 'celery'
+
+        return app
+
+    def test_countdown(self, celery_setup: CeleryTestSetup):
+        s = noop.s().set(queue=celery_setup.worker.worker_queue)
+
+        result = s.apply_async(countdown=5)
+
+        result.get(timeout=10)
+
+    def test_eta(self, celery_setup: CeleryTestSetup):
+        s = noop.s().set(queue=celery_setup.worker.worker_queue)
+
+        result = s.apply_async(eta=datetime.now(datetime_timezone.utc) + timedelta(0, 5))
+
+        result.get(timeout=10)
+
+    def test_eta_str(self, celery_setup: CeleryTestSetup):
+        s = noop.s().set(queue=celery_setup.worker.worker_queue)
+
+        result = s.apply_async(eta=(datetime.now(datetime_timezone.utc) + timedelta(0, 5)).isoformat())
+
+        result.get(timeout=10)
+
+    def test_eta_in_the_past(self, celery_setup: CeleryTestSetup):
+        s = noop.s().set(queue=celery_setup.worker.worker_queue)
+
+        result = s.apply_async(eta=(datetime.now(datetime_timezone.utc) - timedelta(0, 5)).isoformat())
+
+        result.get(timeout=10)

--- a/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
+++ b/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
@@ -12,13 +12,73 @@ from t.smoke.tasks import noop
 from t.smoke.tests.quorum_queues.conftest import RabbitMQManagementBroker
 
 
-class test_broker_configuration:
+class test_broker_configuration_quorum:
     @pytest.fixture
     def default_worker_app(self, default_worker_app: Celery) -> Celery:
         app = default_worker_app
         app.conf.broker_transport_options = {"confirm_publish": True}
         app.conf.task_default_queue_type = "quorum"
         app.conf.broker_native_delayed_delivery = True
+        app.conf.broker_native_delayed_delivery_queue_type = 'quorum'
+        app.conf.task_default_exchange_type = 'topic'
+        app.conf.task_default_routing_key = 'celery'
+
+        return app
+
+    def test_native_delayed_delivery_queue_configuration(
+        self,
+        celery_setup: CeleryTestSetup,
+        default_worker_app: Celery
+    ):
+        broker: RabbitMQManagementBroker = celery_setup.broker
+        api = broker.get_management_url() + "/api/queues"
+        response = requests.get(api, auth=HTTPBasicAuth("guest", "guest"))
+        assert response.status_code == 200
+        res = response.json()
+        assert isinstance(res, list)
+
+        res = [queue for queue in res if queue["name"].startswith('celery_delayed')]
+
+        assert len(res) == 28
+
+        for queue in res:
+            queue_level = int(queue["name"].split("_")[-1])
+
+            queue_arguments = queue["arguments"]
+            if queue_level == 0:
+                assert queue_arguments["x-dead-letter-exchange"] == "celery_delayed_delivery"
+            else:
+                assert queue_arguments["x-dead-letter-exchange"] == f"celery_delayed_{queue_level - 1}"
+
+            assert queue_arguments["x-message-ttl"] == pow(2, queue_level) * 1000
+
+            conf = default_worker_app.conf
+            assert queue_arguments["x-queue-type"] == conf.broker_native_delayed_delivery_queue_type
+
+    def test_native_delayed_delivery_exchange_configuration(self, celery_setup: CeleryTestSetup):
+        broker: RabbitMQManagementBroker = celery_setup.broker
+        api = broker.get_management_url() + "/api/exchanges"
+        response = requests.get(api, auth=HTTPBasicAuth("guest", "guest"))
+        assert response.status_code == 200
+        res = response.json()
+        assert isinstance(res, list)
+
+        res = [exchange for exchange in res if exchange["name"].startswith('celery_delayed')]
+
+        assert len(res) == 29
+
+        for exchange in res:
+            assert exchange["type"] == "topic"
+
+
+class test_broker_configuration_classic:
+    @pytest.fixture
+    def default_worker_app(self, default_worker_app: Celery) -> Celery:
+        app = default_worker_app
+        app.conf.broker_transport_options = {"confirm_publish": True}
+        app.conf.task_default_queue_type = "quorum"
+        app.conf.broker_native_delayed_delivery = True
+        app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         app.conf.task_default_exchange_type = 'topic'
         app.conf.task_default_routing_key = 'celery'
 

--- a/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
+++ b/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
@@ -12,6 +12,57 @@ from t.smoke.tasks import noop
 from t.smoke.tests.quorum_queues.conftest import RabbitMQManagementBroker
 
 
+@pytest.fixture
+def queues(celery_setup: CeleryTestSetup) -> list:
+    broker: RabbitMQManagementBroker = celery_setup.broker
+    api = broker.get_management_url() + "/api/queues"
+    response = requests.get(api, auth=HTTPBasicAuth("guest", "guest"))
+    assert response.status_code == 200
+
+    queues = response.json()
+    assert isinstance(queues, list)
+
+    return queues
+
+
+@pytest.fixture
+def exchanges(celery_setup: CeleryTestSetup) -> list:
+    broker: RabbitMQManagementBroker = celery_setup.broker
+    api = broker.get_management_url() + "/api/exchanges"
+    response = requests.get(api, auth=HTTPBasicAuth("guest", "guest"))
+    assert response.status_code == 200
+
+    exchanges = response.json()
+    assert isinstance(exchanges, list)
+
+    return exchanges
+
+
+def queue_configuration_test_helper(celery_setup, queues):
+    res = [queue for queue in queues if queue["name"].startswith('celery_delayed')]
+    assert len(res) == 28
+    for queue in res:
+        queue_level = int(queue["name"].split("_")[-1])
+
+        queue_arguments = queue["arguments"]
+        if queue_level == 0:
+            assert queue_arguments["x-dead-letter-exchange"] == "celery_delayed_delivery"
+        else:
+            assert queue_arguments["x-dead-letter-exchange"] == f"celery_delayed_{queue_level - 1}"
+
+        assert queue_arguments["x-message-ttl"] == pow(2, queue_level) * 1000
+
+        conf = celery_setup.app.conf
+        assert queue_arguments["x-queue-type"] == conf.broker_native_delayed_delivery_queue_type
+
+
+def exchange_configuration_test_helper(exchanges):
+    res = [exchange for exchange in exchanges if exchange["name"].startswith('celery_delayed')]
+    assert len(res) == 29
+    for exchange in res:
+        assert exchange["type"] == "topic"
+
+
 class test_broker_configuration_quorum:
     @pytest.fixture
     def default_worker_app(self, default_worker_app: Celery) -> Celery:
@@ -26,48 +77,13 @@ class test_broker_configuration_quorum:
 
     def test_native_delayed_delivery_queue_configuration(
         self,
-        celery_setup: CeleryTestSetup,
-        default_worker_app: Celery
+        queues: list,
+        celery_setup: CeleryTestSetup
     ):
-        broker: RabbitMQManagementBroker = celery_setup.broker
-        api = broker.get_management_url() + "/api/queues"
-        response = requests.get(api, auth=HTTPBasicAuth("guest", "guest"))
-        assert response.status_code == 200
-        res = response.json()
-        assert isinstance(res, list)
+        queue_configuration_test_helper(celery_setup, queues)
 
-        res = [queue for queue in res if queue["name"].startswith('celery_delayed')]
-
-        assert len(res) == 28
-
-        for queue in res:
-            queue_level = int(queue["name"].split("_")[-1])
-
-            queue_arguments = queue["arguments"]
-            if queue_level == 0:
-                assert queue_arguments["x-dead-letter-exchange"] == "celery_delayed_delivery"
-            else:
-                assert queue_arguments["x-dead-letter-exchange"] == f"celery_delayed_{queue_level - 1}"
-
-            assert queue_arguments["x-message-ttl"] == pow(2, queue_level) * 1000
-
-            conf = default_worker_app.conf
-            assert queue_arguments["x-queue-type"] == conf.broker_native_delayed_delivery_queue_type
-
-    def test_native_delayed_delivery_exchange_configuration(self, celery_setup: CeleryTestSetup):
-        broker: RabbitMQManagementBroker = celery_setup.broker
-        api = broker.get_management_url() + "/api/exchanges"
-        response = requests.get(api, auth=HTTPBasicAuth("guest", "guest"))
-        assert response.status_code == 200
-        res = response.json()
-        assert isinstance(res, list)
-
-        res = [exchange for exchange in res if exchange["name"].startswith('celery_delayed')]
-
-        assert len(res) == 29
-
-        for exchange in res:
-            assert exchange["type"] == "topic"
+    def test_native_delayed_delivery_exchange_configuration(self, exchanges: list, celery_setup: CeleryTestSetup):
+        exchange_configuration_test_helper(exchanges)
 
 
 class test_broker_configuration_classic:
@@ -84,46 +100,14 @@ class test_broker_configuration_classic:
 
     def test_native_delayed_delivery_queue_configuration(
         self,
+        queues: list,
         celery_setup: CeleryTestSetup,
         default_worker_app: Celery
     ):
-        broker: RabbitMQManagementBroker = celery_setup.broker
-        api = broker.get_management_url() + "/api/queues"
-        response = requests.get(api, auth=HTTPBasicAuth("guest", "guest"))
-        assert response.status_code == 200
-        res = response.json()
-        assert isinstance(res, list)
+        queue_configuration_test_helper(celery_setup, queues)
 
-        res = [queue for queue in res if queue["name"].startswith('celery_delayed')]
-
-        assert len(res) == 28
-
-        for queue in res:
-            queue_level = int(queue["name"].split("_")[-1])
-
-            queue_arguments = queue["arguments"]
-            if queue_level == 0:
-                assert queue_arguments["x-dead-letter-exchange"] == "celery_delayed_delivery"
-            else:
-                assert queue_arguments["x-dead-letter-exchange"] == f"celery_delayed_{queue_level - 1}"
-
-            assert queue_arguments["x-message-ttl"] == pow(2, queue_level) * 1000
-            assert queue_arguments["x-queue-type"] == 'classic'
-
-    def test_native_delayed_delivery_exchange_configuration(self, celery_setup: CeleryTestSetup):
-        broker: RabbitMQManagementBroker = celery_setup.broker
-        api = broker.get_management_url() + "/api/exchanges"
-        response = requests.get(api, auth=HTTPBasicAuth("guest", "guest"))
-        assert response.status_code == 200
-        res = response.json()
-        assert isinstance(res, list)
-
-        res = [exchange for exchange in res if exchange["name"].startswith('celery_delayed')]
-
-        assert len(res) == 29
-
-        for exchange in res:
-            assert exchange["type"] == "topic"
+    def test_native_delayed_delivery_exchange_configuration(self, exchanges: list, celery_setup: CeleryTestSetup):
+        exchange_configuration_test_helper(exchanges)
 
 
 class test_native_delayed_delivery:

--- a/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
+++ b/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
@@ -110,7 +110,7 @@ class test_broker_configuration_classic:
                 assert queue_arguments["x-dead-letter-exchange"] == f"celery_delayed_{queue_level - 1}"
 
             assert queue_arguments["x-message-ttl"] == pow(2, queue_level) * 1000
-            assert queue_arguments["x-queue-type"] == 'quorum'
+            assert queue_arguments["x-queue-type"] == 'classic'
 
     def test_native_delayed_delivery_exchange_configuration(self, celery_setup: CeleryTestSetup):
         broker: RabbitMQManagementBroker = celery_setup.broker

--- a/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
+++ b/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
@@ -50,9 +50,7 @@ class test_broker_configuration:
                 assert queue_arguments["x-dead-letter-exchange"] == f"celery_delayed_{queue_level - 1}"
 
             assert queue_arguments["x-message-ttl"] == pow(2, queue_level) * 1000
-
-            conf = default_worker_app.conf
-            assert queue_arguments["x-queue-type"] == conf.broker_native_delayed_delivery_queue_type
+            assert queue_arguments["x-queue-type"] == 'quorum'
 
     def test_native_delayed_delivery_exchange_configuration(self, celery_setup: CeleryTestSetup):
         broker: RabbitMQManagementBroker = celery_setup.broker

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1424,7 +1424,13 @@ class test_App:
 
     def test_native_delayed_delivery_countdown(self):
         self.app.amqp = MagicMock(name='amqp')
-        self.app.amqp.router.route.return_value = {'queue': Queue('testcelery', routing_key='testcelery')}
+        self.app.amqp.router.route.return_value = {
+            'queue': Queue(
+                'testcelery',
+                routing_key='testcelery',
+                exchange=Exchange('testcelery', type='topic')
+            )
+        }
         self.app.conf.broker_url = 'amqp://'
         self.app.conf.broker_native_delayed_delivery = True
 
@@ -1449,7 +1455,13 @@ class test_App:
 
     def test_native_delayed_delivery_eta_datetime(self):
         self.app.amqp = MagicMock(name='amqp')
-        self.app.amqp.router.route.return_value = {'queue': Queue('testcelery', routing_key='testcelery')}
+        self.app.amqp.router.route.return_value = {
+            'queue': Queue(
+                'testcelery',
+                routing_key='testcelery',
+                exchange=Exchange('testcelery', type='topic')
+            )
+        }
         self.app.conf.broker_url = 'amqp://'
         self.app.conf.broker_native_delayed_delivery = True
         self.app.now = Mock(return_value=datetime(2024, 8, 24, tzinfo=datetime_timezone.utc))
@@ -1475,7 +1487,13 @@ class test_App:
 
     def test_native_delayed_delivery_eta_str(self):
         self.app.amqp = MagicMock(name='amqp')
-        self.app.amqp.router.route.return_value = {'queue': Queue('testcelery', routing_key='testcelery')}
+        self.app.amqp.router.route.return_value = {
+            'queue': Queue(
+                'testcelery',
+                routing_key='testcelery',
+                exchange=Exchange('testcelery', type='topic')
+            )
+        }
         self.app.conf.broker_url = 'amqp://'
         self.app.conf.broker_native_delayed_delivery = True
         self.app.now = Mock(return_value=datetime(2024, 8, 24, tzinfo=datetime_timezone.utc))
@@ -1505,11 +1523,52 @@ class test_App:
         self.app.conf.broker_url = 'amqp://'
         self.app.conf.broker_native_delayed_delivery = True
 
-        self.app.send_task('foo', (1, 2))
+        self.app.send_task('foo', (1, 2), countdown=-10)
 
         self.app.amqp.send_task_message.assert_called_once_with(ANY, ANY, ANY, queue=Queue(
             'testcelery',
             routing_key='testcelery'
+        ))
+
+    def test_native_delayed_delivery_countdown_in_the_past(self):
+        self.app.amqp = MagicMock(name='amqp')
+        self.app.amqp.router.route.return_value = {
+            'queue': Queue(
+                'testcelery',
+                routing_key='testcelery',
+                exchange=Exchange('testcelery', type='topic')
+            )
+        }
+        self.app.conf.broker_url = 'amqp://'
+        self.app.conf.broker_native_delayed_delivery = True
+
+        self.app.send_task('foo', (1, 2))
+
+        self.app.amqp.send_task_message.assert_called_once_with(ANY, ANY, ANY, queue=Queue(
+            'testcelery',
+            routing_key='testcelery',
+            exchange=Exchange('testcelery', type='topic')
+        ))
+
+    def test_native_delayed_delivery_eta_in_the_past(self):
+        self.app.amqp = MagicMock(name='amqp')
+        self.app.amqp.router.route.return_value = {
+            'queue': Queue(
+                'testcelery',
+                routing_key='testcelery',
+                exchange=Exchange('testcelery', type='topic')
+            )
+        }
+        self.app.conf.broker_url = 'amqp://'
+        self.app.conf.broker_native_delayed_delivery = True
+        self.app.now = Mock(return_value=datetime(2024, 8, 24, tzinfo=datetime_timezone.utc))
+
+        self.app.send_task('foo', (1, 2), eta=datetime(2024, 8, 23).isoformat())
+
+        self.app.amqp.send_task_message.assert_called_once_with(ANY, ANY, ANY, queue=Queue(
+            'testcelery',
+            routing_key='testcelery',
+            exchange=Exchange('testcelery', type='topic')
         ))
 
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1499,6 +1499,7 @@ class test_App:
             }
         ))
 
+
 class test_defaults:
 
     def test_strtobool(self):

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1499,6 +1499,19 @@ class test_App:
             }
         ))
 
+    def test_native_delayed_delivery_no_eta_or_countdown(self):
+        self.app.amqp = MagicMock(name='amqp')
+        self.app.amqp.router.route.return_value = {'queue': Queue('testcelery', routing_key='testcelery')}
+        self.app.conf.broker_url = 'amqp://'
+        self.app.conf.broker_native_delayed_delivery = True
+
+        self.app.send_task('foo', (1, 2))
+
+        self.app.amqp.send_task_message.assert_called_once_with(ANY, ANY, ANY, queue=Queue(
+            'testcelery',
+            routing_key='testcelery'
+        ))
+
 
 class test_defaults:
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -11,10 +11,10 @@ from datetime import datetime, timedelta
 from datetime import timezone as datetime_timezone
 from pickle import dumps, loads
 from typing import Optional
-from unittest.mock import DEFAULT, Mock, patch, ANY, MagicMock
+from unittest.mock import ANY, DEFAULT, MagicMock, Mock, patch
 
 import pytest
-from kombu import Queue, Exchange
+from kombu import Exchange, Queue
 from pydantic import BaseModel, ValidationInfo, model_validator
 from vine import promise
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1441,18 +1441,13 @@ class test_App:
             'celery_delayed_27',
             type='topic',
         )
-        self.app.amqp.send_task_message.assert_called_once_with(ANY, ANY, ANY, queue=Queue(
-            'celery_delayed_27',
+        self.app.amqp.send_task_message.assert_called_once_with(
+            ANY,
+            ANY,
+            ANY,
             exchange=exchange,
-            routing_key='0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.1.1.1.0.testcelery',
-            queue_arguments={
-                "x-queue-type": "quorum",
-                "x-dead-letter-strategy": "at-least-once",
-                "x-overflow": "reject-publish",
-                "x-message-ttl": pow(2, 27) * 1000,
-                "x-dead-letter-exchange": 'celery_delayed_26',
-            }
-        ))
+            routing_key='0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.1.1.1.0.testcelery'
+        )
 
     def test_native_delayed_delivery_eta_datetime(self):
         self.app.amqp = MagicMock(name='amqp')
@@ -1473,18 +1468,13 @@ class test_App:
             'celery_delayed_27',
             type='topic',
         )
-        self.app.amqp.send_task_message.assert_called_once_with(ANY, ANY, ANY, queue=Queue(
-            'celery_delayed_27',
+        self.app.amqp.send_task_message.assert_called_once_with(
+            ANY,
+            ANY,
+            ANY,
             exchange=exchange,
-            routing_key='0.0.0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.0.testcelery',
-            queue_arguments={
-                "x-queue-type": "quorum",
-                "x-dead-letter-strategy": "at-least-once",
-                "x-overflow": "reject-publish",
-                "x-message-ttl": pow(2, 27) * 1000,
-                "x-dead-letter-exchange": 'celery_delayed_26',
-            }
-        ))
+            routing_key='0.0.0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.0.testcelery'
+        )
 
     def test_native_delayed_delivery_eta_str(self):
         self.app.amqp = MagicMock(name='amqp')
@@ -1505,18 +1495,13 @@ class test_App:
             'celery_delayed_27',
             type='topic',
         )
-        self.app.amqp.send_task_message.assert_called_once_with(ANY, ANY, ANY, queue=Queue(
-            'celery_delayed_27',
+        self.app.amqp.send_task_message.assert_called_once_with(
+            ANY,
+            ANY,
+            ANY,
             exchange=exchange,
             routing_key='0.0.0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.0.testcelery',
-            queue_arguments={
-                "x-queue-type": "quorum",
-                "x-dead-letter-strategy": "at-least-once",
-                "x-overflow": "reject-publish",
-                "x-message-ttl": pow(2, 27) * 1000,
-                "x-dead-letter-exchange": 'celery_delayed_26',
-            }
-        ))
+        )
 
     def test_native_delayed_delivery_no_eta_or_countdown(self):
         self.app.amqp = MagicMock(name='amqp')
@@ -1526,10 +1511,15 @@ class test_App:
 
         self.app.send_task('foo', (1, 2), countdown=-10)
 
-        self.app.amqp.send_task_message.assert_called_once_with(ANY, ANY, ANY, queue=Queue(
-            'testcelery',
-            routing_key='testcelery'
-        ))
+        self.app.amqp.send_task_message.assert_called_once_with(
+            ANY,
+            ANY,
+            ANY,
+            queue=Queue(
+                'testcelery',
+                routing_key='testcelery'
+            )
+        )
 
     def test_native_delayed_delivery_countdown_in_the_past(self):
         self.app.amqp = MagicMock(name='amqp')
@@ -1545,11 +1535,16 @@ class test_App:
 
         self.app.send_task('foo', (1, 2))
 
-        self.app.amqp.send_task_message.assert_called_once_with(ANY, ANY, ANY, queue=Queue(
-            'testcelery',
-            routing_key='testcelery',
-            exchange=Exchange('testcelery', type='topic')
-        ))
+        self.app.amqp.send_task_message.assert_called_once_with(
+            ANY,
+            ANY,
+            ANY,
+            queue=Queue(
+                'testcelery',
+                routing_key='testcelery',
+                exchange=Exchange('testcelery', type='topic')
+            )
+        )
 
     def test_native_delayed_delivery_eta_in_the_past(self):
         self.app.amqp = MagicMock(name='amqp')
@@ -1566,11 +1561,16 @@ class test_App:
 
         self.app.send_task('foo', (1, 2), eta=datetime(2024, 8, 23).isoformat())
 
-        self.app.amqp.send_task_message.assert_called_once_with(ANY, ANY, ANY, queue=Queue(
-            'testcelery',
-            routing_key='testcelery',
-            exchange=Exchange('testcelery', type='topic')
-        ))
+        self.app.amqp.send_task_message.assert_called_once_with(
+            ANY,
+            ANY,
+            ANY,
+            queue=Queue(
+                'testcelery',
+                routing_key='testcelery',
+                exchange=Exchange('testcelery', type='topic')
+            )
+        )
 
     def test_native_delayed_delivery_direct_exchange(self, caplog):
         self.app.amqp = MagicMock(name='amqp')
@@ -1586,11 +1586,16 @@ class test_App:
 
         self.app.send_task('foo', (1, 2), countdown=10)
 
-        self.app.amqp.send_task_message.assert_called_once_with(ANY, ANY, ANY, queue=Queue(
-            'testcelery',
-            routing_key='testcelery',
-            exchange=Exchange('testcelery', type='direct')
-        ))
+        self.app.amqp.send_task_message.assert_called_once_with(
+            ANY,
+            ANY,
+            ANY,
+            queue=Queue(
+                'testcelery',
+                routing_key='testcelery',
+                exchange=Exchange('testcelery', type='direct')
+            )
+        )
 
         assert len(caplog.records) == 1
         record: LogRecord = caplog.records[0]

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1272,7 +1272,8 @@ class test_App:
     def test_bugreport(self):
         assert self.app.bugreport()
 
-    def test_send_task__connection_provided(self):
+    @patch('celery.app.base.detect_quorum_queues', return_value=[False, ""])
+    def test_send_task__connection_provided(self, detect_quorum_queues):
         connection = Mock(name='connection')
         router = Mock(name='router')
         router.route.return_value = {}
@@ -1423,7 +1424,8 @@ class test_App:
         except TypeError as e:
             pytest.fail(f'raise unexcepted error {e}')
 
-    def test_native_delayed_delivery_countdown(self):
+    @patch('celery.app.base.detect_quorum_queues', return_value=[True, "testcelery"])
+    def test_native_delayed_delivery_countdown(self, detect_quorum_queues):
         self.app.amqp = MagicMock(name='amqp')
         self.app.amqp.router.route.return_value = {
             'queue': Queue(
@@ -1432,8 +1434,6 @@ class test_App:
                 exchange=Exchange('testcelery', type='topic')
             )
         }
-        self.app.producer_pool.connections.connection = 'amqp'
-        self.app.conf.broker_native_delayed_delivery = True
 
         self.app.send_task('foo', (1, 2), countdown=30)
 
@@ -1449,7 +1449,8 @@ class test_App:
             routing_key='0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.1.1.1.0.testcelery'
         )
 
-    def test_native_delayed_delivery_eta_datetime(self):
+    @patch('celery.app.base.detect_quorum_queues', return_value=[True, "testcelery"])
+    def test_native_delayed_delivery_eta_datetime(self, detect_quorum_queues):
         self.app.amqp = MagicMock(name='amqp')
         self.app.amqp.router.route.return_value = {
             'queue': Queue(
@@ -1458,8 +1459,6 @@ class test_App:
                 exchange=Exchange('testcelery', type='topic')
             )
         }
-        self.app.producer_pool.connections.connection = 'amqp'
-        self.app.conf.broker_native_delayed_delivery = True
         self.app.now = Mock(return_value=datetime(2024, 8, 24, tzinfo=datetime_timezone.utc))
 
         self.app.send_task('foo', (1, 2), eta=datetime(2024, 8, 25))
@@ -1476,7 +1475,8 @@ class test_App:
             routing_key='0.0.0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.0.testcelery'
         )
 
-    def test_native_delayed_delivery_eta_str(self):
+    @patch('celery.app.base.detect_quorum_queues', return_value=[True, "testcelery"])
+    def test_native_delayed_delivery_eta_str(self, detect_quorum_queues):
         self.app.amqp = MagicMock(name='amqp')
         self.app.amqp.router.route.return_value = {
             'queue': Queue(
@@ -1485,8 +1485,6 @@ class test_App:
                 exchange=Exchange('testcelery', type='topic')
             )
         }
-        self.app.producer_pool.connections.connection = 'amqp'
-        self.app.conf.broker_native_delayed_delivery = True
         self.app.now = Mock(return_value=datetime(2024, 8, 24, tzinfo=datetime_timezone.utc))
 
         self.app.send_task('foo', (1, 2), eta=datetime(2024, 8, 25).isoformat())
@@ -1503,11 +1501,10 @@ class test_App:
             routing_key='0.0.0.0.0.0.0.0.0.0.0.1.0.1.0.1.0.0.0.1.1.0.0.0.0.0.0.0.testcelery',
         )
 
-    def test_native_delayed_delivery_no_eta_or_countdown(self):
+    @patch('celery.app.base.detect_quorum_queues', return_value=[True, "testcelery"])
+    def test_native_delayed_delivery_no_eta_or_countdown(self, detect_quorum_queues):
         self.app.amqp = MagicMock(name='amqp')
         self.app.amqp.router.route.return_value = {'queue': Queue('testcelery', routing_key='testcelery')}
-        self.app.producer_pool.connections.connection = 'amqp'
-        self.app.conf.broker_native_delayed_delivery = True
 
         self.app.send_task('foo', (1, 2), countdown=-10)
 
@@ -1521,7 +1518,8 @@ class test_App:
             )
         )
 
-    def test_native_delayed_delivery_countdown_in_the_past(self):
+    @patch('celery.app.base.detect_quorum_queues', return_value=[True, "testcelery"])
+    def test_native_delayed_delivery_countdown_in_the_past(self, detect_quorum_queues):
         self.app.amqp = MagicMock(name='amqp')
         self.app.amqp.router.route.return_value = {
             'queue': Queue(
@@ -1530,8 +1528,6 @@ class test_App:
                 exchange=Exchange('testcelery', type='topic')
             )
         }
-        self.app.producer_pool.connections.connection = 'amqp'
-        self.app.conf.broker_native_delayed_delivery = True
 
         self.app.send_task('foo', (1, 2))
 
@@ -1546,7 +1542,8 @@ class test_App:
             )
         )
 
-    def test_native_delayed_delivery_eta_in_the_past(self):
+    @patch('celery.app.base.detect_quorum_queues', return_value=[True, "testcelery"])
+    def test_native_delayed_delivery_eta_in_the_past(self, detect_quorum_queues):
         self.app.amqp = MagicMock(name='amqp')
         self.app.amqp.router.route.return_value = {
             'queue': Queue(
@@ -1555,8 +1552,6 @@ class test_App:
                 exchange=Exchange('testcelery', type='topic')
             )
         }
-        self.app.producer_pool.connections.connection = 'amqp'
-        self.app.conf.broker_native_delayed_delivery = True
         self.app.now = Mock(return_value=datetime(2024, 8, 24, tzinfo=datetime_timezone.utc))
 
         self.app.send_task('foo', (1, 2), eta=datetime(2024, 8, 23).isoformat())
@@ -1572,7 +1567,8 @@ class test_App:
             )
         )
 
-    def test_native_delayed_delivery_direct_exchange(self, caplog):
+    @patch('celery.app.base.detect_quorum_queues', return_value=[True, "testcelery"])
+    def test_native_delayed_delivery_direct_exchange(self, detect_quorum_queues, caplog):
         self.app.amqp = MagicMock(name='amqp')
         self.app.amqp.router.route.return_value = {
             'queue': Queue(
@@ -1581,8 +1577,6 @@ class test_App:
                 exchange=Exchange('testcelery', type='direct')
             )
         }
-        self.app.producer_pool.connections.connection = 'amqp'
-        self.app.conf.broker_native_delayed_delivery = True
 
         self.app.send_task('foo', (1, 2), countdown=10)
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1432,7 +1432,7 @@ class test_App:
                 exchange=Exchange('testcelery', type='topic')
             )
         }
-        self.app.conf.broker_url = 'amqp://'
+        self.app.producer_pool.connections.connection = 'amqp'
         self.app.conf.broker_native_delayed_delivery = True
 
         self.app.send_task('foo', (1, 2), countdown=30)
@@ -1458,7 +1458,7 @@ class test_App:
                 exchange=Exchange('testcelery', type='topic')
             )
         }
-        self.app.conf.broker_url = 'amqp://'
+        self.app.producer_pool.connections.connection = 'amqp'
         self.app.conf.broker_native_delayed_delivery = True
         self.app.now = Mock(return_value=datetime(2024, 8, 24, tzinfo=datetime_timezone.utc))
 
@@ -1485,7 +1485,7 @@ class test_App:
                 exchange=Exchange('testcelery', type='topic')
             )
         }
-        self.app.conf.broker_url = 'amqp://'
+        self.app.producer_pool.connections.connection = 'amqp'
         self.app.conf.broker_native_delayed_delivery = True
         self.app.now = Mock(return_value=datetime(2024, 8, 24, tzinfo=datetime_timezone.utc))
 
@@ -1506,7 +1506,7 @@ class test_App:
     def test_native_delayed_delivery_no_eta_or_countdown(self):
         self.app.amqp = MagicMock(name='amqp')
         self.app.amqp.router.route.return_value = {'queue': Queue('testcelery', routing_key='testcelery')}
-        self.app.conf.broker_url = 'amqp://'
+        self.app.producer_pool.connections.connection = 'amqp'
         self.app.conf.broker_native_delayed_delivery = True
 
         self.app.send_task('foo', (1, 2), countdown=-10)
@@ -1530,7 +1530,7 @@ class test_App:
                 exchange=Exchange('testcelery', type='topic')
             )
         }
-        self.app.conf.broker_url = 'amqp://'
+        self.app.producer_pool.connections.connection = 'amqp'
         self.app.conf.broker_native_delayed_delivery = True
 
         self.app.send_task('foo', (1, 2))
@@ -1555,7 +1555,7 @@ class test_App:
                 exchange=Exchange('testcelery', type='topic')
             )
         }
-        self.app.conf.broker_url = 'amqp://'
+        self.app.producer_pool.connections.connection = 'amqp'
         self.app.conf.broker_native_delayed_delivery = True
         self.app.now = Mock(return_value=datetime(2024, 8, 24, tzinfo=datetime_timezone.utc))
 
@@ -1581,7 +1581,7 @@ class test_App:
                 exchange=Exchange('testcelery', type='direct')
             )
         }
-        self.app.conf.broker_url = 'amqp://'
+        self.app.producer_pool.connections.connection = 'amqp'
         self.app.conf.broker_native_delayed_delivery = True
 
         self.app.send_task('foo', (1, 2), countdown=10)

--- a/t/unit/app/test_backends.py
+++ b/t/unit/app/test_backends.py
@@ -115,8 +115,8 @@ class test_backends:
 
     @pytest.mark.celery(
         result_backend=f'{CachedBackendWithTreadTrucking.__module__}.'
-                       f'{CachedBackendWithTreadTrucking.__qualname__}'
-                       f'+memory://')
+        f'{CachedBackendWithTreadTrucking.__qualname__}'
+        f'+memory://')
     def test_backend_thread_safety(self):
         @self.app.task
         def dummy_add_task(x, y):

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -377,6 +377,7 @@ class MyCustomException(Exception):
 
 class UnpickleableException(Exception):
     """Exception that doesn't survive a pickling roundtrip (dump + load)."""
+
     def __init__(self, foo, bar):
         super().__init__(foo)
         self.bar = bar

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -686,13 +686,6 @@ class test_Tasks:
         tasks = Tasks(c)
         assert tasks.qos_global(c) is True
 
-    def test_qos_global_worker_detect_quorum_queues_true_native_delayed_delivery_true(self):
-        c = self.c
-        c.app.conf.broker_native_delayed_delivery = True
-        c.app.amqp.queues = {"celery": Mock(queue_arguments=None)}
-        tasks = Tasks(c)
-        assert tasks.qos_global(c) is False
-
     def test_qos_global_worker_detect_quorum_queues_true_with_quorum_queues(self):
         c = self.c
         self.c.connection.transport.driver_type = 'amqp'

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -686,6 +686,13 @@ class test_Tasks:
         tasks = Tasks(c)
         assert tasks.qos_global(c) is True
 
+    def test_qos_global_worker_detect_quorum_queues_true_native_delayed_delivery_true(self):
+        c = self.c
+        c.app.conf.broker_native_delayed_delivery = True
+        c.app.amqp.queues = {"celery": Mock(queue_arguments=None)}
+        tasks = Tasks(c)
+        assert tasks.qos_global(c) is False
+
     def test_qos_global_worker_detect_quorum_queues_true_with_quorum_queues(self):
         c = self.c
         self.c.connection.transport.driver_type = 'amqp'
@@ -696,6 +703,7 @@ class test_Tasks:
     def test_qos_global_eta_warning(self):
         c = self.c
         self.c.connection.transport.driver_type = 'amqp'
+        c.app.conf.broker_native_delayed_delivery = False
         c.app.amqp.queues = {"celery": Mock(queue_arguments={"x-queue-type": "quorum"})}
         tasks = Tasks(c)
         with pytest.warns(CeleryWarning, match=ETA_TASKS_NO_GLOBAL_QOS_WARNING % "celery"):

--- a/t/unit/worker/test_native_delayed_delivery.py
+++ b/t/unit/worker/test_native_delayed_delivery.py
@@ -1,5 +1,5 @@
 from logging import LogRecord
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from kombu import Exchange, Queue
 
@@ -7,59 +7,17 @@ from celery.worker.consumer.delayed_delivery import DelayedDelivery
 
 
 class test_DelayedDelivery:
-    def test_include_if_delivery_set_to_false(self):
+    @patch('celery.worker.consumer.delayed_delivery.detect_quorum_queues', return_value=[False, ""])
+    def test_include_if_no_quorum_queues_detected(self, detect_quorum_queues):
         consumer_mock = Mock()
-        consumer_mock.app.conf.broker_native_delayed_delivery = False
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 
         assert delayed_delivery.include_if(consumer_mock) is False
 
-    def test_include_if_delivery_set_to_false_and_not_rabbitmq_broker(self):
+    @patch('celery.worker.consumer.delayed_delivery.detect_quorum_queues', return_value=[True, ""])
+    def test_include_if_quorum_queues_detected(self, detect_quorum_queues):
         consumer_mock = Mock()
-        consumer_mock.app.conf.broker_native_delayed_delivery = False
-        consumer_mock.app.conf.broker_url = 'redis://'
-        consumer_mock.connection_for_write().transport.driver_type = 'redis'
-
-        delayed_delivery = DelayedDelivery(consumer_mock)
-
-        assert delayed_delivery.include_if(consumer_mock) is False
-
-    def test_include_if_delivery_set_to_false_and_rabbitmq_broker(self):
-        consumer_mock = Mock()
-        consumer_mock.app.conf.broker_native_delayed_delivery = False
-        consumer_mock.app.conf.broker_url = 'amqp://'
-        consumer_mock.connection_for_write().transport.driver_type = 'amqp'
-
-        delayed_delivery = DelayedDelivery(consumer_mock)
-
-        assert delayed_delivery.include_if(consumer_mock) is False
-
-    def test_include_if_delivery_set_to_false_and_rabbitmq_broker2(self):
-        consumer_mock = Mock()
-        consumer_mock.app.conf.broker_native_delayed_delivery = False
-        consumer_mock.app.conf.broker_url = 'py-amqp://'
-        consumer_mock.connection_for_write().transport.driver_type = 'amqp'
-
-        delayed_delivery = DelayedDelivery(consumer_mock)
-
-        assert delayed_delivery.include_if(consumer_mock) is False
-
-    def test_include_if_delivery_set_to_true_and_rabbitmq_broker(self):
-        consumer_mock = Mock()
-        consumer_mock.app.conf.broker_native_delayed_delivery = True
-        consumer_mock.app.conf.broker_url = 'amqp://'
-        consumer_mock.connection_for_write().transport.driver_type = 'amqp'
-
-        delayed_delivery = DelayedDelivery(consumer_mock)
-
-        assert delayed_delivery.include_if(consumer_mock) is True
-
-    def test_include_if_delivery_set_to_true_and_rabbitmq_broker2(self):
-        consumer_mock = Mock()
-        consumer_mock.app.conf.broker_native_delayed_delivery = True
-        consumer_mock.app.conf.broker_url = 'py-amqp://'
-        consumer_mock.connection_for_write().transport.driver_type = 'amqp'
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 

--- a/t/unit/worker/test_native_delayed_delivery.py
+++ b/t/unit/worker/test_native_delayed_delivery.py
@@ -19,6 +19,7 @@ class test_DelayedDelivery:
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery = False
         consumer_mock.app.conf.broker_url = 'redis://'
+        consumer_mock.connection.transport.driver_type = 'redis'
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 
@@ -28,6 +29,7 @@ class test_DelayedDelivery:
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery = False
         consumer_mock.app.conf.broker_url = 'amqp://'
+        consumer_mock.connection.transport.driver_type = 'amqp'
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 
@@ -37,6 +39,7 @@ class test_DelayedDelivery:
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery = False
         consumer_mock.app.conf.broker_url = 'py-amqp://'
+        consumer_mock.connection.transport.driver_type = 'amqp'
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 
@@ -46,6 +49,7 @@ class test_DelayedDelivery:
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery = True
         consumer_mock.app.conf.broker_url = 'amqp://'
+        consumer_mock.connection.transport.driver_type = 'amqp'
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 
@@ -55,6 +59,7 @@ class test_DelayedDelivery:
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery = True
         consumer_mock.app.conf.broker_url = 'py-amqp://'
+        consumer_mock.connection.transport.driver_type = 'amqp'
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 

--- a/t/unit/worker/test_native_delayed_delivery.py
+++ b/t/unit/worker/test_native_delayed_delivery.py
@@ -68,6 +68,7 @@ class test_DelayedDelivery:
     def test_start_native_delayed_delivery_direct_exchange(self, caplog):
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
+        consumer_mock.app.conf.broker_url = 'amqp://'
         consumer_mock.app.amqp.queues = {
             'celery': Queue('celery', exchange=Exchange('celery', type='direct'))
         }
@@ -89,6 +90,7 @@ class test_DelayedDelivery:
     def test_start_native_delayed_delivery_topic_exchange(self, caplog):
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
+        consumer_mock.app.conf.broker_url = 'amqp://'
         consumer_mock.app.amqp.queues = {
             'celery': Queue('celery', exchange=Exchange('celery', type='topic'))
         }
@@ -102,6 +104,7 @@ class test_DelayedDelivery:
     def test_start_native_delayed_delivery_fanout_exchange(self, caplog):
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
+        consumer_mock.app.conf.broker_url = 'amqp://'
         consumer_mock.app.amqp.queues = {
             'celery': Queue('celery', exchange=Exchange('celery', type='fanout'))
         }

--- a/t/unit/worker/test_native_delayed_delivery.py
+++ b/t/unit/worker/test_native_delayed_delivery.py
@@ -48,7 +48,7 @@ class test_DelayedDelivery:
 
         assert delayed_delivery.include_if(consumer_mock) is True
 
-    def test_include_if_delivery_set_to_True_and_rabbitmq_broker2(self):
+    def test_include_if_delivery_set_to_true_and_rabbitmq_broker2(self):
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery = True
         consumer_mock.app.conf.broker_url = 'py-amqp://'

--- a/t/unit/worker/test_native_delayed_delivery.py
+++ b/t/unit/worker/test_native_delayed_delivery.py
@@ -1,0 +1,58 @@
+from unittest.mock import Mock
+
+from celery.worker.consumer.delayed_delivery import DelayedDelivery
+
+
+class test_DelayedDelivery:
+    def test_include_if_delivery_set_to_false(self):
+        consumer_mock = Mock()
+        consumer_mock.app.conf.broker_native_delayed_delivery = False
+
+        delayed_delivery = DelayedDelivery(consumer_mock)
+
+        assert delayed_delivery.include_if(consumer_mock) is False
+
+    def test_include_if_delivery_set_to_false_and_not_rabbitmq_broker(self):
+        consumer_mock = Mock()
+        consumer_mock.app.conf.broker_native_delayed_delivery = False
+        consumer_mock.app.conf.broker_url = 'redis://'
+
+        delayed_delivery = DelayedDelivery(consumer_mock)
+
+        assert delayed_delivery.include_if(consumer_mock) is False
+
+    def test_include_if_delivery_set_to_false_and_rabbitmq_broker(self):
+        consumer_mock = Mock()
+        consumer_mock.app.conf.broker_native_delayed_delivery = False
+        consumer_mock.app.conf.broker_url = 'amqp://'
+
+        delayed_delivery = DelayedDelivery(consumer_mock)
+
+        assert delayed_delivery.include_if(consumer_mock) is False
+
+    def test_include_if_delivery_set_to_false_and_rabbitmq_broker2(self):
+        consumer_mock = Mock()
+        consumer_mock.app.conf.broker_native_delayed_delivery = False
+        consumer_mock.app.conf.broker_url = 'py-amqp://'
+
+        delayed_delivery = DelayedDelivery(consumer_mock)
+
+        assert delayed_delivery.include_if(consumer_mock) is False
+
+    def test_include_if_delivery_set_to_true_and_rabbitmq_broker(self):
+        consumer_mock = Mock()
+        consumer_mock.app.conf.broker_native_delayed_delivery = True
+        consumer_mock.app.conf.broker_url = 'amqp://'
+
+        delayed_delivery = DelayedDelivery(consumer_mock)
+
+        assert delayed_delivery.include_if(consumer_mock) is True
+
+    def test_include_if_delivery_set_to_True_and_rabbitmq_broker2(self):
+        consumer_mock = Mock()
+        consumer_mock.app.conf.broker_native_delayed_delivery = True
+        consumer_mock.app.conf.broker_url = 'py-amqp://'
+
+        delayed_delivery = DelayedDelivery(consumer_mock)
+
+        assert delayed_delivery.include_if(consumer_mock) is True

--- a/t/unit/worker/test_native_delayed_delivery.py
+++ b/t/unit/worker/test_native_delayed_delivery.py
@@ -1,7 +1,7 @@
 from logging import LogRecord
 from unittest.mock import Mock
 
-from kombu import Queue, Exchange
+from kombu import Exchange, Queue
 
 from celery.worker.consumer.delayed_delivery import DelayedDelivery
 
@@ -73,9 +73,12 @@ class test_DelayedDelivery:
         assert len(caplog.records) == 1
         record: LogRecord = caplog.records[0]
         assert record.levelname == "WARNING"
-        assert record.message == ("Exchange celery is a direct exchange "
-                                         "and native delayed delivery do not support direct exchanges.\n"
-                                         "ETA tasks published to this exchange will block the worker until the ETA arrives.")
+        assert record.message == (
+            "Exchange celery is a direct exchange "
+            "and native delayed delivery do not support direct exchanges.\n"
+            "ETA tasks published to this exchange "
+            "will block the worker until the ETA arrives."
+        )
 
     def test_start_native_delayed_delivery_topic_exchange(self, caplog):
         consumer_mock = Mock()

--- a/t/unit/worker/test_native_delayed_delivery.py
+++ b/t/unit/worker/test_native_delayed_delivery.py
@@ -19,7 +19,7 @@ class test_DelayedDelivery:
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery = False
         consumer_mock.app.conf.broker_url = 'redis://'
-        consumer_mock.connection.transport.driver_type = 'redis'
+        consumer_mock.connection_for_write().transport.driver_type = 'redis'
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 
@@ -29,7 +29,7 @@ class test_DelayedDelivery:
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery = False
         consumer_mock.app.conf.broker_url = 'amqp://'
-        consumer_mock.connection.transport.driver_type = 'amqp'
+        consumer_mock.connection_for_write().transport.driver_type = 'amqp'
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 
@@ -39,7 +39,7 @@ class test_DelayedDelivery:
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery = False
         consumer_mock.app.conf.broker_url = 'py-amqp://'
-        consumer_mock.connection.transport.driver_type = 'amqp'
+        consumer_mock.connection_for_write().transport.driver_type = 'amqp'
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 
@@ -49,7 +49,7 @@ class test_DelayedDelivery:
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery = True
         consumer_mock.app.conf.broker_url = 'amqp://'
-        consumer_mock.connection.transport.driver_type = 'amqp'
+        consumer_mock.connection_for_write().transport.driver_type = 'amqp'
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 
@@ -59,7 +59,7 @@ class test_DelayedDelivery:
         consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery = True
         consumer_mock.app.conf.broker_url = 'py-amqp://'
-        consumer_mock.connection.transport.driver_type = 'amqp'
+        consumer_mock.connection_for_write().transport.driver_type = 'amqp'
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 
@@ -67,6 +67,7 @@ class test_DelayedDelivery:
 
     def test_start_native_delayed_delivery_direct_exchange(self, caplog):
         consumer_mock = Mock()
+        consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         consumer_mock.app.amqp.queues = {
             'celery': Queue('celery', exchange=Exchange('celery', type='direct'))
         }
@@ -87,6 +88,7 @@ class test_DelayedDelivery:
 
     def test_start_native_delayed_delivery_topic_exchange(self, caplog):
         consumer_mock = Mock()
+        consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         consumer_mock.app.amqp.queues = {
             'celery': Queue('celery', exchange=Exchange('celery', type='topic'))
         }
@@ -99,6 +101,7 @@ class test_DelayedDelivery:
 
     def test_start_native_delayed_delivery_fanout_exchange(self, caplog):
         consumer_mock = Mock()
+        consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         consumer_mock.app.amqp.queues = {
             'celery': Queue('celery', exchange=Exchange('celery', type='fanout'))
         }


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Fixes #9149.
Since ETA tasks will block the worker when using quorum queues we had to provide an alternative solution that will support ETA tasks on RabbitMQ.
This PR provides a solution based on NServiceBus' [implementation](https://docs.particular.net/transports/rabbitmq/delayed-delivery) of native delayed delivery.
The solution is based on a series of exchanges and queues as detailed in NServiceBus' documentation.
To use this feature you need to enable the `broker_native_delayed_delivery` configuration setting when using quorum queues.
