### PR TITLE
Fix AttributeError when pool_cls is a string in Django fixups

### DIFF
--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -217,7 +217,11 @@ class DjangoWorkerFixup:
             # Support Django < 4.1
             connections = self._db.connections.all()
 
-        is_prefork = "prefork" in self.worker.pool_cls.__module__
+        pool_cls = self.worker.pool_cls
+        if isinstance(pool_cls, str):
+            is_prefork = "prefork" in pool_cls
+        else:
+            is_prefork = "prefork" in pool_cls.__module__
 
         for conn in connections:
             try:


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'str' object has no attribute '__module__'` when running Flower with Celery 5.6.1.
<img width="1385" height="658" alt="image" src="https://github.com/user-attachments/assets/483b0b68-acb6-416f-b611-b67097d6e542" />


## Changes

- Modified `celery/fixups/django.py` to check if `pool_cls` is a string before accessing `.__module__`
- Added test case `test_close_database_pool_cls_as_string` to cover this scenario

## Root Cause

In `_close_database()` method at line 220, the code assumes `pool_cls` is a class with a `__module__` attribute:

```python
is_prefork = "prefork" in self.worker.pool_cls.__module__
```

However, when Flower initializes, `pool_cls` can still be a string (e.g., `'prefork'`) instead of the resolved class object.

## Fix

```python
pool_cls = self.worker.pool_cls
if isinstance(pool_cls, str):
    is_prefork = "prefork" in pool_cls
else:
    is_prefork = "prefork" in pool_cls.__module__
```

## Error Traceback (before fix)

```
File "/usr/local/lib/python3.12/site-packages/celery/fixups/django.py", line 220, in _close_database
    is_prefork = "prefork" in self.worker.pool_cls.__module__
                              │    │      └ 'prefork'
                              │    └ <Worker: celery@75efc8aa2596 (INIT)>
                              └ <celery.fixups.django.DjangoWorkerFixup object>

AttributeError: 'str' object has no attribute '__module__'
```

## Test Plan

- [x] Added unit test `test_close_database_pool_cls_as_string` 
- [x] Existing tests pass

Fixes #10042