### PR TITLE
fix(): preserve group order in replaced signature

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -544,7 +544,7 @@ class Task:
                 If supplied, this value will be used as the task’s id instead
                 of generating one automatically. Be careful to avoid collisions
                 when overriding task ids.
-                
+
         Returns:
             celery.result.AsyncResult: Promise of future evaluation.
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1741,7 +1741,7 @@ class group(Signature):
 
     def _apply_tasks(self, tasks, producer=None, app=None, p=None,
                      add_to_parent=None, chord=None,
-                     args=None, kwargs=None, **options):
+                     args=None, kwargs=None, group_index=None, **options):
         """Run all the tasks in the group.
 
         This is used by :meth:`apply_async` to run all the tasks in the group

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1741,7 +1741,7 @@ class group(Signature):
 
     def _apply_tasks(self, tasks, producer=None, app=None, p=None,
                      add_to_parent=None, chord=None,
-                     args=None, kwargs=None, **options, group_index=None):
+                     args=None, kwargs=None, group_index=None, **options):
         """Run all the tasks in the group.
 
         This is used by :meth:`apply_async` to run all the tasks in the group

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1741,7 +1741,7 @@ class group(Signature):
 
     def _apply_tasks(self, tasks, producer=None, app=None, p=None,
                      add_to_parent=None, chord=None,
-                     args=None, kwargs=None, group_index=None, **options):
+                     args=None, kwargs=None, **options, group_index=None):
         """Run all the tasks in the group.
 
         This is used by :meth:`apply_async` to run all the tasks in the group

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1576,6 +1576,8 @@ class test_group:
         assert res_obj.get(timeout=TIMEOUT) == [42, 1337]
 
     def test_task_replace_with_group_preserves_group_order(self, manager):
+        if manager.app.conf.result_backend.startswith("rpc"):
+            raise pytest.skip("RPC result backend does not support replacing with a group")
         orig_sig = group([add_to_all.s([2, 1], 1), add_to_all.s([4, 3], 1)] * 10)
         res_obj = orig_sig.delay()
         assert res_obj.get(timeout=TIMEOUT) == [[3, 2], [5, 4]] * 10

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1575,6 +1575,13 @@ class test_group:
         res_obj = orig_sig.delay()
         assert res_obj.get(timeout=TIMEOUT) == [42, 1337]
 
+    def test_task_replace_with_group_preserves_group_order(self, manager):
+        # if not manager.app.conf.result_backend.startswith("redis"):
+        #     raise pytest.skip("Requires redis result backend.")
+        orig_sig = group([add_to_all.s([2, 1], 1), add_to_all.s([4, 3], 1)] * 10)
+        res_obj = orig_sig.delay()
+        assert res_obj.get(timeout=TIMEOUT) == [[3, 2], [5, 4]] * 10
+
 
 def assert_ids(r, expected_value, expected_root_id, expected_parent_id):
     root_id, parent_id, value = r.get(timeout=TIMEOUT)

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1576,8 +1576,6 @@ class test_group:
         assert res_obj.get(timeout=TIMEOUT) == [42, 1337]
 
     def test_task_replace_with_group_preserves_group_order(self, manager):
-        # if not manager.app.conf.result_backend.startswith("redis"):
-        #     raise pytest.skip("Requires redis result backend.")
         orig_sig = group([add_to_all.s([2, 1], 1), add_to_all.s([4, 3], 1)] * 10)
         res_obj = orig_sig.delay()
         assert res_obj.get(timeout=TIMEOUT) == [[3, 2], [5, 4]] * 10

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1243,6 +1243,12 @@ class test_group(CanvasCase):
             assert isinstance(result, AsyncResult)
             assert group_id is not None
 
+    def test_task_replace_with_group_preserves_group_order(self):
+        self.app.conf.task_always_eager = True
+        sig = self.replace_with_group.s(1, 2)
+        res = self.helper_test_get_delay(sig.delay())
+        assert res == [3, 2]
+
 
 class test_chord(CanvasCase):
     def test__get_app_does_not_exhaust_generator(self):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Preserve group ordering when replacing a task with a group.
It should not be allowed to pass a `group_index` in the options, otherwise all tasks in the group will have the same `group_index` and the ordering is not deterministic.

Related issue: https://github.com/celery/celery/issues/9909
