### PR TITLE
 munally reverted https://github.com/celery/celery/pull/9824

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -168,7 +168,8 @@ class DjangoWorkerFixup:
             if c and c.connection:
                 self._maybe_close_db_fd(c)
 
-        # use the _ version to avoid DB_REUSE preventing the conn.close() call
+        # use the _close_database(force=True) to avoid DB_REUSE preventing connection closure
+        # and to ensure full connection close (not just close_if_unusable_or_obsolete) on worker process init
         self._close_database(force=True)
         self.close_cache()
 

--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -200,6 +200,16 @@ class DjangoWorkerFixup:
         self._db_recycles += 1
 
     def _close_database(self, force: bool = False) -> None:
+        """Close database connections.
+
+        Args:
+            force: If True, unconditionally close all connections via conn.close().
+                   If False (default), only close unusable or obsolete connections
+                   via conn.close_if_unusable_or_obsolete().
+
+        Use force=True during worker process initialization to ensure clean slate.
+        Use default (False) during normal task lifecycle for connection reuse optimization.
+        """
         for conn in self._db.connections.all():
             try:
                 if force:

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -196,7 +196,7 @@ class test_DjangoWorkerFixup(FixupCase):
                         f.on_worker_process_init()
                         mcf.assert_called_with(conns[1].connection)
                         f.close_cache.assert_called_with()
-                        f._close_database.assert_called_with()
+                        f._close_database.assert_called_with(force=True)
 
                         f.validate_models = Mock(name='validate_models')
                         patching.setenv('FORKED_BY_MULTIPROCESSING', '1')
@@ -264,25 +264,34 @@ class test_DjangoWorkerFixup(FixupCase):
             f._db.connections = Mock()  # ConnectionHandler
             f._db.connections.all.side_effect = lambda: conns
 
-            f._close_database()
+            f._close_database(force=True)
             conns[0].close.assert_called_with()
+            conns[0].close_if_unusable_or_obsolete.assert_not_called()
             conns[1].close.assert_called_with()
+            conns[1].close_if_unusable_or_obsolete.assert_not_called()
             conns[2].close.assert_called_with()
-
+            conns[2].close_if_unusable_or_obsolete.assert_not_called()
+            for conn in conns:
+                conn.reset_mock()
+            f._close_database()
+            conns[0].close.assert_not_called()
+            conns[0].close_if_unusable_or_obsolete.assert_called_with()
+            conns[1].close.assert_not_called()
+            conns[1].close_if_unusable_or_obsolete.assert_called_with()
+            conns[2].close.assert_not_called()
+            conns[2].close_if_unusable_or_obsolete.assert_called_with()
             conns[1].close.side_effect = KeyError(
                 'omg')
+            f._close_database()
+            with pytest.raises(KeyError):
+                f._close_database(force=True)
+
+            conns[1].close.side_effect = None
+            conns[1].close_if_unusable_or_obsolete.side_effect = KeyError(
+                'omg')
+            f._close_database(force=True)
             with pytest.raises(KeyError):
                 f._close_database()
-
-    def test_close_database_always_closes_connections(self):
-        with self.fixup_context(self.app) as (f, _, _):
-            conn = Mock()
-            f._db.connections.all = Mock(return_value=[conn])
-            f.close_database()
-            conn.close.assert_called_once_with()
-            # close_if_unusable_or_obsolete is not safe to call in all conditions, so avoid using
-            # it to optimize connection handling.
-            conn.close_if_unusable_or_obsolete.assert_not_called()
 
     def test_close_database_skip_conn_pool(self):
         class Connection:
@@ -335,11 +344,6 @@ class test_DjangoWorkerFixup(FixupCase):
             f.close_database()
             conn.close.assert_called_once_with()
             conn.close_pool.assert_not_called()
-
-    def test_close_cache_raises_error(self):
-        with self.fixup_context(self.app) as (f, _, _):
-            f._cache.close_caches.side_effect = AttributeError
-            f.close_cache()
 
     def test_close_cache(self):
         with self.fixup_context(self.app) as (f, _, _):


### PR DESCRIPTION
## Manual Revert
Reverts PR #9824, which applied Django’s `CONN_MAX_AGE` to Celery’s DB connections. This caused unintended persistent connections in workers, leading to connection buildup and instability. Restores previous explicit connection-handling behavior to maintain expected worker stability.