### PR TITLE
Fix invalid pytz dependency specifier (>dev) in 5.1.x

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-pytz>dev
+pytz>=2021.3
 billiard>=3.6.4.0,<4.0
 kombu>=5.1.0,<6.0
 vine>=5.0.0,<6.0


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Summary
In Celery **5.1.2**, both `requirements/default.txt` and `requirements/dev.txt`
list an invalid requirement: pytz>dev

This is **not PEP 440–compliant** and breaks downstream tools (pip, piptools, Bazel)
when building from source. For example, Bazel fails with:
```
packaging._tokenizer.ParserSyntaxError:
Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
pytz (>dev)
```

Later versions (>=5.2.3) fixed this in `default.txt` (`pytz>=2021.3`), but
`dev.txt` still contains the invalid specifier.

## Changes
- Replaced `pytz>dev` with `pytz>=2021.3` in `requirements/default.txt`.

## Why backport?
- This issue **still exists in the PyPI sdist/wheel for 5.1.2**.
- Many enterprise environments (like ours) pin to Celery 5.1.x for compatibility.
- Without a patch release, anyone installing 5.1.2 from source may hit this build error.

## Request
Please consider releasing **5.1.3** as a hotfix, so that the corrected metadata
is published to PyPI and downstream users are not blocked.

Fixes #9916

