### PR TITLE
Use `docker compose` in Contributing's doc build section

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -718,7 +718,7 @@ Build the documentation by running:
 
 .. code-block:: console
 
-    $ docker-compose -f docker/docker-compose.yml up --build docs
+    $ docker compose -f docker/docker-compose.yml up --build docs
 
 The service will start a local docs server at ``:7000``. The server is using
 ``sphinx-autobuild`` with the ``--watch`` option enabled, so you can live


### PR DESCRIPTION
## Description

This PR updates the usage of `docker-compose` to` docker compose` in the Contributing document.

In the other parts of the project, we already use `docker compose`, so this change is intended to ensure consistency throughout the codebase. The `docker compose` command is now the recommended approach, as it aligns with the latest Docker CLI functionality, removing the need for a separate docker-compose binary. This update does not introduce any new features or changes to the existing functionality.

Please review the changes and let me know if any further adjustments are needed.