### PR TITLE
Fix broker connection retry attempt counter in the error log

### DIFF
--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -492,7 +492,7 @@ class Consumer:
         def _error_handler(exc, interval, next_step=CONNECTION_RETRY_STEP):
             if getattr(conn, 'alt', None) and interval == 0:
                 next_step = CONNECTION_FAILOVER
-            else:
+            elif interval > 0:
                 self.broker_connection_retry_attempt += 1
             next_step = next_step.format(
                 when=humanize_seconds(interval, 'in', ' '),

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -492,7 +492,8 @@ class Consumer:
         def _error_handler(exc, interval, next_step=CONNECTION_RETRY_STEP):
             if getattr(conn, 'alt', None) and interval == 0:
                 next_step = CONNECTION_FAILOVER
-            self.broker_connection_retry_attempt += 1
+            else:
+                self.broker_connection_retry_attempt += 1
             next_step = next_step.format(
                 when=humanize_seconds(interval, 'in', ' '),
                 retries=self.broker_connection_retry_attempt,

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -157,6 +157,10 @@ class Consumer:
     #: connection attempt.
     first_connection_attempt = True
 
+    #: Counter to track number of conn retry attempts
+    #: to broker. Will be reset to 0 once successful
+    broker_connection_retry_attempt = 0
+
     class Blueprint(bootsteps.Blueprint):
         """Consumer blueprint."""
 
@@ -488,9 +492,10 @@ class Consumer:
         def _error_handler(exc, interval, next_step=CONNECTION_RETRY_STEP):
             if getattr(conn, 'alt', None) and interval == 0:
                 next_step = CONNECTION_FAILOVER
+            self.broker_connection_retry_attempt += 1
             next_step = next_step.format(
                 when=humanize_seconds(interval, 'in', ' '),
-                retries=int(interval / 2),
+                retries=self.broker_connection_retry_attempt,
                 max_retries=self.app.conf.broker_connection_max_retries)
             error(CONNECTION_ERROR, conn.as_uri(), exc, next_step)
 
@@ -532,6 +537,7 @@ class Consumer:
             callback=maybe_shutdown,
         )
         self.first_connection_attempt = False
+        self.broker_connection_retry_attempt = 0
         return conn
 
     def _flush_events(self):

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -405,6 +405,8 @@ class test_Consumer(ConsumerTestCase):
         self.app.conf.broker_connection_max_retries = 3
         self.app._connection = _amqp_connection()
         conn = self.app._connection.return_value
+        # Placeholder alt connection to satisfy failover condition
+        conn.alt = [conn]
         c = self.get_consumer()
         assert c.connect()
         errback = conn.ensure_connection.call_args[0][0]
@@ -414,6 +416,8 @@ class test_Consumer(ConsumerTestCase):
         assert error.call_args[0][3] == 'Trying again in 4.00 seconds... (2/3)'
         errback(Mock(), 12)
         assert error.call_args[0][3] == 'Trying again in 12.00 seconds... (3/3)'
+        errback(Mock(), 0)
+        assert getattr(c, 'broker_connection_retry_attempt', 0) == 3
 
     def test_cancel_long_running_tasks_on_connection_loss(self):
         c = self.get_consumer()

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -412,8 +412,8 @@ class test_Consumer(ConsumerTestCase):
         assert error.call_args[0][3] == 'Trying again in 2.00 seconds... (1/3)'
         errback(Mock(), 4)
         assert error.call_args[0][3] == 'Trying again in 4.00 seconds... (2/3)'
-        errback(Mock(), 6)
-        assert error.call_args[0][3] == 'Trying again in 6.00 seconds... (3/3)'
+        errback(Mock(), 12)
+        assert error.call_args[0][3] == 'Trying again in 12.00 seconds... (3/3)'
 
     def test_cancel_long_running_tasks_on_connection_loss(self):
         c = self.get_consumer()


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description
When the consumer fails to connect to broker, the error logs retry counter stalls after some time. More can be found in this issue : https://github.com/celery/celery/issues/9340

## Design 
Maintains a counter in the consumer to track retry attempts, this is because the interval returned from kombu is not sufficient indicator for the retry count and will be interval_max after a few retry attempts. 

## Changes
- [x] Changes for the retry counter
- [x] Fixing a linter issue (additional whitespace on empty line)