### PR TITLE
default strict to False for pydantic tasks

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -548,7 +548,7 @@ class Celery:
         base=None,
         bind=False,
         pydantic: bool = False,
-        pydantic_strict: bool = True,
+        pydantic_strict: bool = False,
         pydantic_context: typing.Optional[typing.Dict[str, typing.Any]] = None,
         pydantic_dump_kwargs: typing.Optional[typing.Dict[str, typing.Any]] = None,
         **options,

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -893,7 +893,7 @@ There are a few more options influencing Pydantic behavior:
 .. attribute:: Task.pydantic_strict
 
    By default, `strict mode <https://docs.pydantic.dev/dev/concepts/strict_mode/>`_
-   is enabled. You can pass ``False`` to disable strict model validation.
+   is disabled. You can pass ``True`` to enable strict model validation.
 
 .. attribute:: Task.pydantic_context
 


### PR DESCRIPTION
## Description

Change default Pydantic model validation to non-strict. The default for Pydantic itself is also non-strict, so I believe this change makes the feature more intuitive. This would fix #9363.