### PR TITLE
Added a utility to format changelogs from the auto-generated GitHub release notes

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -48,6 +48,7 @@ help:
 	@echo "  apicheck   to verify that all modules are present in autodoc"
 	@echo "  configcheck to verify that all modules are present in autodoc"
 	@echo "  spelling   to perform a spell check"
+	@echo "  changelog  to generate a changelog from GitHub auto-generated release notes"
 
 .PHONY: clean
 clean:
@@ -238,3 +239,14 @@ pseudoxml:
 .PHONY: livehtml
 livehtml:
 	sphinx-autobuild -b html --host 0.0.0.0 --port 7000 --watch $(APP) -c . $(SOURCEDIR) $(BUILDDIR)/html
+
+.PHONY: changelog
+changelog:
+	@echo "Usage Instructions:"
+	@echo "1. Generate release notes using GitHub: https://github.com/celery/celery/releases/new"
+	@echo "   - Copy everything that's generated to your clipboard."
+	@echo "   - pre-commit lines will be removed automatically."
+	@echo "2. Run 'make -C docs changelog' from the root dir, to manually process the changes and output the formatted text."
+	@echo ""
+	@echo "Processing changelog from clipboard..."
+	python ./changelog_formatter.py --clipboard

--- a/docs/changelog_formatter.py
+++ b/docs/changelog_formatter.py
@@ -2,9 +2,10 @@
 
 import re
 import sys
+
 import click
 import pyperclip
-from colorama import init, Fore
+from colorama import Fore, init
 
 # Initialize colorama for color support in terminal
 init(autoreset=True)
