### PR TITLE
docs: typo in canvas.rst

### DIFF
--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -469,7 +469,6 @@ Here're some examples:
 
 .. warning::
 
-    :ref:`guide-routing`.
     With more complex workflows, the default JSON serializer has been observed to
     drastically inflate message sizes due to recursive references, leading to
     resource issues. The *pickle* serializer is not vulnerable to this and may


### PR DESCRIPTION
## Description

Followup to https://github.com/celery/celery/pull/9743 -- remove unintended line that got added because I was copypasting around a snippet to get the rst syntax

cc: @auvipy Thanks for the quick merge of the last one; I spotted this mistake while looking at the rendering of `main` docs (https://docs.celeryq.dev/en/main/userguide/canvas.html)