### PR TITLE
Set TestWorkController.__test__

### DIFF
--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -30,6 +30,10 @@ test_worker_stopped = Signal(
 class TestWorkController(worker.WorkController):
     """Worker that can synchronize on being fully started."""
 
+    # When this class is imported in pytest files, prevent pytest from thinking
+    # this is a test class
+    __test__ = False
+
     logger_queue = None
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
When importing `TestWorkController` into test files, pytest considers it a test class, causing the following warning:

```
../../../usr/local/lib/python3.11/site-packages/celery/contrib/testing/worker.py:30: 10 warnings
  /usr/local/lib/python3.11/site-packages/celery/contrib/testing/worker.py:30: PytestCollectionWarning: cannot collect test class 'TestWorkController' because it has a __init__ constructor (from: tests/feature_tests/app/api/api_v1/controllers/public/test_certificate_managers.py)
    class TestWorkController(worker.WorkController):
```

Importing this class is common for type annotating, e.g.:

```
test_module.py

from celery.contrib.testing.worker import TestWorkController

def test_stuff(celery_worker: TestWorkController):
  ...
```

Prevent pytest from discovering this class by setting `__test__ = False`. Documentation: https://docs.pytest.org/en/stable/example/pythoncollection.html#customizing-test-collection