### PR TITLE
print is not thread safe, and should not be used in signal handlers

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -78,7 +78,7 @@ def active_thread_count():
 
 
 def safe_say(msg, fd=sys.stderr):
-    os.write(fd.fileno(), f'\n{msg}\n'.encode('utf-8'))
+    os.write(fd.fileno(), f'\n{msg}\n'.encode())
 
 
 class Worker(WorkController):

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -77,8 +77,8 @@ def active_thread_count():
                if not t.name.startswith('Dummy-'))
 
 
-def safe_say(msg, f=sys.__stderr__):
-    print(f'\n{msg}', file=f, flush=True)
+def safe_say(msg, fd=sys.stderr):
+    os.write(fd.fileno(), f'\n{msg}\n'.encode('utf-8'))
 
 
 class Worker(WorkController):
@@ -286,7 +286,7 @@ def _shutdown_handler(worker, sig='TERM', how='Warm',
             if current_process()._name == 'MainProcess':
                 if callback:
                     callback(worker)
-                safe_say(f'worker: {how} shutdown (MainProcess)', sys.__stdout__)
+                safe_say(f'worker: {how} shutdown (MainProcess)', sys.stdout)
                 signals.worker_shutting_down.send(
                     sender=worker.hostname, sig=sig, how=how,
                     exitcode=exitcode,
@@ -317,8 +317,7 @@ else:  # pragma: no cover
 
 
 def on_SIGINT(worker):
-    safe_say('worker: Hitting Ctrl+C again will terminate all running tasks!',
-             sys.__stdout__)
+    safe_say('worker: Hitting Ctrl+C again will terminate all running tasks!', sys.stdout)
     install_worker_term_hard_handler(worker, sig='SIGINT')
 
 
@@ -344,8 +343,7 @@ def install_worker_restart_handler(worker, sig='SIGHUP'):
     def restart_worker_sig_handler(*args):
         """Signal handler restarting the current python program."""
         set_in_sighandler(True)
-        safe_say(f"Restarting celery worker ({' '.join(sys.argv)})",
-                 sys.__stdout__)
+        safe_say(f"Restarting celery worker ({' '.join(sys.argv)})", sys.stdout)
         import atexit
         atexit.register(_reload_current_worker)
         from celery.worker import state

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -77,8 +77,10 @@ def active_thread_count():
                if not t.name.startswith('Dummy-'))
 
 
-def safe_say(msg, fd=sys.stderr):
-    os.write(fd.fileno(), f'\n{msg}\n'.encode())
+def safe_say(msg, fd=None):
+    if fd is None:
+        fd = sys.stderr
+    os.write(fd.fileno(), f'\n{msg}\n'.encode('utf-8'))
 
 
 class Worker(WorkController):

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -80,7 +80,7 @@ def active_thread_count():
 def safe_say(msg, fd=None):
     if fd is None:
         fd = sys.stderr
-    os.write(fd.fileno(), f'\n{msg}\n'.encode('utf-8'))
+    os.write(fd.fileno(), f'\n{msg}\n'.encode())
 
 
 class Worker(WorkController):

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -18,8 +18,8 @@ from kombu.transport.base import Message
 from kombu.transport.memory import Transport
 from kombu.utils.uuid import uuid
 
-from celery.apps.worker import safe_say
 import t.skip
+from celery.apps.worker import safe_say
 from celery.bootsteps import CLOSE, RUN, TERMINATE, StartStopStep
 from celery.concurrency.base import BasePool
 from celery.exceptions import (ImproperlyConfigured, InvalidTaskError, TaskRevokedError, WorkerShutdown,

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -18,6 +18,7 @@ from kombu.transport.base import Message
 from kombu.transport.memory import Transport
 from kombu.utils.uuid import uuid
 
+from celery.apps.worker import safe_say
 import t.skip
 from celery.bootsteps import CLOSE, RUN, TERMINATE, StartStopStep
 from celery.concurrency.base import BasePool
@@ -1193,3 +1194,16 @@ class test_WorkController(ConsumerCase):
             assert isinstance(w.semaphore, LaxBoundedSemaphore)
             P = w.pool
             P.start()
+
+def test_safe_say_defaults_to_stderr(capfd):
+    safe_say("hello")
+    captured = capfd.readouterr()
+    assert "\nhello\n" == captured.err
+    assert "" == captured.out
+
+def test_safe_say_writes_to_std_out(capfd):
+    safe_say("out", sys.stdout)
+    captured = capfd.readouterr()
+    assert "\nout\n" == captured.out
+    assert "" == captured.err
+


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

I sometime got  `RuntimeError: reentrant call inside <_io.BufferedWriter name='<stdout>'>` during worker's lifecycle. 

see others have similar issue https://stackoverflow.com/questions/45680378/how-to-explain-the-reentrant-runtimeerror-caused-by-printing-in-signal-handlers#comment126485747_56330763

We should not use `print` inside signal handlers because it's not thread-safe (not actually safe as the name suggested). There might be other cases of `print` inside signal handlers, but I was only able to identify these obvious ones. 😄 

See similar issue and thread in [gunicorn](https://github.com/benoitc/gunicorn/pull/3064#issuecomment-1788134170).

An alternative solution is not to log/print anything. 


<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
