### PR TITLE
Update canvas.rst to fix output result from chain object

### DIFF
--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -461,17 +461,7 @@ Here're some examples:
 
         >>> res = (add.s(4, 4) | group(add.si(i, i) for i in range(10)))()
         >>> res.get()
-        <GroupResult: de44df8c-821d-4c84-9a6a-44769c738f98 [
-            bc01831b-9486-4e51-b046-480d7c9b78de,
-            2650a1b8-32bf-4771-a645-b0a35dcc791b,
-            dcbee2a5-e92d-4b03-b6eb-7aec60fd30cf,
-            59f92e0a-23ea-41ce-9fad-8645a0e7759c,
-            26e1e707-eccf-4bf4-bbd8-1e1729c3cce3,
-            2d10a5f4-37f0-41b2-96ac-a973b1df024d,
-            e13d3bdb-7ae3-4101-81a4-6f17ee21df2d,
-            104b2be0-7b75-44eb-ac8e-f9220bdfa140,
-            c5c551a5-0386-4973-aa37-b65cbeb2624b,
-            83f72d71-4b71-428e-b604-6f16599a9f37]>
+        [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
 
         >>> res.parent.get()
         8


### PR DESCRIPTION
## Description

The output of the following code:
```python
res = (add.s(4, 4) | group(add.si(i, i) for i in range(10)))
res.get()
```
should be:
```
[0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
```
but in documentation is wrongly:
```
<GroupResult: de44df8c-821d-4c84-9a6a-44769c738f98 [
    bc01831b-9486-4e51-b046-480d7c9b78de,
    2650a1b8-32bf-4771-a645-b0a35dcc791b,
    dcbee2a5-e92d-4b03-b6eb-7aec60fd30cf,
    59f92e0a-23ea-41ce-9fad-8645a0e7759c,
    26e1e707-eccf-4bf4-bbd8-1e1729c3cce3,
    2d10a5f4-37f0-41b2-96ac-a973b1df024d,
    e13d3bdb-7ae3-4101-81a4-6f17ee21df2d,
    104b2be0-7b75-44eb-ac8e-f9220bdfa140,
    c5c551a5-0386-4973-aa37-b65cbeb2624b,
    83f72d71-4b71-428e-b604-6f16599a9f37]>
```