### PR TITLE
Added worker_enable_soft_shutdown_on_idle

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -310,6 +310,7 @@ NAMESPACES = Namespace(
             False, type='bool'
         ),
         soft_shutdown_timeout=Option(0.0, type='float'),
+        enable_soft_shutdown_on_idle=Option(False, type='bool'),
         concurrency=Option(None, type='int'),
         consumer=Option('celery.worker.consumer:Consumer', type='string'),
         direct=Option(False, type='bool', old={'celery_worker_direct'}),

--- a/celery/worker/worker.py
+++ b/celery/worker/worker.py
@@ -423,8 +423,12 @@ class WorkController:
             soft shutdown timeout even if it is set as it makes no sense to wait for
             the timeout when there are no tasks to process.
         """
-        requests = tuple(state.active_requests)
         app = self.app
+        requests = tuple(state.active_requests)
+
+        if app.conf.worker_enable_soft_shutdown_on_idle:
+            requests = True
+
         if app.conf.worker_soft_shutdown_timeout > 0 and requests:
             log = f"Initiating Soft Shutdown, terminating in {app.conf.worker_soft_shutdown_timeout} seconds"
             logger.warning(log)

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3292,11 +3292,24 @@ is initiated and the worker is terminated.
 This will apply also when the worker initiate :ref:`cold shutdown <worker-cold-shutdown>` without doing a warm shutdown first.
 
 If the value is set to 0.0, the soft shutdown will be practically disabled. Regardless of the value, the soft shutdown
-will be disabled if there are no tasks running.
+will be disabled if there are no tasks running (unless :setting:`worker_enable_soft_shutdown_on_idle` is enabled).
 
 Experiment with this value to find the optimal time for your tasks to finish gracefully before the worker is terminated.
 Recommended values can be 10, 30, 60 seconds. Too high value can lead to a long waiting time before the worker is terminated
 and trigger a :sig:`KILL` signal to forcefully terminate the worker by the host system.
+
+.. setting:: worker_enable_soft_shutdown_on_idle
+
+``worker_enable_soft_shutdown_on_idle``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.5
+
+Default: False.
+
+If the :setting:`worker_soft_shutdown_timeout` is set to a value greater than 0.0, the worker will skip
+the :ref:`soft shutdown <worker-soft-shutdown>` anyways if there are no tasks running. This setting will
+enable the soft shutdown even if there are no tasks running.
 
 .. _conf-events:
 

--- a/docs/userguide/workers.rst
+++ b/docs/userguide/workers.rst
@@ -163,6 +163,8 @@ the worker to perform the cold shutdown a little more gracefully.
 
 The soft shutdown is disabled by default to maintain backward compatibility with the :ref:`worker-cold-shutdown`
 behavior. To enable the soft shutdown, set :setting:`worker_soft_shutdown_timeout` to a positive float value.
+The soft shutdown will be skipped if there are no tasks running. To force the soft shutdown, *also* enable the
+:setting:`worker_enable_soft_shutdown_on_idle` setting.
 
 For example, when setting ``worker_soft_shutdown_timeout=3``, the worker will allow 3 seconds for all currently
 executing tasks to finish before it terminates. If the time limit is reached, the worker will initiate a cold shutdown

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -1202,3 +1202,27 @@ class test_WorkController(ConsumerCase):
         with patch("celery.worker.worker.sleep") as sleep:
             worker.wait_for_soft_shutdown()
             sleep.assert_called_with(worker.app.conf.worker_soft_shutdown_timeout)
+
+    def test_wait_for_soft_shutdown_no_tasks(self):
+        worker = self.worker
+        worker.app.conf.worker_soft_shutdown_timeout = 10
+        worker.app.conf.worker_enable_soft_shutdown_on_idle = True
+        state.active_requests.clear()
+        with patch("celery.worker.worker.sleep") as sleep:
+            worker.wait_for_soft_shutdown()
+            sleep.assert_called_with(worker.app.conf.worker_soft_shutdown_timeout)
+
+    def test_wait_for_soft_shutdown_no_wait(self):
+        worker = self.worker
+        request = Mock(name='task', id='1234213')
+        state.task_accepted(request)
+        with patch("celery.worker.worker.sleep") as sleep:
+            worker.wait_for_soft_shutdown()
+            sleep.assert_not_called()
+
+    def test_wait_for_soft_shutdown_no_wait_no_tasks(self):
+        worker = self.worker
+        worker.app.conf.worker_enable_soft_shutdown_on_idle = True
+        with patch("celery.worker.worker.sleep") as sleep:
+            worker.wait_for_soft_shutdown()
+            sleep.assert_not_called()


### PR DESCRIPTION
Allows the [soft shutdown](https://docs.celeryq.dev/en/latest/userguide/workers.html#soft-shutdown) to be enabled even if no tasks are running.
This is useful when ETA tasks were received but still didn’t start and there’s a cold shutdown.
The soft shutdown timer should allow enough time for ETA tasks to be re-queued, just like with normal running tasks during soft shutdown that were canceled when the timeout expired.

Without enabling this flag but still setting a soft shutdown timeout, when ETA tasks are received, and there’s a cold shutdown and there are no tasks running, the worker will terminate immediately and might not re-queue the ETA tasks on time. This may be relevant for #1810 (and https://github.com/celery/kombu/issues/533).