### PR TITLE
Support apply_async without queue argument on quorum queues

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -833,8 +833,9 @@ class Celery:
             options, route_name or name, args, kwargs, task_type)
 
         driver_type = self.producer_pool.connections.connection.transport.driver_type
+        quorum_queues_detected = detect_quorum_queues(self, driver_type)
 
-        if (eta or countdown) and detect_quorum_queues(self, driver_type)[0]:
+        if (eta or countdown) and quorum_queues_detected[0]:
 
             queue = options.get("queue")
             exchange_type = queue.exchange.type if queue else options["exchange_type"]

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -833,9 +833,8 @@ class Celery:
             options, route_name or name, args, kwargs, task_type)
 
         driver_type = self.producer_pool.connections.connection.transport.driver_type
-        quorum_queues_detected = detect_quorum_queues(self, driver_type)
 
-        if (eta or countdown) and quorum_queues_detected[0]:
+        if (eta or countdown) and detect_quorum_queues(self, driver_type)[0]:
 
             queue = options.get("queue")
             exchange_type = queue.exchange.type if queue else options["exchange_type"]

--- a/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
+++ b/t/smoke/tests/quorum_queues/test_native_delayed_delivery.py
@@ -127,6 +127,32 @@ class test_native_delayed_delivery:
 
         result.get(timeout=10)
 
+    def test_countdown__no_queue_arg(self, celery_setup: CeleryTestSetup):
+        task_route_function = lambda *args, **kwargs: {  # noqa: E731
+            "routing_key": "celery",
+            "exchange": "celery",
+            "exchange_type": "topic",
+        }
+        celery_setup.app.conf.task_routes = (task_route_function,)
+        s = noop.s().set()
+
+        result = s.apply_async()
+
+        result.get(timeout=3)
+
+    def test_countdown__no_queue_arg__countdown(self, celery_setup: CeleryTestSetup):
+        task_route_function = lambda *args, **kwargs: {  # noqa: E731
+            "routing_key": "celery",
+            "exchange": "celery",
+            "exchange_type": "topic",
+        }
+        celery_setup.app.conf.task_routes = (task_route_function,)
+        s = noop.s().set()
+
+        result = s.apply_async(countdown=5)
+
+        result.get(timeout=10)
+
     def test_eta(self, celery_setup: CeleryTestSetup):
         s = noop.s().set(queue=celery_setup.worker.worker_queue)
 


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

- Added support for `apply_async` calls without queue argument
- Reduce logic if no eta/countdown specified 
- Added unit and smoke tests

Fixing an issue I found - https://github.com/celery/celery/issues/9685.

## Verifications 

### Smoke tests
```
uvx --with . --with pytest_celery --with pytest --with pdbpp --with redis --with pydantic --with pytest-xdist pytest t/smoke/tests/quorum_queues/test_native_delayed_delivery.py -v -k no_queue_arg -s -n 2
```
![image](https://github.com/user-attachments/assets/af069770-4780-47b0-a5b5-5f984db7cdab)

### Unit tests
```
cd ~/Code/celery/docker
docker compose run -it --rm celery bash
pyenv exec python3.12 -m pytest t/unit/app/test_app.py -k no_queue_arg -v
```

![image](https://github.com/user-attachments/assets/3743089a-696c-4781-8b45-d758c752258b)
