### PR TITLE
Revert "Use Django DB max age connection setting"

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -168,7 +168,7 @@ class DjangoWorkerFixup:
                 self._maybe_close_db_fd(c)
 
         # use the _ version to avoid DB_REUSE preventing the conn.close() call
-        self._close_database(force=True)
+        self._close_database()
         self.close_cache()
 
     def _maybe_close_db_fd(self, c: "BaseDatabaseWrapper") -> None:
@@ -197,13 +197,10 @@ class DjangoWorkerFixup:
             self._close_database()
         self._db_recycles += 1
 
-    def _close_database(self, force: bool = False) -> None:
+    def _close_database(self) -> None:
         for conn in self._db.connections.all():
             try:
-                if force:
-                    conn.close()
-                else:
-                    conn.close_if_unusable_or_obsolete()
+                conn.close()
             except self.interface_errors:
                 pass
             except self.DatabaseError as exc:

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -274,6 +274,16 @@ class test_DjangoWorkerFixup(FixupCase):
             with pytest.raises(KeyError):
                 f._close_database()
 
+    def test_close_database_always_closes_connections(self):
+        with self.fixup_context(self.app) as (f, _, _):
+            conn = Mock()
+            f._db.connections.all = Mock(return_value=[conn])
+            f.close_database()
+            conn.close.assert_called_once_with()
+            # close_if_unusable_or_obsolete is not safe to call in all conditions, so avoid using
+            # it to optimize connection handling.
+            conn.close_if_unusable_or_obsolete.assert_not_called()
+
     def test_close_cache(self):
         with self.fixup_context(self.app) as (f, _, _):
             f.close_cache()

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -284,6 +284,11 @@ class test_DjangoWorkerFixup(FixupCase):
             # it to optimize connection handling.
             conn.close_if_unusable_or_obsolete.assert_not_called()
 
+    def test_close_cache_raises_error(self):
+        with self.fixup_context(self.app) as (f, _, _):
+            f._cache.close_caches.side_effect = AttributeError
+            f.close_cache()
+
     def test_close_cache(self):
         with self.fixup_context(self.app) as (f, _, _):
             f.close_cache()

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -196,7 +196,7 @@ class test_DjangoWorkerFixup(FixupCase):
                         f.on_worker_process_init()
                         mcf.assert_called_with(conns[1].connection)
                         f.close_cache.assert_called_with()
-                        f._close_database.assert_called_with(force=True)
+                        f._close_database.assert_called_with()
 
                         f.validate_models = Mock(name='validate_models')
                         patching.setenv('FORKED_BY_MULTIPROCESSING', '1')
@@ -264,35 +264,13 @@ class test_DjangoWorkerFixup(FixupCase):
             f._db.connections = Mock()  # ConnectionHandler
             f._db.connections.all.side_effect = lambda: conns
 
-            f._close_database(force=True)
-            conns[0].close.assert_called_with()
-            conns[0].close_if_unusable_or_obsolete.assert_not_called()
-            conns[1].close.assert_called_with()
-            conns[1].close_if_unusable_or_obsolete.assert_not_called()
-            conns[2].close.assert_called_with()
-            conns[2].close_if_unusable_or_obsolete.assert_not_called()
-
-            for conn in conns:
-                conn.reset_mock()
-
             f._close_database()
-            conns[0].close.assert_not_called()
-            conns[0].close_if_unusable_or_obsolete.assert_called_with()
-            conns[1].close.assert_not_called()
-            conns[1].close_if_unusable_or_obsolete.assert_called_with()
-            conns[2].close.assert_not_called()
-            conns[2].close_if_unusable_or_obsolete.assert_called_with()
+            conns[0].close.assert_called_with()
+            conns[1].close.assert_called_with()
+            conns[2].close.assert_called_with()
 
             conns[1].close.side_effect = KeyError(
                 'omg')
-            f._close_database()
-            with pytest.raises(KeyError):
-                f._close_database(force=True)
-
-            conns[1].close.side_effect = None
-            conns[1].close_if_unusable_or_obsolete.side_effect = KeyError(
-                'omg')
-            f._close_database(force=True)
             with pytest.raises(KeyError):
                 f._close_database()
 


### PR DESCRIPTION
This reverts commit f0c9b40bd4aa7228afa20f589e50f2e4225d804e (cc @whtsky @auvipy)

This reverts PR #6134 and stops using the close_if_unusable_or_obsolete API since there are edge cases where it's unable to detect if a connection if actually unusable, see the relevant Django issue which is marked as `wontfix`: https://code.djangoproject.com/ticket/30646 (see also https://forum.djangoproject.com/t/close-if-unusable-or-obsolete-fails-to-close-unusable-connections/41900).

A celery-specific way to introduce one of these edge cases is to run a task with a timeout that gets interrupted via `SIGALRM` while a query is executing. The connection will be unusable but considered usable by Django, causing the next invocation of a task on that worker to fail.

Since this is an optimization that can't be reliably used, Celery ought to close the connection after each task instead of trying to manage connections in a way similar to how the Django application does.

## Description

Sorry for the verbose timeline but this optimization has a bit of a history in Celery.

### Timeline
#### June 2017 
#4116 is filed citing that Celery doesn't reuse database connections the same way Django does
#### Sept 2017
#4292 is added to start reusing Django connections via `close_if_unusable_or_obsolete`
#### July 2018 - Apr 2019
#4878, #5483, and https://github.com/celery/django-celery-results/issues/58 crop up as a result of #4292
#### May 2019 
The optimization gets reverted in #5515 
#### June 2020
#6134 reintroduces this optimization to attempt to fix #4116 once and for all