### PR TITLE
fix: (#9773) task_id must not be empty with chain as body of a chord

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -2234,9 +2234,8 @@ class _chord(Signature):
             options.pop('task_id', None)
             body.options.update(options)
 
-        # Use group_id as task_id to ensure the chord body gets the
-        # correct ID for error propagation when group tasks fail
-        bodyres = body.freeze(group_id, root_id=root_id)
+        body_task_id = task_id or uuid()
+        bodyres = body.freeze(body_task_id, group_id=group_id, root_id=root_id)
 
         # Chains should not be passed to the header tasks. See #3771
         options.pop('chain', None)

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -2234,7 +2234,9 @@ class _chord(Signature):
             options.pop('task_id', None)
             body.options.update(options)
 
-        bodyres = body.freeze(task_id, root_id=root_id)
+        # Use group_id as task_id to ensure the chord body gets the
+        # correct ID for error propagation when group tasks fail
+        bodyres = body.freeze(group_id, root_id=root_id)
 
         # Chains should not be passed to the header tasks. See #3771
         options.pop('chain', None)

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -3152,7 +3152,7 @@ class test_chord:
         redis_connection.delete(errback_key, body_key)
 
     @pytest.mark.parametrize(
-        "body",
+        "input_body",
         [
             (lambda: add.si(9, 7)),
             (

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -3194,9 +3194,9 @@ class test_chord:
     def test_chord_error_propagation_with_different_body_types(
         self, manager, caplog, input_body
     ) -> None:
-        """Integration test for issue #8578: task_id must not be empty on chain of groups.
+        """Integration test for issue #9773: task_id must not be empty on chain of groups.
 
-        This test reproduces the exact scenario from GitHub issue #8578 where a chord
+        This test reproduces the exact scenario from GitHub issue #9773 where a chord
         with a failing group task and a chain body causes a ValueError during error handling.
 
         The test verifies that:

--- a/t/smoke/tests/test_canvas.py
+++ b/t/smoke/tests/test_canvas.py
@@ -105,7 +105,7 @@ class test_chord:
         assert res.get(timeout=RESULT_TIMEOUT) == ["body_task"] * 3
 
     @pytest.mark.parametrize(
-        "body",
+        "input_body",
         [
             (lambda queue: add.si(9, 7).set(queue=queue)),
             (

--- a/t/smoke/tests/test_canvas.py
+++ b/t/smoke/tests/test_canvas.py
@@ -147,7 +147,7 @@ class test_chord:
     def test_chord_error_propagation_with_different_body_types(
         self, celery_setup: CeleryTestSetup, input_body
     ) -> None:
-        """Reproduce issue #8578 with different chord body types.
+        """Reproduce issue #9773 with different chord body types.
 
         This test verifies that the "task_id must not be empty" error is fixed
         regardless of the chord body type. The issue occurs when:

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1841,10 +1841,10 @@ class test_chord(CanvasCase):
         # Run the chord
         result = test_chord.run(header, body, (), task_id="external-task-id")
 
-        # Verify the body now has a proper ID set (should be the group_id)
-        # This is checked by accessing the body's ID after freezing
-        assert body.id == group_id
-        assert result.id is not None
+        # Verify the frozen result now has a proper ID set (should be the group_id)
+        # This is checked by accessing the result's ID after freezing
+        assert result.id == group_id
+        assert body.id is not None
         assert result.parent is not None
 
 

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1783,11 +1783,11 @@ class test_chord(CanvasCase):
             assert header_task.options['link_error'] == [err.clone(immutable=True)]
         assert c.body.options["link_error"] == [err]
 
-    def test_chord_run_uses_group_id_for_body_freeze(self):
-        """Test that chord.run() uses group_id instead of task_id for body.freeze().
+    def test_chord_run_ensures_body_has_valid_task_id(self):
+        """Test that chord.run() ensures body always gets a valid task ID.
 
-        This is the unit test for the fix to issue #8578. The chord body should be
-        frozen with the group_id to ensure proper error handling and task identification.
+        This is the unit test for the fix to issue #9773. The chord body should always
+        be frozen with a valid task ID to prevent "task_id must not be empty" errors.
         """
         # Create a chord with header group and body chain
         header = group([self.add.s(1, 1), self.add.s(2, 2)])
@@ -1803,31 +1803,42 @@ class test_chord(CanvasCase):
         with patch.object(body, "freeze", wraps=body.freeze) as mock_freeze:
             test_chord.run(header, body, (), task_id=chord_task_id)
 
-            # Assert that body.freeze was called with group_id, not chord task_id
-            mock_freeze.assert_called_once_with(group_task_id, root_id=None)
+            # Assert that body.freeze was called with the provided task_id and group_id
+            mock_freeze.assert_called_once_with(
+                chord_task_id, group_id=group_task_id, root_id=None
+            )
 
-    def test_chord_run_generates_group_id_when_none_provided(self):
-        """Test that chord.run() generates a group_id when header has no task_id."""
+    def test_chord_run_generates_task_id_when_none_provided(self):
+        """Test that chord.run() generates a task_id when none is provided."""
         # Create a chord with header group and body chain (no task_id set)
         header = group([self.add.s(1, 1), self.add.s(2, 2)])
         body = chain(self.add.s(10, 10), self.add.s(20, 20))
         test_chord = chord(header, body)
 
+        # Set group ID
+        group_id = "test-group-id"
+        header.options["task_id"] = group_id
+
         # Use patch to spy on body.freeze method
         with patch.object(body, "freeze", wraps=body.freeze) as mock_freeze:
             test_chord.run(header, body, (), task_id=None)
 
-            # Assert that body.freeze was called with a generated UUID (not None)
+            # Assert that body.freeze was called with a generated UUID and group_id
             mock_freeze.assert_called_once()
             args, kwargs = mock_freeze.call_args
-            task_id = args[0] if args else kwargs.get("_id")
-            assert task_id is not None
+            body_task_id = args[0] if args else kwargs.get("_id")
+            passed_group_id = kwargs.get("group_id")
+
+            # Body should get a unique task ID (not None, not group_id)
+            assert body_task_id is not None
+            assert body_task_id != group_id  # Should be different from group_id
+            assert passed_group_id == group_id  # But should know its group
 
     def test_chord_run_body_freeze_prevents_task_id_empty_error(self):
         """Test that proper body.freeze() call prevents 'task_id must not be empty' error.
 
-        This test ensures that when chord body is frozen with group_id, subsequent error
-        handling won't encounter the "task_id must not be empty" error.
+        This test ensures that when chord body is frozen with a valid task ID,
+        subsequent error handling won't encounter the "task_id must not be empty" error.
         """
         # Create chord components
         header = group([self.add.s(1, 1), self.add.s(2, 2)])
@@ -1838,14 +1849,35 @@ class test_chord(CanvasCase):
         group_id = "test-group-12345"
         header.options["task_id"] = group_id
 
-        # Run the chord
-        result = test_chord.run(header, body, (), task_id="external-task-id")
+        # Run the chord with external task ID
+        external_task_id = "external-task-id"
+        result = test_chord.run(header, body, (), task_id=external_task_id)
 
-        # Verify the frozen result now has a proper ID set (should be the group_id)
-        # This is checked by accessing the result's ID after freezing
-        assert result.id == group_id
+        # Verify the frozen result has the external task ID, not group_id
+        assert result.id == external_task_id
         assert body.id is not None
         assert result.parent is not None
+
+        # Body should know its group but have its own ID
+        assert body.options.get('group_id') == group_id or body.id != group_id
+
+    def test_chord_run_body_freeze_with_no_external_task_id(self):
+        """Test chord body gets unique ID when no external task_id provided."""
+        header = group([self.add.s(1, 1), self.add.s(2, 2)])
+        body = chain(self.add.s(10, 10), self.add.s(20, 20))
+        test_chord = chord(header, body)
+
+        group_id = "test-group-12345"
+        header.options["task_id"] = group_id
+
+        # Run chord without external task ID
+        result = test_chord.run(header, body, (), task_id=None)
+
+        # Body should get unique ID, different from group_id
+        assert result.id is not None
+        assert result.id != group_id
+        assert body.id is not None
+        assert body.id != group_id
 
 
 class test_maybe_signature(CanvasCase):


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
(Fixes #9773)

When using chords with a group containing failing tasks and a chain body, error propagation fails with:
```
ValueError: task_id must not be empty. Got None instead.
```

This happens because the chord body can be frozen with `None` as its task ID, causing error handling to break when trying to propagate failures from the group to the callback.

### Root Cause

In `celery/canvas.py`, the `_chord.run()` method was freezing the body with a potentially `None` task_id:

```python
# BEFORE (problematic):
bodyres = body.freeze(task_id, root_id=root_id)  # task_id can be None!
```

**The issue:**
- `task_id` can be `None` when chord is called without explicit ID
- When a group task fails, error handling looks for `callback.id` to propagate the error  
- Since the body was frozen with `None`, `callback.id` ends up being `None`
- This causes the "task_id must not be empty" error during error storage

### Solution

Ensure the chord body always gets a valid, unique task ID while maintaining proper group relationships:

```python
# AFTER (correct):
body_task_id = task_id or uuid()
bodyres = body.freeze(body_task_id, group_id=group_id, root_id=root_id)
```

**Why this is correct:**
- **Fixes the immediate issue**: Body always has a valid ID for error handling (never `None`)
- **Maintains uniqueness**: Each task gets its own Redis storage key (no collisions)
- **Preserves relationships**: Body is properly linked to the group via `group_id` parameter

### Testing
The fix includes tests covering:
- Error propagation with different chord body types (single task, chain, group, chord)
- Proper task ID generation when none is provided
- Verification that body tasks get unique IDs while maintaining group membership
- Integration tests ensuring no regression in existing functionality