### PR TITLE
worker_max_memory_per_child: kilobyte is 1024 bytes

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3207,16 +3207,16 @@ it's replaced with a new one. Default is no limit.
 Default: No limit.
 Type: int (kilobytes)
 
-Maximum amount of resident memory, in kilobytes, that may be consumed by a
-worker before it will be replaced by a new worker. If a single
-task causes a worker to exceed this limit, the task will be
-completed, and the worker will be replaced afterwards.
+Maximum amount of resident memory, in kilobytes (1024 bytes), that may be
+consumed by a worker before it will be replaced by a new worker. If a single
+task causes a worker to exceed this limit, the task will be completed, and the
+worker will be replaced afterwards.
 
 Example:
 
 .. code-block:: python
 
-    worker_max_memory_per_child = 12000  # 12MB
+    worker_max_memory_per_child = 12288  # 12 * 1024 = 12 MB
 
 .. setting:: worker_disable_rate_limits
 


### PR DESCRIPTION
## Description

The max RSS value, [provided](https://github.com/celery/billiard/blob/main/billiard/compat.py#L242-L279) and [used](https://github.com/celery/billiard/blob/main/billiard/pool.py#L378-L385) by billiard to determine if a worker process should be recycled based on `worker_max_memory_per_child` is in multiples of 1024 bytes, technically, kibibytes This PR clarifies this in the option's documentation, without introducing the `kibibyte` term, to avoid broader discussion at this point.
