### PR TITLE
Add `__class_getitem__` to generic classes

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -306,3 +306,4 @@ Narasux, 2024/09/09
 Colin Watson, 2025/03/01
 Lucas Infante, 2025/05/15
 Diego Margoni, 2025/07/01
+Brian Helba, 2026/01/12

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -5,6 +5,7 @@ import inspect
 import os
 import sys
 import threading
+import types
 import typing
 import warnings
 from collections import UserDict, defaultdict, deque
@@ -1265,6 +1266,8 @@ class Celery:
             attrs['__reduce__'] = __reduce__
 
         return type(name or Class.__name__, (Class,), attrs)
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
     def _rgetattr(self, path):
         return attrgetter(path)(self)

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -1,5 +1,6 @@
 """Task implementation: request context and the task base class."""
 import sys
+import types
 
 from billiard.einfo import ExceptionInfo, ExceptionWithTraceback
 from kombu import serialization
@@ -431,6 +432,8 @@ class Task:
         finally:
             self.pop_request()
             _task_stack.pop()
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
     def __reduce__(self):
         # - tasks are pickled into the name of the task only, and the receiver

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -7,6 +7,7 @@
 
 import itertools
 import operator
+import types
 import warnings
 from abc import ABCMeta, abstractmethod
 from collections import deque
