### PR TITLE
Fixed Redis error in the smoke tests: "Possible SECURITY ATTACK detected"

### DIFF
--- a/t/smoke/tests/test_worker.py
+++ b/t/smoke/tests/test_worker.py
@@ -1,24 +1,13 @@
 from time import sleep
 
 import pytest
-from pytest_celery import (ALL_CELERY_BROKERS, CELERY_LOCALSTACK_BROKER, RESULT_TIMEOUT, CeleryTestBroker,
-                           CeleryTestSetup, CeleryTestWorker, RabbitMQTestBroker, _is_vendor_installed)
+from pytest_celery import RESULT_TIMEOUT, CeleryTestSetup, CeleryTestWorker, RabbitMQTestBroker
 
 import celery
 from celery import Celery
 from celery.canvas import chain, group
 from t.smoke.conftest import SuiteOperations, WorkerKill, WorkerRestart
 from t.smoke.tasks import long_running_task
-
-if _is_vendor_installed("localstack"):
-    ALL_CELERY_BROKERS.add(CELERY_LOCALSTACK_BROKER)
-
-
-@pytest.fixture(params=ALL_CELERY_BROKERS)
-def celery_broker(request: pytest.FixtureRequest) -> CeleryTestBroker:  # type: ignore
-    broker: CeleryTestBroker = request.getfixturevalue(request.param)
-    yield broker
-    broker.teardown()
 
 
 def assert_container_exited(worker: CeleryTestWorker, attempts: int = RESULT_TIMEOUT):


### PR DESCRIPTION
Adding SQS (via Localstack) to some of the smoke tests caused the following error **sometimes**:
```console
Possible SECURITY ATTACK detected. It looks like somebody is sending POST or Host: commands to Redis. This is likely due to an attacker attempting to use Cross Protocol Scripting to compromise your Redis instance.
```

It appears to happen only when Celery uses SQS broker and Redis backend, and only sometimes.
Potentially, Celery is using the `http` protocol to communicate with Redis instead of Redis’s own TCP protocol. This is potentially due to a bug in Celery, as SQS does work with `http` URLs.