### PR TITLE
Docs: clarify `result_extended` vs periodic task metadata and show `headers["periodic_task_name"]` example

### DIFF
--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -812,6 +812,24 @@ setting or by using the ``ignore_result`` option:
 If you'd like to store additional metadata about the task in the result backend
 set the :setting:`result_extended` setting to ``True``.
 
+.. note::
+
+   ``result_extended`` controls what *Celery* includes as extended task metadata,
+   but it does not automatically add scheduler-specific metadata.
+   For example, some integrations (e.g. :pypi:`django-celery-beat` together with
+   :pypi:`django-celery-results`) may record the *periodic task name* in the result
+   backend only when the scheduler provides it as part of the published message.
+
+   When you call tasks manually using ``apply_async``/``delay``, that periodic task
+   context is usually not present unless you add it explicitly (e.g. via message
+   headers/properties in ``apply_async`` options). For example:
+
+   .. code-block:: python
+
+      result = task.apply_async(
+          headers={"periodic_task_name": "task_name"},
+      )
+
 .. seealso::
 
    For more information on tasks, please see :ref:`guide-tasks`.


### PR DESCRIPTION
This PR updates the Celery “Calling Tasks” documentation to clarify that enabling `result_extended` affects Celery’s extended result metadata, but does **not** automatically add scheduler-specific metadata (such as a periodic task name).

In particular, integrations like `django-celery-beat` + `django-celery-results` may store a periodic task name in the result backend only when that context is included in the published message. When tasks are sent manually via `apply_async()`/`delay()`, this context is typically absent unless explicitly provided.

#### What changed
- Added a `.. note::` to `docs/userguide/calling.rst` under **Results options** explaining the above distinction.
- Included a small example showing how to attach a periodic task name via message headers:

```python
result = task.apply_async(
    headers={"periodic_task_name": "task_name"},
)
```

#### References
- Original report/discussion from `django-celery-results`: https://github.com/celery/django-celery-results/issues/376