### PR TITLE
Updated rabbitmq doc about using quorum queues with task routes

### DIFF
--- a/docs/getting-started/backends-and-brokers/rabbitmq.rst
+++ b/docs/getting-started/backends-and-brokers/rabbitmq.rst
@@ -196,6 +196,21 @@ Celery supports `Quorum Queues`_ by setting the ``x-queue-type`` header to ``quo
 
 If you'd like to change the type of the default queue, set the :setting:`task_default_queue_type` setting to ``quorum``.
 
+Another way to configure `Quorum Queues`_ is by relying on default settings and using ``task_routes``:
+
+.. code-block:: python
+
+    task_default_queue_type = "quorum"
+    task_default_exchange_type = "topic"
+    task_default_queue = "my-queue"
+    broker_transport_options = {"confirm_publish": True}
+
+    task_routes = {
+        "*": {
+            "routing_key": "my-queue",
+        },
+    }
+
 Celery automatically detects if quorum queues are used using the :setting:`worker_detect_quorum_queues` setting.
 We recommend to keep the default behavior turned on.
 


### PR DESCRIPTION
## Description

Updated rabbitmq doc about using quorum queues with task routes.

After the pull request fixing the bug was merged - https://github.com/celery/celery/pull/9686. 


## Verification 

```
docker compose -f docker/docker-compose.yml up --build docs
```

http://localhost:7001/getting-started/backends-and-brokers/rabbitmq.html

![image](https://github.com/user-attachments/assets/3e2567b7-03fb-426f-8fb7-8b4a92eefab7)
