### PR TITLE
Remove Python 4.0 version condition for pytest dependencies

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 pytest==8.4.2
 pytest-celery[all]>=1.2.0,<1.3.0
-pytest-rerunfailures>=15.0; python_version >= "3.9" and python_version < "4.0"
-pytest-subtests>=0.14.1; python_version >= "3.9" and python_version < "4.0"
+pytest-rerunfailures>=15.0; python_version >= "3.9"
+pytest-subtests>=0.14.1; python_version >= "3.9"
 pytest-timeout==2.4.0
 pytest-click==1.1.0
 pytest-order==1.3.0


### PR DESCRIPTION
These were added in
* https://github.com/celery/celery/commit/f1ddd58647ee24bee4f74c9c4e45812728cfd514
* https://github.com/celery/celery/commit/c4e4bab4a62c499a368b0921253149c8f02554ad

but they are not helpful. Decided to clean in https://github.com/celery/celery/pull/9987#discussion_r2510046671