### PR TITLE
remove importlib-metadata as not needed in python3.8 anymore

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,6 +5,5 @@ click>=8.1.2,<9.0
 click-didyoumean>=0.3.0
 click-repl>=0.2.0
 click-plugins>=1.1.1
-importlib-metadata>=3.6; python_version < '3.8'
 backports.zoneinfo[tzdata]>=0.2.1; python_version < '3.9'
 python-dateutil>=2.8.2


### PR DESCRIPTION
is there anywhere else we need to remove this?