### PR TITLE
Fix `celery --loader` option parsing

### DIFF
--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -11,7 +11,6 @@ except ImportError:
 
 import click
 import click.exceptions
-from click.types import ParamType
 from click_didyoumean import DYMGroup
 from click_plugins import with_plugins
 


### PR DESCRIPTION
## Description

Closes https://github.com/celery/celery/issues/9360 by importing the Celery application _after_ setting the environment variables it'll need at import time.

This pull request illustrates the minimum code changes needed to fix the issue, but isn't necessarily the best fix. Cleaner suggestions are welcome.