### PR TITLE
Fix arithmetic overflow for MSSQL result backend

### DIFF
--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -10,6 +10,7 @@ from .session import ResultModelBase
 
 __all__ = ('Task', 'TaskExtended', 'TaskSet')
 
+DialectSpecificInteger = sa.Integer().with_variant(sa.BigInteger, 'mssql')
 
 class Task(ResultModelBase):
     """Task result/status."""
@@ -17,7 +18,7 @@ class Task(ResultModelBase):
     __tablename__ = 'celery_taskmeta'
     __table_args__ = {'sqlite_autoincrement': True}
 
-    id = sa.Column(sa.Integer, sa.Sequence('task_id_sequence'),
+    id = sa.Column(DialectSpecificInteger, sa.Sequence('task_id_sequence'),
                    primary_key=True, autoincrement=True)
     task_id = sa.Column(sa.String(155), unique=True)
     status = sa.Column(sa.String(50), default=states.PENDING)
@@ -80,7 +81,7 @@ class TaskSet(ResultModelBase):
     __tablename__ = 'celery_tasksetmeta'
     __table_args__ = {'sqlite_autoincrement': True}
 
-    id = sa.Column(sa.Integer, sa.Sequence('taskset_id_sequence'),
+    id = sa.Column(DialectSpecificInteger, sa.Sequence('taskset_id_sequence'),
                    autoincrement=True, primary_key=True)
     taskset_id = sa.Column(sa.String(155), unique=True)
     result = sa.Column(PickleType, nullable=True)


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Apparently, not too many people are using celery with MSSQL. This change must fix #8634. 

Perhaps there is no other way neither place to do this better: 
SQLAlchemy seems to behave correctly: it uses Integer when specified, and it’s not SQLAlchemy's business that Integer cannot fit a sequence.  As a consequence, the application should use proper field types. 