@@ -809,6 +810,8 @@ class Signature(dict):
         """
         args, kwargs, _ = self._merge(args, kwargs, {}, force=True)
         return reprcall(self['task'], args, kwargs)
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
     def __deepcopy__(self, memo):
         memo[id(self)] = self

--- a/celery/local.py
+++ b/celery/local.py
@@ -8,6 +8,7 @@ Parts of this module is Copyright by Werkzeug Team.
 
 import operator
 import sys
+import types
 from functools import reduce
 from importlib import import_module
 from types import ModuleType
@@ -429,6 +430,8 @@ class class_property:
         self.__doc__ = info.__doc__
         self.__name__ = info.__name__
         self.__module__ = info.__module__
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
     def __get__(self, obj, type=None):
         if obj and type is None:

--- a/celery/result.py
+++ b/celery/result.py
@@ -2,6 +2,7 @@
 
 import datetime
 import time
+import types
 from collections import deque
 from contextlib import contextmanager
 from weakref import proxy
@@ -383,6 +384,8 @@ class AsyncResult(ResultBase):
             if parent:
                 graph.add_edge(parent, node)
         return graph
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
     def __str__(self):
         """`str(self) -> self.id`."""

--- a/celery/utils/objects.py
+++ b/celery/utils/objects.py
@@ -1,4 +1,5 @@
 """Object related utilities, including introspection, etc."""
+import types
 from functools import reduce
 
 __all__ = ('Bunch', 'FallbackContext', 'getitem_property', 'mro_lookup')
@@ -89,6 +90,8 @@ class FallbackContext:
     def __exit__(self, *exc_info):
         if self._context is not None:
             return self._context.__exit__(*exc_info)
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
 
 class getitem_property:

--- a/celery/utils/threads.py
+++ b/celery/utils/threads.py
@@ -4,6 +4,7 @@ import socket
 import sys
 import threading
 import traceback
+import types
 from contextlib import contextmanager
 from threading import TIMEOUT_MAX as THREAD_TIMEOUT_MAX
 
@@ -226,6 +227,8 @@ class _LocalStack:
         else:
             return stack.pop()
 
+    __class_getitem__ = classmethod(types.GenericAlias)
+
     def __len__(self):
         stack = getattr(self._local, 'stack', None)
         return len(stack) if stack else 0
@@ -316,6 +319,8 @@ class _FastLocalStack(threading.local):
             return self.stack[-1]
         except (AttributeError, IndexError):
             return None
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
     def __len__(self):
         return len(self.stack)

--- a/t/unit/test_generics.py
+++ b/t/unit/test_generics.py
@@ -1,0 +1,72 @@
+import contextlib
+import sys
+import typing
+from typing import get_args
+
+import pytest
+
+from celery.app import Celery
+from celery.app.task import Context, Task
+from celery.canvas import Signature
+from celery.local import class_property
+from celery.result import AsyncResult
+from celery.utils.objects import FallbackContext
+from celery.utils.threads import _FastLocalStack, _LocalStack
+
+
+class test_Generics:
+    def test_Celery__class_getitem__(self):
+        app = Celery[Task]()
+        assert isinstance(app, Celery), "Celery can be instantiated with type parameters"
+        assert get_args(Celery[Task]) == (Task,), "__class_getitem__ returns a GenericAlias"
+
+    def test_Task__class_getitem__(self):
+        task = Task[[int], str]()
+        assert isinstance(task, Task), "Task can be instantiated with type parameters"
+        assert get_args(Task[[int], str]) == ([int], str),  "__class_getitem__ returns a GenericAlias"
+
+    @pytest.mark.usefixtures('depends_on_current_app')
+    def test_AsyncResult__class_getitem__(self):
+        result = AsyncResult[str]("some-id")
+        assert isinstance(result, AsyncResult), "AsyncResult can be instantiated with type parameters"
+        assert get_args(AsyncResult[str]) == (str,), "__class_getitem__ returns a GenericAlias"
+
+    def test_Signature__class_getitem__(self):
+        s = Signature[str]()
+        assert isinstance(s, Signature), "Signature can be instantiated with type parameters"
+        assert get_args(Signature[str]) == (str,), "__class_getitem__ returns a GenericAlias"
+
+    def test__LocalStack__class_getitem__(self):
+        stack = _LocalStack[Context]()
+        assert isinstance(stack, _LocalStack), "_LocalStack can be instantiated with type parameters"
+        assert get_args(_LocalStack[Context]) == (Context,), "__class_getitem__ returns a GenericAlias"
+
+    def test__FastLocalStack__class_getitem__(self):
+        s = _FastLocalStack[Context]()
+        assert isinstance(s, _FastLocalStack), "_FastLocalStack can be instantiated with type parameters"
+        assert get_args(_FastLocalStack[Context]) == (Context,), "__class_getitem__ returns a GenericAlias"
+
+    def test_FallbackContext__class_getitem__(self):
+        @contextlib.contextmanager
+        def make_thing(int_count):
+            yield f'dynamic_thing_{int_count}'
+
+        thing_manager = FallbackContext[str, [int]]('static_thing', make_thing)
+        assert isinstance(thing_manager, FallbackContext), "FallbackContext can be instantiated with type parameters"
+        assert get_args(FallbackContext[str, [int]]) == (str, [int]), "__class_getitem__ returns a GenericAlias"
+
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="typing.Self is only available in Python 3.11 or newer.")
+    def test_class_property__class_getitem__(self):
+        class Thing:
+            def _get_my_prop(self):
+                return "hello"
+
+            def _set_my_prop(self, str_value):
+                pass
+
+            my_prop = class_property[typing.Self, str](_get_my_prop, _set_my_prop)
+
+        assert isinstance(Thing.__dict__['my_prop'], class_property), \
+            "class_property can be instantiated with type parameters"
+        assert Thing.my_prop == "hello", "class_property works as expected"
+        assert get_args(class_property[Thing, str]) == (Thing, str), "__class_getitem__ returns a GenericAlias"


### PR DESCRIPTION
This will not change any behavior in normal usage, but will enable the `celery-types` project to use generics for:
* `Celery`
* `Task`
* `AsyncResult`
* `Signature`
* `_LocalStack`
* `_FastLocalStack`
* `FallbackContext`
* `class_property`

For example, this will allow annotations like:
```python
app = Celery[CustomTask]()
```

See the recent discussion: https://github.com/sbdchd/celery-types/issues/157#issuecomment-3696892836