### PR TITLE
Unroll group when chaining a group with a single item to another signature when using the | operator

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1583,6 +1583,10 @@ class group(Signature):
 
     def __or__(self, other):
         # group() | task -> chord
+        # If the group is unrolled, return a chain instead
+        g = maybe_unroll_group(self)
+        if not isinstance(g, group):
+            return g | other
         return chord(self, body=other, app=self._app)
 
     def skew(self, start=1.0, stop=None, step=1.0):

--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -849,6 +849,28 @@ if you plan to use it as part of a larger canvas.
         >>> chain(group(add.s(1, 1)), add.s(2))
         add(1, 1) | add(2)
 
+.. warning::
+
+    .. versionadded:: 5.5
+
+    Before Celery 5.5 the following group would be upgraded to a chord instead of being unrolled:
+
+    .. code-block:: pycon
+
+        >>> from celery import chain, group
+        >>> from tasks import add
+        >>> group(add.s(1, 1)) | add.s(2)
+        %add([add(1, 1)], 2)
+
+    This was fixed in Celery 5.5 and now the group is correctly unrolled into a single signature.
+
+    .. code-block:: pycon
+
+        >>> from celery import chain, group
+        >>> from tasks import add
+        >>> group(add.s(1, 1)) | add.s(2)
+        add(1, 1) | add(2)
+
 .. _canvas-chord:
 
 Chords

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1694,18 +1694,18 @@ class test_chord:
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
 
-        c = group([add_to_all_to_chord.s([1, 2, 3], 4)]) | identity.s()
+        c = group([identity.si(1), add_to_all_to_chord.s([1, 2, 3], 4)]) | identity.s()
         res = c()
-        assert sorted(res.get()) == [0, 5, 6, 7]
+        assert sorted(res.get()) == [0, 1, 5, 6, 7]
 
     @flaky
     def test_add_chord_to_chord(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):
             raise pytest.skip('Requires redis result backend.')
 
-        c = group([add_chord_to_chord.s([1, 2, 3], 4)]) | identity.s()
+        c = group([identity.si(1), add_chord_to_chord.s([1, 2, 3], 4)]) | identity.s()
         res = c()
-        assert sorted(res.get()) == [0, 5 + 6 + 7]
+        assert sorted(res.get()) == [0, 1, 5 + 6 + 7]
 
     @flaky
     def test_eager_chord_inside_task(self, manager):

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1165,7 +1165,7 @@ class test_tasks(TasksCase):
             self.mytask.replace(sig1)
 
     def test_replace_callback(self):
-        c = group([self.mytask.s()], app=self.app)
+        c = group([self.mytask.s(), self.mytask.s()], app=self.app)
         c.freeze = Mock(name='freeze')
         c.delay = Mock(name='delay')
         self.mytask.request.id = 'id'


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Before this change the following group would be upgraded to a chord:

```python
>>> from celery import chain, group
>>> from tasks import add
>>> group(add.s(1, 1)) | add.s(2)
%add([add(1, 1)], 2)
```

After this change the group is correctly unrolled into a single signature:

``` python
>>> from celery import chain, group
>>> from tasks import add
>>> group(add.s(1, 1)) | add.s(2)
add(1, 1) | add(2)
```

This is a breaking change but it is a necessary one since chain(group(add.s(1,2)), add.s(1)) correctly unrolls the group into a single signature. The breaking change is documented.