### PR TITLE
Pin tblib to ==3.1.0

### DIFF
--- a/requirements/extras/tblib.txt
+++ b/requirements/extras/tblib.txt
@@ -1,2 +1,1 @@
-tblib>=1.5.0;python_version>='3.8.0'
-tblib>=1.3.0;python_version<'3.8.0'
+tblib==3.1.0


### PR DESCRIPTION
Pin tblib to ==3.1.0 to ensure consistent traceback serialization across Python versions.
