### PR TITLE
feat: define exception_safe_to_retry for redisbackend

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -359,6 +359,11 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         connparams.update(query)
         return connparams
 
+    def exception_safe_to_retry(self, exc):
+        if isinstance(exc, self.connection_errors):
+            return True
+        return False
+
     @cached_property
     def retry_policy(self):
         retry_policy = super().retry_policy


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description
As `exception_safe_to_retry()` is currently not defined for RedisBackend, operations like `store_result` or `get_task_meta` do not retry even with `result_backend_always_retry=True`.

This PR proposes to retry those operations on `self.connection_errors` in a similar fashion to the `ElastichsearchBackend`.

Fixes #9613.
 
<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
