### PR TITLE
fix: prevent celery from hanging due to spawned greenlet errors in greenlet drainers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage.xml
 test.db
 pip-wheel-metadata/
 .python-version
+.tool-versions
 .vscode/
 integration-tests-config.json
 [0-9]*

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -124,8 +124,9 @@ class greenletDrainer(Drainer):
             self._send_drain_complete_event()
             try:
                 self._shutdown.set()
-            except Exception:
-                pass
+            except RuntimeError as e:
+                import logging
+                logging.error(f"Failed to set shutdown event: {e}")
 
     def start(self):
         if self._shutdown.is_set():

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -3,10 +3,8 @@ import socket
 import threading
 import time
 from collections import deque
-from collections.abc import Callable
 from queue import Empty
 from time import sleep
-from typing import Optional
 from weakref import WeakKeyDictionary
 
 from kombu.utils.compat import detect_environment
@@ -70,8 +68,8 @@ class Drainer:
 
 
 class greenletDrainer(Drainer):
-    spawn: Callable[[Callable[[], None]], object]
-    _exc: Optional[Exception] = None
+    spawn = None
+    _exc = None
     _g = None
     _drain_complete_event = None    # event, sended (and recreated) after every drain_events iteration
 

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -159,7 +159,7 @@ class greenletDrainer(Drainer):
             if self._exc is not None:
                 raise self._exc
             else:
-                raise Exception(E_CELERY_RESTART_REQUIRED)
+                raise CeleryRestartRequired(E_CELERY_RESTART_REQUIRED)
 
 
 @register_drainer('eventlet')

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -13,9 +13,7 @@ from celery import states
 from celery.exceptions import TimeoutError
 from celery.utils.threads import THREAD_TIMEOUT_MAX
 
