### PR TITLE
Fix broken images on PyPI page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Sponsors
 Blacksmith
 ----------
 
-.. image:: ./docs/images/blacksmith-logo-white-on-black.svg
+.. image:: https://github.com/celery/celery/blob/main/docs/images/blacksmith-logo-white-on-black.svg
    :alt: Blacksmith logo
    :width: 240px
    :target: https://blacksmith.sh/
@@ -47,7 +47,7 @@ Blacksmith
 CloudAMQP
 ---------
 
-.. image:: ./docs/images/cloudamqp-logo-lightbg.svg
+.. image:: https://github.com/celery/celery/blob/main/docs/images/cloudamqp-logo-lightbg.svg
    :alt: CloudAMQP logo
    :width: 240px
    :target: https://www.cloudamqp.com/


### PR DESCRIPTION
## Issue
Fixes #10065

Changed the relative links to absolute links for making the images visible on the [PyPI documentation](https://pypi.org/project/celery) too