### PR TITLE
Prevent event_mask from being overwritten.

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -116,7 +116,7 @@ if hasattr(select, 'poll'):
         fd_to_mask = {}
 
         if readers:
-            for fd in map(_ensure_integral_fd, writers):
+            for fd in map(_ensure_integral_fd, readers):
                 fd_to_mask[fd] = fd_to_mask.get(fd, 0) | POLLIN
         if writers:
             for fd in map(_ensure_integral_fd, writers):

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -299,6 +299,10 @@ class test_AsynPool:
             _, writeable, _ = asynpool._select(writers={f, }, err={f, })
             assert f.fileno() in writeable
 
+        with tempfile.TemporaryFile('r') as f:
+            readable, _, _ = asynpool._select(readers={f, }, err={f, })
+            assert f.fileno() in readable
+
     def test_promise(self):
         fun = Mock()
         x = asynpool.promise(fun, (1,), {'foo': 1})

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -1,6 +1,7 @@
 import errno
 import os
 import socket
+import tempfile
 from itertools import cycle
 from unittest.mock import Mock, patch
 
@@ -292,6 +293,11 @@ class test_AsynPool:
             poll.side_effect.errno = 34134
             with pytest.raises(socket.error):
                 asynpool._select({3}, poll=poll)
+
+    def test_select_unpatched(self):
+        with tempfile.TemporaryFile('w') as f:
+            _, writeable, _ = asynpool._select(writers={f, }, err={f, })
+            assert f.fileno() in writeable
 
     def test_promise(self):
         fun = Mock()


### PR DESCRIPTION
## Description

Current implementation of _select_imp has a limitation that, for example, when same `fd` appears in both argument `writers` and `err`, the event_mask of `fd` will end up being `POLLERR` instead of `POLLOUT | POLLERR`.

This may lead to celery not consuming task after app restart.

If an error occurs while writing job to celery worker and at the same time celery app restarts, `AsyncPool._active_writers` will contain the writing job and method `AsyncPool._flush_writer` will be triggered, providing the same `fds` for both `writers` and `err` to `_select -> _select_imp`. If the worker proc is still alive and related fd is writable (i.e. no error), the variable `writable`, `readable` returned by `_select` call will both be empty and `again` will be 0, and the loop `while fds:` will never ends
```python
    def _flush_writer(self, proc, writer):
        fds = {proc.inq._writer}
        try:
            while fds:
                if not proc._is_alive():
                    break  # process exited
                readable, writable, again = _select(
                    writers=fds, err=fds, timeout=0.5,
                )
                if not again and (writable or readable):
                    try:
                        next(writer)
                    except (StopIteration, OSError, EOFError):
                        break
        finally:
            self._active_writers.discard(writer)
```

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
