### PR TITLE
#9597: Ensure surpassing Hard Timeout limit when task_acks_on_failure_or_timeout is False rejects the task

### DIFF
--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -602,8 +602,8 @@ class Request:
         is_worker_lost = isinstance(exc, WorkerLostError)
         if self.task.acks_late:
             reject = (
-                self.task.reject_on_worker_lost and
-                is_worker_lost
+                (self.task.reject_on_worker_lost and is_worker_lost)
+                or (isinstance(exc, TimeLimitExceeded) and not self.task.acks_on_failure_or_timeout)
             )
             ack = self.task.acks_on_failure_or_timeout
             if reject:


### PR DESCRIPTION
## Description

Ensure surpassing Hard Timeout limit when `task_acks_on_failure_or_timeout` is False rejects the task

Fixes  #9596 
