### PR TITLE
Added DeepWiki to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,7 @@
 :Web: https://docs.celeryq.dev/en/stable/index.html
 :Download: https://pypi.org/project/celery/
 :Source: https://github.com/celery/celery/
+:DeepWiki: |deepwiki|
 :Keywords: task, queue, job, async, rabbitmq, amqp, redis,
   python, distributed, actors
 
@@ -584,3 +585,8 @@ file in the top distribution directory for the full license text.
 .. |downloads| image:: https://pepy.tech/badge/celery
     :alt: Downloads
     :target: https://pepy.tech/project/celery
+
+.. |deepwiki| image:: https://devin.ai/assets/deepwiki-badge.png
+    :alt: Ask http://DeepWiki.com
+    :target: https://deepwiki.com/celery/celery
+    :width: 125px


### PR DESCRIPTION
The team from [Cognition.ai](https://cognition.ai/) has introduced a new AI-based documentation that is free for open-source projects called DeepWiki.

Official Announcement from X: https://x.com/cognition_labs/status/1915816544480989288

This PR adds a link to the celery’s deepwiki in the main README:
![CleanShot 2025-05-03 at 17 06 38@2x](https://github.com/user-attachments/assets/8b386bb8-4d43-461e-b26f-c21e7d654bc9)

Check it out live:
[<img src="https://devin.ai/assets/deepwiki-badge.png" alt="Ask http://DeepWiki.com" height="20"/>](https://deepwiki.com/celery/celery)

![CleanShot 2025-05-03 at 17 00 34@2x](https://github.com/user-attachments/assets/6f740243-8ccc-449c-a80b-4bc4df0e760a)
