### PR TITLE
Added Soft Shutdown Mechanism

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -157,7 +157,7 @@ jobs:
         -   name: >
                 Run tox for
                 "${{ matrix.python-version }}-smoke"
-            timeout-minutes: 20
+            timeout-minutes: 30
             run: >
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k failover
@@ -231,7 +231,7 @@ jobs:
         -   name: >
                 Run tox for
                 "${{ matrix.python-version }}-smoke"
-            timeout-minutes: 20
+            timeout-minutes: 30
             run: >
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k stamping
@@ -268,7 +268,7 @@ jobs:
         -   name: >
                 Run tox for
                 "${{ matrix.python-version }}-smoke"
-            timeout-minutes: 20
+            timeout-minutes: 30
             run: >
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_canvas.py
@@ -305,7 +305,7 @@ jobs:
         -   name: >
                 Run tox for
                 "${{ matrix.python-version }}-smoke"
-            timeout-minutes: 20
+            timeout-minutes: 30
             run: >
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_consumer.py
@@ -342,7 +342,7 @@ jobs:
         -   name: >
                 Run tox for
                 "${{ matrix.python-version }}-smoke"
-            timeout-minutes: 20
+            timeout-minutes: 30
             run: >
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_control.py
@@ -379,7 +379,7 @@ jobs:
         -   name: >
                 Run tox for
                 "${{ matrix.python-version }}-smoke"
-            timeout-minutes: 20
+            timeout-minutes: 30
             run: >
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_signals.py
@@ -416,7 +416,7 @@ jobs:
         -   name: >
                 Run tox for
                 "${{ matrix.python-version }}-smoke"
-            timeout-minutes: 20
+            timeout-minutes: 30
             run: >
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_tasks.py
@@ -453,7 +453,7 @@ jobs:
         -   name: >
                 Run tox for
                 "${{ matrix.python-version }}-smoke"
-            timeout-minutes: 20
+            timeout-minutes: 30
             run: >
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_thread_safe.py
@@ -490,7 +490,7 @@ jobs:
         -   name: >
                 Run tox for
                 "${{ matrix.python-version }}-smoke"
-            timeout-minutes: 20
+            timeout-minutes: 30
             run: >
                 tox --verbose --verbose -e
                 "${{ matrix.python-version }}-smoke" -- -n auto -k test_worker.py

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -309,6 +309,7 @@ NAMESPACES = Namespace(
         cancel_long_running_tasks_on_connection_loss=Option(
             False, type='bool'
         ),
+        soft_shutdown_timeout=Option(0.0, type='float'),
         concurrency=Option(None, type='int'),
         consumer=Option('celery.worker.consumer:Consumer', type='string'),
         direct=Option(False, type='bool', old={'celery_worker_direct'}),

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -278,15 +278,27 @@ class Worker(WorkController):
         )
 
 
-def _shutdown_handler(worker, sig='TERM', how='Warm',
-                      callback=None, exitcode=EX_OK):
+def _shutdown_handler(worker: Worker, sig='TERM', how='Warm', callback=None, exitcode=EX_OK, verbose=True):
+    """Install signal handler for warm/cold shutdown.
+
+    The handler will run from the MainProcess.
+
+    Args:
+        worker (Worker): The worker that received the signal.
+        sig (str, optional): The signal that was received. Defaults to 'TERM'.
+        how (str, optional): The type of shutdown to perform. Defaults to 'Warm'.
+        callback (Callable, optional): Signal handler. Defaults to None.
+        exitcode (int, optional): The exit code to use. Defaults to EX_OK.
+        verbose (bool, optional): Whether to print the type of shutdown. Defaults to True.
+    """
     def _handle_request(*args):
         with in_sighandler():
             from celery.worker import state
             if current_process()._name == 'MainProcess':
                 if callback:
                     callback(worker)
