### PR TITLE
Fixes #9119: inject dispatch_uid for retry-wrapped receivers

### DIFF
--- a/celery/utils/dispatch/signal.py
+++ b/celery/utils/dispatch/signal.py
@@ -54,6 +54,9 @@ def _boundmethod_safe_weakref(obj):
 def _make_lookup_key(receiver, sender, dispatch_uid):
     if dispatch_uid:
         return (dispatch_uid, _make_id(sender))
+    # Issue #9119 - retry-wrapped functions use the underlying function for dispatch_uid
+    elif hasattr(receiver, '_dispatch_uid'):
+        return (receiver._dispatch_uid, _make_id(sender))
     else:
         return (_make_id(receiver), _make_id(sender))
 
@@ -170,6 +173,7 @@ class Signal:  # pragma: no cover
                         # it up later with the original func id
                         options['dispatch_uid'] = _make_id(fun)
                     fun = _retry_receiver(fun)
+                    fun._dispatch_uid = options['dispatch_uid']
 
                 self._connect_signal(fun, sender, options['weak'],
                                      options['dispatch_uid'])

--- a/t/unit/utils/test_dispatcher.py
+++ b/t/unit/utils/test_dispatcher.py
@@ -185,7 +185,7 @@ class test_Signal:
         garbage_collect()
         self._testIsClean(a_signal)
 
-    @pytest.mark.xfail(reason="Issue #9119")
+    # @pytest.mark.xfail(reason="Issue #9119")
     def test_disconnect_retryable_decorator(self):
         # Regression test for https://github.com/celery/celery/issues/9119
 

--- a/t/unit/utils/test_dispatcher.py
+++ b/t/unit/utils/test_dispatcher.py
@@ -2,8 +2,6 @@ import gc
 import sys
 import time
 
-import pytest
-
 from celery.utils.dispatch import Signal
 
 if sys.platform.startswith('java'):
@@ -185,7 +183,6 @@ class test_Signal:
         garbage_collect()
         self._testIsClean(a_signal)
 
-    # @pytest.mark.xfail(reason="Issue #9119")
     def test_disconnect_retryable_decorator(self):
         # Regression test for https://github.com/celery/celery/issues/9119
 


### PR DESCRIPTION
## Description
Fixes #9119 (or tries to)

This approach assumes we want to do the dispatch_uid calculation for the user behind the scenes, and that we want to handle both the decorator and non-decorator usecases for `signal.connect(receiver, sender=sender, retry=True)`

Notes:
- edited _make_lookup_key instead of _make_id, doesn't seem to be much of a difference, but I wanted the change as far up the stack as possible so devs can see it sooner
- we can potentially also use functools.wraps and `__wrapped__` (i.e., `functools.wraps(fun)(retry_over_time)` in decorator form), but this is a bit too generic for this type of solution, which may cause other issues



