### PR TITLE
fixing rpc message reporting

### DIFF
--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -184,11 +184,6 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
         # By default we don't have to declare anything when sending a result.
         pass
 
-    def on_result_fulfilled(self, result):
-        # This usually cancels the queue after the result is received,
-        # but we don't have to cancel since we have one queue per process.
-        pass
-
     def as_uri(self, include_password=True):
         return 'rpc://'
 


### PR DESCRIPTION
 when result.get() is used it creates a consumer that is supposed to be stopped when the on_result_fulfilled() is called, but because the method overrides the original implementation with a pass, this consumer is never stopped, and the AsyncResult._get_task_meta() stops working.

Closes #4084
