### PR TITLE
Bugfix: Chord with a chord in header doesn't invoke error callback on inner chord header failure (default config)

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -2307,6 +2307,13 @@ class _chord(Signature):
                 CPendingDeprecationWarning
             )
 
+        # Edge case for nested chords in the header
+        for task in maybe_list(self.tasks) or []:
+            if isinstance(task, chord):
+                # Let the nested chord do the error linking itself on its
+                # header and body where needed, based on the current configuration
+                task.link_error(errback)
+
         self.body.link_error(errback)
         return errback
 

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1746,7 +1746,7 @@ class test_chord(CanvasCase):
             group(signature('t'), signature('t'))
         ]
         for chord_header in headers:
-            c = chord(chord_header, signature('t'))
+            c = chord(chord_header, signature('t'), app=self.app)
             sig = signature('t')
             errback = c.link_error(sig)
             assert errback == sig
@@ -1754,7 +1754,7 @@ class test_chord(CanvasCase):
     @pytest.mark.usefixtures('depends_on_current_app')
     def test_flag_allow_error_cb_on_chord_header_with_dict_callback(self):
         self.app.conf.task_allow_error_cb_on_chord_header = True
-        c = chord(group(signature('th1'), signature('th2')), signature('tbody'))
+        c = chord(group(signature('th1'), signature('th2')), signature('tbody'), app=self.app)
         errback_dict = dict(signature('tcb'))
         errback = c.link_error(errback_dict)
         assert errback == errback_dict
@@ -1783,7 +1783,7 @@ class test_chord(CanvasCase):
     def test_link_error_on_chord_header(self, header):
         """ Test that link_error on a chord also links the header """
         self.app.conf.task_allow_error_cb_on_chord_header = True
-        c = chord(header, signature('body'))
+        c = chord(header, signature('body'), app=self.app)
         err = signature('err')
         errback = c.link_error(err)
         assert errback == err

--- a/t/unit/tasks/test_stamping.py
+++ b/t/unit/tasks/test_stamping.py
@@ -1300,13 +1300,13 @@ class test_stamping_mechanism(CanvasCase):
 
         with subtests.test("chord header"):
             self.app.conf.task_allow_error_cb_on_chord_header = True
-            canvas = chord(tasks(), self.identity.si("body"))
+            canvas = chord(tasks(), self.identity.si("body"), app=self.app)
             canvas.link_error(s("group_link_error"))
             canvas.stamp(CustomStampingVisitor())
 
         with subtests.test("chord body"):
             self.app.conf.task_allow_error_cb_on_chord_header = False
-            canvas = chord(tasks(), self.identity.si("body"))
+            canvas = chord(tasks(), self.identity.si("body"), app=self.app)
             canvas.link_error(s("group_link_error"))
             canvas.stamp(CustomStampingVisitor())
 


### PR DESCRIPTION
Fix #9107

### Before Fix, Test Fails
```console
t/integration/test_canvas.py::test_chord::test_nested_chord_header_link_error [Confirm the body was not executed] SUBPASS
t/integration/test_canvas.py::test_chord::test_nested_chord_header_link_error [Confirm only one errback was called] SUBFAIL
t/integration/test_canvas.py::test_chord::test_nested_chord_header_link_error FAILED
```

### After Fix, Test Passes
```console
t/integration/test_canvas.py::test_chord::test_nested_chord_header_link_error [Confirm the body was not executed] SUBPASS
t/integration/test_canvas.py::test_chord::test_nested_chord_header_link_error [Confirm only one errback was called] SUBPASS
t/integration/test_canvas.py::test_chord::test_nested_chord_header_link_error PASSED
```