### PR TITLE
[docs] fix first-steps

### DIFF
--- a/docs/getting-started/first-steps-with-celery.rst
+++ b/docs/getting-started/first-steps-with-celery.rst
@@ -245,7 +245,7 @@ the message broker (a popular combination):
 
 To read more about result backends please see :ref:`task-result-backends`.
 
-Now with the result backend configured, close the current python session and import the
+Now with the result backend configured, restart the worker, close the current python session and import the
 ``tasks`` module again to put the changes into effect. This time you'll hold on to the
 :class:`~@AsyncResult` instance returned when you call a task:
 


### PR DESCRIPTION
Worker must restart after a backend change.

Otherwise, the `result.get()` call would time out.
