### PR TITLE
Remove `setup_logger` from COMPAT_MODULES

### DIFF
--- a/celery/local.py
+++ b/celery/local.py
@@ -397,7 +397,6 @@ COMPAT_MODULES = {
         },
         'log': {
             'get_default_logger': 'log.get_default_logger',
-            'setup_logger': 'log.setup_logger',
             'setup_logging_subsystem': 'log.setup_logging_subsystem',
             'redirect_stdouts_to_logger': 'log.redirect_stdouts_to_logger',
         },


### PR DESCRIPTION
In commit 5a0c4585, the deprecated `log.setup_logger` method was removed; however `COMPAT_MODULES` didn't receive the requisite update.

The issue doesn't really manifest itself in normal usage of Celery. It was only when using `gc.get_objects()` that it triggered a `repr` in Celery to fail.

```
File "/python3.12/site-packages/celery/local.py", line 121, in __repr__ obj = self._get_current_object()
      ^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/python3.12/site-packages/celery/local.py", line 105, in _get_current_object return loc(*self.__args, **self.__kwargs)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/python3.12/site-packages/celery/local.py", line 390, in getappattr return current_app._rgetattr(path)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/python3.12/site-packages/celery/app/base.py", line 1245, in _rgetattr return attrgetter(path)(self)
       ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Logging' object has no attribute 'setup_logger'
```

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
