### PR TITLE
Fix tests with Click 8.2

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -303,3 +303,4 @@ Shamil Abdulaev, 2024/08/05
 Nikos Atlas, 2024/08/26
 Marc Bresson, 2024/09/02
 Narasux, 2024/09/09
+Colin Watson, 2025/03/01

--- a/t/unit/app/test_preload_cli.py
+++ b/t/unit/app/test_preload_cli.py
@@ -38,7 +38,7 @@ def test_preload_options(subcommand_with_params: Tuple[str, ...], isolated_cli_r
         catch_exceptions=False,
     )
 
-    assert "No such option: --ini" in res_without_preload.stdout
+    assert "No such option: --ini" in res_without_preload.output
     assert res_without_preload.exit_code == 2
 
     res_with_preload = isolated_cli_runner.invoke(
@@ -53,4 +53,4 @@ def test_preload_options(subcommand_with_params: Tuple[str, ...], isolated_cli_r
         catch_exceptions=False,
     )
 
-    assert res_with_preload.exit_code == 0, res_with_preload.stdout
+    assert res_with_preload.exit_code == 0, res_with_preload.output

--- a/t/unit/bin/test_control.py
+++ b/t/unit/bin/test_control.py
@@ -33,8 +33,8 @@ def test_custom_remote_command(celery_cmd, custom_cmd, isolated_cli_runner: CliR
         [*_GLOBAL_OPTIONS, celery_cmd, *_INSPECT_OPTIONS, *custom_cmd],
         catch_exceptions=False,
     )
-    assert res.exit_code == EX_UNAVAILABLE, (res, res.stdout)
-    assert res.stdout.strip() == 'Error: No nodes replied within time constraint'
+    assert res.exit_code == EX_UNAVAILABLE, (res, res.output)
+    assert res.output.strip() == 'Error: No nodes replied within time constraint'
 
 
 @pytest.mark.parametrize(
@@ -54,8 +54,8 @@ def test_unrecognized_remote_command(celery_cmd, remote_cmd, isolated_cli_runner
         [*_GLOBAL_OPTIONS, celery_cmd, *_INSPECT_OPTIONS, remote_cmd],
         catch_exceptions=False,
     )
-    assert res.exit_code == 2, (res, res.stdout)
-    assert f'Error: Command {remote_cmd} not recognized. Available {celery_cmd} commands: ' in res.stdout
+    assert res.exit_code == 2, (res, res.output)
+    assert f'Error: Command {remote_cmd} not recognized. Available {celery_cmd} commands: ' in res.output
 
 
 _expected_inspect_regex = (


### PR DESCRIPTION
## Description

https://github.com/pallets/click/pull/2523 introduced changes to `click.testing.Result` that broke a few unit tests in celery.  Although this Click version hasn't been fully released yet, this adjusts Celery to work with both old and new versions.