### PR TITLE
refactor: add beat_cron_starting_deadline documentation warning

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3934,6 +3934,10 @@ When using cron, the number of seconds :mod:`~celery.bin.beat` can look back
 when deciding whether a cron schedule is due. When set to `None`, cronjobs that
 are past due will always run immediately.
 
+.. warning::
+
+    Setting this higher than 3600 (1 hour) is highly discouraged.
+
 .. setting:: beat_logfile
 
 ``beat_logfile``


### PR DESCRIPTION
## Description

according to https://github.com/celery/django-celery-beat/issues/809 comments and https://github.com/celery/django-celery-beat/pull/899 , I have added a warning in beat_cron_starting_deadline section of document to discourage people from setting this config higher than 3600