### PR TITLE
print is not thread-safe, so should not be used in signal handler

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -80,7 +80,8 @@ def active_thread_count():
 def safe_say(msg, fd=None):
     if fd is None:
         fd = sys.stderr
-    os.write(fd.fileno(), f'\n{msg}\n'.encode())
+    if hasattr(fd, 'fileno') and fd.fileno() is not None:
+        os.write(fd.fileno(), f'\n{msg}\n'.encode())
 
 
 class Worker(WorkController):

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -464,7 +464,8 @@ def install_worker_restart_handler(worker, sig='SIGHUP'):
     def restart_worker_sig_handler(*args):
         """Signal handler restarting the current python program."""
         set_in_sighandler(True)
-        safe_say(f"Restarting celery worker ({' '.join(sys.argv)})", sys.__stdout__)
+        safe_say(f"Restarting celery worker ({' '.join(sys.argv)})",
+                 sys.__stdout__)
         import atexit
         atexit.register(_reload_current_worker)
         from celery.worker import state

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -79,7 +79,7 @@ def active_thread_count():
 
 def safe_say(msg, fd=None):
     if fd is None:
-        fd = sys.stderr
+        fd = sys.__stderr__
     if hasattr(fd, 'fileno') and fd.fileno() is not None:
         os.write(fd.fileno(), f'\n{msg}\n'.encode())
 
