### PR TITLE
support Request termination for gevent

### DIFF
--- a/celery/concurrency/gevent.py
+++ b/celery/concurrency/gevent.py
@@ -167,4 +167,5 @@ class TaskPool(base.BasePool):
 
 
 def _terminate(self, signal):
-    self.kill()
+    # Done in `TaskPool.terminate_job`
+    pass

--- a/celery/concurrency/gevent.py
+++ b/celery/concurrency/gevent.py
@@ -1,5 +1,6 @@
 """Gevent execution pool."""
 import functools
+import types
 from time import monotonic
 
 from kombu.asynchronous import timer as _timer
@@ -121,6 +122,7 @@ class TaskPool(base.BasePool):
                                    target, args, kwargs, callback, accept_callback,
                                    self.getpid, timeout=timeout, timeout_callback=timeout_callback)
         self._add_to_pool_map(id(greenlet), greenlet)
+        greenlet.terminate = types.MethodType(_terminate, greenlet)
         return greenlet
 
     def grow(self, n=1):
@@ -162,3 +164,7 @@ class TaskPool(base.BasePool):
     @staticmethod
     def _cleanup_after_job_finish(greenlet, pool_map, pid):
         del pool_map[pid]
+
+
+def _terminate(self, signal):
+    self.kill()


### PR DESCRIPTION
PR https://github.com/celery/celery/pull/9083 adds support for terminating gevent jobs.

I can confirm @dwick observation https://github.com/celery/celery/issues/9083#issuecomment-2344292931_

```
[2024-11-28 23:25:56,623: ERROR/MainProcess] pidbox command error: AttributeError("'gevent._gevent_cgreenlet.Greenlet' object has no attribute 'terminate'")
Traceback (most recent call last):
  File ".../python3.9/site-packages/kombu/pidbox.py", line 102, in dispatch
    reply = handle(method, arguments)
  File ".../python3.9/site-packages/kombu/pidbox.py", line 124, in handle_cast
    return self.handle(method, arguments)
  File ".../python3.9/site-packages/kombu/pidbox.py", line 118, in handle
    return self.handlers[method](self.state, **arguments)
  File "/home/denolf/dev/celery/celery/worker/control.py", line 149, in revoke
    task_ids = _revoke(state, task_ids, terminate, signal, **kwargs)
  File "/home/denolf/dev/celery/celery/worker/control.py", line 224, in _revoke
    request.terminate(state.consumer.pool, signal=signum)
  File "/home/denolf/dev/celery/celery/worker/request.py", line 423, in terminate
    obj.terminate(signal)
AttributeError: 'gevent._gevent_cgreenlet.Greenlet' object has no attribute 'terminate'
```

The reason is this

```python
class Request:
    """A request for task execution."""

    def terminate(self, pool, signal=None):
        signal = _signals.signum(signal or TERM_SIGNAME)
        if self.time_start:
            pool.terminate_job(self.worker_pid, signal)   # Ask for termination with the pool
            self._announce_revoked('terminated', True, signal, False)
        else:
            self._terminate_on_ack = pool, signal
        if self._apply_result is not None:
            obj = self._apply_result()  # is a weakref
            if obj is not None:
                obj.terminate(signal)  # Ask for termination with the greenlet itself
```

In this MR was bind `terminate` to the greenlet instance when returned from `on_apply`.