### PR TITLE
docs: mention of json serializer recursive reference message size blowup (#5000)

### DIFF
--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -517,6 +517,13 @@ json -- JSON is supported in many programming languages, is now
         the original one. That is, ``loads(dumps(x)) != x`` if x has non-string
         keys.
 
+    .. warning::
+
+        With more complex workflows created using :ref:`guide-canvas`, the JSON
+        serializer has been observed to drastically inflate message sizes due to
+        recursive references, leading to resource issues. The *pickle* serializer
+        is not vulnerable to this and may therefore be preferable in such cases.
+
 pickle -- If you have no desire to support any language other than
     Python, then using the pickle encoding will gain you the support of
     all built-in Python data types (except class instances), smaller

--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -467,6 +467,14 @@ Here're some examples:
         8
 
 
+.. warning::
+
+    :ref:`guide-routing`.
+    With more complex workflows, the default JSON serializer has been observed to
+    drastically inflate message sizes due to recursive references, leading to
+    resource issues. The *pickle* serializer is not vulnerable to this and may
+    therefore be preferable in such cases.
+
 .. _canvas-chain:
 
 Chains


### PR DESCRIPTION
## Description

Warn in the docs about using json serializer with complex workflows, as discussed in https://github.com/celery/celery/discussions/7029#discussioncomment-13375291

Here is how I isolated the issue to the serializer and recursive references
https://github.com/celery/celery/discussions/7029#discussioncomment-13375579

The docs make some mention of recursive references under the *yaml* serializer, but for me only *pickle* worked for sidestepping the message size issue
https://docs.celeryq.dev/en/stable/userguide/calling.html#serializers:~:text=recursive%20references