### PR TITLE
Show broker_connection_retry_on_startup warning only if it evaluates as False

### DIFF
--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -505,13 +505,14 @@ class Consumer:
             # to determine whether connection retries are disabled.
             retry_disabled = not self.app.conf.broker_connection_retry
 
-            warnings.warn(
-                CPendingDeprecationWarning(
-                    f"The broker_connection_retry configuration setting will no longer determine\n"
-                    f"whether broker connection retries are made during startup in Celery 6.0 and above.\n"
-                    f"If you wish to retain the existing behavior for retrying connections on startup,\n"
-                    f"you should set broker_connection_retry_on_startup to {self.app.conf.broker_connection_retry}.")
-            )
+            if retry_disabled:
+                warnings.warn(
+                    CPendingDeprecationWarning(
+                        "The broker_connection_retry configuration setting will no longer determine\n"
+                        "whether broker connection retries are made during startup in Celery 6.0 and above.\n"
+                        "If you wish to refrain from retrying connections on startup,\n"
+                        "you should set broker_connection_retry_on_startup to False instead.")
+                )
         else:
             if self.first_connection_attempt:
                 retry_disabled = not self.app.conf.broker_connection_retry_on_startup

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -452,12 +452,12 @@ class test_Consumer(ConsumerTestCase):
         c.app.conf.broker_connection_retry_on_startup = broker_connection_retry_on_startup
         c.app.conf.broker_connection_retry = broker_connection_retry
 
-        if broker_connection_retry_on_startup is None:
-            with subtests.test("Deprecation warning when startup is None"):
-                with pytest.deprecated_call():
-                    c.ensure_connected(Mock())
-
         if broker_connection_retry is False:
+            if broker_connection_retry_on_startup is None:
+                with subtests.test("Deprecation warning when startup is None"):
+                    with pytest.deprecated_call():
+                        c.ensure_connected(Mock())
+
             with subtests.test("Does not retry when connect throws an error and retry is set to false"):
                 conn = Mock()
                 conn.connect.side_effect = ConnectionError()


### PR DESCRIPTION
<!-- 
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).
-->

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fixes #9225. As said in the issue, the warning is confusing if the user is sticking to the defaults already (as there's nothing to do). With this PR, the warning is shown only if the configuration would actually change with the 6.0 update.
