### PR TITLE
Correct the error description in exception message when validate soft_time_limit

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -301,3 +301,4 @@ Johannes Faigle, 2024/06/18
 Giovanni Giampauli, 2024/06/26
 Shamil Abdulaev, 2024/08/05
 Nikos Atlas, 2024/08/26
+Narasux, 2024/09/09

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -543,7 +543,7 @@ class Task:
             TypeError: If not enough arguments are passed, or too many
                 arguments are passed.  Note that signature checks may
                 be disabled by specifying ``@task(typing=False)``.
-            ValueError: If soft_time_limit and time_limit both set
+            ValueError: If soft_time_limit and time_limit both are set
                 but soft_time_limit is greater than time_limit
             kombu.exceptions.OperationalError: If a connection to the
                transport cannot be made, or if the connection is lost.

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -543,8 +543,8 @@ class Task:
             TypeError: If not enough arguments are passed, or too many
                 arguments are passed.  Note that signature checks may
                 be disabled by specifying ``@task(typing=False)``.
-            ValueError: If soft_time_limit and time_limit are set,
-                and soft_time_limit is less than time_limit
+            ValueError: If soft_time_limit and time_limit both set
+                but soft_time_limit is greater than time_limit
             kombu.exceptions.OperationalError: If a connection to the
                transport cannot be made, or if the connection is lost.
 
@@ -553,7 +553,7 @@ class Task:
             :meth:`kombu.Producer.publish`.
         """
         if self.soft_time_limit and self.time_limit and self.soft_time_limit > self.time_limit:
-            raise ValueError('soft_time_limit must be greater than or equal to time_limit')
+            raise ValueError('soft_time_limit must be less than or equal to time_limit')
 
         if self.typing:
             try:

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -477,7 +477,7 @@ class test_tasks:
     @flaky
     def test_soft_time_limit_exceeding_time_limit(self):
 
-        with pytest.raises(ValueError, match='soft_time_limit must be greater than or equal to time_limit'):
+        with pytest.raises(ValueError, match='soft_time_limit must be less than or equal to time_limit'):
             result = soft_time_limit_must_exceed_time_limit.apply_async()
             result.get(timeout=5)
 

--- a/t/smoke/tests/test_tasks.py
+++ b/t/smoke/tests/test_tasks.py
@@ -140,5 +140,5 @@ class test_time_limit:
 
     def test_soft_time_limit_must_exceed_time_limit(self, celery_setup: CeleryTestSetup):
         sig = soft_time_limit_must_exceed_time_limit.s()
-        with pytest.raises(ValueError, match="soft_time_limit must be greater than or equal to time_limit"):
+        with pytest.raises(ValueError, match="soft_time_limit must be less than or equal to time_limit"):
             sig.apply_async(queue=celery_setup.worker.worker_queue)

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1421,7 +1421,7 @@ class test_tasks(TasksCase):
 
             assert yyy_result.state == 'FAILURE'
         except ValueError as e:
-            assert str(e) == 'soft_time_limit must be greater than or equal to time_limit'
+            assert str(e) == 'soft_time_limit must be less than or equal to time_limit'
 
 
 class test_apply_task(TasksCase):


### PR DESCRIPTION
## Description

I noticed that in PR #9173 a check was added to ensure that `soft_time_limit `must be less than or equal to `time_limit`. However, the current exception message conflicts with the checking logic and may mislead Celery users. So I submitting a PR to correct these.
