### PR TITLE
Improve user-friendly error messages for result backend in CLI

### DIFF
--- a/celery/bin/result.py
+++ b/celery/bin/result.py
@@ -3,6 +3,11 @@ import click
 
 from celery.bin.base import CeleryCommand, CeleryOption, handle_preload_options
 
+try:
+    from redis.exceptions import ConnectionError as RedisConnectionError
+except ImportError:
+    RedisConnectionError = None
+
 
 @click.command(cls=CeleryCommand)
 @click.argument('task_id')
@@ -24,7 +29,16 @@ def result(ctx, task_id, task, traceback):
 
     result_cls = app.tasks[task].AsyncResult if task else app.AsyncResult
     task_result = result_cls(task_id)
-    value = task_result.traceback if traceback else task_result.get()
-
-    # TODO: Prettify result
-    ctx.obj.echo(value)
+    try:
+        value = task_result.traceback if traceback else task_result.get()
+        ctx.obj.echo(value)
+    except NotImplementedError:
+        ctx.obj.echo("[Error] Celery result_backend is not configured. Cannot fetch task results.\nPlease add result_backend to your configuration, e.g.: result_backend='redis://localhost:6379/0'", err=True)
+    except (ConnectionError, OSError) as exc:
+        ctx.obj.echo(f"[Error] Cannot connect to result_backend: {exc}\nPlease check your configuration and ensure the backend service (e.g., Redis, database) is running.", err=True)
+    except Exception as exc:
+        # Also catch redis.exceptions.ConnectionError if available
+        if RedisConnectionError and isinstance(exc, RedisConnectionError):
+            ctx.obj.echo(f"[Error] Cannot connect to result_backend: {exc}\nPlease check your configuration and ensure the backend service (e.g., Redis, database) is running.", err=True)
+        else:
+            ctx.obj.echo(f"[Error] An unexpected error occurred while fetching task result: {exc}", err=True)


### PR DESCRIPTION
1. Show clear error when result_backend is not configured or cannot connect (e.g., Redis not running)
2. Catch redis.exceptions.ConnectionError for better compatibility
3. Make CLI output more helpful for end users
