### PR TITLE
Stop importing pytest_subtests

### DIFF
--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta, timezone
 from time import monotonic, sleep
 
 import pytest
-import pytest_subtests  # noqa
 
 from celery import chain, chord, group, signature
 from celery.backends.base import BaseKeyValueStoreBackend

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable
 from unittest.mock import ANY, MagicMock, Mock, call, patch, sentinel
 
 import pytest
-import pytest_subtests  # noqa
 
 from celery._state import _task_stack
 from celery.canvas import (Signature, _chain, _maybe_group, _merge_dictionaries, chain, chord, chunks, group,

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -1,7 +1,6 @@
 import collections
 
 import pytest
-import pytest_subtests  # noqa
 from kombu.utils.functional import lazy
 
 from celery.utils.functional import (DummyContext, first, firstmethod, fun_accepts_kwargs, fun_takes_argument,


### PR DESCRIPTION
This doesn't seem to be necessary either with pytest<9 (where pytest-subtests was a separate package) or with pytest>=9 (where subtest support is integrated into pytest).