### PR TITLE
Relaxed smoke tests flaky tests mechanism

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps=
 commands =
     unit: pytest -vv --maxfail=10 --capture=no -v --cov=celery --cov-report=xml --cov-report term {posargs}
     integration: pytest -xsvv t/integration {posargs}
-    smoke: pytest -xsvv t/smoke --dist=loadscope --reruns 5 --reruns-delay 60 --rerun-except AssertionError {posargs}
+    smoke: pytest -xsvv t/smoke --dist=loadscope --reruns 5 --reruns-delay 10 {posargs}
 setenv =
     PIP_EXTRA_INDEX_URL=https://celery.github.io/celery-wheelhouse/repo/simple/
     BOTO_CONFIG = /dev/null


### PR DESCRIPTION
In the integration tests, flaky means up to 5 runs.
In the smoke tests, it was the same plus-minus except if there was an assertion error.

This PR matches the smoke tests’ flaky behavior to the integration tests, allowing even failed tests due to test assertion to retry.