### PR TITLE
ISSUE-9704: Update documentation of result_expires, filesystem backend is supported

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -885,9 +885,9 @@ on backend specifications).
 .. note::
 
     For the moment this only works with the AMQP, database, cache, Couchbase,
-    and Redis backends.
+    filesystem and Redis backends.
 
-    When using the database backend, ``celery beat`` must be
+    When using the database or filesystem backend, ``celery beat`` must be
     running for the results to be expired.
 
 .. setting:: result_cache_max


### PR DESCRIPTION
ISSUE-9704: Update documentation of result_expires, filesystem backend is supported if celery beat is active

## Description
Fixes #9704 by updating the `result_expires` userguide documentation since filesystem backends support it since 7 years.

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
