### PR TITLE
Fix cassandra backend port settings not working

### DIFF
--- a/celery/backends/cassandra.py
+++ b/celery/backends/cassandra.py
@@ -96,7 +96,7 @@ class CassandraBackend(BaseBackend):
         self.servers = servers or conf.get('cassandra_servers', None)
         self.bundle_path = bundle_path or conf.get(
             'cassandra_secure_bundle_path', None)
-        self.port = port or conf.get('cassandra_port', 9042)
+        self.port = port or conf.get('cassandra_port', None) or 9042
         self.keyspace = keyspace or conf.get('cassandra_keyspace', None)
         self.table = table or conf.get('cassandra_table', None)
         self.cassandra_options = conf.get('cassandra_options', {})

--- a/celery/backends/cassandra.py
+++ b/celery/backends/cassandra.py
@@ -86,7 +86,7 @@ class CassandraBackend(BaseBackend):
     supports_autoexpire = True      # autoexpire supported via entry_ttl
 
     def __init__(self, servers=None, keyspace=None, table=None, entry_ttl=None,
-                 port=9042, bundle_path=None, **kwargs):
+                 port=None, bundle_path=None, **kwargs):
         super().__init__(**kwargs)
 
         if not cassandra:
@@ -96,7 +96,7 @@ class CassandraBackend(BaseBackend):
         self.servers = servers or conf.get('cassandra_servers', None)
         self.bundle_path = bundle_path or conf.get(
             'cassandra_secure_bundle_path', None)
-        self.port = port or conf.get('cassandra_port', None)
+        self.port = port or conf.get('cassandra_port', 9042)
         self.keyspace = keyspace or conf.get('cassandra_keyspace', None)
         self.table = table or conf.get('cassandra_table', None)
         self.cassandra_options = conf.get('cassandra_options', {})

--- a/t/unit/backends/test_cassandra.py
+++ b/t/unit/backends/test_cassandra.py
@@ -267,4 +267,11 @@ class test_CassandraBackend:
             'cql_version': '3.2.1',
             'protocol_version': 3
         }
-        mod.CassandraBackend(app=self.app)
+        x = mod.CassandraBackend(app=self.app)
+        # Default port is 9042
+        assert x.port == 9042
+
+        # Valid options with port specified
+        self.app.conf.cassandra_port = 1234
+        x = mod.CassandraBackend(app=self.app)
+        assert x.port == 1234

--- a/t/unit/backends/test_cassandra.py
+++ b/t/unit/backends/test_cassandra.py
@@ -267,6 +267,7 @@ class test_CassandraBackend:
             'cql_version': '3.2.1',
             'protocol_version': 3
         }
+        self.app.conf.cassandra_port = None
         x = mod.CassandraBackend(app=self.app)
         # Default port is 9042
         assert x.port == 9042


### PR DESCRIPTION
## Description

**Fix for Port Configuration in CassandraBackend Constructor**

Fixes #5226, which was marked as closed but unresolved.
The issue arises from the default parameter `port=9042` in the `CassandraBackend` constructor, which inadvertently prevents the application from using a port number specified through the `cassandra_port` configuration setting.

### Problem Details:
- The constructor of `CassandraBackend` class defines `port=9042` as a default argument.
- When `ForkPoolWorker` initializes `CassandraBackend` without specifying the port, it defaults to `9042`.
- Consequently, the configuration setting `conf.get('cassandra_port', None)` is overlooked, and the specified port in the configuration is not utilized.

### Changes Made:
```py
class CassandraBackend(BaseBackend):
    ...
    def __init__(self, ..., port=None, ..., **kwargs):
        ...
        self.port = port or conf.get('cassandra_port', None) or 9042
```
- Removed the default value of `9042` from the `port` parameter in the constructor.
- Adjusted the assignment of `self.port` to ensure it uses the `cassandra_port` from the config if no port is explicitly provided during initialization.

This modification ensures that the port configuration via `cassandra_port` is respected, allowing for flexible deployment configurations.