@@ -15,7 +16,7 @@ PATTERN = re.compile(r"^\*\s*(.*?)\s+by\s+@[\w-]+\s+in\s+https://github\.com/[\w
 
 def read_changes_file(filename):
     try:
-        with open(filename, "r") as f:
+        with open(filename) as f:
             return f.readlines()
     except FileNotFoundError:
         print(f"Error: {filename} file not found.")

--- a/docs/changelog_formatter.py
+++ b/docs/changelog_formatter.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+import click
+import pyperclip
+from colorama import init, Fore
+
+# Initialize colorama for color support in terminal
+init(autoreset=True)
+
+# Regular expression pattern to match the required lines
+PATTERN = re.compile(r"^\*\s*(.*?)\s+by\s+@[\w-]+\s+in\s+https://github\.com/[\w-]+/[\w-]+/pull/(\d+)")
+
+
+def read_changes_file(filename):
+    try:
+        with open(filename, "r") as f:
+            return f.readlines()
+    except FileNotFoundError:
+        print(f"Error: {filename} file not found.")
+        sys.exit(1)
+
+
+def read_from_clipboard():
+    text = pyperclip.paste()
+    return text.splitlines()
+
+
+def process_line(line):
+    line = line.strip()
+
+    # Skip lines containing '[pre-commit.ci]'
+    if "[pre-commit.ci]" in line:
+        return None
+
+    # Skip lines starting with '## What's Changed'
+    if line.startswith("## What's Changed"):
+        return None
+
+    # Stop processing if '## New Contributors' is encountered
+    if line.startswith("## New Contributors"):
+        return "STOP_PROCESSING"
+
+    # Skip lines that don't start with '* '
+    if not line.startswith("* "):
+        return None
+
+    match = PATTERN.match(line)
+    if match:
+        description, pr_number = match.groups()
+        return f"- {description} (#{pr_number})"
+    return None
+
+
+@click.command()
+@click.option(
+    "--source",
+    "-s",
+    type=click.Path(exists=True),
+    help="Source file to read from. If not provided, reads from clipboard.",
+)
+@click.option(
+    "--dest",
+    "-d",
+    type=click.File("w"),
+    default="-",
+    help="Destination file to write to. Defaults to standard output.",
+)
+@click.option(
+    "--clipboard",
+    "-c",
+    is_flag=True,
+    help="Read input from clipboard explicitly.",
+)
+def main(source, dest, clipboard):
+    # Determine the source of input
+    if clipboard or (not source and not sys.stdin.isatty()):
+        # Read from clipboard
+        lines = read_from_clipboard()
+    elif source:
+        # Read from specified file
+        lines = read_changes_file(source)
+    else:
+        # Default: read from clipboard
+        lines = read_from_clipboard()
+
+    output_lines = []
+    for line in lines:
+        output_line = process_line(line)
+        if output_line == "STOP_PROCESSING":
+            break
+        if output_line:
+            output_lines.append(output_line)
+
+    output_text = "\n".join(output_lines)
+
+    # Prepare the header
+    version = "x.y.z"
+    underline = "=" * len(version)
+
+    header = f"""
+.. _version-{version}:
+
+{version}
+{underline}
+
+:release-date: <YYYY-MM-DD>
+:release-by: <FULL NAME>
+
+What's Changed
+~~~~~~~~~~~~~~
+"""
+
+    # Combine header and output
+    final_output = header + output_text
+
+    # Write output to destination
+    if dest.name == "<stdout>":
+        print(Fore.GREEN + "Copy the following text to Changelog.rst:")
+        print(Fore.YELLOW + header)
+        print(Fore.CYAN + output_text)
+    else:
+        dest.write(final_output + "\n")
+        dest.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -9,3 +9,4 @@ sphinx2rst>=1.0
 # Disable cyanide until it's fully updated.
 # cyanide>=1.0.1
 bumpversion==0.6.0
+pyperclip==1.9.0


### PR DESCRIPTION
# New Utility to Format Changelogs from Auto-Generated GitHub Release Notes

This PR introduces a utility script and updates the docs Makefile to streamline the process of generating formatted changelogs from GitHub's auto-generated release notes.

## Changes Overview

1. **Added `changelog_formatter.py` script** in the `docs/` directory:
   - Reads the auto-generated release notes from the clipboard.
   - Processes the text to format the changelog entries.
   - Filters out unnecessary lines (e.g., pre-commit updates, new contributors).
   - Outputs a formatted changelog section ready to be pasted into `Changelog.rst`.

2. **Updated `docs/Makefile`:**
   - Added a new `changelog` target that provides usage instructions and runs the `changelog_formatter.py` script.
   - Included help information for the new `changelog` target in the `help` section.

3. **Updated `requirements/pkgutils.txt`:**
   - Added `pyperclip==1.9.0` to handle clipboard operations within the script.

## Detailed Description

### 1. `changelog_formatter.py` Script

- **Purpose:** Automates the formatting of changelog entries from GitHub's release notes.
- **Features:**
  - **Clipboard Integration:** Reads input directly from the clipboard to simplify the workflow.
  - **Automatic Filtering:** Removes lines related to pre-commit updates and other non-essential information.
  - **Customizable Output:** Outputs a formatted changelog section with placeholders for version, release date, and author.

- **Usage:**
  - Copy the auto-generated release notes from GitHub to your clipboard.
  - Run the script via the Makefile target to process and format the changelog.

- **Example Output:**

  ```
  Copy the following text to Changelog.rst:

  .. _version-x.y.z:

  x.y.z
  =====

  :release-date: <YYYY-MM-DD>
  :release-by: <FULL NAME>

  What's Changed
  ~~~~~~~~~~~~~~

  - Fix: Treat dbm.error as a corrupted schedule file (#9331)
  - Pin pre-commit to latest version 4.0.1 (#9343)
  - Bump mypy from 1.12.1 to 1.13.0 (#9373)
  - Pass timeout and confirm_timeout to producer.publish() (#9374)
  - Bump Kombu to v5.5.0rc2 (#9382)
  - Bump pytest-cov from 5.0.0 to 6.0.0 (#9388)
  - Default strict to False for Pydantic tasks (#9393)
  ```

### 2. `docs/Makefile` Updates

- **Added `changelog` Target:**
  - Provides usage instructions directly in the terminal.
  - Executes the `changelog_formatter.py` script with the `--clipboard` option.

- **Updated `help` Section:**
  - Included information about the new `changelog` target for easier discovery.

  ```makefile
  .PHONY: changelog
  changelog:
  	@echo "Usage Instructions:"
  	@echo "1. Generate release notes using GitHub: https://github.com/celery/celery/releases/new"
  	@echo "   - Copy everything that's generated to your clipboard."
  	@echo "   - pre-commit lines will be removed automatically."
  	@echo "2. Run 'make -C docs changelog' from the root dir to process the changes and output the formatted text."
  	@echo ""
  	@echo "Processing changelog from clipboard..."
  	python ./changelog_formatter.py --clipboard
  ```

### 3. `requirements/pkgutils.txt` Update

- **Added Dependency:**
  - `pyperclip==1.9.0` is now required for clipboard operations used in the script.

## Usage Instructions

1. **Generate Release Notes:**
   - Navigate to [GitHub Releases](https://github.com/celery/celery/releases/new).
   - Generate the release notes for the new version.
   - **Copy** the entire generated content to your clipboard.

2. **Process the Changelog:**
   - From the root directory of the project, run:
     ```bash
     make -C docs changelog
     ```
   - The script will output the formatted changelog to the terminal, highlighting sections with colors for better readability.

3. **Update `Changelog.rst`:**
   - **Copy** the formatted output from the terminal.
   - **Paste** it into the `Changelog.rst` file within the appropriate version section.
   - Replace placeholders:
     - `x.y.z` with the new version number.
     - `<YYYY-MM-DD>` with the release date.
     - `<FULL NAME>` with your full name.

## Benefits

- **Streamlined Workflow:** Simplifies the process of updating the changelog with a consistent format.
- **Automation:** Reduces manual editing by filtering out irrelevant information automatically.
- **Consistency:** Ensures that all changelog entries adhere to the project's formatting standards.
- **Ease of Use:** Integrates seamlessly with existing development workflows via the Makefile.

## Additional Notes

- **Color Output:** The script uses `colorama` to highlight sections when outputting to the terminal for better readability.
- **Dependencies:** Ensure that all required packages are installed:
  ```bash
  pip install -r requirements/pkgutils.txt
  ```
- **Extensibility:** The script can be further customized to adjust formatting or handle additional edge cases as needed.

## Checklist

- [x] Added `changelog_formatter.py` script.
- [x] Updated `docs/Makefile` with a new `changelog` target and help information.
- [x] Updated `requirements/pkgutils.txt` to include `pyperclip`.
- [x] Tested the script to ensure it works as expected.
- [x] Updated documentation and usage instructions.

---

![Warp 2024-11-12 18 09 59](https://github.com/user-attachments/assets/41e8d780-4e5b-4c61-a0a3-366564475344)

Input (copied to clipboard):
```RST
## What's Changed
* Fix: Treat dbm.error as a corrupted schedule file by @stumpylog in https://github.com/celery/celery/pull/9331
* Pin pre-commit to latest version 4.0.1 by @pyup-bot in https://github.com/celery/celery/pull/9343
* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/celery/celery/pull/9369
* Bump mypy from 1.12.1 to 1.13.0 by @dependabot in https://github.com/celery/celery/pull/9373
* Pass timeout and confirm_timeout to producer.publish() by @thedrow in https://github.com/celery/celery/pull/9374
* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/celery/celery/pull/9379
* Bump Kombu to v5.5.0rc2 by @Nusnus in https://github.com/celery/celery/pull/9382
* Bump pytest-cov from 5.0.0 to 6.0.0 by @dependabot in https://github.com/celery/celery/pull/9388
* default strict to False for pydantic tasks by @mathiasertl in https://github.com/celery/celery/pull/9393

## New Contributors
* @0x2b3bfa0 made their first contribution in https://github.com/celery/celery/pull/9361
* @hmnfalahi made their first contribution in https://github.com/celery/celery/pull/9362
* @Niennienzz made their first contribution in https://github.com/celery/celery/pull/9398
* @SlowMo24 made their first contribution in https://github.com/celery/celery/pull/9405

**Full Changelog**: https://github.com/celery/celery/compare/v5.5.0rc1...v5.5.0rc2
```
Output:
![Warp 2024-11-12 18 09 44](https://github.com/user-attachments/assets/cb61c6df-8c2e-42fb-95c2-a3981007a570)
