### PR TITLE
fix(perform_pending_operations): prevent task duplication on shutdown…

### DIFF
--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -412,6 +412,7 @@ class Consumer:
         )
 
     def shutdown(self):
+        self.perform_pending_operations()
         self.blueprint.shutdown(self)
 
     def stop(self):

--- a/celery/worker/loops.py
+++ b/celery/worker/loops.py
@@ -119,8 +119,10 @@ def synloop(obj, connection, consumer, blueprint, hub, qos,
 
     obj.on_ready()
 
-    while blueprint.state == RUN and obj.connection:
-        state.maybe_shutdown()
+    def _loop_cycle():
+        """
+        Perform one iteration of the blocking event loop.
+        """
         if heartbeat_error[0] is not None:
             raise heartbeat_error[0]
         if qos.prev != qos.value:
@@ -133,3 +135,9 @@ def synloop(obj, connection, consumer, blueprint, hub, qos,
         except OSError:
             if blueprint.state == RUN:
                 raise
+
+    while blueprint.state == RUN and obj.connection:
+        try:
+            state.maybe_shutdown()
+        finally:
+            _loop_cycle()

--- a/t/unit/test_loops.py
+++ b/t/unit/test_loops.py
@@ -1,0 +1,57 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from celery import bootsteps
+from celery.worker.loops import synloop
+
+
+def test_synloop_perform_pending_operations_on_system_exit():
+    # Mock dependencies
+    obj = Mock()
+    connection = Mock()
+    consumer = Mock()
+    blueprint = Mock()
+    hub = Mock()
+    qos = Mock()
+    heartbeat = Mock()
+    clock = Mock()
+
+    # Set up the necessary attributes
+    obj.create_task_handler.return_value = Mock()
+    obj.perform_pending_operations = Mock()
+    obj.on_ready = Mock()
+    obj.pool.is_green = False
+    obj.connection = True
+
+    blueprint.state = bootsteps.RUN  # Simulate RUN state
+
+    qos.prev = qos.value = Mock()
+
+    # Mock state.maybe_shutdown to raise SystemExit
+    with patch("celery.worker.loops.state") as mock_state:
+        mock_state.maybe_shutdown.side_effect = SystemExit
+
+        # Call synloop and expect SystemExit to be raised
+        with pytest.raises(SystemExit):
+            synloop(
+                obj,
+                connection,
+                consumer,
+                blueprint,
+                hub,
+                qos,
+                heartbeat,
+                clock,
+                hbrate=2.0,
+            )
+
+    # Assert that perform_pending_operations was called even after SystemExit
+    obj.perform_pending_operations.assert_called_once()
+
+    # Assert that connection.drain_events was called
+    connection.drain_events.assert_called_with(timeout=2.0)
+
+    # Assert other important method calls
+    obj.on_ready.assert_called_once()
+    consumer.consume.assert_called_once()


### PR DESCRIPTION
## Description

Resolved an issue where completed tasks were restored on shutdown, causing duplicates for recursive tasks in gevent/eventlet modes (#5663). The problem was that `perform_pending_operations()` was not called before `SystemExit` was raised in `synloop`.

Fixes #5663

