### PR TITLE
Fix `AsyncResult.forget()` with couchdb backend method raises `TypeError: a bytes-like object is required, not 'str'`

### DIFF
--- a/celery/backends/couchdb.py
+++ b/celery/backends/couchdb.py
@@ -96,4 +96,5 @@ class CouchBackend(KeyValueStoreBackend):
         return [self.get(key) for key in keys]
 
     def delete(self, key):
+        key = bytes_to_str(key)
         self.connection.delete(key)

--- a/t/unit/backends/test_couchdb.py
+++ b/t/unit/backends/test_couchdb.py
@@ -118,6 +118,7 @@ class test_CouchBackend:
             assert x.password == 'mysecret'
             assert x.port == 123
 
+
 class CouchSessionMock:
     """
     Mock for `requests.session` that emulates couchdb storage.
@@ -126,7 +127,7 @@ class CouchSessionMock:
     _store = {}
 
     def request(self, method, url, stream=False, data=None, params=None,
-                 headers=None, **kw):
+                headers=None, **kw):
         tid = urlparse(url).path.split("/")[-1]
 
         response = Mock()
@@ -151,7 +152,7 @@ class CouchSessionMock:
             del self._store[tid]
             response.content = str_to_bytes(f'{{"ok":true,"id":"{tid}","rev":"1-revid"}}')
         else:
-            raise NotImplemented(f"CouchSessionMock.request() does not handle {method} method")
+            raise NotImplementedError(f"CouchSessionMock.request() does not handle {method} method")
 
         return response
 

--- a/t/unit/backends/test_couchdb.py
+++ b/t/unit/backends/test_couchdb.py
@@ -1,8 +1,8 @@
 from unittest.mock import MagicMock, Mock, sentinel
+from urllib.parse import urlparse
 
 import pytest
 from kombu.utils.encoding import str_to_bytes
-from urllib.parse import urlparse
 
 from celery import states, uuid
 from celery.app import backends

--- a/t/unit/backends/test_couchdb.py
+++ b/t/unit/backends/test_couchdb.py
@@ -1,8 +1,10 @@
 from unittest.mock import MagicMock, Mock, sentinel
 
 import pytest
+from kombu.utils.encoding import str_to_bytes
+from urllib.parse import urlparse
 
-from celery import states
+from celery import states, uuid
 from celery.app import backends
 from celery.backends import couchdb as module
 from celery.backends.couchdb import CouchBackend
@@ -115,3 +117,96 @@ class test_CouchBackend:
             assert x.username == 'johndoe'
             assert x.password == 'mysecret'
             assert x.port == 123
+
+class CouchSessionMock:
+    """
+    Mock for `requests.session` that emulates couchdb storage.
+    """
+
+    _store = {}
+
+    def request(self, method, url, stream=False, data=None, params=None,
+                 headers=None, **kw):
+        tid = urlparse(url).path.split("/")[-1]
+
+        response = Mock()
+        response.headers = {"content-type": "application/json"}
+        response.status_code = 200
+        response.content = b''
+
+        if method == "GET":
+            if tid not in self._store:
+                return self._not_found_response()
+            response.content = self._store.get(tid)
+        elif method == "PUT":
+            self._store[tid] = data
+            response.content = str_to_bytes(f'{{"ok":true,"id":"{tid}","rev":"1-revid"}}')
+        elif method == "HEAD":
+            if tid not in self._store:
+                return self._not_found_response()
+            response.headers.update({"etag": "1-revid"})
+        elif method == "DELETE":
+            if tid not in self._store:
+                return self._not_found_response()
+            del self._store[tid]
+            response.content = str_to_bytes(f'{{"ok":true,"id":"{tid}","rev":"1-revid"}}')
+        else:
+            raise NotImplemented(f"CouchSessionMock.request() does not handle {method} method")
+
+        return response
+
+    def _not_found_response(self):
+        response = Mock()
+        response.headers = {"content-type": "application/json"}
+        response.status_code = 404
+        response.content = str_to_bytes('{"error":"not_found","reason":"missing"}')
+        return response
+
+
+class test_CouchBackend_result:
+    def setup_method(self):
+        self.backend = CouchBackend(app=self.app)
+        resource = pycouchdb.resource.Resource("resource-url", session=CouchSessionMock())
+        self.backend._connection = pycouchdb.client.Database(resource, "container")
+
+    def test_get_set_forget(self):
+        tid = uuid()
+        self.backend.store_result(tid, "successful-result", states.SUCCESS)
+        assert self.backend.get_state(tid) == states.SUCCESS
+        assert self.backend.get_result(tid) == "successful-result"
+        self.backend.forget(tid)
+        assert self.backend.get_state(tid) == states.PENDING
+
+    def test_mark_as_started(self):
+        tid = uuid()
+        self.backend.mark_as_started(tid)
+        assert self.backend.get_state(tid) == states.STARTED
+
+    def test_mark_as_revoked(self):
+        tid = uuid()
+        self.backend.mark_as_revoked(tid)
+        assert self.backend.get_state(tid) == states.REVOKED
+
+    def test_mark_as_retry(self):
+        tid = uuid()
+        try:
+            raise KeyError('foo')
+        except KeyError as exception:
+            import traceback
+            trace = '\n'.join(traceback.format_stack())
+            self.backend.mark_as_retry(tid, exception, traceback=trace)
+            assert self.backend.get_state(tid) == states.RETRY
+            assert isinstance(self.backend.get_result(tid), KeyError)
+            assert self.backend.get_traceback(tid) == trace
+
+    def test_mark_as_failure(self):
+        tid = uuid()
+        try:
+            raise KeyError('foo')
+        except KeyError as exception:
+            import traceback
+            trace = '\n'.join(traceback.format_stack())
+            self.backend.mark_as_failure(tid, exception, traceback=trace)
+            assert self.backend.get_state(tid) == states.FAILURE
+            assert isinstance(self.backend.get_result(tid), KeyError)
+            assert self.backend.get_traceback(tid) == trace


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fix for #9864