### PR TITLE
Added "loglevel verbose" to Redis containers in smoke tests

### DIFF
--- a/t/smoke/redis.conf
+++ b/t/smoke/redis.conf
@@ -3,3 +3,4 @@ protected-mode no
 save ""
 appendonly no
 maxmemory-policy noeviction
+loglevel verbose


### PR DESCRIPTION
This is the last random issue in the smoke tests that causes false positives.
Adding more logs to better analyze the reason it keeps happening.
```console
Possible SECURITY ATTACK detected. It looks like somebody is sending POST or Host: commands to Redis. This is likely due to an attacker attempting to use Cross Protocol Scripting to compromise your Redis instance.
```