### PR TITLE
Allowing managed credentials for azureblockblob

### DIFF
--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -1,165 +1,70 @@
-"""The Azure Storage Block Blob backend for Celery."""
+import logging
+from celery.backends.azureblockblob import (
+    AzureBlockBlobBackend as _AzureBlockBlobBackend,
+)
 from kombu.utils import cached_property
-from kombu.utils.encoding import bytes_to_str
+from azure.core.exceptions import ResourceExistsError
+from azure.storage.blob import BlobServiceClient
+from kombu.transport.azurestoragequeues import Transport as AzureStorageQueuesTransport
 
-from celery.exceptions import ImproperlyConfigured
-from celery.utils.log import get_logger
+logger = logging.getLogger(__name__)
 
-from .base import KeyValueStoreBackend
+""" 
+Context:
+We are using Azure Service Bus as a broker, but it does not support a
+result backend.  I don't think it would be possible to add support for it,
+since Service Bus is really a queue, so you can't retrieve a message bsed on
+a key.  
 
-try:
-    import azure.storage.blob as azurestorage
-    from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
-    from azure.storage.blob import BlobServiceClient
-except ImportError:
-    azurestorage = None
-
-__all__ = ("AzureBlockBlobBackend",)
-
-LOGGER = get_logger(__name__)
-AZURE_BLOCK_BLOB_CONNECTION_PREFIX = 'azureblockblob://'
+Since we already use blob storage, we can use the AzureBlockBlobBackend
+to store the results in blob storage.  However, the existing implementation 
+does not support DefaultAzureCredential, so we need to extend it.
+(PR Pending to Celery)
+"""
 
 
-class AzureBlockBlobBackend(KeyValueStoreBackend):
-    """Azure Storage Block Blob backend for Celery."""
+class AzureBlockBlobBackend(_AzureBlockBlobBackend):
+    """
 
-    def __init__(self,
-                 url=None,
-                 container_name=None,
-                 *args,
-                 **kwargs):
-        super().__init__(*args, **kwargs)
+    Connection String
+    =================
 
-        if azurestorage is None or azurestorage.__version__ < '12':
-            raise ImproperlyConfigured(
-                "You need to install the azure-storage-blob v12 library to"
-                "use the AzureBlockBlob backend")
+    Connection string can have the following formats:
 
-        conf = self.app.conf
+    .. code-block::
 
-        self._connection_string = self._parse_url(url)
-
-        self._container_name = (
-            container_name or
-            conf["azureblockblob_container_name"])
-
-        self.base_path = conf.get('azureblockblob_base_path', '')
-        self._connection_timeout = conf.get(
-            'azureblockblob_connection_timeout', 20
-        )
-        self._read_timeout = conf.get('azureblockblob_read_timeout', 120)
-
-    @classmethod
-    def _parse_url(cls, url, prefix=AZURE_BLOCK_BLOB_CONNECTION_PREFIX):
-        connection_string = url[len(prefix):]
-        if not connection_string:
-            raise ImproperlyConfigured("Invalid URL")
-
-        return connection_string
+        azureblockblob://CONNECTION_STRING
+        azureblockblob://DefaultAzureCredential@STORAGE_ACCOUNT_URL
+        azureblockblob://ManagedIdentityCredential@STORAGE_ACCOUNT_URL
+    """
 
     @cached_property
     def _blob_service_client(self):
+        logger.info("Welcome inside the custom AzureBlockBlobBackend")
         """Return the Azure Storage Blob service client.
 
         If this is the first call to the property, the client is created and
         the container is created if it doesn't yet exist.
 
         """
