### PR TITLE
Allow passing Celery objects to the Click entry point

### DIFF
--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -62,6 +62,11 @@ else:
               '--app',
               envvar='APP',
               cls=CeleryOption,
+              # May take either: a str when invoked from command line (Click),
+              # or a Celery object when invoked from inside Celery; hence the
+              # UNPROCESSED type, to prevent Click from converting the Celery
+              # object into its str representation.
+              type=click.UNPROCESSED,
               help_group="Global Options")
 @click.option('-b',
               '--broker',
@@ -131,25 +136,26 @@ def celery(ctx, app, broker, result_backend, loader, config, workdir,
     if skip_checks:
         os.environ['CELERY_SKIP_CHECKS'] = 'true'
 
-    try:
-        app_object = find_app(app)
-    except ModuleNotFoundError as e:
-        if e.name != app:
+    if isinstance(app, str):
+        try:
+            app = find_app(app)
+        except ModuleNotFoundError as e:
+            if e.name != app:
+                exc = traceback.format_exc()
+                ctx.fail(
+                    UNABLE_TO_LOAD_APP_ERROR_OCCURRED.format(app, exc)
+                )
+            ctx.fail(UNABLE_TO_LOAD_APP_MODULE_NOT_FOUND.format(e.name))
+        except AttributeError as e:
+            attribute_name = e.args[0].capitalize()
+            ctx.fail(UNABLE_TO_LOAD_APP_APP_MISSING.format(attribute_name))
+        except Exception:
             exc = traceback.format_exc()
             ctx.fail(
                 UNABLE_TO_LOAD_APP_ERROR_OCCURRED.format(app, exc)
             )
-        ctx.fail(UNABLE_TO_LOAD_APP_MODULE_NOT_FOUND.format(e.name))
-    except AttributeError as e:
-        attribute_name = e.args[0].capitalize()
-        ctx.fail(UNABLE_TO_LOAD_APP_APP_MISSING.format(attribute_name))
-    except Exception:
-        exc = traceback.format_exc()
-        ctx.fail(
-            UNABLE_TO_LOAD_APP_ERROR_OCCURRED.format(app, exc)
-        )
 
-    ctx.obj = CLIContext(app=app_object, no_color=no_color, workdir=workdir,
+    ctx.obj = CLIContext(app=app, no_color=no_color, workdir=workdir,
                          quiet=quiet)
 
     # User options

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -64,8 +64,8 @@ else:
               cls=CeleryOption,
               # May take either: a str when invoked from command line (Click),
               # or a Celery object when invoked from inside Celery; hence the
-              # UNPROCESSED type, to prevent Click from converting the Celery
-              # object into its str representation.
+              # need to prevent Click from "processing" the Celery object and
+              # converting it into its str representation.
               type=click.UNPROCESSED,
               help_group="Global Options")
 @click.option('-b',


### PR DESCRIPTION
Fixes https://github.com/celery/celery/pull/9361#discussion_r1850451189 🤦🏼 

> [!NOTE]
> I didn't expect the command-line entry point to be called from inside Celery with an object instead of a string. 🙃 

> [!TIP]
> Consider enabling the [hide whitespace](https://github.blog/news-insights/product-news/ignore-white-space-in-code-review/) option in the diff when reviewing this pull request.