### PR TITLE
Revert "Update elasticsearch requirement from <=9.1.2 to <=9.2.1"

### DIFF
--- a/requirements/extras/elasticsearch.txt
+++ b/requirements/extras/elasticsearch.txt
@@ -1,2 +1,2 @@
-elasticsearch<=9.2.1
+elasticsearch<=9.1.2
 elastic-transport<=9.1.0


### PR DESCRIPTION
This do not support python 3.9 anymore. so lets wait until we start merging v5.7 issues. until January 31 or around that?

Reverts celery/celery#10053