### PR TITLE
Make wheel metadata reproducible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ NAME = 'celery'
 
 # -*- Extras -*-
 
-EXTENSIONS = {
+EXTENSIONS = (
     'arangodb',
     'auth',
     'azureblockblob',
@@ -43,7 +43,7 @@ EXTENSIONS = {
     'yaml',
     'zookeeper',
     'zstd'
-}
+)
 
 # -*- Distribution Meta -*-
 


### PR DESCRIPTION
## Description

The various `Provides-Extra` sections in the built wheel's `METADATA` file were shuffled arbitrarily between different builds, which made it more difficult to detect other reproducibility issues (see https://reproducible-builds.org/).  There doesn't seem any reason for `EXTENSIONS` here to be a set; a tuple will work just as well, and adds an ordering guarantee.