### PR TITLE
Avoid using a group of one as it is now unrolled into a chain

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1696,23 +1696,23 @@ class test_chord:
         res1 = c1()
         assert res1.get(timeout=TIMEOUT) == [29, 38]
 
-    @flaky
+    # @flaky
     def test_add_to_chord(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
 
-        c = group([add_to_all_to_chord.s([1, 2, 3], 4)]) | identity.s()
+        c = group([identity.si(1), add_to_all_to_chord.s([1, 2, 3], 4)]) | identity.s()
         res = c()
-        assert sorted(res.get()) == [0, 5, 6, 7]
+        assert sorted(res.get()) == [0, 1, 5, 6, 7]
 
     @flaky
     def test_add_chord_to_chord(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
 
-        c = group([add_chord_to_chord.s([1, 2, 3], 4)]) | identity.s()
+        c = group([identity.si(1), add_chord_to_chord.s([1, 2, 3], 4)]) | identity.s()
         res = c()
-        assert sorted(res.get()) == [0, 5 + 6 + 7]
+        assert sorted(res.get()) == [0, 1, 5 + 6 + 7]
 
     @flaky
     def test_eager_chord_inside_task(self, manager):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Fix integration test failures due to #9456 unrolling a group of one chained to a task.