-        client = BlobServiceClient.from_connection_string(
-            self._connection_string,
-            connection_timeout=self._connection_timeout,
-            read_timeout=self._read_timeout
+        # Leveraging the work that Kombu already did for us
+        credential_, url = AzureStorageQueuesTransport.parse_uri(
+            self._connection_string
+        )
+        client = BlobServiceClient(
+            account_url=url,
+            credential=credential_,
+            read_timeout=self._read_timeout,
         )
 
         try:
             client.create_container(name=self._container_name)
             msg = f"Container created with name {self._container_name}."
         except ResourceExistsError:
-            msg = f"Container with name {self._container_name} already." \
+            msg = (
+                f"Container with name {self._container_name} already."
                 "exists. This will not be created."
-        LOGGER.info(msg)
+            )
+        logger.info(msg)
 
         return client
-
-    def get(self, key):
-        """Read the value stored at the given key.
-
-        Args:
-              key: The key for which to read the value.
-        """
-        key = bytes_to_str(key)
-        LOGGER.debug("Getting Azure Block Blob %s/%s", self._container_name, key)
-
-        blob_client = self._blob_service_client.get_blob_client(
-            container=self._container_name,
-            blob=f'{self.base_path}{key}',
-        )
-
-        try:
-            return blob_client.download_blob().readall().decode()
-        except ResourceNotFoundError:
-            return None
-
-    def set(self, key, value):
-        """Store a value for a given key.
-
-        Args:
-              key: The key at which to store the value.
-              value: The value to store.
-
-        """
-        key = bytes_to_str(key)
-        LOGGER.debug(f"Creating azure blob at {self._container_name}/{key}")
-
-        blob_client = self._blob_service_client.get_blob_client(
-            container=self._container_name,
-            blob=f'{self.base_path}{key}',
-        )
-
-        blob_client.upload_blob(value, overwrite=True)
-
-    def mget(self, keys):
-        """Read all the values for the provided keys.
-
-        Args:
-              keys: The list of keys to read.
-
-        """
-        return [self.get(key) for key in keys]
-
-    def delete(self, key):
-        """Delete the value at a given key.
-
-        Args:
-              key: The key of the value to delete.
-
-        """
-        key = bytes_to_str(key)
-        LOGGER.debug(f"Deleting azure blob at {self._container_name}/{key}")
-
-        blob_client = self._blob_service_client.get_blob_client(
-            container=self._container_name,
-            blob=f'{self.base_path}{key}',
-        )
-
-        blob_client.delete_blob()
-
-    def as_uri(self, include_password=False):
-        if include_password:
-            return (
-                f'{AZURE_BLOCK_BLOB_CONNECTION_PREFIX}'
-                f'{self._connection_string}'
-            )
-
-        connection_string_parts = self._connection_string.split(';')
-        account_key_prefix = 'AccountKey='
-        redacted_connection_string_parts = [
-            f'{account_key_prefix}**' if part.startswith(account_key_prefix)
-            else part
-            for part in connection_string_parts
-        ]
-
-        return (
-            f'{AZURE_BLOCK_BLOB_CONNECTION_PREFIX}'
-            f'{";".join(redacted_connection_string_parts)}'
-        )

--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -1,10 +1,10 @@
 """The Azure Storage Block Blob backend for Celery."""
+from kombu.transport.azurestoragequeues import Transport as AzureStorageQueuesTransport
 from kombu.utils import cached_property
 from kombu.utils.encoding import bytes_to_str
 
 from celery.exceptions import ImproperlyConfigured
 from celery.utils.log import get_logger
-from kombu.transport.azurestoragequeues import Transport as AzureStorageQueuesTransport
 
 from .base import KeyValueStoreBackend
 

--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -1,46 +1,72 @@
-import logging
-from celery.backends.azureblockblob import (
-    AzureBlockBlobBackend as _AzureBlockBlobBackend,
-)
+"""The Azure Storage Block Blob backend for Celery."""
 from kombu.utils import cached_property
-from azure.core.exceptions import ResourceExistsError
-from azure.storage.blob import BlobServiceClient
+from kombu.utils.encoding import bytes_to_str
+
+from celery.exceptions import ImproperlyConfigured
+from celery.utils.log import get_logger
 from kombu.transport.azurestoragequeues import Transport as AzureStorageQueuesTransport
 
-logger = logging.getLogger(__name__)
+from .base import KeyValueStoreBackend
 
-""" 
-Context:
-We are using Azure Service Bus as a broker, but it does not support a
-result backend.  I don't think it would be possible to add support for it,
-since Service Bus is really a queue, so you can't retrieve a message bsed on
-a key.  
+try:
+    import azure.storage.blob as azurestorage
+    from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
+    from azure.storage.blob import BlobServiceClient
+except ImportError:
+    azurestorage = None
 
-Since we already use blob storage, we can use the AzureBlockBlobBackend
-to store the results in blob storage.  However, the existing implementation 
-does not support DefaultAzureCredential, so we need to extend it.
-(PR Pending to Celery)
-"""
+__all__ = ("AzureBlockBlobBackend",)
+
+LOGGER = get_logger(__name__)
+AZURE_BLOCK_BLOB_CONNECTION_PREFIX = 'azureblockblob://'
 
 
-class AzureBlockBlobBackend(_AzureBlockBlobBackend):
-    """
+class AzureBlockBlobBackend(KeyValueStoreBackend):
+    """Azure Storage Block Blob backend for Celery."""
 
-    Connection String
-    =================
-
-    Connection string can have the following formats:
-
-    .. code-block::
+    def __init__(self,
+                 url=None,
+                 container_name=None,
+                 *args,
+                 **kwargs):
+        """
+        Supported URL formats:
 
         azureblockblob://CONNECTION_STRING
         azureblockblob://DefaultAzureCredential@STORAGE_ACCOUNT_URL
         azureblockblob://ManagedIdentityCredential@STORAGE_ACCOUNT_URL
-    """
+        """
+        super().__init__(*args, **kwargs)
+
+        if azurestorage is None or azurestorage.__version__ < '12':
+            raise ImproperlyConfigured(
+                "You need to install the azure-storage-blob v12 library to"
+                "use the AzureBlockBlob backend")
+
+        conf = self.app.conf
+
+        self._connection_string = self._parse_url(url)
+
+        self._container_name = (
+            container_name or
+            conf["azureblockblob_container_name"])
+
+        self.base_path = conf.get('azureblockblob_base_path', '')
+        self._connection_timeout = conf.get(
+            'azureblockblob_connection_timeout', 20
+        )
+        self._read_timeout = conf.get('azureblockblob_read_timeout', 120)
+
+    @classmethod
+    def _parse_url(cls, url, prefix=AZURE_BLOCK_BLOB_CONNECTION_PREFIX):
+        connection_string = url[len(prefix):]
+        if not connection_string:
+            raise ImproperlyConfigured("Invalid URL")
+
+        return connection_string
 
     @cached_property
     def _blob_service_client(self):
-        logger.info("Welcome inside the custom AzureBlockBlobBackend")
         """Return the Azure Storage Blob service client.
 
         If this is the first call to the property, the client is created and
@@ -61,10 +87,91 @@ class AzureBlockBlobBackend(_AzureBlockBlobBackend):
             client.create_container(name=self._container_name)
             msg = f"Container created with name {self._container_name}."
         except ResourceExistsError:
-            msg = (
-                f"Container with name {self._container_name} already."
+            msg = f"Container with name {self._container_name} already." \
                 "exists. This will not be created."
-            )
-        logger.info(msg)
+        LOGGER.info(msg)
 
         return client
+
+    def get(self, key):
+        """Read the value stored at the given key.
+
+        Args:
+              key: The key for which to read the value.
+        """
+        key = bytes_to_str(key)
+        LOGGER.debug("Getting Azure Block Blob %s/%s", self._container_name, key)
+
+        blob_client = self._blob_service_client.get_blob_client(
+            container=self._container_name,
+            blob=f'{self.base_path}{key}',
+        )
+
+        try:
+            return blob_client.download_blob().readall().decode()
+        except ResourceNotFoundError:
+            return None
+
+    def set(self, key, value):
+        """Store a value for a given key.
+
+        Args:
+              key: The key at which to store the value.
+              value: The value to store.
+
+        """
+        key = bytes_to_str(key)
+        LOGGER.debug(f"Creating azure blob at {self._container_name}/{key}")
+
+        blob_client = self._blob_service_client.get_blob_client(
+            container=self._container_name,
+            blob=f'{self.base_path}{key}',
+        )
+
+        blob_client.upload_blob(value, overwrite=True)
+
+    def mget(self, keys):
+        """Read all the values for the provided keys.
+
+        Args:
+              keys: The list of keys to read.
+
+        """
+        return [self.get(key) for key in keys]
+
+    def delete(self, key):
+        """Delete the value at a given key.
+
+        Args:
+              key: The key of the value to delete.
+
+        """
+        key = bytes_to_str(key)
+        LOGGER.debug(f"Deleting azure blob at {self._container_name}/{key}")
+
+        blob_client = self._blob_service_client.get_blob_client(
+            container=self._container_name,
+            blob=f'{self.base_path}{key}',
+        )
+
+        blob_client.delete_blob()
+
+    def as_uri(self, include_password=False):
+        if include_password:
+            return (
+                f'{AZURE_BLOCK_BLOB_CONNECTION_PREFIX}'
+                f'{self._connection_string}'
+            )
+
+        connection_string_parts = self._connection_string.split(';')
+        account_key_prefix = 'AccountKey='
+        redacted_connection_string_parts = [
+            f'{account_key_prefix}**' if part.startswith(account_key_prefix)
+            else part
+            for part in connection_string_parts
+        ]
+
+        return (
+            f'{AZURE_BLOCK_BLOB_CONNECTION_PREFIX}'
+            f'{";".join(redacted_connection_string_parts)}'
+        )

--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -73,7 +73,10 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
         the container is created if it doesn't yet exist.
 
         """
-        if "DefaultAzureCredential" in self._connection_string or "ManagedIdentityCredential" in self._connection_string:
+        if (
+            "DefaultAzureCredential" in self._connection_string or
+            "ManagedIdentityCredential" in self._connection_string
+        ):
             # Leveraging the work that Kombu already did for us
             credential_, url = AzureStorageQueuesTransport.parse_uri(
                 self._connection_string

--- a/requirements/extras/azureblockblob.txt
+++ b/requirements/extras/azureblockblob.txt
@@ -1,1 +1,2 @@
 azure-storage-blob>=12.15.0
+azure-identity>=1.19.0

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -70,7 +70,7 @@ class test_AzureBlockBlobBackend:
         url = "azureblockblob://DefaultAzureCredential@dummy_account_url"
         backend = AzureBlockBlobBackend(app=self.app, url=url)
         assert backend._blob_service_client is not None
-        mock_kombu_transport.parse_uri.assert_called_once_with(url)
+        mock_kombu_transport.parse_uri.assert_called_once_with(url.replace("azureblockblob://", ""))
         mock_blob_service_client.assert_called_once_with(
             account_url="dummy_account_url",
             credential=credential_mock,
@@ -87,7 +87,7 @@ class test_AzureBlockBlobBackend:
         url = "azureblockblob://ManagedIdentityCredential@dummy_account_url"
         backend = AzureBlockBlobBackend(app=self.app, url=url)
         assert backend._blob_service_client is not None
-        mock_kombu_transport.parse_uri.assert_called_once_with(url)
+        mock_kombu_transport.parse_uri.assert_called_once_with(url.replace("azureblockblob://", ""))
         mock_blob_service_client.assert_called_once_with(
             account_url="dummy_account_url",
             credential=credential_mock,

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -60,16 +60,17 @@ class test_AzureBlockBlobBackend:
         # ...but only once per backend instance
         assert backend._blob_service_client is not None
         assert mock_blob_service_client_instance.create_container.call_count == 1
-        
+
     @patch(MODULE_TO_MOCK + ".AzureStorageQueuesTransport")
     @patch(MODULE_TO_MOCK + ".BlobServiceClient")
     def test_create_client__default_azure_credentials(self, mock_blob_service_client, mock_kombu_transport):
         credential_mock = Mock()
         mock_blob_service_client.return_value = Mock()
         mock_kombu_transport.parse_uri.return_value = (credential_mock, "dummy_account_url")
-        backend = AzureBlockBlobBackend(app=self.app, url="azureblockblob://DefaultAzureCredential@dummy_account_url")
+        url = "azureblockblob://DefaultAzureCredential@dummy_account_url"
+        backend = AzureBlockBlobBackend(app=self.app, url=url)
         assert backend._blob_service_client is not None
-        mock_kombu_transport.parse_uri.assert_called_once_with("DefaultAzureCredential@dummy_account_url")
+        mock_kombu_transport.parse_uri.assert_called_once_with(url)
         mock_blob_service_client.assert_called_once_with(
             account_url="dummy_account_url",
             credential=credential_mock,
@@ -83,9 +84,10 @@ class test_AzureBlockBlobBackend:
         credential_mock = Mock()
         mock_blob_service_client.return_value = Mock()
         mock_kombu_transport.parse_uri.return_value = (credential_mock, "dummy_account_url")
-        backend = AzureBlockBlobBackend(app=self.app, url="azureblockblob://ManagedIdentityCredential@dummy_account_url")
+        url = "azureblockblob://ManagedIdentityCredential@dummy_account_url"
+        backend = AzureBlockBlobBackend(app=self.app, url=url)
         assert backend._blob_service_client is not None
-        mock_kombu_transport.parse_uri.assert_called_once_with("ManagedIdentityCredential@dummy_account_url")
+        mock_kombu_transport.parse_uri.assert_called_once_with(url)
         mock_blob_service_client.assert_called_once_with(
             account_url="dummy_account_url",
             credential=credential_mock,

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -60,6 +60,38 @@ class test_AzureBlockBlobBackend:
         # ...but only once per backend instance
         assert backend._blob_service_client is not None
         assert mock_blob_service_client_instance.create_container.call_count == 1
+        
+    @patch(MODULE_TO_MOCK + ".AzureStorageQueuesTransport")
+    @patch(MODULE_TO_MOCK + ".BlobServiceClient")
+    def test_create_client__default_azure_credentials(self, mock_blob_service_client, mock_kombu_transport):
+        credential_mock = Mock()
+        mock_blob_service_client.return_value = Mock()
+        mock_kombu_transport.parse_uri.return_value = (credential_mock, "dummy_account_url")
+        backend = AzureBlockBlobBackend(app=self.app, url="azureblockblob://DefaultAzureCredential@dummy_account_url")
+        assert backend._blob_service_client is not None
+        mock_kombu_transport.parse_uri.assert_called_once_with("DefaultAzureCredential@dummy_account_url")
+        mock_blob_service_client.assert_called_once_with(
+            account_url="dummy_account_url",
+            credential=credential_mock,
+            connection_timeout=backend._connection_timeout,
+            read_timeout=backend._read_timeout,
+        )
+
+    @patch(MODULE_TO_MOCK + ".AzureStorageQueuesTransport")
+    @patch(MODULE_TO_MOCK + ".BlobServiceClient")
+    def test_create_client__managed_identity_azure_credentials(self, mock_blob_service_client, mock_kombu_transport):
+        credential_mock = Mock()
+        mock_blob_service_client.return_value = Mock()
+        mock_kombu_transport.parse_uri.return_value = (credential_mock, "dummy_account_url")
+        backend = AzureBlockBlobBackend(app=self.app, url="azureblockblob://ManagedIdentityCredential@dummy_account_url")
+        assert backend._blob_service_client is not None
+        mock_kombu_transport.parse_uri.assert_called_once_with("ManagedIdentityCredential@dummy_account_url")
+        mock_blob_service_client.assert_called_once_with(
+            account_url="dummy_account_url",
+            credential=credential_mock,
+            connection_timeout=backend._connection_timeout,
+            read_timeout=backend._read_timeout,
+        )
 
     @patch(MODULE_TO_MOCK + ".BlobServiceClient")
     def test_configure_client(self, mock_blob_service_factory):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

AzureBlockBlobBackend currently only supports fully qualified connection strings.  In many environments, a connection string is not available, but instead credentials are loaded via Azure Identity (eg. when using an App Registration).  
The Kombu brokers already support this.  This PR is based on the work there so that it's possible to use a ManagedIdentityCredential or DefaultAzureCredential.  