-                safe_say(f'worker: {how} shutdown (MainProcess)', sys.__stdout__)
+                if verbose:
+                    safe_say(f'worker: {how} shutdown (MainProcess)', sys.__stdout__)
                 signals.worker_shutting_down.send(
                     sender=worker.hostname, sig=sig, how=how,
                     exitcode=exitcode,
@@ -297,19 +309,126 @@ def _shutdown_handler(worker, sig='TERM', how='Warm',
     platforms.signals[sig] = _handle_request
 
 
+def on_hard_shutdown(worker: Worker):
+    """Signal handler for hard shutdown.
+
+    The handler will terminate the worker immediately by force using the exit code ``EX_FAILURE``.
+
+    In practice, you should never get here, as the standard shutdown process should be enough.
+    This handler is only for the worst-case scenario, where the worker is stuck and cannot be
+    terminated gracefully (e.g., spamming the Ctrl+C in the terminal to force the worker to terminate).
+
+    Args:
+        worker (Worker): The worker that received the signal.
+
+    Raises:
+        WorkerTerminate: This exception will be raised in the MainProcess to terminate the worker immediately.
+    """
+    from celery.exceptions import WorkerTerminate
+    raise WorkerTerminate(EX_FAILURE)
+
+
+def during_soft_shutdown(worker: Worker):
+    """This signal handler is called when the worker is in the middle of the soft shutdown process.
+
+    When the worker is in the soft shutdown process, it is waiting for tasks to finish. If the worker
+    receives a SIGINT (Ctrl+C) or SIGQUIT signal (or possibly SIGTERM if REMAP_SIGTERM is set to "SIGQUIT"),
+    the handler will cancels all unacked requests to allow the worker to terminate gracefully and replace the
+    signal handler for SIGINT and SIGQUIT with the hard shutdown handler ``on_hard_shutdown`` to terminate
+    the worker immediately by force next time the signal is received.
+
+    It will give the worker once last chance to gracefully terminate (the cold shutdown), after canceling all
+    unacked requests, before using the hard shutdown handler to terminate the worker forcefully.
+
+    Args:
+        worker (Worker): The worker that received the signal.
+    """
+    # Replace the signal handler for SIGINT (Ctrl+C) and SIGQUIT (and possibly SIGTERM)
+    # with the hard shutdown handler to terminate the worker immediately by force
+    install_worker_term_hard_handler(worker, sig='SIGINT', callback=on_hard_shutdown, verbose=False)
+    install_worker_term_hard_handler(worker, sig='SIGQUIT', callback=on_hard_shutdown)
+
+    # Cancel all unacked requests and allow the worker to terminate naturally
+    worker.consumer.cancel_all_unacked_requests()
+
+    # We get here if the worker was in the middle of the soft (cold) shutdown process,
+    # and the matching signal was received. This can typically happen when the worker is
+    # waiting for tasks to finish, and the user decides to still cancel the running tasks.
+    # We give the worker the last chance to gracefully terminate by letting the soft shutdown
+    # waiting time to finish, which is running in the MainProcess from the previous signal handler call.
+    safe_say('Waiting gracefully for cold shutdown to complete...', sys.__stdout__)
+
+
+def on_cold_shutdown(worker: Worker):
+    """Signal handler for cold shutdown.
+
+    Registered for SIGQUIT and SIGINT (Ctrl+C) signals. If REMAP_SIGTERM is set to "SIGQUIT", this handler will also
+    be registered for SIGTERM.
+
+    This handler will initiate the cold (and soft if enabled) shutdown procesdure for the worker.
+
+    Worker running with N tasks:
+        - SIGTERM:
+            -The worker will initiate the warm shutdown process until all tasks are finished. Additional.
+            SIGTERM signals will be ignored. SIGQUIT will transition to the cold shutdown process described below.
+        - SIGQUIT:
+            - The worker will initiate the cold shutdown process.
+            - If the soft shutdown is enabled, the worker will wait for the tasks to finish up to the soft
+            shutdown timeout (practically having a limited warm shutdown just before the cold shutdown).
+            - Cancel all tasks (from the MainProcess) and allow the worker to complete the cold shutdown
+            process gracefully.
+
+    Caveats:
+        - SIGINT (Ctrl+C) signal is defined to replace itself with the cold shutdown (SIGQUIT) after first use,
+        and to emit a message to the user to hit Ctrl+C again to initiate the cold shutdown process. But, most
+        important, it will also be caught in WorkController.start() to initiate the warm shutdown process.
+        - SIGTERM will also be handled in WorkController.start() to initiate the warm shutdown process (the same).
+        - If REMAP_SIGTERM is set to "SIGQUIT", the SIGTERM signal will be remapped to SIGQUIT, and the cold
+        shutdown process will be initiated instead of the warm shutdown process using SIGTERM.
+        - If SIGQUIT is received (also via SIGINT) during the cold/soft shutdown process, the handler will cancel all
+        unacked requests but still wait for the soft shutdown process to finish before terminating the worker
+        gracefully. The next time the signal is received though, the worker will terminate immediately by force.
+
+    So, the purpose of this handler is to allow waiting for the soft shutdown timeout, then cancel all tasks from
+    the MainProcess and let the WorkController.terminate() to terminate the worker naturally. If the soft shutdown
+    is disabled, it will immediately cancel all tasks let the cold shutdown finish normally.
+
+    Args:
+        worker (Worker): The worker that received the signal.
+    """
+    safe_say('worker: Hitting Ctrl+C again will terminate all running tasks!', sys.__stdout__)
+
+    # Replace the signal handler for SIGINT (Ctrl+C) and SIGQUIT (and possibly SIGTERM)
+    install_worker_term_hard_handler(worker, sig='SIGINT', callback=during_soft_shutdown)
+    install_worker_term_hard_handler(worker, sig='SIGQUIT', callback=during_soft_shutdown)
+    if REMAP_SIGTERM == "SIGQUIT":
+        install_worker_term_hard_handler(worker, sig='SIGTERM', callback=during_soft_shutdown)
+    # else, SIGTERM will print the _shutdown_handler's message and do nothing, every time it is received..
+
+    # Initiate soft shutdown process (if enabled and tasks are running)
+    worker.wait_for_soft_shutdown()
+
+    # Cancel all unacked requests and allow the worker to terminate naturally
+    worker.consumer.cancel_all_unacked_requests()
+
+    # Stop the pool to allow successful tasks call on_success()
+    worker.consumer.pool.stop()
+
+
+# Allow SIGTERM to be remapped to SIGQUIT to initiate cold shutdown instead of warm shutdown using SIGTERM
 if REMAP_SIGTERM == "SIGQUIT":
     install_worker_term_handler = partial(
-        _shutdown_handler, sig='SIGTERM', how='Cold', exitcode=EX_FAILURE,
+        _shutdown_handler, sig='SIGTERM', how='Cold', callback=on_cold_shutdown, exitcode=EX_FAILURE,
     )
 else:
     install_worker_term_handler = partial(
         _shutdown_handler, sig='SIGTERM', how='Warm',
     )
 
+
 if not is_jython:  # pragma: no cover
     install_worker_term_hard_handler = partial(
-        _shutdown_handler, sig='SIGQUIT', how='Cold',
-        exitcode=EX_FAILURE,
+        _shutdown_handler, sig='SIGQUIT', how='Cold', callback=on_cold_shutdown, exitcode=EX_FAILURE,
     )
 else:  # pragma: no cover
     install_worker_term_handler = \
@@ -317,9 +436,9 @@ else:  # pragma: no cover
 
 
 def on_SIGINT(worker):
-    safe_say('worker: Hitting Ctrl+C again will terminate all running tasks!',
+    safe_say('worker: Hitting Ctrl+C again will initiate cold shutdown, terminating all running tasks!',
              sys.__stdout__)
-    install_worker_term_hard_handler(worker, sig='SIGINT')
+    install_worker_term_hard_handler(worker, sig='SIGINT', verbose=False)
 
 
 if not is_jython:  # pragma: no cover

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -730,6 +730,18 @@ class Consumer:
             self=self, state=self.blueprint.human_state(),
         )
 
+    def cancel_all_unacked_requests(self):
+        """Cancel all unacked requests with late acknowledgement enabled."""
+
+        def should_cancel(request):
+            return request.task.acks_late and not request.acknowledged
+
+        requests_to_cancel = tuple(filter(should_cancel, active_requests))
+
+        if requests_to_cancel:
+            for request in requests_to_cancel:
+                request.cancel(self.pool)
+
 
 class Evloop(bootsteps.StartStopStep):
     """Event loop service.

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -777,7 +777,7 @@ def create_request_cls(base, task, pool, hostname, eventer,
                 if isinstance(exc, (SystemExit, KeyboardInterrupt)):
                     raise exc
                 return self.on_failure(retval, return_ok=True)
-            task_ready(self)
+            task_ready(self, successful=True)
 
             if acks_late:
                 self.acknowledge()

--- a/celery/worker/worker.py
+++ b/celery/worker/worker.py
@@ -15,6 +15,7 @@ The worker consists of several components, all managed by bootsteps
 import os
 import sys
 from datetime import datetime, timezone
+from time import sleep
 
 from billiard import cpu_count
 from kombu.utils.compat import detect_environment
@@ -241,7 +242,7 @@ class WorkController:
                 not self.app.IS_WINDOWS)
 
     def stop(self, in_sighandler=False, exitcode=None):
-        """Graceful shutdown of the worker server."""
+        """Graceful shutdown of the worker server (Warm shutdown)."""
         if exitcode is not None:
             self.exitcode = exitcode
         if self.blueprint.state == RUN:
@@ -251,7 +252,7 @@ class WorkController:
         self._send_worker_shutdown()
 
     def terminate(self, in_sighandler=False):
-        """Not so graceful shutdown of the worker server."""
+        """Not so graceful shutdown of the worker server (Cold shutdown)."""
         if self.blueprint.state != TERMINATE:
             self.signal_consumer_close()
             if not in_sighandler or self.pool.signal_safe:
@@ -407,3 +408,24 @@ class WorkController:
             'worker_disable_rate_limits', disable_rate_limits,
         )
         self.worker_lost_wait = either('worker_lost_wait', worker_lost_wait)
+
+    def wait_for_soft_shutdown(self):
+        """Wait :setting:`worker_soft_shutdown_timeout` if soft shutdown is enabled.
+
+        To enable soft shutdown, set the :setting:`worker_soft_shutdown_timeout` in the
+        configuration. Soft shutdown can be used to allow the worker to finish processing
+        few more tasks before initiating a cold shutdown. This mechanism allows the worker
+        to finish short tasks that are already in progress and requeue long-running tasks
+        to be picked up by another worker.
+
+        .. warning::
+            If there are no tasks in the worker, the worker will not wait for the
+            soft shutdown timeout even if it is set as it makes no sense to wait for
+            the timeout when there are no tasks to process.
+        """
+        requests = tuple(state.active_requests)
+        app = self.app
+        if app.conf.worker_soft_shutdown_timeout > 0 and requests:
+            log = f"Initiating Soft Shutdown, terminating in {app.conf.worker_soft_shutdown_timeout} seconds"
+            logger.warning(log)
+            sleep(app.conf.worker_soft_shutdown_timeout)

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3275,6 +3275,29 @@ Default: Enabled.
 Automatically detect if any of the queues in :setting:`task_queues` are quorum queues
 (including the :setting:`task_default_queue`) and disable the global QoS if any quorum queue is detected.
 
+.. setting:: worker_soft_shutdown_timeout
+
+``worker_soft_shutdown_timeout``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.5
+
+Default: 0.0.
+
+The standard :ref:`warm shutdown <worker-warm-shutdown>` will wait for all tasks to finish before shutting down
+unless the cold shutdown is triggered. The :ref:`soft shutdown <worker-soft-shutdown>` will add a waiting time
+before the cold shutdown is initiated. This setting specifies how long the worker will wait before the cold shutdown
+is initiated and the worker is terminated.
+
+This will apply also when the worker initiate :ref:`cold shutdown <worker-cold-shutdown>` without doing a warm shutdown first.
+
+If the value is set to 0.0, the soft shutdown will be practically disabled. Regardless of the value, the soft shutdown
+will be disabled if there are no tasks running.
+
+Experiment with this value to find the optimal time for your tasks to finish gracefully before the worker is terminated.
+Recommended values can be 10, 30, 60 seconds. Too high value can lead to a long waiting time before the worker is terminated
+and trigger a :sig:`KILL` signal to forcefully terminate the worker by the host system.
+
 .. _conf-events:
 
 Events

--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -134,6 +134,8 @@ Cold Shutdown
 Cold shutdown is initiated when the worker receives the :sig:`QUIT` signal. The worker will stop
 all currently executing tasks and terminate immediately.
 
+.. _worker-REMAP_SIGTERM:
+
 .. note::
 
     If the environment variable ``REMAP_SIGTERM`` is set to ``SIGQUIT``, the worker will also initiate

--- a/t/smoke/tests/failover/test_worker_failover.py
+++ b/t/smoke/tests/failover/test_worker_failover.py
@@ -7,8 +7,6 @@ from celery import Celery
 from t.smoke.conftest import SuiteOperations, WorkerKill
 from t.smoke.tasks import long_running_task
 
-MB = 1024 * 1024
-
 
 @pytest.fixture
 def celery_worker_cluster(
@@ -26,8 +24,6 @@ class test_worker_failover(SuiteOperations):
     def default_worker_app(self, default_worker_app: Celery) -> Celery:
         app = default_worker_app
         app.conf.task_acks_late = True
-        if app.conf.broker_url.startswith("redis"):
-            app.conf.broker_transport_options = {"visibility_timeout": 1}
         return app
 
     def test_killing_first_worker(

--- a/t/smoke/tests/test_consumer.py
+++ b/t/smoke/tests/test_consumer.py
@@ -16,9 +16,15 @@ def default_worker_app(default_worker_app: Celery) -> Celery:
     app.conf.worker_prefetch_multiplier = WORKER_PREFETCH_MULTIPLIER
     app.conf.worker_concurrency = WORKER_CONCURRENCY
     if app.conf.broker_url.startswith("redis"):
-        app.conf.broker_transport_options = {"visibility_timeout": 1}
+        app.conf.broker_transport_options = {
+            "visibility_timeout": 1,
+            "polling_interval": 1,
+        }
     if app.conf.result_backend.startswith("redis"):
-        app.conf.result_backend_transport_options = {"visibility_timeout": 1}
+        app.conf.result_backend_transport_options = {
+            "visibility_timeout": 1,
+            "polling_interval": 1,
+        }
     return app
 
 

--- a/t/smoke/tests/test_worker.py
+++ b/t/smoke/tests/test_worker.py
@@ -1,10 +1,26 @@
-import pytest
-from pytest_celery import RESULT_TIMEOUT, CeleryTestSetup
+from time import sleep
 
+import pytest
+from pytest_celery import RESULT_TIMEOUT, CeleryTestSetup, CeleryTestWorker, RabbitMQTestBroker
+
+import celery
 from celery import Celery
-from celery.canvas import chain
-from t.smoke.conftest import SuiteOperations, WorkerRestart
+from celery.canvas import chain, group
+from t.smoke.conftest import SuiteOperations, WorkerKill, WorkerRestart
 from t.smoke.tasks import long_running_task
+
+
+def assert_container_exited(worker: CeleryTestWorker, attempts: int = RESULT_TIMEOUT):
+    """It might take a few moments for the container to exit after the worker is killed."""
+    while attempts:
+        worker.container.reload()
+        if worker.container.status == "exited":
+            break
+        attempts -= 1
+        sleep(1)
+
+    worker.container.reload()
+    assert worker.container.status == "exited"
 
 
 @pytest.mark.parametrize("method", list(WorkerRestart.Method))
@@ -43,3 +59,341 @@ class test_worker_restart(SuiteOperations):
         assert first_res.get(RESULT_TIMEOUT) is True
         self.restart_worker(celery_setup.worker, method)
         assert second_res.get(RESULT_TIMEOUT) is True
+
+
+class test_worker_shutdown(SuiteOperations):
+    @pytest.fixture
+    def default_worker_app(self, default_worker_app: Celery) -> Celery:
+        app = default_worker_app
+        app.conf.task_acks_late = True
+        return app
+
+    def test_warm_shutdown(self, celery_setup: CeleryTestSetup):
+        queue = celery_setup.worker.worker_queue
+        worker = celery_setup.worker
+        sig = long_running_task.si(5, verbose=True).set(queue=queue)
+        res = sig.delay()
+
+        worker.wait_for_log("Starting long running task")
+        self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+        worker.wait_for_log("worker: Warm shutdown (MainProcess)")
+        worker.wait_for_log(f"long_running_task[{res.id}] succeeded")
+
+        assert_container_exited(worker)
+        assert res.get(RESULT_TIMEOUT)
+
+    def test_multiple_warm_shutdown_does_nothing(self, celery_setup: CeleryTestSetup):
+        queue = celery_setup.worker.worker_queue
+        worker = celery_setup.worker
+        sig = long_running_task.si(5, verbose=True).set(queue=queue)
+        res = sig.delay()
+
+        worker.wait_for_log("Starting long running task")
+        for _ in range(3):
+            self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+        worker.wait_for_log(f"long_running_task[{res.id}] succeeded")
+
+        assert_container_exited(worker)
+        assert res.get(RESULT_TIMEOUT)
+
+    def test_cold_shutdown(self, celery_setup: CeleryTestSetup):
+        queue = celery_setup.worker.worker_queue
+        worker = celery_setup.worker
+        sig = long_running_task.si(5, verbose=True).set(queue=queue)
+        res = sig.delay()
+
+        worker.wait_for_log("Starting long running task")
+        self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+        worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+        worker.assert_log_does_not_exist(f"long_running_task[{res.id}] succeeded")
+
+        assert_container_exited(worker)
+
+        with pytest.raises(celery.exceptions.TimeoutError):
+            res.get(timeout=5)
+
+    def test_hard_shutdown_from_warm(self, celery_setup: CeleryTestSetup):
+        queue = celery_setup.worker.worker_queue
+        worker = celery_setup.worker
+        sig = long_running_task.si(420, verbose=True).set(queue=queue)
+        sig.delay()
+
+        worker.wait_for_log("Starting long running task")
+        self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+        self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+        self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+
+        worker.wait_for_log("worker: Warm shutdown (MainProcess)")
+        worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+
+        assert_container_exited(worker)
+
+    def test_hard_shutdown_from_cold(self, celery_setup: CeleryTestSetup):
+        queue = celery_setup.worker.worker_queue
+        worker = celery_setup.worker
+        sig = long_running_task.si(420, verbose=True).set(queue=queue)
+        sig.delay()
+
+        worker.wait_for_log("Starting long running task")
+        self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+        self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+
+        worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+
+        assert_container_exited(worker)
+
+    class test_REMAP_SIGTERM(SuiteOperations):
+        @pytest.fixture
+        def default_worker_env(self, default_worker_env: dict) -> dict:
+            default_worker_env.update({"REMAP_SIGTERM": "SIGQUIT"})
+            return default_worker_env
+
+        def test_cold_shutdown(self, celery_setup: CeleryTestSetup):
+            queue = celery_setup.worker.worker_queue
+            worker = celery_setup.worker
+            sig = long_running_task.si(5, verbose=True).set(queue=queue)
+            res = sig.delay()
+
+            worker.wait_for_log("Starting long running task")
+            self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+            worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+            worker.assert_log_does_not_exist(f"long_running_task[{res.id}] succeeded")
+
+            assert_container_exited(worker)
+
+        def test_hard_shutdown_from_cold(self, celery_setup: CeleryTestSetup):
+            queue = celery_setup.worker.worker_queue
+            worker = celery_setup.worker
+            sig = long_running_task.si(420, verbose=True).set(queue=queue)
+            sig.delay()
+
+            worker.wait_for_log("Starting long running task")
+            self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+            self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+
+            worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+
+            assert_container_exited(worker)
+
+    class test_worker_soft_shutdown_timeout(SuiteOperations):
+        @pytest.fixture
+        def default_worker_app(self, default_worker_app: Celery) -> Celery:
+            app = default_worker_app
+            app.conf.worker_soft_shutdown_timeout = 10
+            return app
+
+        def test_soft_shutdown(self, celery_setup: CeleryTestSetup):
+            app = celery_setup.app
+            queue = celery_setup.worker.worker_queue
+            worker = celery_setup.worker
+            sig = long_running_task.si(5, verbose=True).set(queue=queue)
+            res = sig.delay()
+
+            worker.wait_for_log("Starting long running task")
+            self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+            worker.wait_for_log(
+                f"Initiating Soft Shutdown, terminating in {app.conf.worker_soft_shutdown_timeout} seconds",
+                timeout=5,
+            )
+            worker.wait_for_log(f"long_running_task[{res.id}] succeeded")
+            worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+
+            assert_container_exited(worker)
+            assert res.get(RESULT_TIMEOUT)
+
+        def test_hard_shutdown_from_soft(self, celery_setup: CeleryTestSetup):
+            queue = celery_setup.worker.worker_queue
+            worker = celery_setup.worker
+            sig = long_running_task.si(420, verbose=True).set(queue=queue)
+            sig.delay()
+
+            worker.wait_for_log("Starting long running task")
+            self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+            self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+            worker.wait_for_log("Waiting gracefully for cold shutdown to complete...")
+            worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+            self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+
+            assert_container_exited(worker)
+
+        class test_REMAP_SIGTERM(SuiteOperations):
+            @pytest.fixture
+            def default_worker_env(self, default_worker_env: dict) -> dict:
+                default_worker_env.update({"REMAP_SIGTERM": "SIGQUIT"})
+                return default_worker_env
+
+            def test_soft_shutdown(self, celery_setup: CeleryTestSetup):
+                app = celery_setup.app
+                queue = celery_setup.worker.worker_queue
+                worker = celery_setup.worker
+                sig = long_running_task.si(5, verbose=True).set(queue=queue)
+                res = sig.delay()
+
+                worker.wait_for_log("Starting long running task")
+                self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+                worker.wait_for_log(
+                    f"Initiating Soft Shutdown, terminating in {app.conf.worker_soft_shutdown_timeout} seconds"
+                )
+                worker.wait_for_log(f"long_running_task[{res.id}] succeeded")
+                worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+
+                assert_container_exited(worker)
+                assert res.get(RESULT_TIMEOUT)
+
+            def test_hard_shutdown_from_soft(self, celery_setup: CeleryTestSetup):
+                queue = celery_setup.worker.worker_queue
+                worker = celery_setup.worker
+                sig = long_running_task.si(420, verbose=True).set(queue=queue)
+                sig.delay()
+
+                worker.wait_for_log("Starting long running task")
+                self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+                self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+                worker.wait_for_log("Waiting gracefully for cold shutdown to complete...")
+                worker.wait_for_log("worker: Cold shutdown (MainProcess)", timeout=5)
+                self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+
+                assert_container_exited(worker)
+
+        class test_reset_visibility_timeout(SuiteOperations):
+            @pytest.fixture
+            def default_worker_app(self, default_worker_app: Celery) -> Celery:
+                app = default_worker_app
+                app.conf.prefetch_multiplier = 2
+                app.conf.worker_concurrency = 10
+                app.conf.broker_transport_options = {
+                    "visibility_timeout": 3600,  # 1 hour
+                    "polling_interval": 1,
+                }
+                return app
+
+            def test_soft_shutdown_reset_visibility_timeout(self, celery_setup: CeleryTestSetup):
+                if isinstance(celery_setup.broker, RabbitMQTestBroker):
+                    pytest.skip("RabbitMQ does not support visibility timeout")
+
+                app = celery_setup.app
+                queue = celery_setup.worker.worker_queue
+                worker = celery_setup.worker
+                sig = long_running_task.si(15, verbose=True).set(queue=queue)
+                res = sig.delay()
+
+                worker.wait_for_log("Starting long running task")
+                self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+                worker.wait_for_log(
+                    f"Initiating Soft Shutdown, terminating in {app.conf.worker_soft_shutdown_timeout} seconds"
+                )
+                worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+                worker.wait_for_log("Restoring 1 unacknowledged message(s)")
+                assert_container_exited(worker)
+                worker.restart()
+                assert res.get(RESULT_TIMEOUT)
+
+            def test_soft_shutdown_reset_visibility_timeout_group_one_finish(self, celery_setup: CeleryTestSetup):
+                if isinstance(celery_setup.broker, RabbitMQTestBroker):
+                    pytest.skip("RabbitMQ does not support visibility timeout")
+
+                app = celery_setup.app
+                queue = celery_setup.worker.worker_queue
+                worker = celery_setup.worker
+                short_task = long_running_task.si(3, verbose=True).set(queue=queue)
+                short_task_res = short_task.freeze()
+                long_task = long_running_task.si(15, verbose=True).set(queue=queue)
+                long_task_res = long_task.freeze()
+                sig = group(short_task, long_task)
+                sig.delay()
+
+                worker.wait_for_log(f"long_running_task[{short_task_res.id}] received")
+                worker.wait_for_log(f"long_running_task[{long_task_res.id}] received")
+                self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+                worker.wait_for_log(
+                    f"Initiating Soft Shutdown, terminating in {app.conf.worker_soft_shutdown_timeout} seconds"
+                )
+                worker.wait_for_log(f"long_running_task[{short_task_res.id}] succeeded")
+                worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+                worker.wait_for_log("Restoring 1 unacknowledged message(s)")
+                assert_container_exited(worker)
+                assert short_task_res.get(RESULT_TIMEOUT)
+
+            def test_soft_shutdown_reset_visibility_timeout_group_none_finish(self, celery_setup: CeleryTestSetup):
+                if isinstance(celery_setup.broker, RabbitMQTestBroker):
+                    pytest.skip("RabbitMQ does not support visibility timeout")
+
+                app = celery_setup.app
+                queue = celery_setup.worker.worker_queue
+                worker = celery_setup.worker
+                short_task = long_running_task.si(15, verbose=True).set(queue=queue)
+                short_task_res = short_task.freeze()
+                long_task = long_running_task.si(15, verbose=True).set(queue=queue)
+                long_task_res = long_task.freeze()
+                sig = group(short_task, long_task)
+                res = sig.delay()
+
+                worker.wait_for_log(f"long_running_task[{short_task_res.id}] received")
+                worker.wait_for_log(f"long_running_task[{long_task_res.id}] received")
+                self.kill_worker(worker, WorkerKill.Method.SIGQUIT)
+                worker.wait_for_log(
+                    f"Initiating Soft Shutdown, terminating in {app.conf.worker_soft_shutdown_timeout} seconds"
+                )
+                worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+                worker.wait_for_log("Restoring 2 unacknowledged message(s)")
+                assert_container_exited(worker)
+                worker.restart()
+                assert res.get(RESULT_TIMEOUT) == [True, True]
+                assert short_task_res.get(RESULT_TIMEOUT)
+                assert long_task_res.get(RESULT_TIMEOUT)
+
+            class test_REMAP_SIGTERM(SuiteOperations):
+                @pytest.fixture
+                def default_worker_env(self, default_worker_env: dict) -> dict:
+                    default_worker_env.update({"REMAP_SIGTERM": "SIGQUIT"})
+                    return default_worker_env
+
+                def test_soft_shutdown_reset_visibility_timeout(self, celery_setup: CeleryTestSetup):
+                    if isinstance(celery_setup.broker, RabbitMQTestBroker):
+                        pytest.skip("RabbitMQ does not support visibility timeout")
+
+                    app = celery_setup.app
+                    queue = celery_setup.worker.worker_queue
+                    worker = celery_setup.worker
+                    sig = long_running_task.si(15, verbose=True).set(queue=queue)
+                    res = sig.delay()
+
+                    worker.wait_for_log("Starting long running task")
+                    self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+                    worker.wait_for_log(
+                        f"Initiating Soft Shutdown, terminating in {app.conf.worker_soft_shutdown_timeout} seconds"
+                    )
+                    worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+                    worker.wait_for_log("Restoring 1 unacknowledged message(s)")
+                    assert_container_exited(worker)
+                    worker.restart()
+                    assert res.get(RESULT_TIMEOUT)
+
+                def test_soft_shutdown_reset_visibility_timeout_group_one_finish(
+                    self,
+                    celery_setup: CeleryTestSetup,
+                ):
+                    if isinstance(celery_setup.broker, RabbitMQTestBroker):
+                        pytest.skip("RabbitMQ does not support visibility timeout")
+
+                    app = celery_setup.app
+                    queue = celery_setup.worker.worker_queue
+                    worker = celery_setup.worker
+                    short_task = long_running_task.si(3, verbose=True).set(queue=queue)
+                    short_task_res = short_task.freeze()
+                    long_task = long_running_task.si(15, verbose=True).set(queue=queue)
+                    long_task_res = long_task.freeze()
+                    sig = group(short_task, long_task)
+                    sig.delay()
+
+                    worker.wait_for_log(f"long_running_task[{short_task_res.id}] received")
+                    worker.wait_for_log(f"long_running_task[{long_task_res.id}] received")
+                    self.kill_worker(worker, WorkerKill.Method.SIGTERM)
+                    worker.wait_for_log(
+                        f"Initiating Soft Shutdown, terminating in {app.conf.worker_soft_shutdown_timeout} seconds"
+                    )
+                    worker.wait_for_log(f"long_running_task[{short_task_res.id}] succeeded")
+                    worker.wait_for_log("worker: Cold shutdown (MainProcess)")
+                    worker.wait_for_log("Restoring 1 unacknowledged message(s)")
+                    assert_container_exited(worker)
+                    assert short_task_res.get(RESULT_TIMEOUT)

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -1193,3 +1193,12 @@ class test_WorkController(ConsumerCase):
             assert isinstance(w.semaphore, LaxBoundedSemaphore)
             P = w.pool
             P.start()
+
+    def test_wait_for_soft_shutdown(self):
+        worker = self.worker
+        worker.app.conf.worker_soft_shutdown_timeout = 10
+        request = Mock(name='task', id='1234213')
+        state.task_accepted(request)
+        with patch("celery.worker.worker.sleep") as sleep:
+            worker.wait_for_soft_shutdown()
+            sleep.assert_called_with(worker.app.conf.worker_soft_shutdown_timeout)


### PR DESCRIPTION
Celery v5.5 introduces a new concept in the worker-stopping mechanism, the “Soft Shutdown”.
The soft shutdown provides a time-limited warm shutdown that is initiated just before the cold shutdown. This allows for a slight delay before the cold shutdown, which improves the gracefulness of the worker teardown procedure. It is most useful with Redis and SQS due to their visibility-timeout mechanism, as it allows the worker enough time to acknowledge successful messages during shutdown and restore the visibility timeout to zero (``[WARNING/MainProcess] Restoring N unacknowledged message(s)``) before the worker process terminates completely. Another benefit is allowing a worker who runs both short and long tasks to finish a few more short tasks before re-queuing the remaining long-running tasks. You will need to experiment to find the right delay value, recommended values can be 10, 30, 60 seconds. Too high value can lead to a long waiting time before the worker is terminated and trigger a KILL signal to terminate the worker by the host system forcefully.

The soft shutdown is disabled by default to maintain backward compatibility with the cold shutdown terminating immediately. To enable it, set the [worker_soft_shutdown_timeout](https://celery--9213.org.readthedocs.build/en/9213/userguide/configuration.html#worker-soft-shutdown-timeout) to the desired delay. The soft shutdown will be initiated with `SIGQUIT` (or `SIGTERM` if `REMAP_SIGTERM=SIGQUIT`), and then the cold shutdown will be initiated automatically after the soft shutdown timeout expires.

To learn more about the different shutdown types, see [new docs](https://celery--9213.org.readthedocs.build/en/9213/userguide/workers.html#worker-shutdown).

In addition, #8282 has been fixed with a new “Hard Shutdown” which is helpful for development purposes where the worker is stuck. You can now spam Ctrl+C to force the process to die, which was previously bugged if the warm shutdown was already initiated.

Lastly, the REMAP_SIGTERM=SIGQUIT “hidden feature” was documented + smoke tested.