### PR TITLE
Fix for apply_async(ignore_result=False)

### DIFF
--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -327,7 +327,7 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
     fun = task if task_has_custom(task, '__call__') else task.run
 
     loader = loader or app.loader
-    ignore_result = task.ignore_result
+    ignore_result = task.request.ignore_result
     track_started = task.track_started
     track_started = not eager and (task.track_started and not ignore_result)
 


### PR DESCRIPTION
`apply_async(ignore_result=False)` now stores the result when `celeryconfig` has `task_ignore_results=True`

See bug description on https://github.com/celery/celery/issues/9654 