### PR TITLE
Unauthorized Changes Cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.14.0
     hooks:
     -   id: mypy
         pass_filenames: false

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -937,8 +937,6 @@ class Task:
         if isinstance(sig, group):
             # Groups get uplifted to a chord so that we can link onto the body
             sig |= self.app.tasks['celery.accumulate'].s(index=0)
-        if isinstance(sig, _chain) and isinstance(sig.tasks[-1], group):
-            sig.tasks[-1] |= self.app.tasks['celery.accumulate'].s(index=0)
         for callback in maybe_list(self.request.callbacks) or []:
             sig.link(callback)
         for errback in maybe_list(self.request.errbacks) or []:

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1583,10 +1583,6 @@ class group(Signature):
 
     def __or__(self, other):
         # group() | task -> chord
-        # If the group is unrolled, return a chain instead
-        g = maybe_unroll_group(self)
-        if not isinstance(g, group):
-            return g | other
         return chord(self, body=other, app=self._app)
 
     def skew(self, start=1.0, stop=None, step=1.0):

--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
     from types import ModuleType
     from typing import Protocol
 
-    from django.db.backends.base.base import BaseDatabaseWrapper
     from django.db.utils import ConnectionHandler
 
     from celery.app.base import Celery
@@ -165,16 +164,15 @@ class DjangoWorkerFixup:
         # network IO that close() might cause.
         for c in self._db.connections.all():
             if c and c.connection:
-                self._maybe_close_db_fd(c)
+                self._maybe_close_db_fd(c.connection)
 
         # use the _ version to avoid DB_REUSE preventing the conn.close() call
         self._close_database(force=True)
         self.close_cache()
 
-    def _maybe_close_db_fd(self, c: "BaseDatabaseWrapper") -> None:
+    def _maybe_close_db_fd(self, fd: IO) -> None:
         try:
-            with c.wrap_database_errors:
-                _maybe_close_fd(c.connection)
+            _maybe_close_fd(fd)
         except self.interface_errors:
             pass
 

--- a/docs/includes/resources.txt
+++ b/docs/includes/resources.txt
@@ -21,7 +21,7 @@ IRC
 Come chat with us on IRC. The **#celery** channel is located at the `Libera Chat`_
 network.
 
-.. _`Libera Chat`: https://libera.chat/
+.. _`Libera Chat`: https://freenode.net
 
 .. _bug-tracker:
 

--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -859,28 +859,6 @@ if you plan to use it as part of a larger canvas.
         >>> chain(group(add.s(1, 1)), add.s(2))
         add(1, 1) | add(2)
 
-.. warning::
-
-    .. versionadded:: 5.5
-
-    Before Celery 5.5 the following group would be upgraded to a chord instead of being unrolled:
-
-    .. code-block:: pycon
-
-        >>> from celery import chain, group
-        >>> from tasks import add
-        >>> group(add.s(1, 1)) | add.s(2)
-        %add([add(1, 1)], 2)
-
-    This was fixed in Celery 5.5 and now the group is correctly unrolled into a single signature.
-
-    .. code-block:: pycon
-
-        >>> from celery import chain, group
-        >>> from tasks import add
-        >>> group(add.s(1, 1)) | add.s(2)
-        add(1, 1) | add(2)
-
 .. _canvas-chord:
 
 Chords

--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -461,7 +461,17 @@ Here're some examples:
 
         >>> res = (add.s(4, 4) | group(add.si(i, i) for i in range(10)))()
         >>> res.get()
