### PR TITLE
Add documentation for task_id param for apply_async function

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -538,6 +538,13 @@ class Task:
                 The headers can be used as an overlay for custom labeling
                 using the :ref:`canvas-stamping` feature.
 
+            task_id (str): Optional argument to override the default task id.
+                By default, Celery generates a unique id (UUID4) for every task
+                submission. You can instead provide your own string identifier.
+                If supplied, this value will be used as the task’s id instead
+                of generating one automatically. Be careful to avoid collisions
+                when overriding task ids.
+                
         Returns:
             celery.result.AsyncResult: Promise of future evaluation.
 

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -56,6 +56,8 @@ The API defines a standard set of execution options, as well as three methods:
     - ``T.apply_async(expires=now + timedelta(days=2))``
         expires in 2 days, set using :class:`~datetime.datetime`.
 
+    - ``T.apply_async(task_id=f'my_own_task_id')``
+        sets the id of the task to my_own_task_id instead of a uuid that is normally generated
 
 Example
 -------


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Added documentation for the task_id parameter to the apply_async function as mentioned in this issue https://github.com/celery/celery/issues/9561. 
