### PR TITLE
remove [bdist_wheel] universal = 0  from setup.cfg as not needed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,6 @@ requires = backports.zoneinfo>=0.2.1;python_version<'3.9'
            billiard >=4.1.0,<5.0
            kombu >= 5.3.4,<6.0.0
 
-[bdist_wheel]
-universal = 0
 
 [metadata]
 license_files = LICENSE


### PR DESCRIPTION
this do not need anymore in python3 only setup

