### PR TITLE
Fixed django example

### DIFF
--- a/examples/django/proj/celery.py
+++ b/examples/django/proj/celery.py
@@ -1,7 +1,5 @@
 import os
 
-from django.conf import settings
-
 from celery import Celery
 
 # Set the default Django settings module for the 'celery' program.
@@ -13,7 +11,7 @@ app = Celery('proj')
 # the configuration object to child processes.
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
-app.config_from_object(f'django.conf:{settings.__name__}', namespace='CELERY')
+app.config_from_object('django.conf:settings', namespace='CELERY')
 
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()

--- a/examples/django/proj/urls.py
+++ b/examples/django/proj/urls.py
@@ -1,4 +1,5 @@
-from django.urls import handler404, handler500, include, url  # noqa
+from django.conf.urls import handler404, handler500  # noqa
+from django.urls import include, path  # noqa
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin


### PR DESCRIPTION
```console
cd examples/django/
```
```console
python manage.py migrate
System check identified some issues:

WARNINGS:
demoapp.Widget: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
Operations to perform:
  Apply all migrations: admin, auth, contenttypes, demoapp, sessions
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying admin.0002_logentry_remove_auto_add... OK
  Applying admin.0003_logentry_add_action_flag_choices... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying auth.0007_alter_validators_add_error_messages... OK
  Applying auth.0008_alter_user_username_max_length... OK
  Applying auth.0009_alter_user_last_name_max_length... OK
  Applying auth.0010_alter_group_name_max_length... OK
  Applying auth.0011_update_proxy_permissions... OK
  Applying auth.0012_alter_user_first_name_max_length... OK
  Applying demoapp.0001_initial... OK
  Applying sessions.0001_initial… OK
```
```console
python manage.py runserver
Watching for file changes with StatReloader
Performing system checks...

System check identified some issues:

WARNINGS:
demoapp.Widget: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.

System check identified 1 issue (0 silenced).
February 18, 2025 - 19:24:17
Django version 5.1.6, using settings 'proj.settings'
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.

^C%                                     
```
```console                                                                                                                                                            
celery -A proj worker -l INFO
 
 -------------- celery@Tomers-MacBook-Pro.local v5.4.0 (opalescent)
--- ***** ----- 
-- ******* ---- macOS-15.3.1-arm64-arm-64bit-Mach-O 2025-02-18 19:24:35
- *** --- * --- 
- ** ---------- [config]
- ** ---------- .> app:         proj:0x10241d160
- ** ---------- .> transport:   amqp://guest:**@localhost:5672//
- ** ---------- .> results:     sqlite:///results.sqlite
- *** --- * --- .> concurrency: 10 (prefork)
-- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
--- ***** ----- 
 -------------- [queues]
                .> celery           exchange=celery(direct) key=celery
                

[tasks]
  . demoapp.tasks.add
  . demoapp.tasks.count_widgets
  . demoapp.tasks.mul
  . demoapp.tasks.rename_widget
  . demoapp.tasks.xsum
  . proj.celery.debug_task

[2025-02-18 19:24:35,685: WARNING/MainProcess] /Users/nusnus/.pyenv/versions/3.13.0/envs/celeryexample_django_py313/lib/python3.13/site-packages/celery/worker/consumer/consumer.py:508: CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
whether broker connection retries are made during startup in Celery 6.0 and above.
If you wish to retain the existing behavior for retrying connections on startup,
you should set broker_connection_retry_on_startup to True.
  warnings.warn(

[2025-02-18 19:24:35,693: INFO/MainProcess] Connected to amqp://guest:**@127.0.0.1:5672//
[2025-02-18 19:24:35,694: WARNING/MainProcess] /Users/nusnus/.pyenv/versions/3.13.0/envs/celeryexample_django_py313/lib/python3.13/site-packages/celery/worker/consumer/consumer.py:508: CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
whether broker connection retries are made during startup in Celery 6.0 and above.
If you wish to retain the existing behavior for retrying connections on startup,
you should set broker_connection_retry_on_startup to True.
  warnings.warn(

[2025-02-18 19:24:35,697: INFO/MainProcess] mingle: searching for neighbors
[2025-02-18 19:24:36,715: INFO/MainProcess] mingle: all alone
[2025-02-18 19:24:36,732: INFO/MainProcess] celery@Tomers-MacBook-Pro.local ready.
^C
worker: Hitting Ctrl+C again will terminate all running tasks!

worker: Warm shutdown (MainProcess)
```