### PR TITLE
Use rabbitmq:3 in stamping smoke tests

### DIFF
--- a/t/smoke/tests/stamping/conftest.py
+++ b/t/smoke/tests/stamping/conftest.py
@@ -7,6 +7,13 @@ from t.smoke.workers.dev import SmokeWorkerContainer
 
 
 @pytest.fixture
+def default_rabbitmq_broker_image() -> str:
+    # Celery 4 doesn't support RabbitMQ 4 due to:
+    # https://github.com/celery/kombu/pull/2098
+    return "rabbitmq:3"
+
+
+@pytest.fixture
 def default_worker_tasks(default_worker_tasks: set) -> set:
     from t.smoke.tests.stamping import tasks as stamping_tasks
 


### PR DESCRIPTION
Fixes:
```console
2024-09-19 22:08:02  
2024-09-19 22:08:02  -------------- celery_legacy_tests_worker@b6c5cd4d3b9a v4.4.7 (cliffs)
2024-09-19 22:08:02 --- ***** ----- 
2024-09-19 22:08:02 -- ******* ---- Linux-6.10.4-linuxkit-aarch64-with-glibc2.36 2024-09-19 19:08:02
2024-09-19 22:08:02 - *** --- * --- 
2024-09-19 22:08:02 - ** ---------- [config]
2024-09-19 22:08:02 - ** ---------- .> app:         celery_test_app:0xffffbd7e8c40
2024-09-19 22:08:02 - ** ---------- .> transport:   amqp://guest:**@5a9ef7a58b66:5672//
2024-09-19 22:08:02 - ** ---------- .> results:     redis://65081c461355/0
2024-09-19 22:08:02 - *** --- * --- .> concurrency: 10 (prefork)
2024-09-19 22:08:02 -- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
2024-09-19 22:08:02 --- ***** ----- 
2024-09-19 22:08:02  -------------- [queues]
2024-09-19 22:08:02                 .> celery_legacy_tests_queue exchange=celery_legacy_tests_queue(direct) key=celery_legacy_tests_queue
2024-09-19 22:08:02                 
2024-09-19 22:08:02 
2024-09-19 22:08:02 [tasks]
2024-09-19 22:08:02   . pytest_celery.vendors.worker.tasks.add
2024-09-19 22:08:02   . pytest_celery.vendors.worker.tasks.add_replaced
2024-09-19 22:08:02   . pytest_celery.vendors.worker.tasks.fail
2024-09-19 22:08:02   . pytest_celery.vendors.worker.tasks.identity
2024-09-19 22:08:02   . pytest_celery.vendors.worker.tasks.noop
2024-09-19 22:08:02   . pytest_celery.vendors.worker.tasks.ping
2024-09-19 22:08:02   . pytest_celery.vendors.worker.tasks.sleep
2024-09-19 22:08:02   . pytest_celery.vendors.worker.tasks.xsum
2024-09-19 22:08:02   . t.integration.tasks.add
2024-09-19 22:08:02   . t.integration.tasks.add_chord_to_chord
2024-09-19 22:08:02   . t.integration.tasks.add_ignore_result
2024-09-19 22:08:02   . t.integration.tasks.add_not_typed
2024-09-19 22:08:02   . t.integration.tasks.add_pydantic
2024-09-19 22:08:02   . t.integration.tasks.add_replaced
2024-09-19 22:08:02   . t.integration.tasks.add_to_all
2024-09-19 22:08:02   . t.integration.tasks.add_to_all_to_chord
2024-09-19 22:08:02   . t.integration.tasks.build_chain_inside_task
2024-09-19 22:08:02   . t.integration.tasks.chain_add
2024-09-19 22:08:02   . t.integration.tasks.chord_add
2024-09-19 22:08:02   . t.integration.tasks.collect_ids
2024-09-19 22:08:02   . t.integration.tasks.delayed_sum
2024-09-19 22:08:02   . t.integration.tasks.delayed_sum_with_soft_guard
2024-09-19 22:08:02   . t.integration.tasks.errback_new_style
2024-09-19 22:08:02   . t.integration.tasks.errback_old_style
2024-09-19 22:08:02   . t.integration.tasks.fail
2024-09-19 22:08:02   . t.integration.tasks.fail_replaced
2024-09-19 22:08:02   . t.integration.tasks.fail_unpickleable
2024-09-19 22:08:02   . t.integration.tasks.identity
2024-09-19 22:08:02   . t.integration.tasks.ids
2024-09-19 22:08:02   . t.integration.tasks.mul
2024-09-19 22:08:02   . t.integration.tasks.print_unicode
2024-09-19 22:08:02   . t.integration.tasks.raise_error
2024-09-19 22:08:02   . t.integration.tasks.rebuild_signature
2024-09-19 22:08:02   . t.integration.tasks.redis_count
2024-09-19 22:08:02   . t.integration.tasks.redis_echo
2024-09-19 22:08:02   . t.integration.tasks.redis_echo_group_id
2024-09-19 22:08:02   . t.integration.tasks.replace_with_chain
2024-09-19 22:08:02   . t.integration.tasks.replace_with_chain_which_raises
2024-09-19 22:08:02   . t.integration.tasks.replace_with_empty_chain
2024-09-19 22:08:02   . t.integration.tasks.replaced_with_me
2024-09-19 22:08:02   . t.integration.tasks.retry
2024-09-19 22:08:02   . t.integration.tasks.retry_once
2024-09-19 22:08:02   . t.integration.tasks.retry_once_headers
2024-09-19 22:08:02   . t.integration.tasks.retry_once_priority
2024-09-19 22:08:02   . t.integration.tasks.retry_unpickleable
2024-09-19 22:08:02   . t.integration.tasks.return_exception
2024-09-19 22:08:02   . t.integration.tasks.return_nested_signature_chain_chain
2024-09-19 22:08:02   . t.integration.tasks.return_nested_signature_chain_chord
2024-09-19 22:08:02   . t.integration.tasks.return_nested_signature_chain_group
2024-09-19 22:08:02   . t.integration.tasks.return_nested_signature_chord_chain
2024-09-19 22:08:02   . t.integration.tasks.return_nested_signature_chord_chord
2024-09-19 22:08:02   . t.integration.tasks.return_nested_signature_chord_group
2024-09-19 22:08:02   . t.integration.tasks.return_nested_signature_group_chain
2024-09-19 22:08:02   . t.integration.tasks.return_nested_signature_group_chord
2024-09-19 22:08:02   . t.integration.tasks.return_nested_signature_group_group
2024-09-19 22:08:02   . t.integration.tasks.return_priority
2024-09-19 22:08:02   . t.integration.tasks.return_properties
2024-09-19 22:08:02   . t.integration.tasks.second_order_replace1
2024-09-19 22:08:02   . t.integration.tasks.second_order_replace2
2024-09-19 22:08:02   . t.integration.tasks.sleeping
2024-09-19 22:08:02   . t.integration.tasks.soft_time_limit_must_exceed_time_limit
2024-09-19 22:08:02   . t.integration.tasks.tsum
2024-09-19 22:08:02   . t.integration.tasks.write_to_file_and_return_int
2024-09-19 22:08:02   . t.integration.tasks.xsum
2024-09-19 22:08:02   . t.smoke.tasks.long_running_task
2024-09-19 22:08:02   . t.smoke.tasks.noop
2024-09-19 22:08:02   . t.smoke.tasks.replace_with_task
2024-09-19 22:08:02   . t.smoke.tasks.self_termination_delay_timeout
2024-09-19 22:08:02   . t.smoke.tasks.self_termination_exhaust_memory
2024-09-19 22:08:02   . t.smoke.tasks.self_termination_sigkill
2024-09-19 22:08:02   . t.smoke.tasks.self_termination_system_exit
2024-09-19 22:08:02   . t.smoke.tasks.soft_time_limit_lower_than_time_limit
2024-09-19 22:08:02   . t.smoke.tasks.soft_time_limit_must_exceed_time_limit
2024-09-19 22:08:02   . t.smoke.tests.stamping.tasks.waitfor
2024-09-19 22:08:02 
2024-09-19 22:08:02 [2024-09-19 19:08:02,811: INFO/MainProcess] Connected to amqp://guest:**@5a9ef7a58b66:5672//
2024-09-19 22:08:02 [2024-09-19 19:08:02,836: INFO/MainProcess] mingle: searching for neighbors
2024-09-19 22:08:03 [2024-09-19 19:08:03,877: INFO/MainProcess] mingle: all alone
2024-09-19 22:08:03 [2024-09-19 19:08:03,891: CRITICAL/MainProcess] Unrecoverable error: TypeError('_unpack_version() takes from 1 to 5 positional arguments but 6 were given')
2024-09-19 22:08:03 Traceback (most recent call last):
2024-09-19 22:08:03   File "/usr/local/lib/python3.10/site-packages/celery/worker/worker.py", line 208, in start
2024-09-19 22:08:03     self.blueprint.start(self)
2024-09-19 22:08:03   File "/usr/local/lib/python3.10/site-packages/celery/bootsteps.py", line 119, in start
2024-09-19 22:08:03     step.start(parent)
2024-09-19 22:08:03   File "/usr/local/lib/python3.10/site-packages/celery/bootsteps.py", line 369, in start
2024-09-19 22:08:03     return self.obj.start()
2024-09-19 22:08:03   File "/usr/local/lib/python3.10/site-packages/celery/worker/consumer/consumer.py", line 318, in start
2024-09-19 22:08:03     blueprint.start(self)
2024-09-19 22:08:03   File "/usr/local/lib/python3.10/site-packages/celery/bootsteps.py", line 119, in start
2024-09-19 22:08:03     step.start(parent)
2024-09-19 22:08:03   File "/usr/local/lib/python3.10/site-packages/celery/worker/consumer/tasks.py", line 33, in start
2024-09-19 22:08:03     qos_global = not c.connection.qos_semantics_matches_spec
2024-09-19 22:08:03   File "/usr/local/lib/python3.10/site-packages/kombu/connection.py", line 833, in qos_semantics_matches_spec
2024-09-19 22:08:03     return self.transport.qos_semantics_matches_spec(self.connection)
2024-09-19 22:08:03   File "/usr/local/lib/python3.10/site-packages/kombu/transport/pyamqp.py", line 154, in qos_semantics_matches_spec
2024-09-19 22:08:03     return version_string_as_tuple(props['version']) < (3, 3)
2024-09-19 22:08:03   File "/usr/local/lib/python3.10/site-packages/kombu/utils/text.py", line 49, in version_string_as_tuple
2024-09-19 22:08:03     v = _unpack_version(*s.split('.'))
2024-09-19 22:08:03 TypeError: _unpack_version() takes from 1 to 5 positional arguments but 6 were given
2024-09-19 22:08:06 [2024-09-19 19:08:06,032: WARNING/MainProcess] Received method (60, 60) during closing channel 2. This method will be ignored
2024-09-19 22:08:06 [2024-09-19 19:08:06,033: WARNING/MainProcess] Received method (60, 60) during closing channel 2. This method will be ignored
```