### PR TITLE
Adjust section in what's new document regarding quorum queues support

### DIFF
--- a/docs/history/whatsnew-5.5.rst
+++ b/docs/history/whatsnew-5.5.rst
@@ -285,11 +285,13 @@ Quorum Queues Initial Support
 -----------------------------
 
 This release introduces the initial support for Quorum Queues with Celery.
+See the documentation for :ref:`using-quorum-queues` for more details.
 
-See new configuration options for more details:
+In addition, you can read about the new configuration options relevant for this feature:
 
 - :setting:`task_default_queue_type`
 - :setting:`worker_detect_quorum_queues`
+- :setting:`broker_native_delayed_delivery_queue_type`
 
 REMAP_SIGTERM
 -------------


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Our what's new document for 5.5 was outdated since #9207 added documentation for quorum queues and we need a reference to it in our release announcement.
This PR adds that reference.