@@ -301,7 +301,7 @@ def _shutdown_handler(worker: Worker, sig='TERM', how='Warm', callback=None, exi
                 if callback:
                     callback(worker)
                 if verbose:
-                    safe_say(f'worker: {how} shutdown (MainProcess)', sys.stdout)
+                    safe_say(f'worker: {how} shutdown (MainProcess)', sys.__stdout__)
                 signals.worker_shutting_down.send(
                     sender=worker.hostname, sig=sig, how=how,
                     exitcode=exitcode,
@@ -359,7 +359,7 @@ def during_soft_shutdown(worker: Worker):
     # waiting for tasks to finish, and the user decides to still cancel the running tasks.
     # We give the worker the last chance to gracefully terminate by letting the soft shutdown
     # waiting time to finish, which is running in the MainProcess from the previous signal handler call.
-    safe_say('Waiting gracefully for cold shutdown to complete...', sys.stdout)
+    safe_say('Waiting gracefully for cold shutdown to complete...', sys.__stdout__)
 
 
 def on_cold_shutdown(worker: Worker):
@@ -399,7 +399,7 @@ def on_cold_shutdown(worker: Worker):
     Args:
         worker (Worker): The worker that received the signal.
     """
-    safe_say('worker: Hitting Ctrl+C again will terminate all running tasks!', sys.stdout)
+    safe_say('worker: Hitting Ctrl+C again will terminate all running tasks!', sys.__stdout__)
 
     # Replace the signal handler for SIGINT (Ctrl+C) and SIGQUIT (and possibly SIGTERM)
     install_worker_term_hard_handler(worker, sig='SIGINT', callback=during_soft_shutdown)
@@ -440,7 +440,7 @@ else:  # pragma: no cover
 
 def on_SIGINT(worker):
     safe_say('worker: Hitting Ctrl+C again will initiate cold shutdown, terminating all running tasks!',
-             sys.stdout)
+             sys.__stdout__)
     install_worker_term_hard_handler(worker, sig='SIGINT', verbose=False)
 
 
@@ -466,7 +466,7 @@ def install_worker_restart_handler(worker, sig='SIGHUP'):
     def restart_worker_sig_handler(*args):
         """Signal handler restarting the current python program."""
         set_in_sighandler(True)
-        safe_say(f"Restarting celery worker ({' '.join(sys.argv)})", sys.stdout)
+        safe_say(f"Restarting celery worker ({' '.join(sys.argv)})", sys.__stdout__)
         import atexit
         atexit.register(_reload_current_worker)
         from celery.worker import state

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -77,9 +77,9 @@ def active_thread_count():
                if not t.name.startswith('Dummy-'))
 
 
-def safe_say(msg, fd=sys.__stderr__):
-    if hasattr(fd, 'fileno') and fd.fileno() is not None:
-        os.write(fd.fileno(), f'\n{msg}\n'.encode())
+def safe_say(msg, f=sys.__stderr__):
+    if hasattr(f, 'fileno') and f.fileno() is not None:
+        os.write(f.fileno(), f'\n{msg}\n'.encode())
 
 
 class Worker(WorkController):

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -77,9 +77,7 @@ def active_thread_count():
                if not t.name.startswith('Dummy-'))
 
 
-def safe_say(msg, fd=None):
-    if fd is None:
-        fd = sys.__stderr__
+def safe_say(msg, fd=sys.__stderr__):
     if hasattr(fd, 'fileno') and fd.fileno() is not None:
         os.write(fd.fileno(), f'\n{msg}\n'.encode())
 

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -77,8 +77,10 @@ def active_thread_count():
                if not t.name.startswith('Dummy-'))
 
 
-def safe_say(msg, f=sys.__stderr__):
-    print(f'\n{msg}', file=f, flush=True)
+def safe_say(msg, fd=None):
+    if fd is None:
+        fd = sys.stderr
+    os.write(fd.fileno(), f'\n{msg}\n'.encode())
 
 
 class Worker(WorkController):
@@ -286,7 +288,7 @@ def _shutdown_handler(worker, sig='TERM', how='Warm',
             if current_process()._name == 'MainProcess':
                 if callback:
                     callback(worker)
-                safe_say(f'worker: {how} shutdown (MainProcess)', sys.__stdout__)
+                safe_say(f'worker: {how} shutdown (MainProcess)', sys.stdout)
                 signals.worker_shutting_down.send(
                     sender=worker.hostname, sig=sig, how=how,
                     exitcode=exitcode,
@@ -317,8 +319,7 @@ else:  # pragma: no cover
 
 
 def on_SIGINT(worker):
-    safe_say('worker: Hitting Ctrl+C again will terminate all running tasks!',
-             sys.__stdout__)
+    safe_say('worker: Hitting Ctrl+C again will terminate all running tasks!', sys.stdout)
     install_worker_term_hard_handler(worker, sig='SIGINT')
 
 
@@ -344,8 +345,7 @@ def install_worker_restart_handler(worker, sig='SIGHUP'):
     def restart_worker_sig_handler(*args):
         """Signal handler restarting the current python program."""
         set_in_sighandler(True)
-        safe_say(f"Restarting celery worker ({' '.join(sys.argv)})",
-                 sys.__stdout__)
+        safe_say(f"Restarting celery worker ({' '.join(sys.argv)})", sys.stdout)
         import atexit
         atexit.register(_reload_current_worker)
         from celery.worker import state

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -19,6 +19,7 @@ from kombu.transport.memory import Transport
 from kombu.utils.uuid import uuid
 
 import t.skip
+from celery.apps.worker import safe_say
 from celery.bootsteps import CLOSE, RUN, TERMINATE, StartStopStep
 from celery.concurrency.base import BasePool
 from celery.exceptions import (ImproperlyConfigured, InvalidTaskError, TaskRevokedError, WorkerShutdown,
@@ -1193,3 +1194,17 @@ class test_WorkController(ConsumerCase):
             assert isinstance(w.semaphore, LaxBoundedSemaphore)
             P = w.pool
             P.start()
+
+
+def test_safe_say_defaults_to_stderr(capfd):
+    safe_say("hello")
+    captured = capfd.readouterr()
+    assert "\nhello\n" == captured.err
+    assert "" == captured.out
+
+
+def test_safe_say_writes_to_std_out(capfd):
+    safe_say("out", sys.stdout)
+    captured = capfd.readouterr()
+    assert "\nout\n" == captured.out
+    assert "" == captured.err

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -1229,15 +1229,16 @@ class test_WorkController(ConsumerCase):
             sleep.assert_not_called()
 
 
-def test_safe_say_defaults_to_stderr(capfd):
-    safe_say("hello")
-    captured = capfd.readouterr()
-    assert "\nhello\n" == captured.err
-    assert "" == captured.out
+class test_WorkerApp:
 
+    def test_safe_say_defaults_to_stderr(self, capfd):
+        safe_say("hello")
+        captured = capfd.readouterr()
+        assert "\nhello\n" == captured.err
+        assert "" == captured.out
 
-def test_safe_say_writes_to_std_out(capfd):
-    safe_say("out", sys.stdout)
-    captured = capfd.readouterr()
-    assert "\nout\n" == captured.out
-    assert "" == captured.err
+    def test_safe_say_writes_to_std_out(self, capfd):
+        safe_say("out", sys.stdout)
+        captured = capfd.readouterr()
+        assert "\nout\n" == captured.out
+        assert "" == captured.err


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

I sometime got  `RuntimeError: reentrant call inside <_io.BufferedWriter name='<stdout>'>` during worker's lifecycle. 

see others have similar issue https://stackoverflow.com/questions/45680378/how-to-explain-the-reentrant-runtimeerror-caused-by-printing-in-signal-handlers#comment126485747_56330763

We should not use `print` inside signal handlers because it's not thread-safe (not actually safe as the name suggested). There might be other cases of `print` inside signal handlers, but I was only able to identify these obvious ones. 😄 

See similar issue and thread in [gunicorn](https://github.com/benoitc/gunicorn/pull/3064#issuecomment-1788134170).

An alternative solution is not to log/print anything. 


<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
