### PR TITLE
Allow celery to spawn rather than fork in concurrency (Addresses #6036)

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -337,6 +337,7 @@ NAMESPACES = Namespace(
         proc_alive_timeout=Option(4.0, type='float'),
         prefetch_multiplier=Option(4, type='int'),
         enable_prefetch_count_reduction=Option(True, type='bool'),
+        disable_prefetch=Option(False, type='bool'),
         redirect_stdouts=Option(
             True, type='bool', old={'celery_redirect_stdouts'},
         ),

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -182,6 +182,14 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
               help_group="Worker Options",
               help="Set custom prefetch multiplier value "
                    "for this worker instance.")
+@click.option('--disable-prefetch',
+              is_flag=True,
+              default=None,
+              callback=lambda ctx, _,
+              value: ctx.obj.app.conf.worker_disable_prefetch if value is None else value,
+              cls=CeleryOption,
+              help_group="Worker Options",
+              help="Disable broker prefetching. The worker will only fetch a task when a process slot is available.")
 @click.option('-c',
               '--concurrency',
               type=int,
@@ -314,6 +322,8 @@ def worker(ctx, hostname=None, pool_cls=None, app=None, uid=None, gid=None,
     """
     try:
         app = ctx.obj.app
+        if 'disable_prefetch' in kwargs and kwargs['disable_prefetch'] is not None:
+            app.conf.worker_disable_prefetch = kwargs.pop('disable_prefetch')
         if ctx.args:
             try:
                 app.config_from_cmdline(ctx.args, namespace='worker')

--- a/celery/concurrency/__init__.py
+++ b/celery/concurrency/__init__.py
@@ -10,6 +10,7 @@ __all__ = ('get_implementation', 'get_available_pool_names',)
 
 ALIASES = {
     'prefork': 'celery.concurrency.prefork:TaskPool',
+    'spawn': 'celery.concurrency.spawn:TaskPool',
     'eventlet': 'celery.concurrency.eventlet:TaskPool',
     'gevent': 'celery.concurrency.gevent:TaskPool',
     'solo': 'celery.concurrency.solo:TaskPool',

--- a/celery/concurrency/spawn.py
+++ b/celery/concurrency/spawn.py
@@ -1,0 +1,19 @@
+"""Spawn execution pool."""
+import os
+
+import billiard
+
+from .prefork import TaskPool as PreforkTaskPool
+
+__all__ = ("TaskPool",)
+
+
+class TaskPool(PreforkTaskPool):
+    """Multiprocessing Pool using the ``spawn`` start method."""
+
+    start_method = "spawn"
+
+    def on_start(self):
+        billiard.set_start_method(self.start_method, force=True)
+        os.environ.setdefault("FORKED_BY_MULTIPROCESSING", "1")
+        super().on_start()

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -788,6 +788,10 @@ to describe the task prefetching *limit*.  There's no actual prefetching involve
 Disabling the prefetch limits is possible, but that means the worker will
 consume as many tasks as it can, as fast as possible.
 
+Since version 5.5 you can use the :option:`--disable-prefetch <celery worker --disable-prefetch>`
+flag (or set :setting:`worker_disable_prefetch` to ``True``) so that a worker
+only fetches a task when one of its processes is free.
+
 A discussion on prefetch limits, and configuration settings for a worker
 that only reserves one task at a time is found here:
 :ref:`optimizing-prefetch-limit`.

--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -136,6 +136,7 @@ Celery is…
         - **Concurrency**
 
             - prefork (multiprocessing),
+            - spawn (multiprocessing using the spawn method),
             - Eventlet_, gevent_
             - thread (multithreaded)
             - `solo` (single threaded)

--- a/docs/history/changelog-5.5.rst
+++ b/docs/history/changelog-5.5.rst
@@ -30,6 +30,8 @@ What's Changed
 - Updated rabbitmq doc about using quorum queues with task routes (#9707)
 - Add: Dumper Unit Test (#9711)
 - Add unit test for event.group_from (#9709)
+- Allow disabling of broker prefetch with the ``worker_disable_prefetch``
+  configuration option (#XXXX)
 - refactor: add beat_cron_starting_deadline documentation warning (#9712)
 - fix: resolve issue #9569 by supporting distinct broker transport options for workers (#9695)
 - Fixes issue with retry callback arguments in DelayedDelivery (#9708)

--- a/docs/history/whatsnew-5.5.rst
+++ b/docs/history/whatsnew-5.5.rst
@@ -358,3 +358,11 @@ actually needed, which can be useful in certain deployment scenarios where you w
 more control over database schema management.
 
 See :ref:`conf-database-result-backend` for complete documentation.
+
+Spawn Pool Option
+-----------------
+
+Added a new ``spawn`` pool implementation. This pool uses Python's
+``spawn`` start method when launching worker processes which is helpful
+when libraries are not fork-safe (for example CUDA based frameworks).
+Enable it with ``-P spawn`` on the command line.

--- a/docs/internals/guide.rst
+++ b/docs/internals/guide.rst
@@ -267,7 +267,7 @@ Module Overview
 
 - celery.concurrency
 
-    Execution pool implementations (prefork, eventlet, gevent, solo, thread).
+    Execution pool implementations (prefork, spawn, eventlet, gevent, solo, thread).
 
 - celery.db
 

--- a/docs/internals/reference/celery.concurrency.spawn.rst
+++ b/docs/internals/reference/celery.concurrency.spawn.rst
@@ -1,0 +1,11 @@
+==============================================================
+ ``celery.concurrency.spawn``
+==============================================================
+
+.. contents::
+    :local:
+.. currentmodule:: celery.concurrency.spawn
+
+.. automodule:: celery.concurrency.spawn
+    :members:
+    :undoc-members:

--- a/docs/internals/reference/index.rst
+++ b/docs/internals/reference/index.rst
@@ -17,6 +17,7 @@
     celery.concurrency
     celery.concurrency.solo
     celery.concurrency.prefork
+    celery.concurrency.spawn
     celery.concurrency.eventlet
     celery.concurrency.gevent
     celery.concurrency.thread

--- a/docs/userguide/concurrency/index.rst
+++ b/docs/userguide/concurrency/index.rst
@@ -20,6 +20,8 @@ Overview of Concurrency Options
 
 - `prefork`: The default option, ideal for CPU-bound tasks and most use cases.
   It is robust and recommended unless there's a specific need for another model.
+- `spawn`: Uses Python's ``spawn`` start method. Helpful when libraries are not
+  fork-safe, for example when using CUDA.
 - `eventlet` and `gevent`: Designed for IO-bound tasks, these models use
   greenlets for high concurrency. Note that certain features, like `soft_timeout`,
   are not available in these modes.  These have detailed documentation pages
@@ -35,6 +37,7 @@ Overview of Concurrency Options
 
     eventlet
     gevent
+    spawn
 
 .. note::
     While alternative models like `eventlet` and `gevent` are available, they

--- a/docs/userguide/concurrency/spawn.rst
+++ b/docs/userguide/concurrency/spawn.rst
@@ -1,0 +1,18 @@
+.. _concurrency-spawn:
+
+=======================
+ Spawn Start Method
+=======================
+
+Celery can use Python's ``spawn`` start method to create worker processes.
+This is useful when libraries used by your tasks are not fork-safe, for
+example when working with CUDA.
+
+Enable this pool using the :option:`celery worker -P` option:
+
+.. code-block:: console
+
+    $ celery -A proj worker -P spawn -c 4
+
+When using ``spawn`` each worker starts in a fresh Python interpreter
+so any global state must be initialized in the child process.

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3131,15 +3131,35 @@ workers, note that the first worker to start will receive four times the
 number of messages initially. Thus the tasks may not be fairly distributed
 to the workers.
 
-To disable prefetching, set :setting:`worker_prefetch_multiplier` to 1.
-Changing that setting to 0 will allow the worker to keep consuming
-as many messages as it wants.
+To limit the broker to only deliver one message per process at a time,
+set :setting:`worker_prefetch_multiplier` to 1. Changing that setting to 0
+will allow the worker to keep consuming as many messages as it wants.
+
+If you need to completely disable broker prefetching while still using
+early acknowledgments, enable :setting:`worker_disable_prefetch`.
+When this option is enabled the worker only fetches a task from the broker
+when one of its processes is available.
+
+You can also enable this via the :option:`--disable-prefetch <celery worker --disable-prefetch>`
+command line flag.
 
 For more on prefetching, read :ref:`optimizing-prefetch-limit`
 
 .. note::
 
     Tasks with ETA/countdown aren't affected by prefetch limits.
+
+.. setting:: worker_disable_prefetch
+
+``worker_disable_prefetch``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``False``.
+
+When enabled, a worker will only consume messages from the broker when it
+has an available process to execute them. This disables prefetching while
+still using early acknowledgments, ensuring that tasks are fairly
+distributed between workers.
 
 .. setting:: worker_enable_prefetch_count_reduction
 

--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -181,9 +181,12 @@ You can enable this behavior by using the following configuration options:
     task_acks_late = True
     worker_prefetch_multiplier = 1
 
-If you want to disable "prefetching of tasks" without using ack_late (because
-your tasks are not idempotent) that's impossible right now and you can join the
-discussion here https://github.com/celery/celery/discussions/7106
+If your tasks cannot be acknowledged late you can disable broker
+prefetching by enabling :setting:`worker_disable_prefetch`. With this
+setting the worker fetches a new task only when an execution slot is
+free, preventing tasks from waiting behind long running ones on busy
+workers. This can also be set from the command line using
+:option:`--disable-prefetch <celery worker --disable-prefetch>`.
 
 Memory Usage
 ------------

--- a/extra/zsh-completion/celery.zsh
+++ b/extra/zsh-completion/celery.zsh
@@ -40,7 +40,7 @@ case "$words[1]" in
     worker)
     _arguments \
     '(-C --concurrency=)'{-C,--concurrency=}'[Number of child processes processing the queue. The default is the number of CPUs.]' \
-    '(--pool)--pool=:::(prefork eventlet gevent solo)' \
+    '(--pool)--pool=:::(prefork spawn eventlet gevent solo)' \
     '(--purge --discard)'{--discard,--purge}'[Purges all waiting tasks before the daemon is started.]' \
     '(-f --logfile=)'{-f,--logfile=}'[Path to log file. If no logfile is specified, stderr is used.]' \
     '(--loglevel=)--loglevel=:::(critical error warning info debug)' \

--- a/t/integration/test_spawn_pool.py
+++ b/t/integration/test_spawn_pool.py
@@ -1,0 +1,20 @@
+import pytest
+
+from .tasks import add
+
+
+@pytest.fixture(scope="session")
+def celery_worker_pool():
+    return "spawn"
+
+
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+def test_basic_task_spawn(manager):
+    results = []
+    for i in range(5):
+        results.append([i + i, add.delay(i, i)])
+    for expected, result in results:
+        assert result.get(timeout=10) == expected
+        assert result.status == "SUCCESS"
+        assert result.ready() is True
+        assert result.successful() is True

--- a/t/unit/concurrency/test_concurrency.py
+++ b/t/unit/concurrency/test_concurrency.py
@@ -163,6 +163,7 @@ class test_get_available_pool_names:
     def test_no_concurrent_futures__returns_no_threads_pool_name(self):
         expected_pool_names = (
             'prefork',
+            'spawn',
             'eventlet',
             'gevent',
             'solo',
@@ -176,6 +177,7 @@ class test_get_available_pool_names:
     def test_concurrent_futures__returns_threads_pool_name(self):
         expected_pool_names = (
             'prefork',
+            'spawn',
             'eventlet',
             'gevent',
             'solo',

--- a/t/unit/concurrency/test_spawn.py
+++ b/t/unit/concurrency/test_spawn.py
@@ -66,7 +66,7 @@ class TestTaskPool(spawn.TaskPool):
 class test_spawn_TaskPool:
     @patch('billiard.set_start_method')
     @patch('billiard.forking_enable')
-    def test_on_start_sets_spawn(self, set_method, mock_forking_enable):
+    def test_on_start_sets_spawn(self, mock_forking_enable, set_method):
         pool = TestTaskPool(1)
         with patch.dict(os.environ, {}, clear=True):
             pool.on_start()

--- a/t/unit/concurrency/test_spawn.py
+++ b/t/unit/concurrency/test_spawn.py
@@ -66,7 +66,7 @@ class TestTaskPool(spawn.TaskPool):
 class test_spawn_TaskPool:
     @patch('billiard.set_start_method')
     @patch('billiard.forking_enable')
-    def test_on_start_sets_spawn(self, mock_forking_enable, set_method):
+    def test_on_start_sets_spawn(self, set_method, mock_forking_enable):
         pool = TestTaskPool(1)
         with patch.dict(os.environ, {}, clear=True):
             pool.on_start()

--- a/t/unit/concurrency/test_spawn.py
+++ b/t/unit/concurrency/test_spawn.py
@@ -1,0 +1,77 @@
+import os
+from unittest.mock import Mock, patch
+
+from celery.concurrency import spawn
+
+
+class MockPool:
+    """Mock pool that prevents actual process creation."""
+    started = False
+    closed = False
+    joined = False
+    terminated = False
+    _state = None
+
+    def __init__(self, *args, **kwargs):
+        self.started = True
+        self._timeout_handler = Mock()
+        self._result_handler = Mock()
+        self.maintain_pool = Mock()
+        self._state = 1  # RUN state
+        self._processes = kwargs.get('processes', 1)
+        self._proc_alive_timeout = kwargs.get('proc_alive_timeout')
+        self._pool = [Mock(pid=i) for i in range(self._processes)]
+
+    def close(self):
+        self.closed = True
+        self._state = 'CLOSE'
+
+    def join(self):
+        self.joined = True
+
+    def terminate(self):
+        self.terminated = True
+
+    def did_start_ok(self):
+        return True
+
+    def apply_async(self, *args, **kwargs):
+        pass
+
+    def terminate_job(self, *args, **kwargs):
+        pass
+
+    def restart(self, *args, **kwargs):
+        pass
+
+    def register_with_event_loop(self, loop):
+        pass
+
+    def flush(self):
+        pass
+
+    def grow(self, n=1):
+        self._processes += n
+
+    def shrink(self, n=1):
+        self._processes -= n
+
+
+class TestTaskPool(spawn.TaskPool):
+    """TaskPool that uses MockPool instead of real billiard pools."""
+    Pool = MockPool
+    BlockingPool = MockPool
+
+
+class test_spawn_TaskPool:
+    @patch('billiard.set_start_method')
+    @patch('billiard.forking_enable')
+    def test_on_start_sets_spawn(self, mock_forking_enable, set_method):
+        pool = TestTaskPool(1)
+        with patch.dict(os.environ, {}, clear=True):
+            pool.on_start()
+            set_method.assert_called_with('spawn', force=True)
+            assert os.environ['FORKED_BY_MULTIPROCESSING'] == '1'
+            # Verify the pool was created
+            assert pool._pool is not None
+            assert pool._pool.started

--- a/t/unit/worker/test_autoscale.py
+++ b/t/unit/worker/test_autoscale.py
@@ -240,7 +240,7 @@ class test_Autoscaler:
     def test_disable_prefetch_respects_max_concurrency(self):
         """Test that disable_prefetch respects autoscale max_concurrency setting"""
         from celery.worker.consumer.tasks import Tasks
-        
+
         # Create a mock consumer with autoscale and disable_prefetch enabled
         consumer = Mock()
         consumer.app = Mock()

--- a/t/unit/worker/test_autoscale.py
+++ b/t/unit/worker/test_autoscale.py
@@ -236,3 +236,51 @@ class test_Autoscaler:
 
         assert all(x.min_concurrency <= i <= x.max_concurrency
                    for i in total_num_processes)
+
+    def test_disable_prefetch_respects_max_concurrency(self):
+        """Test that disable_prefetch respects autoscale max_concurrency setting"""
+        from celery.worker.consumer.tasks import Tasks
+        
+        # Create a mock consumer with autoscale and disable_prefetch enabled
+        consumer = Mock()
+        consumer.app = Mock()
+        consumer.app.conf.worker_disable_prefetch = True
+        consumer.pool = Mock()
+        consumer.pool.num_processes = 10
+        consumer.controller = Mock()
+        consumer.controller.max_concurrency = 5  # Lower than pool processes
+        
+        # Mock task consumer setup
+        consumer.task_consumer = Mock()
+        consumer.task_consumer.channel = Mock()
+        consumer.task_consumer.channel.qos = Mock()
+        consumer.task_consumer.channel.qos.can_consume = Mock(return_value=True)
+        
+        # Mock the connection and other required attributes
+        consumer.connection = Mock()
+        consumer.connection.default_channel = Mock()
+        consumer.initial_prefetch_count = 20
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+        
+        # Mock the amqp TaskConsumer
+        consumer.app.amqp = Mock()
+        consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+        
+        tasks_instance = Tasks(consumer)
+        
+        # Mock 5 reserved requests (at autoscale limit of 5)
+        mock_requests = [Mock() for _ in range(5)]
+        with patch('celery.worker.state.reserved_requests', mock_requests):
+            tasks_instance.start(consumer)
+            
+            # Should not be able to consume when at autoscale limit
+            assert consumer.task_consumer.channel.qos.can_consume() is False
+            
+        # Test with 4 reserved requests (under autoscale limit of 5)
+        mock_requests = [Mock() for _ in range(4)]
+        with patch('celery.worker.state.reserved_requests', mock_requests):
+            tasks_instance.start(consumer)
+            
+            # Should be able to consume when under autoscale limit
+            assert consumer.task_consumer.channel.qos.can_consume() is True

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -495,6 +495,155 @@ class test_Consumer(ConsumerTestCase):
                 with pytest.raises(ConnectionError):
                     c.ensure_connected(conn)
 
+    def test_disable_prefetch_not_enabled(self):
+        """Test that disable_prefetch doesn't affect behavior when disabled"""
+        self.app.conf.worker_disable_prefetch = False
+        
+        # Test the core logic by creating a mock consumer and Tasks instance
+        from celery.worker.consumer.tasks import Tasks
+        consumer = Mock()
+        consumer.app = self.app
+        consumer.pool = Mock()
+        consumer.pool.num_processes = 4
+        consumer.controller = Mock()
+        consumer.controller.max_concurrency = None
+        consumer.initial_prefetch_count = 16
+        consumer.connection = Mock()
+        consumer.connection.default_channel = Mock()
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+        
+        # Mock task consumer
+        consumer.task_consumer = Mock()
+        consumer.task_consumer.channel = Mock()
+        consumer.task_consumer.channel.qos = Mock()
+        original_can_consume = Mock(return_value=True)
+        consumer.task_consumer.channel.qos.can_consume = original_can_consume
+        consumer.task_consumer.qos = Mock()
+        
+        consumer.app.amqp = Mock()
+        consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+        
+        tasks_instance = Tasks(consumer)
+        tasks_instance.start(consumer)
+        
+        # Should not modify can_consume method when disabled
+        assert consumer.task_consumer.channel.qos.can_consume == original_can_consume
+
+    def test_disable_prefetch_enabled_basic(self):
+        """Test that disable_prefetch modifies can_consume when enabled"""
+        self.app.conf.worker_disable_prefetch = True
+        
+        # Test the core logic by creating a mock consumer and Tasks instance
+        from celery.worker.consumer.tasks import Tasks
+        consumer = Mock()
+        consumer.app = self.app
+        consumer.pool = Mock()
+        consumer.pool.num_processes = 4
+        consumer.controller = Mock()
+        consumer.controller.max_concurrency = None
+        consumer.initial_prefetch_count = 16
+        consumer.connection = Mock()
+        consumer.connection.default_channel = Mock()
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+        
+        # Mock task consumer
+        consumer.task_consumer = Mock()
+        consumer.task_consumer.channel = Mock()
+        consumer.task_consumer.channel.qos = Mock()
+        original_can_consume = Mock(return_value=True)
+        consumer.task_consumer.channel.qos.can_consume = original_can_consume
+        consumer.task_consumer.qos = Mock()
+        
+        consumer.app.amqp = Mock()
+        consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+        
+        tasks_instance = Tasks(consumer)
+        
+        with patch('celery.worker.state.reserved_requests', []):
+            tasks_instance.start(consumer)
+            
+            # Should modify can_consume method when enabled
+            assert callable(consumer.task_consumer.channel.qos.can_consume)
+            assert consumer.task_consumer.channel.qos.can_consume != original_can_consume
+
+    def test_disable_prefetch_respects_reserved_requests_limit(self):
+        """Test that disable_prefetch respects reserved requests limit"""
+        self.app.conf.worker_disable_prefetch = True
+        
+        # Test the core logic by creating a mock consumer and Tasks instance
+        from celery.worker.consumer.tasks import Tasks
+        consumer = Mock()
+        consumer.app = self.app
+        consumer.pool = Mock()
+        consumer.pool.num_processes = 4
+        consumer.controller = Mock()
+        consumer.controller.max_concurrency = None
+        consumer.initial_prefetch_count = 16
+        consumer.connection = Mock()
+        consumer.connection.default_channel = Mock()
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+        
+        # Mock task consumer
+        consumer.task_consumer = Mock()
+        consumer.task_consumer.channel = Mock()
+        consumer.task_consumer.channel.qos = Mock()
+        consumer.task_consumer.channel.qos.can_consume = Mock(return_value=True)
+        consumer.task_consumer.qos = Mock()
+        
+        consumer.app.amqp = Mock()
+        consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+        
+        tasks_instance = Tasks(consumer)
+        
+        # Mock 4 reserved requests (at limit of 4)
+        mock_requests = [Mock(), Mock(), Mock(), Mock()]
+        with patch('celery.worker.state.reserved_requests', mock_requests):
+            tasks_instance.start(consumer)
+            
+            # Should not be able to consume when at limit
+            assert consumer.task_consumer.channel.qos.can_consume() is False
+
+    def test_disable_prefetch_respects_autoscale_max_concurrency(self):
+        """Test that disable_prefetch respects autoscale max_concurrency limit"""
+        self.app.conf.worker_disable_prefetch = True
+        
+        # Test the core logic by creating a mock consumer and Tasks instance
+        from celery.worker.consumer.tasks import Tasks
+        consumer = Mock()
+        consumer.app = self.app
+        consumer.pool = Mock()
+        consumer.pool.num_processes = 4
+        consumer.controller = Mock()
+        consumer.controller.max_concurrency = 2  # Lower than pool processes
+        consumer.initial_prefetch_count = 16
+        consumer.connection = Mock()
+        consumer.connection.default_channel = Mock()
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+        
+        # Mock task consumer
+        consumer.task_consumer = Mock()
+        consumer.task_consumer.channel = Mock()
+        consumer.task_consumer.channel.qos = Mock()
+        consumer.task_consumer.channel.qos.can_consume = Mock(return_value=True)
+        consumer.task_consumer.qos = Mock()
+        
+        consumer.app.amqp = Mock()
+        consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+        
+        tasks_instance = Tasks(consumer)
+        
+        # Mock 2 reserved requests (at autoscale limit of 2)
+        mock_requests = [Mock(), Mock()]
+        with patch('celery.worker.state.reserved_requests', mock_requests):
+            tasks_instance.start(consumer)
+            
+            # Should not be able to consume when at autoscale limit
+            assert consumer.task_consumer.channel.qos.can_consume() is False
+
 
 @pytest.mark.parametrize(
     "broker_connection_retry_on_startup,is_connection_loss_on_startup",


### PR DESCRIPTION
## Description

Addresses this issue:

https://github.com/celery/celery/issues/6036

Allows for a separate concurrency multi-processing method other than `prefork` which is `spawn`. Uses `spawn` under the hood rather than `fork`. 

This is pretty much necessary to use scalable concurrent celery worker processes in many cases when using external libraries and SDKs that have their own specific behaviour for threading. We ran into issues a lot with `gcloud` and `gRPC` for example when using fork, which spawn completely fixes.

