### PR TITLE
Fix pending_result memory leak

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -137,6 +137,8 @@ class AsyncResult(ResultBase):
         self._cache = None
         if self.parent:
             self.parent.forget()
+
+        self.backend.remove_pending_result(self)
         self.backend.forget(self.id)
 
     def revoke(self, connection=None, terminate=False, signal=None,


### PR DESCRIPTION
## Description
Async results create subscriptions and they get stored in the backend's _pending_results store. The [docs](https://docs.celeryq.dev/en/stable/userguide/tasks.html#result-backends) clearly warns about the mandatory use of either get or forget to clean up resources. Still these subscriptions aren't cleaned up when only forget is called for example. 
See #9797 for more details.

## Changes(Fixes #9797)
Added a call to backend.remove_pending_result when forget is called to release any subscriptions and references stored in the backend.
