### PR TITLE
asynpool: Don't return from inside a finally block

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -408,7 +408,6 @@ class ResultHandler(_pool.ResultHandler):
                 setblocking(reader, 0)
             except OSError:
                 result = remove(fd)
-                
         return result
 
 


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Simple fix for the Python 3.14 issue mentioned in [this discussion](https://github.com/celery/celery/discussions/9985). Simply omit the `return` keyword inside of the finally block.