### PR TITLE
Add log when global qos is disabled

### DIFF
--- a/celery/worker/consumer/tasks.py
+++ b/celery/worker/consumer/tasks.py
@@ -42,6 +42,8 @@ class Tasks(bootsteps.StartStopStep):
         c.update_strategies()
 
         qos_global = self.qos_global(c)
+        if qos_global is False:
+            logger.info("Global QoS is disabled. Prefetch count in now static.")
 
         # set initial prefetch count
         c.connection.default_channel.basic_qos(


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

We should report to the user that global QoS is disabled.
This PR adds a log when that happens.