### PR TITLE
Remove importlib_metadata leftovers

### DIFF
--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -3,11 +3,7 @@ import os
 import pathlib
 import sys
 import traceback
-
-try:
-    from importlib.metadata import entry_points
-except ImportError:
-    from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 import click
 import click.exceptions

--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -4,11 +4,7 @@ import sys
 import warnings
 from contextlib import contextmanager
 from importlib import import_module, reload
-
-try:
-    from importlib.metadata import entry_points
-except ImportError:
-    from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 from kombu.utils.imports import symbol_by_name
 


### PR DESCRIPTION
## Description

Celery's use of `importlib_metadata` was removed in #9612 (since Celery now requires Python 3.8+ which contains `importlib.metadata` in the standard library), but a few conditional imports were left behind.