### PR TITLE
Remove dependency on `pycurl`

### DIFF
--- a/requirements/extras/sqs.txt
+++ b/requirements/extras/sqs.txt
@@ -1,5 +1,3 @@
 boto3>=1.26.143
-pycurl>=7.43.0.5,<7.45.4; sys_platform != 'win32' and platform_python_implementation=="CPython" and python_version < "3.9"
-pycurl>=7.45.4; sys_platform != 'win32' and platform_python_implementation=="CPython" and python_version >= "3.9"
 urllib3>=1.26.16
 kombu[sqs]>=5.3.4

--- a/requirements/test-ci-default.txt
+++ b/requirements/test-ci-default.txt
@@ -21,5 +21,4 @@
 git+https://github.com/celery/kombu.git
 
 # SQS dependencies other than boto
-pycurl>=7.43.0.5,<7.45.4; sys_platform != 'win32' and platform_python_implementation=="CPython" and python_version < "3.9"
-pycurl>=7.45.4; sys_platform != 'win32' and platform_python_implementation=="CPython" and python_version >= "3.9"
+urllib3>=1.26.16


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

The dependency on `pycurl` was removed from `kombu[sqs]` in https://github.com/celery/kombu/pull/2134, so is no longer required here.

See #3619
