### PR TITLE
fix(django): catch the right error when trying to close db connection

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from types import ModuleType
     from typing import Protocol
 
+    from django.db.backends.base.base import BaseDatabaseWrapper
     from django.db.utils import ConnectionHandler
 
     from celery.app.base import Celery
@@ -164,15 +165,16 @@ class DjangoWorkerFixup:
         # network IO that close() might cause.
         for c in self._db.connections.all():
             if c and c.connection:
-                self._maybe_close_db_fd(c.connection)
+                self._maybe_close_db_fd(c)
 
         # use the _ version to avoid DB_REUSE preventing the conn.close() call
         self._close_database(force=True)
         self.close_cache()
 
-    def _maybe_close_db_fd(self, fd: IO) -> None:
+    def _maybe_close_db_fd(self, c: "BaseDatabaseWrapper") -> None:
         try:
-            _maybe_close_fd(fd)
+            with c.wrap_database_errors:
+                _maybe_close_fd(c.connection)
         except self.interface_errors:
             pass
 

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -183,7 +183,7 @@ class test_DjangoWorkerFixup(FixupCase):
             with patch('celery.fixups.django._maybe_close_fd') as mcf:
                 _all = f._db.connections.all = Mock()
                 conns = _all.return_value = [
-                    Mock(), Mock(),
+                    Mock(), MagicMock(),
                 ]
                 conns[0].connection = None
                 with patch.object(f, 'close_cache'):


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Fixes #9310 
As explained in the issue, `_maybe_close_db_fd` tries to catch django's db-agnostic errors (such as `django.db.InterfaceError`), but `_maybe_close_fd` raises a db-specific error (eg. `pyscog2.InterfaceError`). 

To fix that, we wrap the call to `_maybe_close_fd` with the `c.wrap_database_errors` context manager (cf [here](https://github.com/django/django/blob/main/django/db/backends/base/base.py#L663)), made for this exact purpose. It prevents the worker to keep raising errors when initializing a process

This can easily be reproduced:
```
from django.db import connections
from celery import Celery
app = Celery("proj", broker="redis://localhost")
worker = app.Worker()

connection = connections.all()[0]
connection.connect()
connection.connection.close()  # for any reason, connection is closed

worker.start()

```
