### PR TITLE
Fix Redis Sentinel ACL authentication support

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -8,6 +8,16 @@ This document contains change notes for bugfix & new features
 in the main branch & 5.6.x series, please see :ref:`whatsnew-5.6` for
 an overview of what's new in Celery 5.6.
 
+.. _version-5.6.1:
+
+5.6.1
+=====
+
+:release-date: TBA
+:release-by:
+
+- Fix Redis Sentinel ACL authentication support
+
 .. _version-5.6.0:
 
 5.6.0

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -683,8 +683,8 @@ class SentinelBackend(RedisBackend):
         for param in ("host", "port", "db", "password"):
             connparams.pop(param)
 
-        # Adding db/password in connparams to connect to the correct instance
-        for param in ("db", "password"):
+        # Adding db/password/username in connparams to connect to the correct instance
+        for param in ("db", "password", "username"):
             if connparams['hosts'] and param in connparams['hosts'][0]:
                 connparams[param] = connparams['hosts'][0].get(param)
         return connparams
@@ -709,7 +709,12 @@ class SentinelBackend(RedisBackend):
 
         master_name = self._transport_options.get("master_name", None)
 
+        credentials = {
+            k: params[k] for k in ("username", "password") if k in params
+        }
+
         return sentinel_instance.master_for(
             service_name=master_name,
             redis_class=self._get_client(),
+            **credentials,
         ).connection_pool

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -173,7 +173,8 @@ class Sentinel(conftest.MockCallbacks):
         self.min_other_sentinels = min_other_sentinels
         self.connection_kwargs = connection_kwargs
 
-    def master_for(self, service_name, redis_class):
+    def master_for(self, service_name, redis_class, **kwargs):
+        self.master_for_kwargs = kwargs
         return random.choice(self.sentinels)
 
 
@@ -1417,3 +1418,56 @@ class test_SentinelBackend:
 
         from celery.backends.redis import SentinelManagedSSLConnection
         assert x.connparams['connection_class'] is SentinelManagedSSLConnection
+
+    def test_url_with_acl_credentials(self):
+        x = self.Backend(
+            'sentinel://myuser:mypass@github.com:123/1;'
+            'sentinel://myuser:mypass@github.com:124/1',
+            app=self.app,
+        )
+        assert x.connparams
+        assert "host" not in x.connparams
+        assert x.connparams['db'] == 1
+        assert "port" not in x.connparams
+        assert x.connparams['password'] == "mypass"
+        assert x.connparams['username'] == "myuser"
+        assert len(x.connparams['hosts']) == 2
+
+        expected_usernames = ["myuser", "myuser"]
+        found_usernames = [cp['username'] for cp in x.connparams['hosts']]
+        assert found_usernames == expected_usernames
+
+    def test_get_pool_with_acl_credentials(self):
+        x = self.Backend(
+            'sentinel://myuser:mypass@github.com:123/1;'
+            'sentinel://myuser:mypass@github.com:124/1',
+            app=self.app,
+        )
+        with patch.object(x, '_get_sentinel_instance') as mock_get_sentinel:
+            mock_sentinel = Mock()
+            mock_sentinel.master_for.return_value = Mock(connection_pool=Mock())
+            mock_get_sentinel.return_value = mock_sentinel
+
+            x._get_pool(**x.connparams)
+
+            mock_sentinel.master_for.assert_called_once()
+            call_kwargs = mock_sentinel.master_for.call_args[1]
+            assert call_kwargs.get('username') == 'myuser'
+            assert call_kwargs.get('password') == 'mypass'
+
+    def test_get_pool_with_password_only(self):
+        x = self.Backend(
+            'sentinel://:mypass@github.com:123/1',
+            app=self.app,
+        )
+        with patch.object(x, '_get_sentinel_instance') as mock_get_sentinel:
+            mock_sentinel = Mock()
+            mock_sentinel.master_for.return_value = Mock(connection_pool=Mock())
+            mock_get_sentinel.return_value = mock_sentinel
+
+            x._get_pool(**x.connparams)
+
+            mock_sentinel.master_for.assert_called_once()
+            call_kwargs = mock_sentinel.master_for.call_args[1]
+            assert 'username' not in call_kwargs
+            assert call_kwargs.get('password') == 'mypass'


### PR DESCRIPTION
## Description

**Support for Redis Sentinel ACL authentication (username + password) in SentinelBackend** 

### Problem

When using Redis Sentinel with ACL authentication (Redis 6.0+ feature), the `SentinelBackend` fails to authenticate because:

1. **`_params_from_url`** - Does not extract the `username` from the sentinel URL. The username is present in `connparams["hosts"][0]["username"]` but was never propagated to the top-level `connparams`.

2. **`_get_pool`** - Does not pass credentials (`username`, `password`) to `sentinel_instance.master_for()` when creating the connection pool.

### Solution

This change fixes both issues:
- Extract `username` from sentinel hosts alongside `db` and `password` in `_params_from_url`
- Pass ACL credentials to `master_for()` in `_get_pool`

### Usage

```python
# Sentinel URL with ACL authentication (username:password)
app.conf.result_backend = 'sentinel://myuser:mypass@sentinel1:26379/0;sentinel://myuser:mypass@sentinel2:26379/0'

app.conf.result_backend_transport_options = {
    'master_name': 'mymaster',
}
```

### Changes
- `celery/backends/redis.py`: Fixed `_params_from_url` and `_get_pool` methods in `SentinelBackend`
- `t/unit/backends/test_redis.py`: Added unit tests for ACL authentication support

### Related Issues
- [#6301 - Complete redis Sentinel documentation in regards to authentication](https://github.com/celery/celery/issues/6301)