### PR TITLE
fix: passes current request context when pushing to request_stack

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -300,3 +300,4 @@ Andy Zickler, 2024/01/18
 Johannes Faigle, 2024/06/18
 Giovanni Giampauli, 2024/06/26
 Shamil Abdulaev, 2024/08/05
+Nikos Atlas, 2024/08/26

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -1114,7 +1114,7 @@ class Task:
         return result
 
     def push_request(self, *args, **kwargs):
-        self.request_stack.push(Context(*args, **kwargs))
+        self.request_stack.push(Context(*args, **{**self.request.__dict__, **kwargs}))
 
     def pop_request(self):
         self.request_stack.pop()


### PR DESCRIPTION
## Problem

Calling a task recursively using `.apply` causes the child task to lose the request Context.

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

the _install_stack_protection worker optimisation patches the BaseTask.__call__ method to call `task.run` directly. when it does not call the `task.run` directly it instead calls the BaseTask.__call__ which pushes the new request to the stack, but only passes the `args,kwargs` of the task bypassing all the options.
https://github.com/celery/celery/blob/78c06af57ec0bc4afe84bf21289d2c0b50dcb313/celery/app/trace.py#L737

the tracer is properly generating the `request` context based on all the options passed and directly pushes to the task stack. also the tracer skips the `__call__` method
https://github.com/celery/celery/blob/78c06af57ec0bc4afe84bf21289d2c0b50dcb313/celery/app/trace.py#L324-L327

the combination of the above leads to the tracer calling the task with only the args and kwargs of the task.
https://github.com/celery/celery/blob/78c06af57ec0bc4afe84bf21289d2c0b50dcb313/celery/app/trace.py#L453

which in turn leads to calling stack protection mentioned above and calling the original `BaseTask.__call__` method which pushes a new Context to the request stack, but only with `args,kwargs` passed by the tracer.
https://github.com/celery/celery/blob/78ac69cfed7c485ba32726deaeaf6401d5e7bc1f/celery/app/task.py#L1117


this commit enhances the push_request method to generate a new context based on the `task.request` which should include all the options required.

Fixes: https://github.com/celery/celery/issues/9199