### PR TITLE
 Allow custom hostname for celery_worker in celery.contrib.pytest / celery.contrib.testing.worker

### DIFF
--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -155,7 +155,7 @@ def _start_worker_thread(app: Celery,
     worker = WorkController(
         app=app,
         concurrency=concurrency,
-        hostname=anon_nodename(),
+        hostname=kwargs.pop("hostname", anon_nodename()),
         pool=pool,
         loglevel=loglevel,
         logfile=logfile,

--- a/t/unit/contrib/test_worker.py
+++ b/t/unit/contrib/test_worker.py
@@ -4,12 +4,12 @@ import pytest
 # to install the celery.ping task that the test lib uses
 import celery.contrib.testing.tasks  # noqa
 from celery import Celery
-from celery.contrib.testing.worker import start_worker
+from celery.contrib.testing.worker import start_worker, TestWorkController
 
 
 class test_worker:
     def setup_method(self):
-        self.app = Celery('celerytest', backend='cache+memory://', broker='memory://',)
+        self.app = Celery('celerytest', backend='cache+memory://', broker='memory://', )
 
         @self.app.task
         def add(x, y):
@@ -45,3 +45,15 @@ class test_worker:
             with start_worker(app=self.app, loglevel=0):
                 result = self.error_task.apply_async()
                 result.get(timeout=5)
+
+    def test_start_worker_with_hostname_config(self):
+        """Make sure a custom hostname can be supplied to the TestWorkController"""
+        test_hostname = 'test_name@test_host'
+        with start_worker(app=self.app, loglevel=0, hostname=test_hostname) as w:
+
+            assert isinstance(w, TestWorkController)
+            assert w.hostname == test_hostname
+
+            result = self.add.s(1, 2).apply_async()
+            val = result.get(timeout=5)
+        assert val == 3

--- a/t/unit/contrib/test_worker.py
+++ b/t/unit/contrib/test_worker.py
@@ -4,7 +4,7 @@ import pytest
 # to install the celery.ping task that the test lib uses
 import celery.contrib.testing.tasks  # noqa
 from celery import Celery
-from celery.contrib.testing.worker import start_worker, TestWorkController
+from celery.contrib.testing.worker import TestWorkController, start_worker
 
 
 class test_worker:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

This PR introduces the functionality to use a user defined hostname during `TestWorkerControlloer` initiallisation. This is useful if the user wants to mimic the '-n'/'--hostname' CLI argument during testing.

Closes #9404 
