### PR TITLE
Fix: Treat dbm.error as a corrupted schedule file

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -1,6 +1,7 @@
 """The periodic task scheduler."""
 
 import copy
+import dbm
 import errno
 import heapq
 import os
@@ -572,7 +573,7 @@ class PersistentScheduler(Scheduler):
                 # new schedule db
                 try:
                     self._store['entries'] = {}
-                except (KeyError, UnicodeDecodeError, TypeError) as exc:
+                except (KeyError, UnicodeDecodeError, TypeError) + dbm.error as exc:
                     self._store = self._destroy_open_corrupted_schedule(exc)
                     continue
             else:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

As is pretty clear from the traceback in the linked issue, the attempt to clear `'entries'` may fail due to `dbm.error`.  This PR updates the code to consider this a corrupted file and handle it with the existing code, rather than crashing on the unhandled exception.

Closes #4777 
