### PR TITLE
Fix Python 3.13 compatibility in events dumper

### DIFF
--- a/celery/events/dumper.py
+++ b/celery/events/dumper.py
@@ -4,7 +4,7 @@ This is a simple program that dumps events to the console
 as they happen.  Think of it like a `tcpdump` for Celery events.
 """
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 from celery.app import app_or_default
 from celery.utils.functional import LRUCache
@@ -48,7 +48,7 @@ class Dumper:
             pass
 
     def on_event(self, ev):
-        timestamp = datetime.utcfromtimestamp(ev.pop('timestamp'))
+        timestamp = datetime.fromtimestamp(ev.pop('timestamp'), timezone.utc)
         type = ev.pop('type').lower()
         hostname = ev.pop('hostname')
         if type.startswith('task-'):

--- a/t/unit/events/test_dumper.py
+++ b/t/unit/events/test_dumper.py
@@ -1,5 +1,5 @@
 import io
-from datetime import datetime
+from datetime import datetime, timezone
 
 from celery.events import dumper
 
@@ -39,7 +39,7 @@ def test_on_event_task_received():
     buf = io.StringIO()
     d = dumper.Dumper(out=buf)
     event = {
-        'timestamp': datetime(2024, 1, 1, 12, 0, 0).timestamp(),
+        'timestamp': datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp(),
         'type': 'task-received',
         'hostname': 'worker1',
         'uuid': 'abc',
@@ -49,7 +49,7 @@ def test_on_event_task_received():
     }
     d.on_event(event.copy())
     output = buf.getvalue()
-    assert 'worker1 [2024-01-01 12:00:00]' in output
+    assert 'worker1 [2024-01-01 12:00:00+00:00]' in output
     assert 'task received' in output
     assert 'mytask(abc) args=(1,) kwargs={}' in output
 
@@ -58,13 +58,13 @@ def test_on_event_non_task():
     buf = io.StringIO()
     d = dumper.Dumper(out=buf)
     event = {
-        'timestamp': datetime(2024, 1, 1, 12, 0, 0).timestamp(),
+        'timestamp': datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp(),
         'type': 'worker-online',
         'hostname': 'worker1',
         'foo': 'bar',
     }
     d.on_event(event.copy())
     output = buf.getvalue()
-    assert 'worker1 [2024-01-01 12:00:00]' in output
+    assert 'worker1 [2024-01-01 12:00:00+00:00]' in output
     assert 'started' in output
     assert 'foo=bar' in output


### PR DESCRIPTION
Replace deprecated datetime.utcfromtimestamp() with datetime.fromtimestamp() using timezone.utc. The deprecated method was removed in Python 3.12+.

Also fix test timezone handling to create proper UTC timestamps and update assertions to expect timezone-aware datetime format.

Fixes failing tests:
- test_on_event_task_received
- test_on_event_non_task

Originally contributed in #9711