### PR TITLE
Add: Dumper Unit Test

### DIFF
--- a/t/unit/events/test_dumper.py
+++ b/t/unit/events/test_dumper.py
@@ -1,0 +1,71 @@
+import io
+import sys
+from datetime import datetime
+import pytest
+from celery.events import dumper
+
+
+def test_humanize_type():
+    assert dumper.humanize_type('worker-online') == 'started'
+    assert dumper.humanize_type('worker-offline') == 'shutdown'
+    assert dumper.humanize_type('worker-heartbeat') == 'heartbeat'
+
+
+def test_dumper_say():
+    buf = io.StringIO()
+    d = dumper.Dumper(out=buf)
+    d.say('hello world')
+    assert 'hello world' in buf.getvalue()
+
+
+def test_format_task_event_output():
+    buf = io.StringIO()
+    d = dumper.Dumper(out=buf)
+    d.format_task_event(
+        hostname='worker1',
+        timestamp=datetime(2024, 1, 1, 12, 0, 0),
+        type='task-succeeded',
+        task='mytask(123) args=(1,) kwargs={}',
+        event={'result': 'ok', 'foo': 'bar'}
+    )
+    output = buf.getvalue()
+    assert 'worker1 [2024-01-01 12:00:00]' in output
+    assert 'task succeeded' in output
+    assert 'mytask(123) args=(1,) kwargs={}' in output
+    assert 'result=ok' in output
+    assert 'foo=bar' in output
+
+
+def test_on_event_task_received():
+    buf = io.StringIO()
+    d = dumper.Dumper(out=buf)
+    event = {
+        'timestamp': datetime(2024, 1, 1, 12, 0, 0).timestamp(),
+        'type': 'task-received',
+        'hostname': 'worker1',
+        'uuid': 'abc',
+        'name': 'mytask',
+        'args': '(1,)',
+        'kwargs': '{}',
+    }
+    d.on_event(event.copy())
+    output = buf.getvalue()
+    assert 'worker1 [2024-01-01 12:00:00]' in output
+    assert 'task received' in output
+    assert 'mytask(abc) args=(1,) kwargs={}' in output
+
+
+def test_on_event_non_task():
+    buf = io.StringIO()
+    d = dumper.Dumper(out=buf)
+    event = {
+        'timestamp': datetime(2024, 1, 1, 12, 0, 0).timestamp(),
+        'type': 'worker-online',
+        'hostname': 'worker1',
+        'foo': 'bar',
+    }
+    d.on_event(event.copy())
+    output = buf.getvalue()
+    assert 'worker1 [2024-01-01 12:00:00]' in output
+    assert 'started' in output
+    assert 'foo=bar' in output


### PR DESCRIPTION
# Pull Request Description

## Description

This pull request adds direct unit tests for the dumper.py module in `celery/events`.  
The new tests cover:

- humanize_type function: Ensures event type strings are correctly humanized.
- `Dumper.say`: Verifies output to the provided stream.
- `Dumper.format_task_event`: Checks formatted output for task events.
- `Dumper.on_event`: Validates output for both task and non-task events.

These tests improve the coverage and reliability of the event dumper utility, making future refactoring safer and easier to review.

No production code is changed; this PR only enhances the test suite.