### PR TITLE
Replacing a task with a chain which contains a group now returns a result instead of hanging

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -937,6 +937,8 @@ class Task:
         if isinstance(sig, group):
             # Groups get uplifted to a chord so that we can link onto the body
             sig |= self.app.tasks['celery.accumulate'].s(index=0)
+        if isinstance(sig, _chain) and isinstance(sig.tasks[-1], group):
+            sig.tasks[-1] |= self.app.tasks['celery.accumulate'].s(index=0)
         for callback in maybe_list(self.request.callbacks) or []:
             sig.link(callback)
         for errback in maybe_list(self.request.errbacks) or []:

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -154,6 +154,11 @@ def replace_with_empty_chain(self, *_):
 
 
 @shared_task(bind=True)
+def replace_with_chain_which_contains_a_group(self):
+    return self.replace(chain(add.s(1, 2), group(add.s(1), add.s(1))))
+
+
+@shared_task(bind=True)
 def add_to_all(self, nums, val):
     """Add the given value to all supplied numbers."""
     subtasks = [add.s(num, val) for num in nums]

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -312,6 +312,11 @@ class test_chain:
 
     @flaky
     def test_replace_with_chain_that_contains_a_group(self, manager):
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.args[0])
+
         s = replace_with_chain_which_contains_a_group.s()
 
         result = s.delay()

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -21,9 +21,9 @@ from .tasks import (ExpectedException, StampOnReplace, add, add_chord_to_chord, 
                     add_to_all_to_chord, build_chain_inside_task, collect_ids, delayed_sum,
                     delayed_sum_with_soft_guard, errback_new_style, errback_old_style, fail, fail_replaced, identity,
                     ids, mul, print_unicode, raise_error, redis_count, redis_echo, redis_echo_group_id,
-                    replace_with_chain, replace_with_chain_which_raises, replace_with_empty_chain,
-                    replace_with_stamped_task, retry_once, return_exception, return_priority, second_order_replace1,
-                    tsum, write_to_file_and_return_int, xsum)
+                    replace_with_chain, replace_with_chain_which_contains_a_group, replace_with_chain_which_raises,
+                    replace_with_empty_chain, replace_with_stamped_task, retry_once, return_exception,
+                    return_priority, second_order_replace1, tsum, write_to_file_and_return_int, xsum)
 
 RETRYABLE_EXCEPTIONS = (OSError, ConnectionError, TimeoutError)
 
@@ -309,6 +309,13 @@ class test_chain:
         expected_messages = [b'In A', b'In B', b'In/Out C', b'Out B',
                              b'Out A']
         assert redis_messages == expected_messages
+
+    @flaky
+    def test_replace_with_chain_that_contains_a_group(self, manager):
+        s = replace_with_chain_which_contains_a_group.s()
+
+        result = s.delay()
+        assert result.get(timeout=TIMEOUT) == [4, 4]
 
     @flaky
     def test_parent_ids(self, manager, num=10):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

The following task

```python
@shared_task(bind=True)
def replace_with_chain_which_contains_a_group(self):
    return self.replace(chain(add.s(1, 2), group(add.s(1), add.s(1))))
```

did not return a result. This PR fixes the issue and now a result is returned correctly instead of hanging until timeout occurs.
