### PR TITLE
Feature/disable prefetch fixes

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -337,6 +337,7 @@ NAMESPACES = Namespace(
         proc_alive_timeout=Option(4.0, type='float'),
         prefetch_multiplier=Option(4, type='int'),
         enable_prefetch_count_reduction=Option(True, type='bool'),
+        disable_prefetch=Option(False, type='bool'),
         redirect_stdouts=Option(
             True, type='bool', old={'celery_redirect_stdouts'},
         ),

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -182,6 +182,14 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
               help_group="Worker Options",
               help="Set custom prefetch multiplier value "
                    "for this worker instance.")
+@click.option('--disable-prefetch',
+              is_flag=True,
+              default=None,
+              callback=lambda ctx, _,
+              value: ctx.obj.app.conf.worker_disable_prefetch if value is None else value,
+              cls=CeleryOption,
+              help_group="Worker Options",
+              help="Disable broker prefetching. The worker will only fetch a task when a process slot is available.")
 @click.option('-c',
               '--concurrency',
               type=int,
@@ -314,6 +322,8 @@ def worker(ctx, hostname=None, pool_cls=None, app=None, uid=None, gid=None,
     """
     try:
         app = ctx.obj.app
+        if 'disable_prefetch' in kwargs and kwargs['disable_prefetch'] is not None:
+            app.conf.worker_disable_prefetch = kwargs.pop('disable_prefetch')
         if ctx.args:
             try:
                 app.config_from_cmdline(ctx.args, namespace='worker')

--- a/celery/worker/consumer/tasks.py
+++ b/celery/worker/consumer/tasks.py
@@ -56,9 +56,8 @@ class Tasks(bootsteps.StartStopStep):
             original_can_consume = channel_qos.can_consume
 
             def can_consume(self):
-                limit = getattr(c.controller, "max_concurrency", None)
-                if limit is None:
-                    limit = c.pool.num_processes
+                # Prefer autoscaler's max_concurrency if set; otherwise fall back to pool size
+                limit = getattr(c.controller, "max_concurrency", None) or c.pool.num_processes
                 if len(state.reserved_requests) >= limit:
                     return False
                 return original_can_consume()

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -788,6 +788,10 @@ to describe the task prefetching *limit*.  There's no actual prefetching involve
 Disabling the prefetch limits is possible, but that means the worker will
 consume as many tasks as it can, as fast as possible.
 
+You can use the :option:`--disable-prefetch <celery worker --disable-prefetch>`
+flag (or set :setting:`worker_disable_prefetch` to ``True``) so that a worker
+only fetches a task when one of its processes is free.
+
 A discussion on prefetch limits, and configuration settings for a worker
 that only reserves one task at a time is found here:
 :ref:`optimizing-prefetch-limit`.

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3131,15 +3131,35 @@ workers, note that the first worker to start will receive four times the
 number of messages initially. Thus the tasks may not be fairly distributed
 to the workers.
 
-To disable prefetching, set :setting:`worker_prefetch_multiplier` to 1.
-Changing that setting to 0 will allow the worker to keep consuming
-as many messages as it wants.
+To limit the broker to only deliver one message per process at a time,
+set :setting:`worker_prefetch_multiplier` to 1. Changing that setting to 0
+will allow the worker to keep consuming as many messages as it wants.
+
+If you need to completely disable broker prefetching while still using
+early acknowledgments, enable :setting:`worker_disable_prefetch`.
+When this option is enabled the worker only fetches a task from the broker
+when one of its processes is available.
+
+You can also enable this via the :option:`--disable-prefetch <celery worker --disable-prefetch>`
+command line flag.
 
 For more on prefetching, read :ref:`optimizing-prefetch-limit`
 
 .. note::
 
     Tasks with ETA/countdown aren't affected by prefetch limits.
+
+.. setting:: worker_disable_prefetch
+
+``worker_disable_prefetch``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``False``.
+
+When enabled, a worker will only consume messages from the broker when it
+has an available process to execute them. This disables prefetching while
+still using early acknowledgments, ensuring that tasks are fairly
+distributed between workers.
 
 .. setting:: worker_enable_prefetch_count_reduction
 

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3203,6 +3203,8 @@ For more on prefetching, read :ref:`optimizing-prefetch-limit`
 ``worker_disable_prefetch``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 5.4
+
 Default: ``False``.
 
 When enabled, a worker will only consume messages from the broker when it

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3203,7 +3203,7 @@ For more on prefetching, read :ref:`optimizing-prefetch-limit`
 ``worker_disable_prefetch``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.4
+.. versionadded:: 5.6
 
 Default: ``False``.
 

--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -181,9 +181,12 @@ You can enable this behavior by using the following configuration options:
     task_acks_late = True
     worker_prefetch_multiplier = 1
 
-If you want to disable "prefetching of tasks" without using ack_late (because
-your tasks are not idempotent) that's impossible right now and you can join the
-discussion here https://github.com/celery/celery/discussions/7106
+If your tasks cannot be acknowledged late you can disable broker
+prefetching by enabling :setting:`worker_disable_prefetch`. With this
+setting the worker fetches a new task only when an execution slot is
+free, preventing tasks from waiting behind long running ones on busy
+workers. This can also be set from the command line using
+:option:`--disable-prefetch <celery worker --disable-prefetch>`.
 
 Memory Usage
 ------------

--- a/t/unit/bin/test_worker.py
+++ b/t/unit/bin/test_worker.py
@@ -6,11 +6,42 @@ from click.testing import CliRunner
 
 from celery.app.log import Logging
 from celery.bin.celery import celery
+from celery.worker.consumer.tasks import Tasks
 
 
 @pytest.fixture(scope='session')
 def use_celery_app_trap():
     return False
+
+
+@pytest.fixture
+def mock_app():
+    app = Mock()
+    app.conf = Mock()
+    app.conf.worker_disable_prefetch = False
+    return app
+
+
+@pytest.fixture
+def mock_consumer(mock_app):
+    consumer = Mock()
+    consumer.app = mock_app
+    consumer.pool = Mock()
+    consumer.pool.num_processes = 4
+    consumer.controller = Mock()
+    consumer.controller.max_concurrency = None
+    consumer.initial_prefetch_count = 16
+    consumer.task_consumer = Mock()
+    consumer.task_consumer.channel = Mock()
+    consumer.task_consumer.channel.qos = Mock()
+    original_can_consume = Mock(return_value=True)
+    consumer.task_consumer.channel.qos.can_consume = original_can_consume
+    consumer.connection = Mock()
+    consumer.update_strategies = Mock()
+    consumer.on_decode_error = Mock()
+    consumer.app.amqp = Mock()
+    consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+    return consumer
 
 
 def test_cli(isolated_cli_runner: CliRunner):
@@ -37,37 +68,42 @@ def test_cli_skip_checks(isolated_cli_runner: CliRunner):
 
 def test_cli_disable_prefetch_flag(isolated_cli_runner: CliRunner):
     Logging._setup = True
-    # Ensure CLI parses --disable-prefetch and passes it into worker startup
-    res = isolated_cli_runner.invoke(
-        celery,
-        ["-A", "t.unit.bin.proj.app", "worker", "--pool", "solo", "--disable-prefetch"],
-        catch_exceptions=False,
-    )
-    # We only assert parsing works and command initializes; worker exits with 1 in tests
-    assert res.exit_code == 1, res.output
+    with patch('celery.bin.worker.worker.callback') as worker_callback_mock:
+        res = isolated_cli_runner.invoke(
+            celery,
+            ["-A", "t.unit.bin.proj.app", "worker", "--pool", "solo", "--disable-prefetch"],
+            catch_exceptions=False,
+        )
+        assert res.exit_code == 0
+        _, kwargs = worker_callback_mock.call_args
+        assert kwargs['disable_prefetch'] is True
 
 
-def test_worker_sets_disable_prefetch_when_true():
-    app_mock = Mock()
-    app_mock.conf = Mock()
-    app_mock.conf.worker_disable_prefetch = False
-    
-    kwargs = {'disable_prefetch': True}
-    if 'disable_prefetch' in kwargs and kwargs['disable_prefetch'] is not None:
-        app_mock.conf.worker_disable_prefetch = kwargs.pop('disable_prefetch')
-    
-    assert app_mock.conf.worker_disable_prefetch is True
-    assert 'disable_prefetch' not in kwargs
+def test_disable_prefetch_affects_qos_behavior(mock_app, mock_consumer):
+    mock_app.conf.worker_disable_prefetch = True
+    original_can_consume = mock_consumer.task_consumer.channel.qos.can_consume
+    with patch('celery.worker.state.reserved_requests', []):
+        tasks_instance = Tasks(mock_consumer)
+        tasks_instance.start(mock_consumer)
+        assert mock_consumer.task_consumer.channel.qos.can_consume != original_can_consume
+        modified_can_consume = mock_consumer.task_consumer.channel.qos.can_consume
+        with patch('celery.worker.state.reserved_requests', list(range(4))):
+            assert not modified_can_consume()
+        with patch('celery.worker.state.reserved_requests', list(range(2))):
+            original_can_consume.return_value = True
+            assert modified_can_consume()
+            original_can_consume.return_value = False
+            assert not modified_can_consume()
 
 
-def test_worker_ignores_disable_prefetch_when_none():
-    app_mock = Mock()
-    app_mock.conf = Mock()
-    app_mock.conf.worker_disable_prefetch = False
-    
-    kwargs = {'disable_prefetch': None}
-    if 'disable_prefetch' in kwargs and kwargs['disable_prefetch'] is not None:
-        app_mock.conf.worker_disable_prefetch = kwargs.pop('disable_prefetch')
-    
-    assert app_mock.conf.worker_disable_prefetch is False
-    assert 'disable_prefetch' in kwargs
+def test_disable_prefetch_none_preserves_behavior(mock_app, mock_consumer):
+    mock_app.conf.worker_disable_prefetch = False
+    kwargs_with_none = {'disable_prefetch': None}
+    if 'disable_prefetch' in kwargs_with_none and kwargs_with_none['disable_prefetch'] is not None:
+        mock_app.conf.worker_disable_prefetch = kwargs_with_none.pop('disable_prefetch')
+    assert mock_app.conf.worker_disable_prefetch is False
+    assert 'disable_prefetch' in kwargs_with_none
+    original_can_consume = mock_consumer.task_consumer.channel.qos.can_consume
+    tasks_instance = Tasks(mock_consumer)
+    tasks_instance.start(mock_consumer)
+    assert mock_consumer.task_consumer.channel.qos.can_consume == original_can_consume

--- a/t/unit/bin/test_worker.py
+++ b/t/unit/bin/test_worker.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -45,3 +45,29 @@ def test_cli_disable_prefetch_flag(isolated_cli_runner: CliRunner):
     )
     # We only assert parsing works and command initializes; worker exits with 1 in tests
     assert res.exit_code == 1, res.output
+
+
+def test_worker_sets_disable_prefetch_when_true():
+    app_mock = Mock()
+    app_mock.conf = Mock()
+    app_mock.conf.worker_disable_prefetch = False
+    
+    kwargs = {'disable_prefetch': True}
+    if 'disable_prefetch' in kwargs and kwargs['disable_prefetch'] is not None:
+        app_mock.conf.worker_disable_prefetch = kwargs.pop('disable_prefetch')
+    
+    assert app_mock.conf.worker_disable_prefetch is True
+    assert 'disable_prefetch' not in kwargs
+
+
+def test_worker_ignores_disable_prefetch_when_none():
+    app_mock = Mock()
+    app_mock.conf = Mock()
+    app_mock.conf.worker_disable_prefetch = False
+    
+    kwargs = {'disable_prefetch': None}
+    if 'disable_prefetch' in kwargs and kwargs['disable_prefetch'] is not None:
+        app_mock.conf.worker_disable_prefetch = kwargs.pop('disable_prefetch')
+    
+    assert app_mock.conf.worker_disable_prefetch is False
+    assert 'disable_prefetch' in kwargs

--- a/t/unit/bin/test_worker.py
+++ b/t/unit/bin/test_worker.py
@@ -33,3 +33,15 @@ def test_cli_skip_checks(isolated_cli_runner: CliRunner):
         )
         assert res.exit_code == 1, (res, res.stdout)
         assert os.environ["CELERY_SKIP_CHECKS"] == "true", "should set CELERY_SKIP_CHECKS"
+
+
+def test_cli_disable_prefetch_flag(isolated_cli_runner: CliRunner):
+    Logging._setup = True
+    # Ensure CLI parses --disable-prefetch and passes it into worker startup
+    res = isolated_cli_runner.invoke(
+        celery,
+        ["-A", "t.unit.bin.proj.app", "worker", "--pool", "solo", "--disable-prefetch"],
+        catch_exceptions=False,
+    )
+    # We only assert parsing works and command initializes; worker exits with 1 in tests
+    assert res.exit_code == 1, res.output

--- a/t/unit/worker/test_autoscale.py
+++ b/t/unit/worker/test_autoscale.py
@@ -249,38 +249,38 @@ class test_Autoscaler:
         consumer.pool.num_processes = 10
         consumer.controller = Mock()
         consumer.controller.max_concurrency = 5  # Lower than pool processes
-        
+
         # Mock task consumer setup
         consumer.task_consumer = Mock()
         consumer.task_consumer.channel = Mock()
         consumer.task_consumer.channel.qos = Mock()
         consumer.task_consumer.channel.qos.can_consume = Mock(return_value=True)
-        
+
         # Mock the connection and other required attributes
         consumer.connection = Mock()
         consumer.connection.default_channel = Mock()
         consumer.initial_prefetch_count = 20
         consumer.update_strategies = Mock()
         consumer.on_decode_error = Mock()
-        
+
         # Mock the amqp TaskConsumer
         consumer.app.amqp = Mock()
         consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
-        
+
         tasks_instance = Tasks(consumer)
-        
+
         # Mock 5 reserved requests (at autoscale limit of 5)
         mock_requests = [Mock() for _ in range(5)]
         with patch('celery.worker.state.reserved_requests', mock_requests):
             tasks_instance.start(consumer)
-            
+
             # Should not be able to consume when at autoscale limit
             assert consumer.task_consumer.channel.qos.can_consume() is False
-            
+
         # Test with 4 reserved requests (under autoscale limit of 5)
         mock_requests = [Mock() for _ in range(4)]
         with patch('celery.worker.state.reserved_requests', mock_requests):
             tasks_instance.start(consumer)
-            
+
             # Should be able to consume when under autoscale limit
             assert consumer.task_consumer.channel.qos.can_consume() is True

--- a/t/unit/worker/test_autoscale.py
+++ b/t/unit/worker/test_autoscale.py
@@ -240,7 +240,7 @@ class test_Autoscaler:
     def test_disable_prefetch_respects_max_concurrency(self):
         """Test that disable_prefetch respects autoscale max_concurrency setting"""
         from celery.worker.consumer.tasks import Tasks
-        
+
         # Create a mock consumer with autoscale and disable_prefetch enabled
         consumer = Mock()
         consumer.app = Mock()

--- a/t/unit/worker/test_autoscale.py
+++ b/t/unit/worker/test_autoscale.py
@@ -236,3 +236,51 @@ class test_Autoscaler:
 
         assert all(x.min_concurrency <= i <= x.max_concurrency
                    for i in total_num_processes)
+
+    def test_disable_prefetch_respects_max_concurrency(self):
+        """Test that disable_prefetch respects autoscale max_concurrency setting"""
+        from celery.worker.consumer.tasks import Tasks
+        
+        # Create a mock consumer with autoscale and disable_prefetch enabled
+        consumer = Mock()
+        consumer.app = Mock()
+        consumer.app.conf.worker_disable_prefetch = True
+        consumer.pool = Mock()
+        consumer.pool.num_processes = 10
+        consumer.controller = Mock()
+        consumer.controller.max_concurrency = 5  # Lower than pool processes
+        
+        # Mock task consumer setup
+        consumer.task_consumer = Mock()
+        consumer.task_consumer.channel = Mock()
+        consumer.task_consumer.channel.qos = Mock()
+        consumer.task_consumer.channel.qos.can_consume = Mock(return_value=True)
+        
+        # Mock the connection and other required attributes
+        consumer.connection = Mock()
+        consumer.connection.default_channel = Mock()
+        consumer.initial_prefetch_count = 20
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+        
+        # Mock the amqp TaskConsumer
+        consumer.app.amqp = Mock()
+        consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+        
+        tasks_instance = Tasks(consumer)
+        
+        # Mock 5 reserved requests (at autoscale limit of 5)
+        mock_requests = [Mock() for _ in range(5)]
+        with patch('celery.worker.state.reserved_requests', mock_requests):
+            tasks_instance.start(consumer)
+            
+            # Should not be able to consume when at autoscale limit
+            assert consumer.task_consumer.channel.qos.can_consume() is False
+            
+        # Test with 4 reserved requests (under autoscale limit of 5)
+        mock_requests = [Mock() for _ in range(4)]
+        with patch('celery.worker.state.reserved_requests', mock_requests):
+            tasks_instance.start(consumer)
+            
+            # Should be able to consume when under autoscale limit
+            assert consumer.task_consumer.channel.qos.can_consume() is True

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -498,7 +498,7 @@ class test_Consumer(ConsumerTestCase):
     def test_disable_prefetch_not_enabled(self):
         """Test that disable_prefetch doesn't affect behavior when disabled"""
         self.app.conf.worker_disable_prefetch = False
-        
+
         # Test the core logic by creating a mock consumer and Tasks instance
         from celery.worker.consumer.tasks import Tasks
         consumer = Mock()
@@ -512,7 +512,7 @@ class test_Consumer(ConsumerTestCase):
         consumer.connection.default_channel = Mock()
         consumer.update_strategies = Mock()
         consumer.on_decode_error = Mock()
-        
+
         # Mock task consumer
         consumer.task_consumer = Mock()
         consumer.task_consumer.channel = Mock()
@@ -520,20 +520,20 @@ class test_Consumer(ConsumerTestCase):
         original_can_consume = Mock(return_value=True)
         consumer.task_consumer.channel.qos.can_consume = original_can_consume
         consumer.task_consumer.qos = Mock()
-        
+
         consumer.app.amqp = Mock()
         consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
-        
+
         tasks_instance = Tasks(consumer)
         tasks_instance.start(consumer)
-        
+
         # Should not modify can_consume method when disabled
         assert consumer.task_consumer.channel.qos.can_consume == original_can_consume
 
     def test_disable_prefetch_enabled_basic(self):
         """Test that disable_prefetch modifies can_consume when enabled"""
         self.app.conf.worker_disable_prefetch = True
-        
+
         # Test the core logic by creating a mock consumer and Tasks instance
         from celery.worker.consumer.tasks import Tasks
         consumer = Mock()
@@ -547,7 +547,7 @@ class test_Consumer(ConsumerTestCase):
         consumer.connection.default_channel = Mock()
         consumer.update_strategies = Mock()
         consumer.on_decode_error = Mock()
-        
+
         # Mock task consumer
         consumer.task_consumer = Mock()
         consumer.task_consumer.channel = Mock()
@@ -555,15 +555,15 @@ class test_Consumer(ConsumerTestCase):
         original_can_consume = Mock(return_value=True)
         consumer.task_consumer.channel.qos.can_consume = original_can_consume
         consumer.task_consumer.qos = Mock()
-        
+
         consumer.app.amqp = Mock()
         consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
-        
+
         tasks_instance = Tasks(consumer)
-        
+
         with patch('celery.worker.state.reserved_requests', []):
             tasks_instance.start(consumer)
-            
+
             # Should modify can_consume method when enabled
             assert callable(consumer.task_consumer.channel.qos.can_consume)
             assert consumer.task_consumer.channel.qos.can_consume != original_can_consume
@@ -571,7 +571,7 @@ class test_Consumer(ConsumerTestCase):
     def test_disable_prefetch_respects_reserved_requests_limit(self):
         """Test that disable_prefetch respects reserved requests limit"""
         self.app.conf.worker_disable_prefetch = True
-        
+
         # Test the core logic by creating a mock consumer and Tasks instance
         from celery.worker.consumer.tasks import Tasks
         consumer = Mock()
@@ -585,31 +585,31 @@ class test_Consumer(ConsumerTestCase):
         consumer.connection.default_channel = Mock()
         consumer.update_strategies = Mock()
         consumer.on_decode_error = Mock()
-        
+
         # Mock task consumer
         consumer.task_consumer = Mock()
         consumer.task_consumer.channel = Mock()
         consumer.task_consumer.channel.qos = Mock()
         consumer.task_consumer.channel.qos.can_consume = Mock(return_value=True)
         consumer.task_consumer.qos = Mock()
-        
+
         consumer.app.amqp = Mock()
         consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
-        
+
         tasks_instance = Tasks(consumer)
-        
+
         # Mock 4 reserved requests (at limit of 4)
         mock_requests = [Mock(), Mock(), Mock(), Mock()]
         with patch('celery.worker.state.reserved_requests', mock_requests):
             tasks_instance.start(consumer)
-            
+
             # Should not be able to consume when at limit
             assert consumer.task_consumer.channel.qos.can_consume() is False
 
     def test_disable_prefetch_respects_autoscale_max_concurrency(self):
         """Test that disable_prefetch respects autoscale max_concurrency limit"""
         self.app.conf.worker_disable_prefetch = True
-        
+
         # Test the core logic by creating a mock consumer and Tasks instance
         from celery.worker.consumer.tasks import Tasks
         consumer = Mock()
@@ -623,24 +623,24 @@ class test_Consumer(ConsumerTestCase):
         consumer.connection.default_channel = Mock()
         consumer.update_strategies = Mock()
         consumer.on_decode_error = Mock()
-        
+
         # Mock task consumer
         consumer.task_consumer = Mock()
         consumer.task_consumer.channel = Mock()
         consumer.task_consumer.channel.qos = Mock()
         consumer.task_consumer.channel.qos.can_consume = Mock(return_value=True)
         consumer.task_consumer.qos = Mock()
-        
+
         consumer.app.amqp = Mock()
         consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
-        
+
         tasks_instance = Tasks(consumer)
-        
+
         # Mock 2 reserved requests (at autoscale limit of 2)
         mock_requests = [Mock(), Mock()]
         with patch('celery.worker.state.reserved_requests', mock_requests):
             tasks_instance.start(consumer)
-            
+
             # Should not be able to consume when at autoscale limit
             assert consumer.task_consumer.channel.qos.can_consume() is False
 

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -495,6 +495,155 @@ class test_Consumer(ConsumerTestCase):
                 with pytest.raises(ConnectionError):
                     c.ensure_connected(conn)
 
+    def test_disable_prefetch_not_enabled(self):
+        """Test that disable_prefetch doesn't affect behavior when disabled"""
+        self.app.conf.worker_disable_prefetch = False
+        
+        # Test the core logic by creating a mock consumer and Tasks instance
+        from celery.worker.consumer.tasks import Tasks
+        consumer = Mock()
+        consumer.app = self.app
+        consumer.pool = Mock()
+        consumer.pool.num_processes = 4
+        consumer.controller = Mock()
+        consumer.controller.max_concurrency = None
+        consumer.initial_prefetch_count = 16
+        consumer.connection = Mock()
+        consumer.connection.default_channel = Mock()
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+        
+        # Mock task consumer
+        consumer.task_consumer = Mock()
+        consumer.task_consumer.channel = Mock()
+        consumer.task_consumer.channel.qos = Mock()
+        original_can_consume = Mock(return_value=True)
+        consumer.task_consumer.channel.qos.can_consume = original_can_consume
+        consumer.task_consumer.qos = Mock()
+        
+        consumer.app.amqp = Mock()
+        consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+        
+        tasks_instance = Tasks(consumer)
+        tasks_instance.start(consumer)
+        
+        # Should not modify can_consume method when disabled
+        assert consumer.task_consumer.channel.qos.can_consume == original_can_consume
+
+    def test_disable_prefetch_enabled_basic(self):
+        """Test that disable_prefetch modifies can_consume when enabled"""
+        self.app.conf.worker_disable_prefetch = True
+        
+        # Test the core logic by creating a mock consumer and Tasks instance
+        from celery.worker.consumer.tasks import Tasks
+        consumer = Mock()
+        consumer.app = self.app
+        consumer.pool = Mock()
+        consumer.pool.num_processes = 4
+        consumer.controller = Mock()
+        consumer.controller.max_concurrency = None
+        consumer.initial_prefetch_count = 16
+        consumer.connection = Mock()
+        consumer.connection.default_channel = Mock()
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+        
+        # Mock task consumer
+        consumer.task_consumer = Mock()
+        consumer.task_consumer.channel = Mock()
+        consumer.task_consumer.channel.qos = Mock()
+        original_can_consume = Mock(return_value=True)
+        consumer.task_consumer.channel.qos.can_consume = original_can_consume
+        consumer.task_consumer.qos = Mock()
+        
+        consumer.app.amqp = Mock()
+        consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+        
+        tasks_instance = Tasks(consumer)
+        
+        with patch('celery.worker.state.reserved_requests', []):
+            tasks_instance.start(consumer)
+            
+            # Should modify can_consume method when enabled
+            assert callable(consumer.task_consumer.channel.qos.can_consume)
+            assert consumer.task_consumer.channel.qos.can_consume != original_can_consume
+
+    def test_disable_prefetch_respects_reserved_requests_limit(self):
+        """Test that disable_prefetch respects reserved requests limit"""
+        self.app.conf.worker_disable_prefetch = True
+        
+        # Test the core logic by creating a mock consumer and Tasks instance
+        from celery.worker.consumer.tasks import Tasks
+        consumer = Mock()
+        consumer.app = self.app
+        consumer.pool = Mock()
+        consumer.pool.num_processes = 4
+        consumer.controller = Mock()
+        consumer.controller.max_concurrency = None
+        consumer.initial_prefetch_count = 16
+        consumer.connection = Mock()
+        consumer.connection.default_channel = Mock()
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+        
+        # Mock task consumer
+        consumer.task_consumer = Mock()
+        consumer.task_consumer.channel = Mock()
+        consumer.task_consumer.channel.qos = Mock()
+        consumer.task_consumer.channel.qos.can_consume = Mock(return_value=True)
+        consumer.task_consumer.qos = Mock()
+        
+        consumer.app.amqp = Mock()
+        consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+        
+        tasks_instance = Tasks(consumer)
+        
+        # Mock 4 reserved requests (at limit of 4)
+        mock_requests = [Mock(), Mock(), Mock(), Mock()]
+        with patch('celery.worker.state.reserved_requests', mock_requests):
+            tasks_instance.start(consumer)
+            
+            # Should not be able to consume when at limit
+            assert consumer.task_consumer.channel.qos.can_consume() is False
+
+    def test_disable_prefetch_respects_autoscale_max_concurrency(self):
+        """Test that disable_prefetch respects autoscale max_concurrency limit"""
+        self.app.conf.worker_disable_prefetch = True
+        
+        # Test the core logic by creating a mock consumer and Tasks instance
+        from celery.worker.consumer.tasks import Tasks
+        consumer = Mock()
+        consumer.app = self.app
+        consumer.pool = Mock()
+        consumer.pool.num_processes = 4
+        consumer.controller = Mock()
+        consumer.controller.max_concurrency = 2  # Lower than pool processes
+        consumer.initial_prefetch_count = 16
+        consumer.connection = Mock()
+        consumer.connection.default_channel = Mock()
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+        
+        # Mock task consumer
+        consumer.task_consumer = Mock()
+        consumer.task_consumer.channel = Mock()
+        consumer.task_consumer.channel.qos = Mock()
+        consumer.task_consumer.channel.qos.can_consume = Mock(return_value=True)
+        consumer.task_consumer.qos = Mock()
+        
+        consumer.app.amqp = Mock()
+        consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+        
+        tasks_instance = Tasks(consumer)
+        
+        # Mock 2 reserved requests (at autoscale limit of 2)
+        mock_requests = [Mock(), Mock()]
+        with patch('celery.worker.state.reserved_requests', mock_requests):
+            tasks_instance.start(consumer)
+            
+            # Should not be able to consume when at autoscale limit
+            assert consumer.task_consumer.channel.qos.can_consume() is False
+
 
 @pytest.mark.parametrize(
     "broker_connection_retry_on_startup,is_connection_loss_on_startup",


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Introduce an option to completely disable broker prefetching without requiring `acks_late`. When enabled, the worker only fetches a new task when an execution slot is available. This prevents head‑of‑line blocking and starvation caused by long‑running tasks.

- Real‑world need: we run long‑lasting tasks (hours) across multiple workers/pods. Prefetch caused busy workers to hold tasks in reserve while idle workers sat empty, leading to severe starvation. Disabling prefetch resolves this by fetching only when a slot is free.
- This work revives and supersedes the stalled discussion and implementation in [PR #9818](https://github.com/celery/celery/pull/9818). All reviewer suggestions from that PR have been applied here.

### What’s included

- New config: `worker_disable_prefetch` (default: False)
- New CLI flag: `--disable-prefetch`
- Core logic: when enabled, wrap `channel.qos.can_consume` to check `reserved_requests` against effective concurrency:
  - use autoscaler `max_concurrency` if present, otherwise pool size
- Documentation updates:
  - user guide (optimizing, configuration) and FAQ explain usage and impact
- Tests:
  - unit tests for consumer/autoscale behavior (including autoscaling edge cases)
  - pytest‑click based CLI test covering `--disable-prefetch`
- Minor nit applied: compute limit via `getattr(c.controller, "max_concurrency", None) or c.pool.num_processes`

### Backward compatibility

- Off by default; existing behavior unchanged.
- When enabled, only reservation timing changes (fetch on free slot); no protocol or API changes.

### Implementation notes

- This is a pragmatic Celery‑side QoS guard. Longer‑term, the ideal place for this behavior would be in Kombu’s QoS, with Celery surfacing the option.

### Testing

- Unit suites for consumer/autoscale/CLI pass locally.
- Docs build and configuration references updated.

### References

- Prior discussion/implementation: [PR #9818](https://github.com/celery/celery/pull/9818)
