### PR TITLE
Fixes issue with retry callback arguments in DelayedDelivery

### DIFF
--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -3,7 +3,7 @@
 This module provides the DelayedDelivery bootstep which handles setup and configuration
 of native delayed delivery functionality when using quorum queues.
 """
-from typing import List, Optional, Set, Union, ValuesView
+from typing import Iterator, List, Optional, Set, Union, ValuesView
 
 from kombu import Connection, Queue
 from kombu.transport.native_delayed_delivery import (bind_queue_to_native_delayed_delivery_exchange,
@@ -168,11 +168,12 @@ class DelayedDelivery(bootsteps.StartStopStep):
                 )
                 raise
 
-    def _on_retry(self, exc: Exception, intervals_count: int) -> None:
+    def _on_retry(self, exc: Exception, interval_range: Iterator[float], intervals_count: int) -> None:
         """Callback for retry attempts.
 
         Args:
             exc: The exception that triggered the retry
+            interval_range: An iterator which returns the time in seconds to sleep next
             intervals_count: Number of retry attempts so far
         """
         logger.warning(

--- a/t/unit/worker/test_native_delayed_delivery.py
+++ b/t/unit/worker/test_native_delayed_delivery.py
@@ -1,10 +1,13 @@
+import itertools
 from logging import LogRecord
+from typing import Iterator
 from unittest.mock import Mock, patch
 
 import pytest
 from kombu import Exchange, Queue
+from kombu.utils.functional import retry_over_time
 
-from celery.worker.consumer.delayed_delivery import DelayedDelivery
+from celery.worker.consumer.delayed_delivery import MAX_RETRIES, RETRY_INTERVAL, DelayedDelivery
 
 
 class test_DelayedDelivery:
@@ -151,13 +154,57 @@ class test_DelayedDelivery:
         delayed_delivery = DelayedDelivery(Mock())
         exc = ConnectionRefusedError("Connection refused")
 
-        delayed_delivery._on_retry(exc, 1)
+        # Create a dummy float iterator
+        interval_range = iter([1.0, 2.0, 3.0])
+        intervals_count = 1
+
+        delayed_delivery._on_retry(exc, interval_range, intervals_count)
 
         assert len(caplog.records) == 1
         record = caplog.records[0]
         assert record.levelname == "WARNING"
         assert "attempt 2/3" in record.message
         assert "Connection refused" in record.message
+
+    def test_on_retry_argument_types(self):
+        delayed_delivery_instance = DelayedDelivery(parent=Mock())
+        fake_exception = ConnectionRefusedError("Simulated failure")
+
+        # Define a custom errback to check types
+        def type_checking_errback(self, exc, interval_range, intervals_count):
+            assert isinstance(exc, Exception), f"Expected Exception, got {type(exc)}"
+            assert isinstance(interval_range, Iterator), f"Expected Iterator, got {type(interval_range)}"
+            assert isinstance(intervals_count, int), f"Expected int, got {type(intervals_count)}"
+
+            peek_iter, interval_range = itertools.tee(interval_range)
+            try:
+                first = next(peek_iter)
+                assert isinstance(first, float)
+            except StopIteration:
+                pass
+
+            return 0.1
+
+        # Patch _setup_delayed_delivery to raise the exception immediately
+        with patch.object(delayed_delivery_instance, '_setup_delayed_delivery', side_effect=fake_exception):
+            # Patch _on_retry properly as a bound method to avoid 'missing self'
+            with patch.object(
+                delayed_delivery_instance,
+                '_on_retry',
+                new=type_checking_errback.__get__(delayed_delivery_instance)
+            ):
+                try:
+                    with pytest.raises(ConnectionRefusedError):
+                        retry_over_time(
+                            delayed_delivery_instance._setup_delayed_delivery,
+                            args=(Mock(), "amqp://localhost"),
+                            catch=(ConnectionRefusedError,),
+                            errback=delayed_delivery_instance._on_retry,
+                            interval_start=RETRY_INTERVAL,
+                            max_retries=MAX_RETRIES,
+                        )
+                except ConnectionRefusedError:
+                    pass  # expected
 
     def test_start_with_no_queues(self, caplog):
         consumer_mock = Mock()


### PR DESCRIPTION
## Description

When setting up the `errback` on `retry_over_time` call during the `start` of the `DelayedDelivery` bootstep, the `_on_retry` method is being used. Reference [here](https://github.com/celery/celery/blob/5c1a13cffe0331391bf8bc808196a1573f8922ad/celery/worker/consumer/delayed_delivery.py#L84-L91).

If we check the signature of the expected function/method for the `errback` in kombu we can see the function/method should expect 3 arguments. Reference [here](https://github.com/celery/kombu/blob/56c1129586bbc4e6af6ff052f4d4791e95419f34/kombu/utils/functional.py#L293-L298).

The `_on_retry` method being used currently expects only 2 arguments. Reference [here](https://github.com/celery/celery/blob/5c1a13cffe0331391bf8bc808196a1573f8922ad/celery/worker/consumer/delayed_delivery.py#L171).

This causes the setup of delayed delivery to completely fail if it encounters an issue on its first try, because it will not be able to retry due to the arguments mismatch mentioned above.

This PR aims to fix the signature of the `_on_retry` method to make it compatible with the expected interface for `errback`.

### ✅ PR Checklist

- [x] I have added **unit tests** to cover the change.
- [x] I have verified that **test coverage does not decrease**.
- [x] I have run `pre-commit` or `tox -e lint` to ensure **style and lint checks pass**.


