### PR TITLE
[RE-APPROVED] fix(django): catch the right error when trying to close db connection

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from types import ModuleType
     from typing import Protocol
 
+    from django.db.backends.base.base import BaseDatabaseWrapper
     from django.db.utils import ConnectionHandler
 
     from celery.app.base import Celery
@@ -164,15 +165,16 @@ class DjangoWorkerFixup:
         # network IO that close() might cause.
         for c in self._db.connections.all():
             if c and c.connection:
-                self._maybe_close_db_fd(c.connection)
+                self._maybe_close_db_fd(c)
 
         # use the _ version to avoid DB_REUSE preventing the conn.close() call
         self._close_database(force=True)
         self.close_cache()
 
-    def _maybe_close_db_fd(self, fd: IO) -> None:
+    def _maybe_close_db_fd(self, c: "BaseDatabaseWrapper") -> None:
         try:
-            _maybe_close_fd(fd)
+            with c.wrap_database_errors:
+                _maybe_close_fd(c.connection)
         except self.interface_errors:
             pass
 

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -156,6 +156,10 @@ class test_DjangoFixup(FixupCase):
                 assert f._worker_fixup is DWF.return_value
 
 
+class InterfaceError(Exception):
+    pass
+
+
 class test_DjangoWorkerFixup(FixupCase):
     Fixup = DjangoWorkerFixup
 
@@ -180,14 +184,15 @@ class test_DjangoWorkerFixup(FixupCase):
 
     def test_on_worker_process_init(self, patching):
         with self.fixup_context(self.app) as (f, _, _):
-            with patch('celery.fixups.django._maybe_close_fd') as mcf:
+            with patch('celery.fixups.django._maybe_close_fd', side_effect=InterfaceError) as mcf:
                 _all = f._db.connections.all = Mock()
                 conns = _all.return_value = [
-                    Mock(), Mock(),
+                    Mock(), MagicMock(),
                 ]
                 conns[0].connection = None
                 with patch.object(f, 'close_cache'):
                     with patch.object(f, '_close_database'):
+                        f.interface_errors = (InterfaceError, )
                         f.on_worker_process_init()
                         mcf.assert_called_with(conns[1].connection)
                         f.close_cache.assert_called_with()


### PR DESCRIPTION
Undo revert for #9392 from #9528.
The changes are approved if the CI passes successfully.

@Lotram FYI