### PR TITLE
Fix mongodb bullet and fix github links in contributions section

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -445,10 +445,10 @@ fetch and checkout a remote branch like this::
 
 **Note:** Any feature or fix branch should be created from ``upstream/main``.
 
-.. _`Fork a Repo`: https://help.github.com/fork-a-repo/
+.. _`Fork a Repo`: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
 .. _`Rebasing merge commits in git`:
     https://web.archive.org/web/20150627054345/http://marketblog.envato.com/general/rebasing-merge-commits-in-git/
-.. _`Rebase`: https://help.github.com/rebase/
+.. _`Rebase`: https://docs.github.com/en/get-started/using-git/about-git-rebase
 
 .. _contributing-docker-development:
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -686,7 +686,7 @@ Can be one of the following:
     Use `Memcached`_ to store the results.
     See :ref:`conf-cache-result-backend`.
 
-*``mongodb``
+* ``mongodb``
     Use `MongoDB`_ to store the results.
     See :ref:`conf-mongodb-result-backend`.
 


### PR DESCRIPTION
## Description

This PR fixes a bullet point for mongodb in the task result backend settings docs and updates a link to Github on forking repos.
