### PR TITLE
Run all smoke tests CI jobs together

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -238,8 +238,8 @@ jobs:
 
   Smoke-canvas:
     needs:
-    - Smoke-stamping
-    if: needs.Smoke-stamping.result == 'success'
+    - Integration
+    if: needs.Integration.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
         fail-fast: false
@@ -275,8 +275,8 @@ jobs:
 
   Smoke-consumer:
     needs:
-    - Smoke-stamping
-    if: needs.Smoke-stamping.result == 'success'
+    - Integration
+    if: needs.Integration.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
         fail-fast: false
@@ -312,8 +312,8 @@ jobs:
 
   Smoke-control:
     needs:
-    - Smoke-stamping
-    if: needs.Smoke-stamping.result == 'success'
+    - Integration
+    if: needs.Integration.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
         fail-fast: false
@@ -349,8 +349,8 @@ jobs:
 
   Smoke-signals:
     needs:
-    - Smoke-stamping
-    if: needs.Smoke-stamping.result == 'success'
+    - Integration
+    if: needs.Integration.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
         fail-fast: false
@@ -386,8 +386,8 @@ jobs:
 
   Smoke-tasks:
     needs:
-    - Smoke-control
-    if: needs.Smoke-control.result == 'success'
+    - Integration
+    if: needs.Integration.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
         fail-fast: false
@@ -423,8 +423,8 @@ jobs:
 
   Smoke-thread_safe:
     needs:
-    - Smoke-control
-    if: needs.Smoke-control.result == 'success'
+    - Integration
+    if: needs.Integration.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
         fail-fast: false
@@ -460,8 +460,8 @@ jobs:
 
   Smoke-worker:
     needs:
-    - Smoke-control
-    if: needs.Smoke-control.result == 'success'
+    - Integration
+    if: needs.Integration.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
         fail-fast: false

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps=
 commands =
     unit: pytest -vv --maxfail=10 --capture=no -v --cov=celery --cov-report=xml --cov-report term {posargs}
     integration: pytest -xsvv t/integration {posargs}
-    smoke: pytest -xsvv t/smoke --dist=loadscope --reruns 10 --reruns-delay 60 --rerun-except AssertionError {posargs}
+    smoke: pytest -xsvv t/smoke --dist=loadscope --reruns 3 --reruns-delay 30 --rerun-except AssertionError {posargs}
 setenv =
     PIP_EXTRA_INDEX_URL=https://celery.github.io/celery-wheelhouse/repo/simple/
     BOTO_CONFIG = /dev/null


### PR DESCRIPTION
With Blacksmith and using only min/max Python versions for the smoke tests, we can undo some optimizations I did before to try and make it more stable.