### PR TITLE
Fix the send_task method when detecting if the native delayed delivery approach is available

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -832,8 +832,8 @@ class Celery:
         options = router.route(
             options, route_name or name, args, kwargs, task_type)
 
-        is_native_delayed_delivery = detect_quorum_queues(self,
-                                                          self.producer_pool.connections.connection.transport_cls)[0]
+        driver_type = self.producer_pool.connections.connection.transport.driver_type
+        is_native_delayed_delivery = detect_quorum_queues(self, driver_type)[0]
         if is_native_delayed_delivery and options['queue'].exchange.type != 'direct':
             if eta:
                 if isinstance(eta, str):

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1448,6 +1448,8 @@ class test_App:
             exchange=exchange,
             routing_key='0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.1.1.1.0.testcelery'
         )
+        driver_type_stub = self.app.amqp.producer_pool.connections.connection.transport.driver_type
+        detect_quorum_queues.assert_called_once_with(self.app, driver_type_stub)
 
     @patch('celery.app.base.detect_quorum_queues', return_value=[True, "testcelery"])
     def test_native_delayed_delivery_eta_datetime(self, detect_quorum_queues):


### PR DESCRIPTION
## Description

The native delayed delivery mechanism for RabbitMQ fails when setting `broker_url` with SSL. This occurs because an incorrect property was passed to the `detect_quorum_queues` method.


I didn't report this issue, no links to attach.