-E_CELERY_RESTART_REQUIRED = """
-Celery must be restarted because a shutdown signal was detected.
-"""
+E_CELERY_RESTART_REQUIRED = "Celery must be restarted because a shutdown signal was detected."
 
 __all__ = (
     'AsyncBackendMixin', 'BaseResultConsumer', 'Drainer',

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -1,4 +1,6 @@
 """Async I/O backend support utilities."""
+
+import logging
 import socket
 import threading
 import time

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -24,6 +24,11 @@ __all__ = (
 
 
 class EventletAdaptedEvent():
+    """
+    An adapted eventlet event, designed to match the API of `threading.Event` and
+    `gevent.event.Event`.
+    """
+
     def __init__(self):
         import eventlet
         self.evt = eventlet.Event()

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -122,7 +122,10 @@ class greenletDrainer(Drainer):
             raise
         finally:
             self._send_drain_complete_event()
-            self._shutdown.set()
+            try:
+                self._shutdown.set()
+            except Exception:
+                pass
 
     def start(self):
         if self._shutdown.is_set():

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -159,7 +159,7 @@ class greenletDrainer(Drainer):
             if self._exc is not None:
                 raise self._exc
             else:
-                raise CeleryRestartRequired(E_CELERY_RESTART_REQUIRED)
+                raise Exception(E_CELERY_RESTART_REQUIRED)
 
 
 @register_drainer('eventlet')

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -121,7 +121,9 @@ class greenletDrainer(Drainer):
                     pass
         except Exception as e:
             self._exc = e
+            raise
         finally:
+            self._send_drain_complete_event()
             self._shutdown.set()
 
     def start(self):
@@ -137,7 +139,6 @@ class greenletDrainer(Drainer):
 
     def stop(self):
         self._stopped.set()
-        self._send_drain_complete_event()
         self._shutdown.wait(THREAD_TIMEOUT_MAX)
 
     def wait_for(self, p, wait, timeout=None):

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -129,7 +129,7 @@ class greenletDrainer(Drainer):
                 logging.error(f"Failed to set shutdown event: {e}")
 
     def start(self):
-        self._ensure_not_shutdown()
+        self._ensure_not_shut_down()
 
         if not self._started.is_set():
             self._g = self.spawn(self.run)
@@ -144,16 +144,16 @@ class greenletDrainer(Drainer):
         if not p.ready:
             self._drain_complete_event.wait(timeout=timeout)
 
-            self._ensure_not_shutdown()
+            self._ensure_not_shut_down()
 
-    def _ensure_not_shutdown(self):
-        """Ensure the drainer has not run to completion.
+    def _ensure_not_shut_down(self):
+        """Currently used to ensure the drainer has not run to completion.
 
-        Raises if the drainer has run to completion (either due to an exception
+        Raises if the shutdown event has been signaled (either due to an exception
         or stop() being called).
 
-        Uses _shutdown event as synchronization to ensure _exc is properly
-        set before checking, avoiding the need for locks.
+        The _shutdown event acts as synchronization to ensure _exc is properly
+        set before it is read from, avoiding need for locks.
         """
         if self._shutdown.is_set():
             if self._exc is not None:

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -125,7 +125,6 @@ class greenletDrainer(Drainer):
             try:
                 self._shutdown.set()
             except RuntimeError as e:
-                import logging
                 logging.error(f"Failed to set shutdown event: {e}")
 
     def start(self):

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -152,7 +152,7 @@ class greenletDrainer(Drainer):
         Raises if the drainer has run to completion (either due to an exception
         or stop() being called).
 
-        Uses _shutdown event as synchronization to ensure _exc is consistently
+        Uses _shutdown event as synchronization to ensure _exc is properly
         set before checking, avoiding the need for locks.
         """
         if self._shutdown.is_set():

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -23,7 +23,7 @@ __all__ = (
 )
 
 
-class EventletAdaptedEvent():
+class EventletAdaptedEvent:
     """
     An adapted eventlet event, designed to match the API of `threading.Event` and
     `gevent.event.Event`.

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -129,9 +129,9 @@ class ResultConsumer(BaseResultConsumer):
         except self._connection_errors:
             try:
                 self._ensure(self._reconnect_pubsub, ())
-            except self._connection_errors:
+            except self._connection_errors as e:
                 logger.critical(E_RETRY_LIMIT_EXCEEDED)
-                raise
+                raise RuntimeError(E_RETRY_LIMIT_EXCEEDED) from e
 
     def _maybe_cancel_ready_task(self, meta):
         if meta['status'] in states.READY_STATES:

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -212,9 +212,12 @@ class test_EventletDrainer(GreenletDrainerTests):
         return g
 
     def teardown_thread(self, thread):
-        import eventlet
-        while not thread.dead:
-            eventlet.sleep(0)
+        try:
+            # eventlet's API acts like a join() rather
+            # than wait, and throws if the greenlet threw
+            thread.wait()
+        except:
+            pass
 
 
 class test_Drainer(DrainerTests):

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -212,7 +212,12 @@ class test_EventletDrainer(GreenletDrainerTests):
         return g
 
     def teardown_thread(self, thread):
-        thread.kill()
+        try:
+            # eventlet's API acts like a join() rather
+            # than wait, and throws if the greenlet threw
+            thread.wait()
+        except Exception:
+            pass
 
 
 class test_Drainer(DrainerTests):

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -175,13 +175,6 @@ class GreenletDrainerTests(DrainerTests):
 
             self.teardown_thread(thread)
 
-        # # ideally we would call `drainer.stop`, but when waiting for the shutdown signal,
-        # # it does not yield back to the spawned greenlet's event loop for some reason
-        # self.drainer._shutdown.set()
-
-        # with pytest.raises(Exception, match=E_CELERY_RESTART_REQUIRED):
-        #     self.drainer.start()
-
 
 @pytest.mark.skipif(
     sys.platform == "win32",

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -212,12 +212,7 @@ class test_EventletDrainer(GreenletDrainerTests):
         return g
 
     def teardown_thread(self, thread):
-        try:
-            # eventlet's API acts like a join() rather
-            # than wait, and throws if the greenlet threw
-            thread.wait()
-        except Exception:
-            pass
+        thread.kill()
 
 
 class test_Drainer(DrainerTests):

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -216,7 +216,7 @@ class test_EventletDrainer(GreenletDrainerTests):
             # eventlet's API acts like a join() rather
             # than wait, and throws if the greenlet threw
             thread.wait()
-        except:
+        except Exception:
             pass
 
 

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -213,8 +213,8 @@ class test_EventletDrainer(GreenletDrainerTests):
 
     def teardown_thread(self, thread):
         try:
-            # eventlet's API acts like a join() rather
-            # than wait, and throws if the greenlet threw
+            # eventlet's wait() propagates any errors on the green thread, unlike
+            # similar methods in gevent or python's threading library
             thread.wait()
         except Exception:
             pass


### PR DESCRIPTION
Fixes https://github.com/celery/celery/issues/4857

## Description

This PR fixes an issue where an error raised in the spawned greenlet from the greenlet drainer causes the drainer to stop retrieving task results. Currently, these errors are only logged, making it difficult for clients to handle the situation effectively. As a result, a client may wait indefinitely for task results that will never be fetched, since the greenlet from the drainer has already stopped running. This change ensures that an error is thrown back to clients, enabling them to handle the error appropriately, such as by exiting or restarting the process.

Here are the steps that we took in our testing to reproduce the issue:
1. Start up Redis.
2. Start an API client that uses `gevent` workers that allow for multiple connections.
3. The API has an endpoint that enqueues a task to the Redis result backend and also waits for the result before sending back a response to the API client.
4. Don't start any celery workers yet.
5. Ensure that we've reduced the max connection retries attempt to be able to get the spawned greenlet to raise an error sooner. We can set this in the celery app configuration for example:
```
    result_backend_transport_options={
        "retry_policy": {
            "max_retries": 1,
        }
    },
```
6. Enqueue a task to Redis successfully using a task's `delay` method.
7. Turn off Redis and confirm that a message was eventually logged after all connection attempts have been exhausted indicating that celery must be restarted.
8. Turn Redis back on.
9. Start a worker, observe that it received and processed the task, however, also observe that the API request is still hanging.
10. We can cancel the initial request, or leave it and make a new request, and see that while the worker receives it and processes it successfully, the API client still hangs due to the stopped spawned greenlet in the drainer, which is requiring a celery restart.

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
11.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
