### PR TITLE
Replace DelayedDelivery connection creation to use context manger

### DIFF
--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -114,33 +114,33 @@ class DelayedDelivery(bootsteps.StartStopStep):
             OSError: If there are network-related issues
             Exception: For other unexpected errors during setup
         """
-        connection: Connection = c.app.connection_for_write(url=broker_url)
-        queue_type = c.app.conf.broker_native_delayed_delivery_queue_type
-        logger.debug(
-            "Setting up delayed delivery for broker %r with queue type %r",
-            broker_url, queue_type
-        )
+        with c.app.connection_for_write(url=broker_url) as connection:
+            queue_type = c.app.conf.broker_native_delayed_delivery_queue_type
+            logger.debug(
+                "Setting up delayed delivery for broker %r with queue type %r",
+                broker_url, queue_type
+            )
 
-        try:
-            declare_native_delayed_delivery_exchanges_and_queues(
-                connection,
-                queue_type
-            )
-        except Exception as e:
-            logger.warning(
-                "Failed to declare exchanges and queues for %r: %s",
-                broker_url, str(e)
-            )
-            raise
+            try:
+                declare_native_delayed_delivery_exchanges_and_queues(
+                    connection,
+                    queue_type
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to declare exchanges and queues for %r: %s",
+                    broker_url, str(e)
+                )
+                raise
 
-        try:
-            self._bind_queues(c.app, connection)
-        except Exception as e:
-            logger.warning(
-                "Failed to bind queues for %r: %s",
-                broker_url, str(e)
-            )
-            raise
+            try:
+                self._bind_queues(c.app, connection)
+            except Exception as e:
+                logger.warning(
+                    "Failed to bind queues for %r: %s",
+                    broker_url, str(e)
+                )
+                raise
 
     def _bind_queues(self, app: Celery, connection: Connection) -> None:
         """Bind all application queues to delayed delivery exchanges.

--- a/t/unit/worker/test_native_delayed_delivery.py
+++ b/t/unit/worker/test_native_delayed_delivery.py
@@ -50,18 +50,23 @@ class test_DelayedDelivery:
         )
 
     def test_start_native_delayed_delivery_topic_exchange(self, caplog):
-        consumer_mock = MagicMock()
+        consumer_mock = Mock()
         consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         consumer_mock.app.conf.broker_url = 'amqp://'
         consumer_mock.app.amqp.queues = {
             'celery': Queue('celery', exchange=Exchange('celery', type='topic'))
         }
+        connection = MagicMock()
+        consumer_mock.app.connection_for_write.return_value = connection
 
         delayed_delivery = DelayedDelivery(consumer_mock)
 
         delayed_delivery.start(consumer_mock)
 
         assert len(caplog.records) == 0
+        # Verify connection context was called
+        assert connection.__enter__.called
+        assert connection.__exit__.called
 
     def test_start_native_delayed_delivery_fanout_exchange(self, caplog):
         consumer_mock = MagicMock()

--- a/t/unit/worker/test_native_delayed_delivery.py
+++ b/t/unit/worker/test_native_delayed_delivery.py
@@ -1,7 +1,7 @@
 import itertools
 from logging import LogRecord
 from typing import Iterator
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from kombu import Exchange, Queue
@@ -28,7 +28,7 @@ class test_DelayedDelivery:
         assert delayed_delivery.include_if(consumer_mock) is True
 
     def test_start_native_delayed_delivery_direct_exchange(self, caplog):
-        consumer_mock = Mock()
+        consumer_mock = MagicMock()
         consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         consumer_mock.app.conf.broker_url = 'amqp://'
         consumer_mock.app.amqp.queues = {
@@ -50,7 +50,7 @@ class test_DelayedDelivery:
         )
 
     def test_start_native_delayed_delivery_topic_exchange(self, caplog):
-        consumer_mock = Mock()
+        consumer_mock = MagicMock()
         consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         consumer_mock.app.conf.broker_url = 'amqp://'
         consumer_mock.app.amqp.queues = {
@@ -64,7 +64,7 @@ class test_DelayedDelivery:
         assert len(caplog.records) == 0
 
     def test_start_native_delayed_delivery_fanout_exchange(self, caplog):
-        consumer_mock = Mock()
+        consumer_mock = MagicMock()
         consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         consumer_mock.app.conf.broker_url = 'amqp://'
         consumer_mock.app.amqp.queues = {
@@ -237,7 +237,7 @@ class test_DelayedDelivery:
             assert isinstance(value, float), f"Expected float, got {type(value)}"
 
     def test_start_with_no_queues(self, caplog):
-        consumer_mock = Mock()
+        consumer_mock = MagicMock()
         consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         consumer_mock.app.conf.broker_url = 'amqp://'
         consumer_mock.app.amqp.queues = {}
@@ -264,7 +264,7 @@ class test_DelayedDelivery:
 
     @patch('celery.worker.consumer.delayed_delivery.declare_native_delayed_delivery_exchanges_and_queues')
     def test_setup_declare_error(self, mock_declare, caplog):
-        consumer_mock = Mock()
+        consumer_mock = MagicMock()
         consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         consumer_mock.app.conf.broker_url = 'amqp://'
         consumer_mock.app.amqp.queues = {
@@ -284,7 +284,7 @@ class test_DelayedDelivery:
 
     @patch('celery.worker.consumer.delayed_delivery.bind_queue_to_native_delayed_delivery_exchange')
     def test_setup_bind_error(self, mock_bind, caplog):
-        consumer_mock = Mock()
+        consumer_mock = MagicMock()
         consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
         consumer_mock.app.conf.broker_url = 'amqp://'
         consumer_mock.app.amqp.queues = {


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
- Replaced `DelayedDelivery` step connection creation to use context manager, so the the connection will be closed when the step is completed. 

Fixing an issue I found - https://github.com/celery/celery/issues/9792.

## Verifications 

Running Celery with my fix, created the exchange and queues needed with binding, and closed the connection. 

```
uvx --no-cache --with /home/bit/Code/celery celery -A app worker --loglevel=debug --without-gossip --without-mingle --without-heartbeat --prefetch-multiplier=1 --concurrency=1
```

Logs - 

![image](https://github.com/user-attachments/assets/ddda00db-a3fc-4d6e-9127-1ad9c8bc0312)

Rabbit connections - only 1 left as expected, for consuming tasks - 

![image](https://github.com/user-attachments/assets/bcff97e5-4cd5-4eec-9845-83c8d424cb45)

Rabbit channels - only 1 channel -

![image](https://github.com/user-attachments/assets/3f6b4a6e-8af6-4da4-abc1-5f2fa215d07c)

Exchanges were created successfully - 

![image](https://github.com/user-attachments/assets/7889ace2-e772-48e7-97ae-422d8534c344)

Queues were created successfully -

![image](https://github.com/user-attachments/assets/a580a9bd-4410-4560-9b59-ad64729de03c)