-        [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+        <GroupResult: de44df8c-821d-4c84-9a6a-44769c738f98 [
+            bc01831b-9486-4e51-b046-480d7c9b78de,
+            2650a1b8-32bf-4771-a645-b0a35dcc791b,
+            dcbee2a5-e92d-4b03-b6eb-7aec60fd30cf,
+            59f92e0a-23ea-41ce-9fad-8645a0e7759c,
+            26e1e707-eccf-4bf4-bbd8-1e1729c3cce3,
+            2d10a5f4-37f0-41b2-96ac-a973b1df024d,
+            e13d3bdb-7ae3-4101-81a4-6f17ee21df2d,
+            104b2be0-7b75-44eb-ac8e-f9220bdfa140,
+            c5c551a5-0386-4973-aa37-b65cbeb2624b,
+            83f72d71-4b71-428e-b604-6f16599a9f37]>
 
         >>> res.parent.get()
         8

--- a/requirements/test-ci-base.txt
+++ b/requirements/test-ci-base.txt
@@ -1,6 +1,6 @@
 pytest-cov==5.0.0; python_version<"3.9"
 pytest-cov==6.0.0; python_version>="3.9"
-pytest-github-actions-annotate-failures==0.3.0
+pytest-github-actions-annotate-failures==0.2.0
 -r extras/redis.txt
 -r extras/sqlalchemy.txt
 -r extras/pymemcache.txt

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -154,11 +154,6 @@ def replace_with_empty_chain(self, *_):
 
 
 @shared_task(bind=True)
-def replace_with_chain_which_contains_a_group(self):
-    return self.replace(chain(add.s(1, 2), group(add.s(1), add.s(1))))
-
-
-@shared_task(bind=True)
 def add_to_all(self, nums, val):
     """Add the given value to all supplied numbers."""
     subtasks = [add.s(num, val) for num in nums]

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -21,9 +21,9 @@ from .tasks import (ExpectedException, StampOnReplace, add, add_chord_to_chord, 
                     add_to_all_to_chord, build_chain_inside_task, collect_ids, delayed_sum,
                     delayed_sum_with_soft_guard, errback_new_style, errback_old_style, fail, fail_replaced, identity,
                     ids, mul, print_unicode, raise_error, redis_count, redis_echo, redis_echo_group_id,
-                    replace_with_chain, replace_with_chain_which_contains_a_group, replace_with_chain_which_raises,
-                    replace_with_empty_chain, replace_with_stamped_task, retry_once, return_exception,
-                    return_priority, second_order_replace1, tsum, write_to_file_and_return_int, xsum)
+                    replace_with_chain, replace_with_chain_which_raises, replace_with_empty_chain,
+                    replace_with_stamped_task, retry_once, return_exception, return_priority, second_order_replace1,
+                    tsum, write_to_file_and_return_int, xsum)
 
 RETRYABLE_EXCEPTIONS = (OSError, ConnectionError, TimeoutError)
 
@@ -309,13 +309,6 @@ class test_chain:
         expected_messages = [b'In A', b'In B', b'In/Out C', b'Out B',
                              b'Out A']
         assert redis_messages == expected_messages
-
-    @flaky
-    def test_replace_with_chain_that_contains_a_group(self, manager):
-        s = replace_with_chain_which_contains_a_group.s()
-
-        result = s.delay()
-        assert result.get(timeout=TIMEOUT) == [4, 4]
 
     @flaky
     def test_parent_ids(self, manager, num=10):

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1696,23 +1696,23 @@ class test_chord:
         res1 = c1()
         assert res1.get(timeout=TIMEOUT) == [29, 38]
 
