### PR TITLE
Revise Python compatibility for Celery versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Celery version 5.6.x runs on:
 - Python (3.9, 3.10, 3.11, 3.12, 3.13)
 - PyPy3.9+ (v7.3.12+)
 
-This is the last version of celery which will support Python 3.9 or newer.
+This is the last version of Celery which will support Python 3.9.
 Celery v5.7.x will work on Python 3.10 or newer versions.
 
 If you're running an older version of Python, you need to be running


### PR DESCRIPTION
Update supported Python versions for Celery.

readme was not updated so this change was required.

