### PR TITLE
Pydantic typehints: Fix optional, allow generics

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -129,7 +129,7 @@ def pydantic_wrapper(
         bound_args = task_signature.bind(*task_args, **task_kwargs)
         for arg_name, arg_value in bound_args.arguments.items():
             arg_annotation = task_signature.parameters[arg_name].annotation
-            if issubclass(arg_annotation, BaseModel):
+            if isinstance(arg_annotation, type) and issubclass(arg_annotation, BaseModel):
                 bound_args.arguments[arg_name] = arg_annotation.model_validate(
                     arg_value,
                     strict=strict,

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -37,6 +37,7 @@ from celery.utils.log import get_logger
 from celery.utils.objects import FallbackContext, mro_lookup
 from celery.utils.time import maybe_make_aware, timezone, to_utc
 
+from ..utils.annotations import annotation_issubclass, get_optional_arg
 # Load all builtin tasks
 from . import backends, builtins  # noqa
 from .annotations import prepare as prepare_annotations
@@ -129,7 +130,12 @@ def pydantic_wrapper(
         bound_args = task_signature.bind(*task_args, **task_kwargs)
         for arg_name, arg_value in bound_args.arguments.items():
             arg_annotation = task_signature.parameters[arg_name].annotation
-            if isinstance(arg_annotation, type) and issubclass(arg_annotation, BaseModel):
+
+            optional_arg = get_optional_arg(arg_annotation)
+            if optional_arg is not None and arg_value is not None:
+                arg_annotation = optional_arg
+
+            if annotation_issubclass(arg_annotation, BaseModel):
                 bound_args.arguments[arg_name] = arg_annotation.model_validate(
                     arg_value,
                     strict=strict,

--- a/celery/utils/annotations.py
+++ b/celery/utils/annotations.py
@@ -32,11 +32,16 @@ def get_optional_arg(annotation: typing.Any) -> typing.Any:
     return None
 
 
-def annotation_issubclass(annotation: typing.Any, cls: type) -> bool:
-    """Test if a given annotation is of the given subclass."""
+def annotation_is_class(annotation: typing.Any) -> bool:
+    """Test if a given annotation is a class that can be used in isinstance()/issubclass()."""
     # isclass() returns True for generic type hints (e.g. `list[str]`) until Python 3.10.
     # NOTE: The guard for Python 3.9 is because types.GenericAlias is only added in Python 3.9. This is not a problem
     #       as the syntax is added in the same version in the first place.
     if (3, 9) <= sys.version_info < (3, 11) and isinstance(annotation, types.GenericAlias):
         return False
-    return isclass(annotation) and issubclass(annotation, cls)
+    return isclass(annotation)
+
+
+def annotation_issubclass(annotation: typing.Any, cls: type) -> bool:
+    """Test if a given annotation is of the given subclass."""
+    return annotation_is_class(annotation) and issubclass(annotation, cls)

--- a/celery/utils/annotations.py
+++ b/celery/utils/annotations.py
@@ -1,0 +1,42 @@
+"""Code related to handling annotations."""
+
+import sys
+import types
+import typing
+from inspect import isclass
+
+
+def is_none_type(value: typing.Any) -> bool:
+    """Check if the given value is a NoneType."""
+    if sys.version_info < (3, 10):
+        # raise Exception('below 3.10', value, type(None))
+        return value is type(None)
+    return value == types.NoneType  # type: ignore[no-any-return]
+
+
+def get_optional_arg(annotation: typing.Any) -> typing.Any:
+    """Get the argument from an Optional[...] annotation, or None if it is no such annotation."""
+    origin = typing.get_origin(annotation)
+    if origin != typing.Union and (sys.version_info >= (3, 10) and origin != types.UnionType):
+        return None
+
+    union_args = typing.get_args(annotation)
+    if len(union_args) != 2:  # Union does _not_ have two members, so it's not an Optional
+        return None
+
+    has_none_arg = any(is_none_type(arg) for arg in union_args)
+    other_arg = next(arg for arg in union_args if not is_none_type(arg))
+
+    if has_none_arg:
+        return other_arg
+    return None
+
+
+def annotation_issubclass(annotation: typing.Any, cls: type) -> bool:
+    """Test if a given annotation is of the given subclass."""
+    # isclass() returns True for generic type hints (e.g. `list[str]`) until Python 3.10.
+    # NOTE: The guard for Python 3.9 is because types.GenericAlias is only added in Python 3.9. This is not a problem
+    #       as the syntax is added in the same version in the first place.
+    if (3, 9) <= sys.version_info < (3, 11) and isinstance(annotation, types.GenericAlias):
+        return False
+    return isclass(annotation) and issubclass(annotation, cls)

--- a/celery/utils/annotations.py
+++ b/celery/utils/annotations.py
@@ -25,10 +25,12 @@ def get_optional_arg(annotation: typing.Any) -> typing.Any:
         return None
 
     has_none_arg = any(is_none_type(arg) for arg in union_args)
-    other_arg = next(arg for arg in union_args if not is_none_type(arg))
+    # There will always be at least one type arg, as we have already established that this is a Union with exactly
+    # two members, and both cannot be None (`Union[None, None]` does not work).
+    type_arg = next(arg for arg in union_args if not is_none_type(arg))  # pragma: no branch
 
     if has_none_arg:
-        return other_arg
+        return type_arg
     return None
 
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -549,8 +549,8 @@ class test_App:
             assert foo(0) == 1
             check.assert_called_once_with(0, kwarg=True)
 
-            assert foo() == 2
-            check.assert_called_once_with(None, kwarg=True)
+            assert foo(None) == 2
+            check.assert_called_with(None, kwarg=True)
 
     def test_task_with_pydantic_with_dict_args(self):
         """Test pydantic task receiving and returning a generic dict argument."""
@@ -638,7 +638,7 @@ class test_App:
             check.assert_called_once_with(None, kwarg=None)
 
             assert foo({'arg_value': 1}, kwarg={'kwarg_value': 2}) == {'ret_value': 1}
-            check.assert_called_once_with(ArgModel(arg_vlaue=1), kwarg=KwargModel(kwarg_value=2))
+            check.assert_called_with(ArgModel(arg_value=1), kwarg=KwargModel(kwarg_value=2))
 
     def test_task_with_pydantic_with_task_name_in_context(self):
         """Test that the task name is passed to as additional context."""

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from datetime import timezone as datetime_timezone
 from pickle import dumps, loads
+from typing import Optional
 from unittest.mock import DEFAULT, Mock, patch
 
 import pytest
@@ -533,6 +534,50 @@ class test_App:
             assert foo(0) == 1
             check.assert_called_once_with(0, kwarg=True)
 
+    def test_task_with_pydantic_with_optional_args(self):
+        """Test pydantic task receiving and returning an optional argument."""
+        with self.Celery() as app:
+            check = Mock()
+
+            @app.task(pydantic=True)
+            def foo(arg: Optional[int], kwarg: Optional[bool] = True) -> Optional[int]:
+                check(arg, kwarg=kwarg)
+                if isinstance(arg, int):
+                    return 1
+                return 2
+
+            assert foo(0) == 1
+            check.assert_called_once_with(0, kwarg=True)
+
+            assert foo() == 2
+            check.assert_called_once_with(None, kwarg=True)
+
+    def test_task_with_pydantic_with_dict_args(self):
+        """Test pydantic task receiving and returning a generic dict argument."""
+        with self.Celery() as app:
+            check = Mock()
+
+            @app.task(pydantic=True)
+            def foo(arg: dict[str, str], kwarg: dict[str, str]) -> dict[str, str]:
+                check(arg, kwarg=kwarg)
+                return {'x': 'y'}
+
+            assert foo({'a': 'b'}, kwarg={'c': 'd'}) == {'x': 'y'}
+            check.assert_called_once_with({'a': 'b'}, kwarg={'c': 'd'})
+
+    def test_task_with_pydantic_with_list_args(self):
+        """Test pydantic task receiving and returning a generic dict argument."""
+        with self.Celery() as app:
+            check = Mock()
+
+            @app.task(pydantic=True)
+            def foo(arg: list[str], kwarg: list[str] = True) -> list[str]:
+                check(arg, kwarg=kwarg)
+                return ['x']
+
+            assert foo(['a'], kwarg=['b']) == ['x']
+            check.assert_called_once_with(['a'], kwarg=['b'])
+
     def test_task_with_pydantic_with_pydantic_arg_and_default_kwarg(self):
         """Test a pydantic task with pydantic arg/kwarg and return value."""
 
@@ -567,6 +612,33 @@ class test_App:
             # Explicitly pass all arguments as kwarg
             assert foo(arg={'arg_value': 5}, kwarg={'kwarg_value': 6}) == {'ret_value': 2}
             check.assert_called_once_with(ArgModel(arg_value=5), kwarg=KwargModel(kwarg_value=6))
+
+    def test_task_with_pydantic_with_optional_pydantic_args(self):
+        """Test pydantic task receiving and returning an optional argument."""
+        class ArgModel(BaseModel):
+            arg_value: int
+
+        class KwargModel(BaseModel):
+            kwarg_value: int
+
+        class ReturnModel(BaseModel):
+            ret_value: int
+
+        with self.Celery() as app:
+            check = Mock()
+
+            @app.task(pydantic=True)
+            def foo(arg: Optional[ArgModel], kwarg: Optional[KwargModel] = None) -> Optional[ReturnModel]:
+                check(arg, kwarg=kwarg)
+                if isinstance(arg, ArgModel):
+                    return ReturnModel(ret_value=1)
+                return None
+
+            assert foo(None) is None
+            check.assert_called_once_with(None, kwarg=None)
+
+            assert foo({'arg_value': 1}, kwarg={'kwarg_value': 2}) == {'ret_value': 1}
+            check.assert_called_once_with(ArgModel(arg_vlaue=1), kwarg=KwargModel(kwarg_value=2))
 
     def test_task_with_pydantic_with_task_name_in_context(self):
         """Test that the task name is passed to as additional context."""

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -552,6 +552,7 @@ class test_App:
             assert foo(None) == 2
             check.assert_called_with(None, kwarg=True)
 
+    @pytest.mark.skipif(sys.version_info < (3, 9), reason="Notation is only supported in Python 3.9 or newer.")
     def test_task_with_pydantic_with_dict_args(self):
         """Test pydantic task receiving and returning a generic dict argument."""
         with self.Celery() as app:
@@ -565,6 +566,7 @@ class test_App:
             assert foo({'a': 'b'}, kwarg={'c': 'd'}) == {'x': 'y'}
             check.assert_called_once_with({'a': 'b'}, kwarg={'c': 'd'})
 
+    @pytest.mark.skipif(sys.version_info < (3, 9), reason="Notation is only supported in Python 3.9 or newer.")
     def test_task_with_pydantic_with_list_args(self):
         """Test pydantic task receiving and returning a generic dict argument."""
         with self.Celery() as app:
@@ -639,6 +641,23 @@ class test_App:
 
             assert foo({'arg_value': 1}, kwarg={'kwarg_value': 2}) == {'ret_value': 1}
             check.assert_called_with(ArgModel(arg_value=1), kwarg=KwargModel(kwarg_value=2))
+
+    @pytest.mark.skipif(sys.version_info < (3, 9), reason="Notation is only supported in Python 3.9 or newer.")
+    def test_task_with_pydantic_with_generic_return_value(self):
+        """Test pydantic task receiving and returning an optional argument."""
+        class ReturnModel(BaseModel):
+            ret_value: int
+
+        with self.Celery() as app:
+            check = Mock()
+
+            @app.task(pydantic=True)
+            def foo() -> dict[str, str]:
+                check()
+                return ReturnModel(ret_value=1)  # type: ignore  # whole point here is that this doesn't match
+
+            assert foo() == ReturnModel(ret_value=1)
+            check.assert_called_once_with()
 
     def test_task_with_pydantic_with_task_name_in_context(self):
         """Test that the task name is passed to as additional context."""

--- a/t/unit/utils/test_annotations.py
+++ b/t/unit/utils/test_annotations.py
@@ -12,11 +12,11 @@ from celery.utils.annotations import annotation_issubclass, get_optional_arg, is
     'value,expected',
     ((3, False), ('x', False), (int, False), (type(None), True)),
 )
-def test_is_none_type(value: typing.Any, expected: bool):
+def test_is_none_type(value: typing.Any, expected: bool) -> None:
     assert is_none_type(value) is expected
 
 
-def test_is_none_type_with_optional_annotations():
+def test_is_none_type_with_optional_annotations() -> None:
     annotation = typing.Optional[int]
     int_type, none_type = typing.get_args(annotation)
     assert int_type == int  # just to make sure that order is correct
@@ -32,7 +32,7 @@ def test_get_optional_arg() -> None:
         optional3: typing.Union[None, int],
         not_optional1: typing.Union[str, int],
         not_optional2: typing.Union[str, int, bool],
-    ):
+    ) -> None:
         pass
 
     parameters = inspect.signature(func).parameters
@@ -47,7 +47,7 @@ def test_get_optional_arg() -> None:
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Notation is only supported in Python 3.10 or newer.")
 def test_get_optional_arg_with_pipe_notation() -> None:
-    def func(optional: int | None, optional2: None | int):
+    def func(optional: int | None, optional2: None | int) -> None:
         pass
 
     parameters = inspect.signature(func).parameters
@@ -60,10 +60,10 @@ def test_annotation_issubclass() -> None:
     def func(
         int_arg: int,
         base_model: BaseModel,
-        list_arg: list,
-        dict_arg: dict,
-        list_typing_arg: typing.List,
-        dict_typing_arg: typing.Dict,
+        list_arg: list,  # type: ignore[type-arg]  # what we test
+        dict_arg: dict,  # type: ignore[type-arg]  # what we test
+        list_typing_arg: typing.List,  # type: ignore[type-arg]  # what we test
+        dict_typing_arg: typing.Dict,  # type: ignore[type-arg]  # what we test
         list_typing_generic_arg: typing.List[str],
         dict_typing_generic_arg: typing.Dict[str, str],
     ) -> None:

--- a/t/unit/utils/test_annotations.py
+++ b/t/unit/utils/test_annotations.py
@@ -1,0 +1,96 @@
+import inspect
+import sys
+import typing
+
+import pytest
+from pydantic import BaseModel
+
+from celery.utils.annotations import annotation_issubclass, get_optional_arg, is_none_type
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    ((3, False), ('x', False), (int, False), (type(None), True)),
+)
+def test_is_none_type(value: typing.Any, expected: bool):
+    assert is_none_type(value) is expected
+
+
+def test_is_none_type_with_optional_annotations():
+    annotation = typing.Optional[int]
+    int_type, none_type = typing.get_args(annotation)
+    assert int_type == int  # just to make sure that order is correct
+    assert is_none_type(int_type) is False
+    assert is_none_type(none_type) is True
+
+
+def test_get_optional_arg() -> None:
+    def func(
+        arg: int,
+        optional: typing.Optional[int],
+        optional2: typing.Union[int, None],
+        optional3: typing.Union[None, int],
+        not_optional1: typing.Union[str, int],
+        not_optional2: typing.Union[str, int, bool],
+    ):
+        pass
+
+    parameters = inspect.signature(func).parameters
+
+    assert get_optional_arg(parameters['arg'].annotation) is None
+    assert get_optional_arg(parameters['optional'].annotation) is int
+    assert get_optional_arg(parameters['optional2'].annotation) is int
+    assert get_optional_arg(parameters['optional3'].annotation) is int
+    assert get_optional_arg(parameters['not_optional1'].annotation) is None
+    assert get_optional_arg(parameters['not_optional2'].annotation) is None
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Notation is only supported in Python 3.10 or newer.")
+def test_get_optional_arg_with_pipe_notation() -> None:
+    def func(optional: int | None, optional2: None | int):
+        pass
+
+    parameters = inspect.signature(func).parameters
+
+    assert get_optional_arg(parameters['optional'].annotation) is int
+    assert get_optional_arg(parameters['optional2'].annotation) is int
+
+
+def test_annotation_issubclass() -> None:
+    def func(
+        int_arg: int,
+        base_model: BaseModel,
+        list_arg: list,
+        dict_arg: dict,
+        list_typing_arg: typing.List,
+        dict_typing_arg: typing.Dict,
+        list_typing_generic_arg: typing.List[str],
+        dict_typing_generic_arg: typing.Dict[str, str],
+    ) -> None:
+        pass
+
+    parameters = inspect.signature(func).parameters
+    assert annotation_issubclass(parameters['int_arg'].annotation, int) is True
+    assert annotation_issubclass(parameters['base_model'].annotation, BaseModel) is True
+    assert annotation_issubclass(parameters['list_arg'].annotation, list) is True
+    assert annotation_issubclass(parameters['dict_arg'].annotation, dict) is True
+
+    # Here the annotation is simply not a class, so function must return False
+    assert annotation_issubclass(parameters['list_typing_arg'].annotation, BaseModel) is False
+    assert annotation_issubclass(parameters['dict_typing_arg'].annotation, BaseModel) is False
+    assert annotation_issubclass(parameters['list_typing_generic_arg'].annotation, BaseModel) is False
+    assert annotation_issubclass(parameters['dict_typing_generic_arg'].annotation, BaseModel) is False
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="Notation is only supported in Python 3.9 or newer.")
+def test_annotation_issubclass_with_generic_classes() -> None:
+    def func(list_arg: list[str], dict_arg: dict[str, str]) -> None:
+        pass
+
+    parameters = inspect.signature(func).parameters
+    assert annotation_issubclass(parameters['list_arg'].annotation, list) is False
+    assert annotation_issubclass(parameters['dict_arg'].annotation, dict) is False
+
+    # issubclass() behaves differently with BaseModel (and maybe other classes?).
+    assert annotation_issubclass(parameters['list_arg'].annotation, BaseModel) is False
+    assert annotation_issubclass(parameters['dict_arg'].annotation, BaseModel) is False


### PR DESCRIPTION
## Description

Various updates to Pydantic model handling:

* `Optional[]` is now supported.
* Fix generic typehints such as `list[str]` or `dict[str, str]` (fixes #9316)
* Update documentation.
* Add more tests for various argument types.

Fixes #9316. Also relates to #9023 and #8751 of course.

Tagging @Nusnus , as requested.