-    # @flaky
+    @flaky
     def test_add_to_chord(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
 
-        c = group([identity.si(1), add_to_all_to_chord.s([1, 2, 3], 4)]) | identity.s()
+        c = group([add_to_all_to_chord.s([1, 2, 3], 4)]) | identity.s()
         res = c()
-        assert sorted(res.get()) == [0, 1, 5, 6, 7]
+        assert sorted(res.get()) == [0, 5, 6, 7]
 
     @flaky
     def test_add_chord_to_chord(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
 
-        c = group([identity.si(1), add_chord_to_chord.s([1, 2, 3], 4)]) | identity.s()
+        c = group([add_chord_to_chord.s([1, 2, 3], 4)]) | identity.s()
         res = c()
-        assert sorted(res.get()) == [0, 1, 5 + 6 + 7]
+        assert sorted(res.get()) == [0, 5 + 6 + 7]
 
     @flaky
     def test_eager_chord_inside_task(self, manager):

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -156,10 +156,6 @@ class test_DjangoFixup(FixupCase):
                 assert f._worker_fixup is DWF.return_value
 
 
-class InterfaceError(Exception):
-    pass
-
-
 class test_DjangoWorkerFixup(FixupCase):
     Fixup = DjangoWorkerFixup
 
@@ -184,15 +180,14 @@ class test_DjangoWorkerFixup(FixupCase):
 
     def test_on_worker_process_init(self, patching):
         with self.fixup_context(self.app) as (f, _, _):
-            with patch('celery.fixups.django._maybe_close_fd', side_effect=InterfaceError) as mcf:
+            with patch('celery.fixups.django._maybe_close_fd') as mcf:
                 _all = f._db.connections.all = Mock()
                 conns = _all.return_value = [
-                    Mock(), MagicMock(),
+                    Mock(), Mock(),
                 ]
                 conns[0].connection = None
                 with patch.object(f, 'close_cache'):
                     with patch.object(f, '_close_database'):
-                        f.interface_errors = (InterfaceError, )
                         f.on_worker_process_init()
                         mcf.assert_called_with(conns[1].connection)
                         f.close_cache.assert_called_with()

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -564,7 +564,7 @@ class test_chain(CanvasCase):
         assert isinstance(new_chain.tasks[0].body, _chain)
 
     def test_chain_of_chord_upgrade_on_chaining(self):
-        c = chord([signature('header')], group(signature('body'), signature('body2')))
+        c = chord([signature('header')], group(signature('body')))
         c = chain(c)
         t = signature('t')
         new_chain = c | t  # t should be chained with the body of c[0] and create a new chord
@@ -1251,19 +1251,6 @@ class test_group(CanvasCase):
             assert isinstance(result, AsyncResult)
             assert group_id is not None
 
-    def test_group_unroll(self, subtests):
-        @self.app.task
-        def test_task(a, b):
-            return
-
-        with subtests.test("single item"):
-            c = group(test_task.s(1, 2)) | test_task.s(1)
-            assert str(c) == "t.unit.tasks.test_canvas.test_task(1, 2) | test_task(1)"
-
-        with subtests.test("regen"):
-            c = group(test_task.s(1, 2) for _ in range(1)) | test_task.s(1)
-            assert str(c) == "t.unit.tasks.test_canvas.test_task(1, 2) | test_task(1)"
-
 
 class test_chord(CanvasCase):
     def test__get_app_does_not_exhaust_generator(self):
@@ -1782,19 +1769,11 @@ class test_chord(CanvasCase):
 
     def test_chord_upgrade_on_chaining(self):
         """ Test that chaining a chord with a group body upgrades to a new chord """
-        c = chord([signature('header')], group(signature('body'), signature('body2')))
-        t = signature('t')
-        stil_chord = c | t  # t should be chained with the body of c and create a new chord
-        assert isinstance(stil_chord, chord)
-        assert isinstance(stil_chord.body, chord)
-
-    def test_no_chord_upgrade_on_chaining_with_group_of_a_single_item(self):
-        """ Test that chaining a chord with a group body upgrades to a new chord """
         c = chord([signature('header')], group(signature('body')))
         t = signature('t')
         stil_chord = c | t  # t should be chained with the body of c and create a new chord
         assert isinstance(stil_chord, chord)
-        assert isinstance(stil_chord.body, _chain)
+        assert isinstance(stil_chord.body, chord)
 
     @pytest.mark.parametrize('header', [
         [signature('s1'), signature('s2')],

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1165,7 +1165,7 @@ class test_tasks(TasksCase):
             self.mytask.replace(sig1)
 
     def test_replace_callback(self):
-        c = group([self.mytask.s(), self.mytask.s()], app=self.app)
+        c = group([self.mytask.s()], app=self.app)
         c.freeze = Mock(name='freeze')
         c.delay = Mock(name='delay')
         self.mytask.request.id = 'id'


### PR DESCRIPTION
Reverting unauthorized code changes due to security incident #9525.

@Lotram @yigitsever @kamalfarahani
Please note that your PRs, #9392, #9509, and #9502, were affected and removed during this cleanup phase.

The changes will be reviewed again and reinstated if approved.
