### PR TITLE
Choose queue type and exchange type when creating missing queues (fix #9671)

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -260,6 +260,8 @@ NAMESPACES = Namespace(
         annotations=Option(type='any'),
         compression=Option(type='string', old={'celery_message_compression'}),
         create_missing_queues=Option(True, type='bool'),
+        create_missing_queue_type=Option('classic', type='string'),
+        create_missing_queue_exchange_type=Option(None, type='string'),
         inherit_parent_priority=Option(False, type='bool'),
         default_delivery_mode=Option(2, type='string'),
         default_queue=Option('celery'),

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -134,6 +134,8 @@ have been moved into a new  ``task_`` prefix.
 ``CELERY_ANNOTATIONS``                     :setting:`task_annotations`
 ``CELERY_COMPRESSION``                     :setting:`task_compression`
 ``CELERY_CREATE_MISSING_QUEUES``           :setting:`task_create_missing_queues`
+``CELERY_CREATE_MISSING_QUEUE_TYPE``       :setting:`task_create_missing_queue_type`
+``CELERY_CREATE_MISSING_QUEUE_EXCHANGE_TYPE`` :setting:`task_create_missing_queue_exchange_type`
 ``CELERY_DEFAULT_DELIVERY_MODE``           :setting:`task_default_delivery_mode`
 ``CELERY_DEFAULT_EXCHANGE``                :setting:`task_default_exchange`
 ``CELERY_DEFAULT_EXCHANGE_TYPE``           :setting:`task_default_exchange_type`
@@ -2618,6 +2620,48 @@ Default: Enabled.
 If enabled (default), any queues specified that aren't defined in
 :setting:`task_queues` will be automatically created. See
 :ref:`routing-automatic`.
+
+.. setting:: task_create_missing_queue_type
+
+``task_create_missing_queue_type``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``"classic"``
+
+When Celery needs to declare a queue that doesn’t exist (i.e., when
+``task_create_missing_queues`` is enabled), this setting defines what type
+of RabbitMQ queue to create.
+
+- ``"classic"`` (default): declares a standard classic queue.
+- ``"quorum"``: declares a RabbitMQ quorum queue (adds ``x-queue-type: quorum``).
+
+.. setting:: task_create_missing_queue_exchange_type
+
+``task_create_missing_queue_exchange_type``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Default: ``None``
+
+If this option is None or the empty string (the default), Celery leaves the
+exchange exactly as returned by your :pyattr:app.amqp.Queues.autoexchange
+hook.
+
+You can set this to a specific exchange type, such as ``"direct"``, ``"topic"``, or
+``"fanout"``, to create the missing queue with that exchange type.
+
+.. tip::
+
+Combine this setting with task_create_missing_queue_type = "quorum"
+to create quorum queues bound to a topic exchange, for example::
+
+    app.conf.task_create_missing_queues=True
+    app.conf.task_create_missing_queue_type="quorum"
+    app.conf.task_create_missing_queue_exchange_type="topic"
+
+.. note::
+
+Like the queue-type setting above, this option does not affect queues
+that you define explicitly in :setting:task_queues; it applies only to
+queues created implicitly at runtime.
 
 .. setting:: task_default_queue
 


### PR DESCRIPTION
## Description

This PR adds **two new optional settings** that control how Celery auto-creates
queues when `task_create_missing_queues = True`:

| Setting | Default | What it does |
|---------|---------|--------------|
| `task_create_missing_queue_type` | `"classic"` | Select the AMQP queue kind: keep the default `"classic"`  or choose the type you need, e.g. `"quorum"`). |
| `task_create_missing_queue_exchange_type` | `None` | Override the exchange type used for the auto-exchange: set to `"topic"`, `"fanout"`, etc. |


## Changes(Fixes #9671)

Add two new settings that apply when Celery autogenerates a queue
(`task_create_missing_queues=True`):

- `task_create_missing_queue_type`

- `task_create_missing_queue_exchange_type`

Backwards compatibility: default behaviour (classic queue + direct exchange) is unchanged.

