### PR TITLE
update mongodb without deprecated `[srv]` extra requirement

### DIFF
--- a/requirements/extras/mongodb.txt
+++ b/requirements/extras/mongodb.txt
@@ -1,1 +1,1 @@
-pymongo[srv]>=4.0.2, <4.9
+pymongo>=4.3, <4.9


### PR DESCRIPTION

## Description

Avoids using `pymongo[srv]`. The extra requirement was removed since `pymongo==4.3`, because the `dnspython` it referred to is now required. The `[srv]` extra was left as an empty list of dependencies for backward compatibility and to avoid pip warnings, but was removed in `pymongo==4.8`. See the linked issue for more details.

- fixes https://github.com/celery/celery/issues/9254

