### PR TITLE
Bump pytest-github-actions-annotate-failures from 0.2.0 to 0.3.0

### DIFF
--- a/requirements/test-ci-base.txt
+++ b/requirements/test-ci-base.txt
@@ -1,6 +1,6 @@
 pytest-cov==5.0.0; python_version<"3.9"
 pytest-cov==6.0.0; python_version>="3.9"
-pytest-github-actions-annotate-failures==0.2.0
+pytest-github-actions-annotate-failures==0.3.0
 -r extras/redis.txt
 -r extras/sqlalchemy.txt
 -r extras/pymemcache.txt


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Revert change in https://github.com/celery/celery/pull/9528/files#diff-2de64045524506f4421c2189a87b9df236379e2976758e6d690b06505290eaa4R3 as this is a legitimate version bump.