### PR TITLE
fix(asynpool): avoid AttributeError when proc lacks _sentinel_poll

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -513,10 +513,11 @@ class AsynPool(_pool.Pool):
             self._event_process_exit, hub, proc)
 
     def _untrack_child_process(self, proc, hub):
-        if proc._sentinel_poll is not None:
-            fd, proc._sentinel_poll = proc._sentinel_poll, None
-            hub.remove(fd)
-            os.close(fd)
+        sentinel_poll = getattr(proc, '_sentinel_poll', None)
+        if sentinel_poll is not None:
+            proc._sentinel_poll = None
+            hub.remove(sentinel_poll)
+            os.close(sentinel_poll)
 
     def register_with_event_loop(self, hub):
         """Register the async pool with the current event loop."""


### PR DESCRIPTION
## Description

Use getattr for safe access to `_sentinel_poll` in `_untrack_child_process`. A race condition during cold shutdown can cause this method to be called with a process that never had _sentinel_poll set or had it cleared.

Fixes #10084 
