### PR TITLE
Fix #9794: Pydantic integration fails with __future__.annotations.

### DIFF
--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -494,6 +494,13 @@ def add_pydantic(data: AddParameterModel) -> AddResultModel:
     return AddResultModel(result=value)
 
 
+@shared_task(pydantic=True)
+def add_pydantic_string_annotations(data: "AddParameterModel") -> "AddResultModel":
+    """Add two numbers, but with string-annotated Pydantic models (__future__.annotations bug)."""
+    value = data.x + data.y
+    return AddResultModel(result=value)
+
+
 if LEGACY_TASKS_DISABLED:
     class StampOnReplace(StampingVisitor):
         stamp = {"StampOnReplace": "This is the replaced task"}

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -16,9 +16,9 @@ from celery.worker import state as worker_state
 
 from .conftest import TEST_BACKEND, get_active_redis_channels, get_redis_connection
 from .tasks import (ClassBasedAutoRetryTask, ExpectedException, add, add_ignore_result, add_not_typed, add_pydantic,
-                    add_pydantic_string_annotations, fail, fail_unpickleable, print_unicode, retry, retry_once, retry_once_headers,
-                    retry_once_priority, retry_unpickleable, return_properties, second_order_replace1, sleeping,
-                    soft_time_limit_must_exceed_time_limit)
+                    add_pydantic_string_annotations, fail, fail_unpickleable, print_unicode, retry, retry_once,
+                    retry_once_headers, retry_once_priority, retry_unpickleable, return_properties,
+                    second_order_replace1, sleeping, soft_time_limit_must_exceed_time_limit)
 
 TIMEOUT = 10
 


### PR DESCRIPTION
## Description
When a project uses `from __future__ import annotations`, all annotations will be stored as strings. This is fairly common, and many projects dictate that any use of type annotations must be accompanied by this import.

The Pydantic integration in Celery introspects the annotations to check if any parameters and/or the return type are subclasses of `pydantic.BaseModel`. This fails when the annotations are `str` instead of the actual class.

This change fixes the issue by optimistically using `typing.get_type_hints()` instead of relying on the annotations included in the result of `inspect.signature()`. This works in most cases, although there can be cases where `get_type_hints()` fails due to circular import chains. In this case, we fall back to the old implementation. A new test has been added to t/integration/test_tasks.py to validate the issue.
