### PR TITLE
documentation: Added a type annotation to the periodic task example

### DIFF
--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -90,7 +90,7 @@ beat schedule list.
     app = Celery()
 
     @app.on_after_configure.connect
-    def setup_periodic_tasks(sender, **kwargs):
+    def setup_periodic_tasks(sender: Celery, **kwargs):
         # Calls test('hello') every 10 seconds.
         sender.add_periodic_task(10.0, test.s('hello'), name='add every 10')
 


### PR DESCRIPTION
## Description

This PR just adds one simple type annotation to the example, making it easier to understand what's the `sender` in the given context.

I'm also thinking that it would be useful if these examples would not use the `s` shorthand or would at least reference its meaning. But I'm unsure how to approach that. (Quick search shows that it does confuse new users, for example: https://github.com/celery/celery/discussions/7964)