### PR TITLE
Clearify docs about infinite max_retries for tasks

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -691,8 +691,8 @@ class Task:
                 this execution.  Changes to this parameter don't propagate to
                 subsequent task retry attempts.  A value of :const:`None`,
                 means "use the default", so if you want infinite retries you'd
-                have to set the :attr:`max_retries` attribute of the task to
-                :const:`None` first.
+                have to set the :attr:`max_retries` attribute of the task class to
+                :const:`None`.
             time_limit (int): If set, overrides the default time limit.
             soft_time_limit (int): If set, overrides the default soft
                 time limit.

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -734,6 +734,17 @@ avoid having all the tasks run at the same moment. It will also cap the
 maximum backoff delay to 10 minutes. All these settings can be customized
 via options documented below.
 
+Retry forever
+------------------------------------
+
+If you want to retry task forever, you should set `max_retries` attribute of the task to ``None``:
+
+.. code-block:: python
+
+    @app.task(max_retries=None)
+    def x():
+        ...
+
 .. versionadded:: 4.4
 
 You can also set `autoretry_for`, `max_retries`, `retry_backoff`, `retry_backoff_max` and `retry_jitter` options in class-based tasks:


### PR DESCRIPTION
## Description

This changes makes docs more clear about infinity retries for tasks.

The changes add the example of passing max_retries=None to the task decorator to build the task with infinity retries. 

Also the changes clarify the docs string of the retry method of the Task removing "first" word, because to make you task retries forever you should only pass the max_retries=None to the Task class itself.
