### PR TITLE
Use durable=True by default everywhere

### DIFF
--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -331,7 +331,7 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
     def binding(self):
         return self.Queue(
             self.oid, self.exchange, self.oid,
-            durable=False,
+            durable=True,
             auto_delete=True,
             expires=self.expires,
         )

--- a/celery/bin/amqp.py
+++ b/celery/bin/amqp.py
@@ -81,10 +81,10 @@ def amqp(ctx):
                 default=False)
 @click.argument('durable',
                 type=bool,
-                default=False)
+                default=True)
 @click.argument('auto_delete',
                 type=bool,
-                default=False)
+                default=True)
 @click.pass_obj
 def exchange_declare(amqp_context, exchange, type, passive, durable,
                      auto_delete):
@@ -158,7 +158,7 @@ def queue_bind(amqp_context, queue, exchange, routing_key):
                 default=False)
 @click.argument('durable',
                 type=bool,
-                default=False)
+                default=True)
 @click.argument('auto_delete',
                 type=bool,
                 default=False)

--- a/celery/events/receiver.py
+++ b/celery/events/receiver.py
@@ -52,7 +52,7 @@ class EventReceiver(ConsumerMixin):
             '.'.join([self.queue_prefix, self.node_id]),
             exchange=self.exchange,
             routing_key=self.routing_key,
-            auto_delete=True, durable=False,
+            auto_delete=True, durable=True,
             message_ttl=queue_ttl,
             expires=queue_expires,
         )

--- a/t/benchmarks/bench_worker.py
+++ b/t/benchmarks/bench_worker.py
@@ -28,8 +28,8 @@ app.conf.update(
             'exchange': 'bench.worker',
             'routing_key': 'bench.worker',
             'no_ack': True,
-            'exchange_durable': False,
-            'queue_durable': False,
+            'exchange_durable': True,
+            'queue_durable': True,
             'auto_delete': True,
         }
     },


### PR DESCRIPTION
## Description

Trying the variant where all queues and exchanges are durable by default.

Discussed at issue [2237](https://github.com/celery/kombu/issues/2237)
RabbitMQ recommendation: [DOC](https://www.rabbitmq.com/docs/queues#durability)
Related to the `kombu` [PR](https://github.com/celery/kombu/pull/2313).

Conf: `cat /etc/rabbitmq/rabbitmq.conf`

```
# https://www.rabbitmq.com/docs/deprecated-features
deprecated_features.permit.transient_nonexcl_queues = false
```

A pretty simple `fix` just changed booleans to `durable=True`

Tested in my DEV environment.
Now running at prod version.

No issues with tasks, queues, managing and pinging/inspecting queues and workers.

I didn't run bundled tests, however. 
Only relied upon my envs.


<details>
  <summary>My celery conf</summary>

```python
def celery_setup():
    # Get creds and hosts
    setup_celery_env()
    # Setup django project
    django.setup()
    #  The backend is specified via the backend argument to Celery
    global app
    if app is None:
        app = Celery('server',
                     broker=RabbitMQCreds.BROKER,
                     backend=backend,
                     )

    app.conf.timezone = 'UTC'
    app.conf.enable_utc = True
    # General config:
    app.conf.update(
        result_backend=result_backend,
        accept_content=['pickle'],
        task_serializer='pickle',
        result_serializer='pickle',
        result_extended=True,
        task_track_started=True,
        beat_scheduler='django_celery_beat.schedulers:DatabaseScheduler',
        database_engine_options={'pool_timeout': 90},
        worker_prefetch_multiplier=1,
        worker_concurrency=1,
        worker_timer_precision=1.0,
        broker_heartbeat=10.0,
        broker_heartbeat_checkrate=2.0,
    )

    app.autodiscover_tasks()
    app.conf.update(
        worker_max_memory_per_child=1024 * 100,
        worker_max_tasks_per_child=100,
        worker_proc_alive_timeout=5.0,
        task_acks_late=False,
        task_acks_on_failure_or_timeout=True,
        worker_cancel_long_running_tasks_on_connection_loss=True,
        task_reject_on_worker_lost=False,
        worker_pool_restarts=True,
        worker_enable_remote_control=True,
        worker_lost_wait=20,
        broker_connection_retry_on_startup=True,
        broker_connection_retry=True,
        broker_connection_max_retries=0,
        broker_connection_timeout=4.0,
        broker_channel_error_retry=True,
        broker_pool_limit=100,
        task_send_sent_event=True,
        worker_send_task_events=True,
        worker_disable_rate_limits=True,
        task_default_queue='w_routines@tentacle.dq2',
        task_default_exchange='someserver',
        task_default_routing_key='w_routines@tentacle.dq2',
        worker_direct=True,
        result_persistent=True,
        task_default_delivery_mode='persistent',
    )
```
</details>

