### PR TITLE
fix: avoid cycle detection in native delayed delivery

### DIFF
--- a/t/integration/test_rabbitmq_quorum_queue_cycle_detection.py
+++ b/t/integration/test_rabbitmq_quorum_queue_cycle_detection.py
@@ -3,7 +3,7 @@ Integration tests for RabbitMQ cycle detection bug with quorum queues.
 
 This reproduces the conditions for
 https://github.com/celery/celery/issues/9867 when running against RabbitMQ
-<4.0.
+<4.0.1.
 """
 
 import os
@@ -70,14 +70,14 @@ def create_test_app_with_quorum_queues():
     # Enable result extended to track retries
     app.conf.result_extended = True
 
-    return app, queue_name
+    return app
 
 
 @pytest.mark.amqp
 @pytest.mark.timeout(35)
-def test_countdown_task_with_retry_loses_message():
+def test_countdown_task_with_retry():
     """Test where a countdown task gets retried with the same delay."""
-    app, queue_name = create_test_app_with_quorum_queues()
+    app = create_test_app_with_quorum_queues()
 
     @app.task(bind=True, default_retry_delay=3, max_retries=1)
     def countdown_task_with_retry(self):
@@ -114,9 +114,9 @@ def test_countdown_task_with_retry_loses_message():
 
 @pytest.mark.amqp
 @pytest.mark.timeout(35)
-def test_non_eta_task_with_multiple_retries_loses_message():
+def test_non_eta_task_with_multiple_retries():
     """Test where a task gets retried twice with the same delay."""
-    app, queue_name = create_test_app_with_quorum_queues()
+    app = create_test_app_with_quorum_queues()
 
     @app.task(bind=True, max_retries=2)
     def non_eta_task_with_retries(self):

--- a/t/integration/test_rabbitmq_quorum_queue_cycle_detection.py
+++ b/t/integration/test_rabbitmq_quorum_queue_cycle_detection.py
@@ -1,0 +1,148 @@
+"""
+Integration tests for RabbitMQ cycle detection bug with quorum queues.
+
+This reproduces the conditions for
+https://github.com/celery/celery/issues/9867 when running against RabbitMQ
+<4.0.
+"""
+
+import os
+
+import pytest
+from kombu import Exchange, Queue
+
+from celery import Celery, exceptions
+from celery.contrib.testing.worker import start_worker
+
+
+class TaskFailedException(Exception):
+    """Test exception for tasks that should fail and retry."""
+    pass
+
+
+def get_rabbitmq_url():
+    """Get RabbitMQ broker URL from environment."""
+    user = os.environ.get("RABBITMQ_DEFAULT_USER", "guest")
+    password = os.environ.get("RABBITMQ_DEFAULT_PASSWORD", "guest")
+    return os.environ.get(
+        "TEST_BROKER", f"pyamqp://{user}:{password}@localhost:5672//")
+
+
+def get_backend_url():
+    """Get backend URL from environment."""
+    return os.environ.get("TEST_BACKEND", "rpc")
+
+
+def create_test_app_with_quorum_queues():
+    """
+    Create Celery app configured for quorum queue testing.
+
+    Returns:
+        Tuple of (app, queue_name)
+    """
+    broker_url = get_rabbitmq_url()
+    backend_url = get_backend_url()
+
+    app = Celery(
+        "test_cycle_detection",
+        broker=broker_url,
+        backend=backend_url,
+    )
+
+    # Configure queue with quorum queue type
+    queue_name = 'test_cycle_queue'
+    default_exchange = Exchange('celery.topic', type='topic')
+
+    app.conf.task_queues = [
+        Queue(
+            queue_name,
+            exchange=default_exchange,
+            routing_key=queue_name,
+            queue_arguments={'x-queue-type': 'quorum'}
+        ),
+    ]
+
+    app.conf.task_default_queue = queue_name
+
+    # Recommended settings for quorum queues
+    app.conf.broker_transport_options = {"confirm_publish": True}
+
+    # Enable result extended to track retries
+    app.conf.result_extended = True
+
+    return app, queue_name
+
+
+@pytest.mark.amqp
+@pytest.mark.timeout(35)
+def test_countdown_task_with_retry_loses_message():
+    """Test where a countdown task gets retried with the same delay."""
+    app, queue_name = create_test_app_with_quorum_queues()
+
+    @app.task(bind=True, default_retry_delay=3, max_retries=1)
+    def countdown_task_with_retry(self):
+        """Task that fails once then succeeds."""
+        # First attempt: fail to trigger retry
+        if self.request.retries < 1:
+            raise self.retry(exc=TaskFailedException("Simulated failure"))
+
+        return self.request.retries
+
+    with start_worker(
+        app,
+        loglevel="INFO",
+        shutdown_timeout=15,
+    ):
+        # Execute task with countdown=3 (same as default_retry_delay)
+        # We need to hit the same delayed buckets to trigger the cycle detection
+        # in RabbitMQ.
+        result = countdown_task_with_retry.apply_async(countdown=3)
+
+        try:
+            # Wait for the task to complete, we must wait at least long enough
+            # for the countdown to be reached and the retry to occur (6s).
+            value = result.get(timeout=15)
+        except exceptions.TimeoutError as e:
+            pytest.fail(
+                f"Task was silently dropped by RabbitMQ due to cycle detection. "
+                f"Exception: {e!r}."
+            )
+
+        assert value == 1, \
+            f"Expected task to succeed after 1 retry, got: {value}"
+
+
+@pytest.mark.amqp
+@pytest.mark.timeout(35)
+def test_non_eta_task_with_multiple_retries_loses_message():
+    """Test where a task gets retried twice with the same delay."""
+    app, queue_name = create_test_app_with_quorum_queues()
+
+    @app.task(bind=True, max_retries=2)
+    def non_eta_task_with_retries(self):
+        """Task that fails twice then succeeds."""
+        # First and second attempts: fail to trigger retry
+        if self.request.retries < 2:
+            raise self.retry(exc=TaskFailedException("Simulated failure"), countdown=3)
+
+        return self.request.retries
+
+    with start_worker(
+        app,
+        loglevel="INFO",
+        shutdown_timeout=15,
+    ):
+        result = non_eta_task_with_retries.apply_async()
+
+        try:
+            # Wait for the task to complete, we must wait at least long enough
+            # for the two retries to occur (6s).
+            value = result.get(timeout=15)
+        except exceptions.TimeoutError as e:
+            pytest.fail(
+                f"Task was silently dropped by RabbitMQ due to cycle detection. "
+                f"Exception: {e!r}"
+            )
+
+        assert value == 2, \
+            f"Expected task to succeed after 2 retries, got: {value}"

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -426,7 +426,7 @@ class test_task_retries(TasksCase):
 
     def test_signature_from_request__filters_x_death_headers(self):
         """
-        Test that X-Death headers are filtered out during retires to prevent
+        Test that X-Death headers are filtered out during retries to prevent
         RabbitMQ cycle detection.
         """
 

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -424,6 +424,37 @@ class test_task_retries(TasksCase):
         sig = self.retry_task.signature_from_request()
         assert sig.options['headers']['custom'] == 10.1
 
+    def test_signature_from_request__filters_x_death_headers(self):
+        """
+        Test that X-Death headers are filtered out during retires to prevent
+        RabbitMQ cycle detection.
+        """
+
+        self.retry_task.push_request()
+        self.retry_task.request.headers = {
+            'custom': 10.1,
+            'x-death': [{'count': 1, 'queue': 'celery_delayed_0'}],
+            'x-first-death-exchange': 'celery_delayed_0',
+            'x-first-death-queue': 'celery_delayed_0',
+            'x-first-death-reason': 'expired',
+            'x-last-death-exchange': 'celery_delayed_0',
+            'x-last-death-queue': 'celery_delayed_0',
+            'x-last-death-reason': 'expired',
+        }
+        sig = self.retry_task.signature_from_request()
+
+        # Custom headers should be preserved
+        assert sig.options['headers']['custom'] == 10.1
+
+        # X-Death related headers should be filtered out
+        assert 'x-death' not in sig.options['headers']
+        assert 'x-first-death-exchange' not in sig.options['headers']
+        assert 'x-first-death-queue' not in sig.options['headers']
+        assert 'x-first-death-reason' not in sig.options['headers']
+        assert 'x-last-death-exchange' not in sig.options['headers']
+        assert 'x-last-death-queue' not in sig.options['headers']
+        assert 'x-last-death-reason' not in sig.options['headers']
+
     def test_signature_from_request__delivery_info(self):
         self.retry_task.push_request()
         self.retry_task.request.delivery_info = {


### PR DESCRIPTION
Avoid RabbitMQ <4.0.1 dead-lettering cycle detection when retrying with native delayed-delivery.
This is achieved by stripping the `x-death`-related headers before publishing tasks.

Fixes #9867. 

When running with RabbitMQ 3.13 before applying the fix we are able to see a reproduction of the issue in the integration testing environment.
Some breadcrumbs have been added to display the message headers and properties for the task being published (retried).
We can see that after the task is published for retry with the `x-death` headers, the task is not received by the worker and instead is lost.
A timeout is reached before the result of the task execution is available.
*Note that the "retry: Retry in 3s: TaskFailedException('Simulated failure')" is printed just after the task is published for retry*
The test error output is added in the following comment to avoid exceeding the pull request description limit.

We only see `Dead-letter queues cycle detected for source quorum queue` logged once by RabbitMQ, as it will not log twice for the same cycle without being restarted.

<details>
<summary>RabbitMQ logs</summary>

```plaintext
rabbit-1  | 2026-02-06 09:37:44.334099+00:00 [notice] <0.44.0> Application syslog exited with reason: stopped
rabbit-1  | 2026-02-06 09:37:44.339656+00:00 [notice] <0.254.0> Logging: switching to configured handler(s); following messages may not be visible in this log output
rabbit-1  | 2026-02-06 09:37:44.339967+00:00 [notice] <0.254.0> Logging: configured log handlers are now ACTIVE
rabbit-1  | 2026-02-06 09:37:44.347824+00:00 [info] <0.254.0> ra: starting system quorum_queues
rabbit-1  | 2026-02-06 09:37:44.347851+00:00 [info] <0.254.0> starting Ra system: quorum_queues in directory: /var/lib/rabbitmq/mnesia/rabbit@07a94984080a/quorum/rabbit@07a94984080a
rabbit-1  | 2026-02-06 09:37:44.401717+00:00 [info] <0.268.0> ra system 'quorum_queues' running pre init for 0 registered servers
rabbit-1  | 2026-02-06 09:37:44.411019+00:00 [info] <0.269.0> ra: meta data store initialised for system quorum_queues. 0 record(s) recovered
rabbit-1  | 2026-02-06 09:37:44.424220+00:00 [notice] <0.274.0> WAL: ra_log_wal init, open tbls: ra_log_open_mem_tables, closed tbls: ra_log_closed_mem_tables
rabbit-1  | 2026-02-06 09:37:44.437265+00:00 [info] <0.254.0> ra: starting system coordination
rabbit-1  | 2026-02-06 09:37:44.437288+00:00 [info] <0.254.0> starting Ra system: coordination in directory: /var/lib/rabbitmq/mnesia/rabbit@07a94984080a/coordination/rabbit@07a94984080a
rabbit-1  | 2026-02-06 09:37:44.438444+00:00 [info] <0.282.0> ra system 'coordination' running pre init for 0 registered servers
rabbit-1  | 2026-02-06 09:37:44.439158+00:00 [info] <0.283.0> ra: meta data store initialised for system coordination. 0 record(s) recovered
rabbit-1  | 2026-02-06 09:37:44.439236+00:00 [notice] <0.288.0> WAL: ra_coordination_log_wal init, open tbls: ra_coordination_log_open_mem_tables, closed tbls: ra_coordination_log_closed_mem_tables
rabbit-1  | 2026-02-06 09:37:44.440742+00:00 [info] <0.254.0> ra: starting system coordination
rabbit-1  | 2026-02-06 09:37:44.440765+00:00 [info] <0.254.0> starting Ra system: coordination in directory: /var/lib/rabbitmq/mnesia/rabbit@07a94984080a/coordination/rabbit@07a94984080a
rabbit-1  | 2026-02-06 09:37:44.516454+00:00 [info] <0.254.0> Waiting for Khepri leader for 30000 ms, 9 retries left
rabbit-1  | 2026-02-06 09:37:44.519737+00:00 [notice] <0.292.0> RabbitMQ metadata store: candidate -> leader in term: 1 machine version: 1
rabbit-1  | 2026-02-06 09:37:44.528764+00:00 [info] <0.254.0> Khepri leader elected
rabbit-1  | 2026-02-06 09:37:44.528797+00:00 [info] <0.254.0> Waiting for Khepri projections for 30000 ms, 9 retries left
rabbit-1  | 2026-02-06 09:37:44.747010+00:00 [info] <0.254.0> 
rabbit-1  | 2026-02-06 09:37:44.747010+00:00 [info] <0.254.0>  Starting RabbitMQ 3.13.7 on Erlang 26.2.5.16 [jit]
rabbit-1  | 2026-02-06 09:37:44.747010+00:00 [info] <0.254.0>  Copyright (c) 2007-2024 Broadcom Inc and/or its subsidiaries
rabbit-1  | 2026-02-06 09:37:44.747010+00:00 [info] <0.254.0>  Licensed under the MPL 2.0. Website: https://rabbitmq.com
rabbit-1  | 
rabbit-1  |   ##  ##      RabbitMQ 3.13.7
rabbit-1  |   ##  ##
rabbit-1  |   ##########  Copyright (c) 2007-2024 Broadcom Inc and/or its subsidiaries
rabbit-1  |   ######  ##
rabbit-1  |   ##########  Licensed under the MPL 2.0. Website: https://rabbitmq.com
rabbit-1  | 
rabbit-1  |   Erlang:      26.2.5.16 [jit]
rabbit-1  |   TLS Library: OpenSSL - OpenSSL 3.1.8 11 Feb 2025
rabbit-1  |   Release series support status: see https://www.rabbitmq.com/release-information
rabbit-1  | 
rabbit-1  |   Doc guides:  https://www.rabbitmq.com/docs
rabbit-1  |   Support:     https://www.rabbitmq.com/docs/contact
rabbit-1  |   Tutorials:   https://www.rabbitmq.com/tutorials
rabbit-1  |   Monitoring:  https://www.rabbitmq.com/docs/monitoring
rabbit-1  |   Upgrading:   https://www.rabbitmq.com/docs/upgrade
rabbit-1  | 
rabbit-1  |   Logs: <stdout>
rabbit-1  | 
rabbit-1  |   Config file(s): /etc/rabbitmq/conf.d/10-defaults.conf
rabbit-1  | 
rabbit-1  |   Starting broker...2026-02-06 09:37:44.748049+00:00 [info] <0.254.0> 
rabbit-1  | 2026-02-06 09:37:44.748049+00:00 [info] <0.254.0>  node           : rabbit@07a94984080a
rabbit-1  | 2026-02-06 09:37:44.748049+00:00 [info] <0.254.0>  home dir       : /var/lib/rabbitmq
rabbit-1  | 2026-02-06 09:37:44.748049+00:00 [info] <0.254.0>  config file(s) : /etc/rabbitmq/conf.d/10-defaults.conf
rabbit-1  | 2026-02-06 09:37:44.748049+00:00 [info] <0.254.0>  cookie hash    : 9QRGhVCYWs6SaDzOZ8pF9Q==
rabbit-1  | 2026-02-06 09:37:44.748049+00:00 [info] <0.254.0>  log(s)         : <stdout>
rabbit-1  | 2026-02-06 09:37:44.748049+00:00 [info] <0.254.0>  data dir       : /var/lib/rabbitmq/mnesia/rabbit@07a94984080a
rabbit-1  | 2026-02-06 09:37:44.985741+00:00 [info] <0.254.0> Running boot step pre_boot defined by app rabbit
rabbit-1  | 2026-02-06 09:37:44.985780+00:00 [info] <0.254.0> Running boot step rabbit_global_counters defined by app rabbit
rabbit-1  | 2026-02-06 09:37:44.985980+00:00 [info] <0.254.0> Running boot step rabbit_osiris_metrics defined by app rabbit
rabbit-1  | 2026-02-06 09:37:44.986039+00:00 [info] <0.254.0> Running boot step rabbit_core_metrics defined by app rabbit
rabbit-1  | 2026-02-06 09:37:44.986192+00:00 [info] <0.254.0> Running boot step rabbit_alarm defined by app rabbit
rabbit-1  | 2026-02-06 09:37:44.995348+00:00 [info] <0.329.0> Memory high watermark set to 1566 MiB (1642289561 bytes) of 3915 MiB (4105723904 bytes) total
rabbit-1  | 2026-02-06 09:37:44.996828+00:00 [info] <0.331.0> Enabling free disk space monitoring (disk free space: 86319226880, total memory: 4105723904)
rabbit-1  | 2026-02-06 09:37:44.996865+00:00 [info] <0.331.0> Disk free limit set to 50MB
rabbit-1  | 2026-02-06 09:37:44.997598+00:00 [info] <0.254.0> Running boot step code_server_cache defined by app rabbit
rabbit-1  | 2026-02-06 09:37:44.997640+00:00 [info] <0.254.0> Running boot step file_handle_cache defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.004144+00:00 [info] <0.334.0> Limiting to approx 1048479 file handles (943629 sockets)
rabbit-1  | 2026-02-06 09:37:45.004222+00:00 [info] <0.335.0> FHC read buffering: OFF
rabbit-1  | 2026-02-06 09:37:45.004242+00:00 [info] <0.335.0> FHC write buffering: ON
rabbit-1  | 2026-02-06 09:37:45.004660+00:00 [info] <0.254.0> Running boot step worker_pool defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.004698+00:00 [info] <0.315.0> Will use 2 processes for default worker pool
rabbit-1  | 2026-02-06 09:37:45.004739+00:00 [info] <0.315.0> Starting worker pool 'worker_pool' with 2 processes in it
rabbit-1  | 2026-02-06 09:37:45.004951+00:00 [info] <0.254.0> Running boot step database defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.005281+00:00 [info] <0.254.0> Peer discovery: configured backend: rabbit_peer_discovery_classic_config
rabbit-1  | 2026-02-06 09:37:45.006110+00:00 [notice] <0.316.0> Feature flags: attempt to enable `detailed_queues_endpoint`...
rabbit-1  | 2026-02-06 09:37:45.055078+00:00 [notice] <0.316.0> Feature flags: `detailed_queues_endpoint` enabled
rabbit-1  | 2026-02-06 09:37:45.055186+00:00 [notice] <0.316.0> Feature flags: attempt to enable `quorum_queue_non_voters`...
rabbit-1  | 2026-02-06 09:37:45.103574+00:00 [notice] <0.316.0> Feature flags: `quorum_queue_non_voters` enabled
rabbit-1  | 2026-02-06 09:37:45.103671+00:00 [notice] <0.316.0> Feature flags: attempt to enable `stream_update_config_command`...
rabbit-1  | 2026-02-06 09:37:45.151419+00:00 [notice] <0.316.0> Feature flags: `stream_update_config_command` enabled
rabbit-1  | 2026-02-06 09:37:45.151531+00:00 [notice] <0.316.0> Feature flags: attempt to enable `stream_filtering`...
rabbit-1  | 2026-02-06 09:37:45.198648+00:00 [notice] <0.316.0> Feature flags: `stream_filtering` enabled
rabbit-1  | 2026-02-06 09:37:45.198766+00:00 [notice] <0.316.0> Feature flags: attempt to enable `stream_sac_coordinator_unblock_group`...
rabbit-1  | 2026-02-06 09:37:45.245995+00:00 [notice] <0.316.0> Feature flags: `stream_sac_coordinator_unblock_group` enabled
rabbit-1  | 2026-02-06 09:37:45.246116+00:00 [notice] <0.316.0> Feature flags: attempt to enable `restart_streams`...
rabbit-1  | 2026-02-06 09:37:45.293200+00:00 [notice] <0.316.0> Feature flags: `restart_streams` enabled
rabbit-1  | 2026-02-06 09:37:45.293298+00:00 [notice] <0.316.0> Feature flags: attempt to enable `message_containers`...
rabbit-1  | 2026-02-06 09:37:45.339335+00:00 [notice] <0.316.0> Feature flags: `message_containers` enabled
rabbit-1  | 2026-02-06 09:37:45.339432+00:00 [notice] <0.316.0> Feature flags: attempt to enable `message_containers_deaths_v2`...
rabbit-1  | 2026-02-06 09:37:45.385134+00:00 [notice] <0.316.0> Feature flags: `message_containers_deaths_v2` enabled
rabbit-1  | 2026-02-06 09:37:45.385280+00:00 [info] <0.254.0> DB: virgin node -> run peer discovery
rabbit-1  | 2026-02-06 09:37:45.385315+00:00 [warning] <0.254.0> Classic peer discovery backend: list of nodes does not contain the local node []
rabbit-1  | 2026-02-06 09:37:45.394394+00:00 [notice] <0.44.0> Application mnesia exited with reason: stopped
rabbit-1  | 2026-02-06 09:37:45.490494+00:00 [info] <0.254.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
rabbit-1  | 2026-02-06 09:37:45.490565+00:00 [info] <0.254.0> Successfully synced tables from a peer
rabbit-1  | 2026-02-06 09:37:45.490610+00:00 [info] <0.254.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
rabbit-1  | 2026-02-06 09:37:45.490649+00:00 [info] <0.254.0> Successfully synced tables from a peer
rabbit-1  | 2026-02-06 09:37:45.493609+00:00 [info] <0.254.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
rabbit-1  | 2026-02-06 09:37:45.493675+00:00 [info] <0.254.0> Successfully synced tables from a peer
rabbit-1  | 2026-02-06 09:37:45.493730+00:00 [info] <0.254.0> Running boot step tracking_metadata_store defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.493765+00:00 [info] <0.556.0> Setting up a table for connection tracking on this node: tracked_connection
rabbit-1  | 2026-02-06 09:37:45.493823+00:00 [info] <0.556.0> Setting up a table for per-vhost connection counting on this node: tracked_connection_per_vhost
rabbit-1  | 2026-02-06 09:37:45.493854+00:00 [info] <0.556.0> Setting up a table for per-user connection counting on this node: tracked_connection_per_user
rabbit-1  | 2026-02-06 09:37:45.493898+00:00 [info] <0.556.0> Setting up a table for channel tracking on this node: tracked_channel
rabbit-1  | 2026-02-06 09:37:45.493943+00:00 [info] <0.556.0> Setting up a table for channel tracking on this node: tracked_channel_per_user
rabbit-1  | 2026-02-06 09:37:45.494014+00:00 [info] <0.254.0> Running boot step networking_metadata_store defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494063+00:00 [info] <0.254.0> Running boot step feature_flags defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494328+00:00 [info] <0.254.0> Running boot step codec_correctness_check defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494362+00:00 [info] <0.254.0> Running boot step external_infrastructure defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494382+00:00 [info] <0.254.0> Running boot step rabbit_event defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494461+00:00 [info] <0.254.0> Running boot step rabbit_registry defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494503+00:00 [info] <0.254.0> Running boot step rabbit_auth_mechanism_amqplain defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494560+00:00 [info] <0.254.0> Running boot step rabbit_auth_mechanism_cr_demo defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494592+00:00 [info] <0.254.0> Running boot step rabbit_auth_mechanism_plain defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494620+00:00 [info] <0.254.0> Running boot step rabbit_exchange_type_direct defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494653+00:00 [info] <0.254.0> Running boot step rabbit_exchange_type_fanout defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494685+00:00 [info] <0.254.0> Running boot step rabbit_exchange_type_headers defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494713+00:00 [info] <0.254.0> Running boot step rabbit_exchange_type_topic defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494741+00:00 [info] <0.254.0> Running boot step rabbit_mirror_queue_mode_all defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494781+00:00 [info] <0.254.0> Running boot step rabbit_mirror_queue_mode_exactly defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494813+00:00 [info] <0.254.0> Running boot step rabbit_mirror_queue_mode_nodes defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494840+00:00 [info] <0.254.0> Running boot step rabbit_priority_queue defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494853+00:00 [info] <0.254.0> Priority queues enabled, real BQ is rabbit_variable_queue
rabbit-1  | 2026-02-06 09:37:45.494884+00:00 [info] <0.254.0> Running boot step rabbit_queue_location_client_local defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494911+00:00 [info] <0.254.0> Running boot step rabbit_queue_location_min_masters defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494947+00:00 [info] <0.254.0> Running boot step rabbit_queue_location_random defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494973+00:00 [info] <0.254.0> Running boot step kernel_ready defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.494983+00:00 [info] <0.254.0> Running boot step rabbit_sysmon_minder defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.495043+00:00 [info] <0.254.0> Running boot step rabbit_epmd_monitor defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.495617+00:00 [info] <0.564.0> epmd monitor knows us, inter-node communication (distribution) port: 25672
rabbit-1  | 2026-02-06 09:37:45.495654+00:00 [info] <0.254.0> Running boot step guid_generator defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.496684+00:00 [info] <0.254.0> Running boot step rabbit_node_monitor defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.496871+00:00 [info] <0.568.0> Starting rabbit_node_monitor (in ignore mode)
rabbit-1  | 2026-02-06 09:37:45.496919+00:00 [info] <0.254.0> Running boot step delegate_sup defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.497314+00:00 [info] <0.254.0> Running boot step rabbit_memory_monitor defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.497420+00:00 [info] <0.254.0> Running boot step rabbit_fifo_dlx_sup defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.497453+00:00 [info] <0.254.0> Running boot step core_initialized defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.497465+00:00 [info] <0.254.0> Running boot step rabbit_channel_tracking_handler defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.497504+00:00 [info] <0.254.0> Running boot step rabbit_connection_tracking_handler defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.497530+00:00 [info] <0.254.0> Running boot step rabbit_definitions_hashing defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.497561+00:00 [info] <0.254.0> Running boot step rabbit_exchange_parameters defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.518059+00:00 [info] <0.254.0> Running boot step rabbit_mirror_queue_misc defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.518306+00:00 [info] <0.254.0> Running boot step rabbit_policies defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.518532+00:00 [info] <0.254.0> Running boot step rabbit_policy defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.518570+00:00 [info] <0.254.0> Running boot step rabbit_queue_location_validator defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.518715+00:00 [info] <0.254.0> Running boot step rabbit_quorum_memory_manager defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.518742+00:00 [info] <0.254.0> Running boot step rabbit_quorum_queue defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.518844+00:00 [info] <0.254.0> Running boot step rabbit_stream_coordinator defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.518976+00:00 [info] <0.254.0> Running boot step rabbit_vhost_limit defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.519011+00:00 [info] <0.254.0> Running boot step rabbit_federation_parameters defined by app rabbitmq_federation
rabbit-1  | 2026-02-06 09:37:45.519066+00:00 [info] <0.254.0> Running boot step rabbit_federation_supervisor defined by app rabbitmq_federation
rabbit-1  | 2026-02-06 09:37:45.524818+00:00 [info] <0.254.0> Running boot step rabbit_federation_queue defined by app rabbitmq_federation
rabbit-1  | 2026-02-06 09:37:45.524897+00:00 [info] <0.254.0> Running boot step rabbit_federation_upstream_exchange defined by app rabbitmq_federation
rabbit-1  | 2026-02-06 09:37:45.524950+00:00 [info] <0.254.0> Running boot step rabbit_mgmt_reset_handler defined by app rabbitmq_management
rabbit-1  | 2026-02-06 09:37:45.524971+00:00 [info] <0.254.0> Running boot step rabbit_mgmt_db_handler defined by app rabbitmq_management_agent
rabbit-1  | 2026-02-06 09:37:45.524986+00:00 [info] <0.254.0> Management plugin: using rates mode 'basic'
rabbit-1  | 2026-02-06 09:37:45.525132+00:00 [info] <0.254.0> Running boot step recovery defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.532907+00:00 [info] <0.254.0> Running boot step empty_db_check defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.532937+00:00 [info] <0.254.0> Will seed default virtual host and user...
rabbit-1  | 2026-02-06 09:37:45.532996+00:00 [info] <0.254.0> Adding vhost '/' (description: 'Default virtual host', tags: [])
rabbit-1  | 2026-02-06 09:37:45.538828+00:00 [info] <0.628.0> Making sure data directory '/var/lib/rabbitmq/mnesia/rabbit@07a94984080a/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L' for vhost '/' exists
rabbit-1  | 2026-02-06 09:37:45.539475+00:00 [info] <0.628.0> Setting segment_entry_count for vhost '/' with 0 queues to '2048'
rabbit-1  | 2026-02-06 09:37:45.546012+00:00 [info] <0.628.0> Starting message stores for vhost '/'
rabbit-1  | 2026-02-06 09:37:45.546108+00:00 [info] <0.637.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_transient": using rabbit_msg_store_ets_index to provide index
rabbit-1  | 2026-02-06 09:37:45.547058+00:00 [info] <0.628.0> Started message store of type transient for vhost '/'
rabbit-1  | 2026-02-06 09:37:45.547151+00:00 [info] <0.641.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent": using rabbit_msg_store_ets_index to provide index
rabbit-1  | 2026-02-06 09:37:45.547500+00:00 [warning] <0.641.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent": rebuilding indices from scratch
rabbit-1  | 2026-02-06 09:37:45.548016+00:00 [info] <0.628.0> Started message store of type persistent for vhost '/'
rabbit-1  | 2026-02-06 09:37:45.548080+00:00 [info] <0.628.0> Recovering 0 queues of type rabbit_classic_queue took 8ms
rabbit-1  | 2026-02-06 09:37:45.548099+00:00 [info] <0.628.0> Recovering 0 queues of type rabbit_quorum_queue took 0ms
rabbit-1  | 2026-02-06 09:37:45.548123+00:00 [info] <0.628.0> Recovering 0 queues of type rabbit_stream_queue took 0ms
rabbit-1  | 2026-02-06 09:37:45.549396+00:00 [info] <0.254.0> Created user 'guest'
rabbit-1  | 2026-02-06 09:37:45.550057+00:00 [info] <0.254.0> Successfully set user tags for user 'guest' to [administrator]
rabbit-1  | 2026-02-06 09:37:45.551586+00:00 [info] <0.254.0> Successfully set permissions for user 'guest' in virtual host '/' to '.*', '.*', '.*'
rabbit-1  | 2026-02-06 09:37:45.551611+00:00 [info] <0.254.0> Running boot step rabbit_observer_cli defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.551655+00:00 [info] <0.254.0> Running boot step rabbit_looking_glass defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.551677+00:00 [info] <0.254.0> Running boot step rabbit_core_metrics_gc defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.551756+00:00 [info] <0.254.0> Running boot step background_gc defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.551817+00:00 [info] <0.254.0> Running boot step routing_ready defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.551831+00:00 [info] <0.254.0> Running boot step pre_flight defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.551848+00:00 [info] <0.254.0> Running boot step notify_cluster defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.551872+00:00 [info] <0.254.0> Running boot step networking defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.551888+00:00 [info] <0.254.0> Running boot step rabbit_quorum_queue_periodic_membership_reconciliation defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.551984+00:00 [info] <0.254.0> Running boot step definition_import_worker_pool defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.552093+00:00 [info] <0.315.0> Starting worker pool 'definition_import_pool' with 2 processes in it
rabbit-1  | 2026-02-06 09:37:45.552358+00:00 [info] <0.254.0> Running boot step cluster_name defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.552390+00:00 [info] <0.254.0> Initialising internal cluster ID to 'rabbitmq-cluster-id-uADiRTVut7dc3iu1-DfGAg'
rabbit-1  | 2026-02-06 09:37:45.553219+00:00 [info] <0.254.0> Running boot step virtual_host_reconciliation defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.553301+00:00 [info] <0.254.0> Running boot step direct_client defined by app rabbit
rabbit-1  | 2026-02-06 09:37:45.553363+00:00 [info] <0.254.0> Running boot step rabbit_federation_exchange defined by app rabbitmq_federation
rabbit-1  | 2026-02-06 09:37:45.553515+00:00 [info] <0.254.0> Running boot step rabbit_management_load_definitions defined by app rabbitmq_management
rabbit-1  | 2026-02-06 09:37:45.553565+00:00 [info] <0.676.0> Resetting node maintenance status
rabbit-1  | 2026-02-06 09:37:45.687887+00:00 [warning] <0.705.0> Deprecated features: `management_metrics_collection`: Feature `management_metrics_collection` is deprecated.
rabbit-1  | 2026-02-06 09:37:45.687887+00:00 [warning] <0.705.0> By default, this feature can still be used for now.
rabbit-1  | 2026-02-06 09:37:45.687887+00:00 [warning] <0.705.0> Its use will not be permitted by default in a future minor RabbitMQ version and the feature will be removed from a future major RabbitMQ version; actual versions to be determined.
rabbit-1  | 2026-02-06 09:37:45.687887+00:00 [warning] <0.705.0> To continue using this feature when it is not permitted by default, set the following parameter in your configuration:
rabbit-1  | 2026-02-06 09:37:45.687887+00:00 [warning] <0.705.0>     "deprecated_features.permit.management_metrics_collection = true"
rabbit-1  | 2026-02-06 09:37:45.687887+00:00 [warning] <0.705.0> To test RabbitMQ as if the feature was removed, set this in your configuration:
rabbit-1  | 2026-02-06 09:37:45.687887+00:00 [warning] <0.705.0>     "deprecated_features.permit.management_metrics_collection = false"
rabbit-1  | 2026-02-06 09:37:48.060254+00:00 [info] <0.742.0> Management plugin: HTTP (non-TLS) listener started on port 15672
rabbit-1  | 2026-02-06 09:37:48.060353+00:00 [info] <0.772.0> Statistics database started.
rabbit-1  | 2026-02-06 09:37:48.060387+00:00 [info] <0.771.0> Starting worker pool 'management_worker_pool' with 3 processes in it
rabbit-1  | 2026-02-06 09:37:48.064337+00:00 [info] <0.790.0> Prometheus metrics: HTTP (non-TLS) listener started on port 15692
rabbit-1  | 2026-02-06 09:37:48.064410+00:00 [info] <0.676.0> Ready to start client connection listeners
rabbit-1  | 2026-02-06 09:37:48.065438+00:00 [info] <0.834.0> started TCP listener on [::]:5672
rabbit-1  |  completed with 5 plugins.
rabbit-1  | 2026-02-06 09:37:48.161644+00:00 [info] <0.676.0> Server startup complete; 5 plugins started.
rabbit-1  | 2026-02-06 09:37:48.161644+00:00 [info] <0.676.0>  * rabbitmq_prometheus
rabbit-1  | 2026-02-06 09:37:48.161644+00:00 [info] <0.676.0>  * rabbitmq_federation
rabbit-1  | 2026-02-06 09:37:48.161644+00:00 [info] <0.676.0>  * rabbitmq_management
rabbit-1  | 2026-02-06 09:37:48.161644+00:00 [info] <0.676.0>  * rabbitmq_management_agent
rabbit-1  | 2026-02-06 09:37:48.161644+00:00 [info] <0.676.0>  * rabbitmq_web_dispatch
rabbit-1  | 2026-02-06 09:37:48.166123+00:00 [info] <0.9.0> Time to start RabbitMQ: 6162 ms
rabbit-1  | 2026-02-06 09:38:09.266481+00:00 [info] <0.839.0> accepting AMQP connection <0.839.0> (172.18.0.1:37300 -> 172.18.0.3:5672)
rabbit-1  | 2026-02-06 09:38:09.271547+00:00 [info] <0.839.0> connection <0.839.0> (172.18.0.1:37300 -> 172.18.0.3:5672): user 'guest' authenticated and granted access to vhost '/'
rabbit-1  | 2026-02-06 09:38:09.275988+00:00 [info] <0.839.0> closing AMQP connection <0.839.0> (172.18.0.1:37300 -> 172.18.0.3:5672, vhost: '/', user: 'guest')
rabbit-1  | 2026-02-06 09:38:09.295719+00:00 [info] <0.855.0> accepting AMQP connection <0.855.0> (172.18.0.1:37312 -> 172.18.0.3:5672)
rabbit-1  | 2026-02-06 09:38:09.299220+00:00 [info] <0.855.0> connection <0.855.0> (172.18.0.1:37312 -> 172.18.0.3:5672): user 'guest' authenticated and granted access to vhost '/'
rabbit-1  | 2026-02-06 09:38:09.314884+00:00 [notice] <0.871.0> queue 'test_cycle_queue' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.315019+00:00 [info] <0.864.0> ra: started cluster %2F_test_cycle_queue with 1 servers
rabbit-1  | 2026-02-06 09:38:09.315019+00:00 [info] <0.864.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.315019+00:00 [info] <0.864.0> Leader: {'%2F_test_cycle_queue',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.320747+00:00 [warning] <0.879.0> Deprecated features: `transient_nonexcl_queues`: Feature `transient_nonexcl_queues` is deprecated.
rabbit-1  | 2026-02-06 09:38:09.320747+00:00 [warning] <0.879.0> By default, this feature can still be used for now.
rabbit-1  | 2026-02-06 09:38:09.320747+00:00 [warning] <0.879.0> Its use will not be permitted by default in a future minor RabbitMQ version and the feature will be removed from a future major RabbitMQ version; actual versions to be determined.
rabbit-1  | 2026-02-06 09:38:09.320747+00:00 [warning] <0.879.0> To continue using this feature when it is not permitted by default, set the following parameter in your configuration:
rabbit-1  | 2026-02-06 09:38:09.320747+00:00 [warning] <0.879.0>     "deprecated_features.permit.transient_nonexcl_queues = true"
rabbit-1  | 2026-02-06 09:38:09.320747+00:00 [warning] <0.879.0> To test RabbitMQ as if the feature was removed, set this in your configuration:
rabbit-1  | 2026-02-06 09:38:09.320747+00:00 [warning] <0.879.0>     "deprecated_features.permit.transient_nonexcl_queues = false"
rabbit-1  | 2026-02-06 09:38:09.324985+00:00 [info] <0.890.0> accepting AMQP connection <0.890.0> (172.18.0.1:37326 -> 172.18.0.3:5672)
rabbit-1  | 2026-02-06 09:38:09.326814+00:00 [info] <0.890.0> connection <0.890.0> (172.18.0.1:37326 -> 172.18.0.3:5672): user 'guest' authenticated and granted access to vhost '/'
rabbit-1  | 2026-02-06 09:38:09.336570+00:00 [notice] <0.904.0> queue 'celery_delayed_27' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.336673+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_27 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.336673+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.336673+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_27',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.349988+00:00 [notice] <0.915.0> queue 'celery_delayed_26' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.350108+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_26 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.350108+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.350108+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_26',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.364954+00:00 [notice] <0.926.0> queue 'celery_delayed_25' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.365086+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_25 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.365086+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.365086+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_25',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.378323+00:00 [notice] <0.937.0> queue 'celery_delayed_24' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.378427+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_24 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.378427+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.378427+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_24',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.390712+00:00 [notice] <0.948.0> queue 'celery_delayed_23' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.390795+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_23 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.390795+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.390795+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_23',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.402949+00:00 [notice] <0.959.0> queue 'celery_delayed_22' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.403046+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_22 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.403046+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.403046+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_22',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.414633+00:00 [notice] <0.970.0> queue 'celery_delayed_21' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.414722+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_21 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.414722+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.414722+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_21',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.426152+00:00 [notice] <0.981.0> queue 'celery_delayed_20' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.426232+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_20 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.426232+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.426232+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_20',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.436924+00:00 [notice] <0.992.0> queue 'celery_delayed_19' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.437002+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_19 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.437002+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.437002+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_19',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.447788+00:00 [notice] <0.1003.0> queue 'celery_delayed_18' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.447868+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_18 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.447868+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.447868+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_18',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.464458+00:00 [notice] <0.1014.0> queue 'celery_delayed_17' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.464601+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_17 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.464601+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.464601+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_17',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.477185+00:00 [notice] <0.1025.0> queue 'celery_delayed_16' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.477304+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_16 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.477304+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.477304+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_16',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.493876+00:00 [notice] <0.1036.0> queue 'celery_delayed_15' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.494018+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_15 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.494018+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.494018+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_15',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.504620+00:00 [notice] <0.1047.0> queue 'celery_delayed_14' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.504726+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_14 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.504726+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.504726+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_14',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.516468+00:00 [notice] <0.1058.0> queue 'celery_delayed_13' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.516560+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_13 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.516560+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.516560+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_13',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.527655+00:00 [notice] <0.1069.0> queue 'celery_delayed_12' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.527735+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_12 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.527735+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.527735+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_12',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.539300+00:00 [notice] <0.1080.0> queue 'celery_delayed_11' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.539435+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_11 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.539435+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.539435+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_11',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.550886+00:00 [notice] <0.1091.0> queue 'celery_delayed_10' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.550987+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_10 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.550987+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.550987+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_10',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.562871+00:00 [notice] <0.1102.0> queue 'celery_delayed_9' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.562957+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_9 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.562957+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.562957+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_9',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.574910+00:00 [notice] <0.1113.0> queue 'celery_delayed_8' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.575004+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_8 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.575004+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.575004+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_8',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.586950+00:00 [notice] <0.1124.0> queue 'celery_delayed_7' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.587032+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_7 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.587032+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.587032+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_7',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.598368+00:00 [notice] <0.1135.0> queue 'celery_delayed_6' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.598444+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_6 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.598444+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.598444+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_6',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.610366+00:00 [notice] <0.1146.0> queue 'celery_delayed_5' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.610447+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_5 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.610447+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.610447+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_5',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.622883+00:00 [notice] <0.1157.0> queue 'celery_delayed_4' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.622976+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_4 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.622976+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.622976+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_4',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.634845+00:00 [notice] <0.1168.0> queue 'celery_delayed_3' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.634930+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_3 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.634930+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.634930+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_3',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.645804+00:00 [notice] <0.1179.0> queue 'celery_delayed_2' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.645886+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_2 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.645886+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.645886+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_2',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.656779+00:00 [notice] <0.1190.0> queue 'celery_delayed_1' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.656872+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_1 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.656872+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.656872+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_1',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.668842+00:00 [notice] <0.1201.0> queue 'celery_delayed_0' in vhost '/': candidate -> leader in term: 1 machine version: 3
rabbit-1  | 2026-02-06 09:38:09.668943+00:00 [info] <0.897.0> ra: started cluster %2F_celery_delayed_0 with 1 servers
rabbit-1  | 2026-02-06 09:38:09.668943+00:00 [info] <0.897.0> 0 servers failed to start: []
rabbit-1  | 2026-02-06 09:38:09.668943+00:00 [info] <0.897.0> Leader: {'%2F_celery_delayed_0',rabbit@07a94984080a}
rabbit-1  | 2026-02-06 09:38:09.718733+00:00 [info] <0.890.0> closing AMQP connection <0.890.0> (172.18.0.1:37326 -> 172.18.0.3:5672, vhost: '/', user: 'guest')
rabbit-1  | 2026-02-06 09:38:09.736445+00:00 [info] <0.1281.0> accepting AMQP connection <0.1281.0> (172.18.0.1:37330 -> 172.18.0.3:5672)
rabbit-1  | 2026-02-06 09:38:09.738255+00:00 [info] <0.1281.0> connection <0.1281.0> (172.18.0.1:37330 -> 172.18.0.3:5672): user 'guest' authenticated and granted access to vhost '/'
rabbit-1  | 2026-02-06 09:38:09.747418+00:00 [info] <0.1298.0> accepting AMQP connection <0.1298.0> (172.18.0.1:37338 -> 172.18.0.3:5672)
rabbit-1  | 2026-02-06 09:38:09.749512+00:00 [info] <0.1298.0> connection <0.1298.0> (172.18.0.1:37338 -> 172.18.0.3:5672): user 'guest' authenticated and granted access to vhost '/'
rabbit-1  | 2026-02-06 09:38:14.817755+00:00 [warning] <0.1193.0> Dead-letter queues cycle detected for source quorum queue 'celery_delayed_1' in vhost '/' with dead-letter exchange exchange 'celery_delayed_0' in vhost '/' and routing keys [undefined]: [<<"celery_delayed_0">>,
rabbit-1  | 2026-02-06 09:38:14.817755+00:00 [warning] <0.1193.0>                                                                                                                                                                                             <<"celery_delayed_1">>,
rabbit-1  | 2026-02-06 09:38:14.817755+00:00 [warning] <0.1193.0>                                                                                                                                                                                             <<"celery_delayed_0">>] This message will not be logged again.
rabbit-1  | 2026-02-06 09:38:14.818416+00:00 [warning] <0.1193.0> Cannot forward any dead-letter messages from source quorum queue 'celery_delayed_1' in vhost '/' with configured dead-letter-exchange exchange 'celery_delayed_0' in vhost '/' and configured dead-letter-routing-key 'undefined'. This can happen either if the dead-letter routing topology is misconfigured (for example no queue bound to dead-letter-exchange or wrong dead-letter-routing-key configured) or if non-mirrored classic queues are bound whose host node is down. Fix this issue to prevent dead-lettered messages from piling up in the source quorum queue. This message will not be logged again.
rabbit-1  | 2026-02-06 09:38:22.835397+00:00 [info] <0.855.0> closing AMQP connection <0.855.0> (172.18.0.1:37312 -> 172.18.0.3:5672, vhost: '/', user: 'guest')
rabbit-1  | 2026-02-06 09:38:22.928588+00:00 [info] <0.1380.0> accepting AMQP connection <0.1380.0> (172.18.0.1:51494 -> 172.18.0.3:5672)
rabbit-1  | 2026-02-06 09:38:22.933372+00:00 [info] <0.1380.0> connection <0.1380.0> (172.18.0.1:51494 -> 172.18.0.3:5672): user 'guest' authenticated and granted access to vhost '/'
rabbit-1  | 2026-02-06 09:38:22.936733+00:00 [info] <0.1380.0> closing AMQP connection <0.1380.0> (172.18.0.1:51494 -> 172.18.0.3:5672, vhost: '/', user: 'guest')
rabbit-1  | 2026-02-06 09:38:22.938862+00:00 [info] <0.1395.0> accepting AMQP connection <0.1395.0> (172.18.0.1:51500 -> 172.18.0.3:5672)
rabbit-1  | 2026-02-06 09:38:22.941585+00:00 [info] <0.1395.0> connection <0.1395.0> (172.18.0.1:51500 -> 172.18.0.3:5672): user 'guest' authenticated and granted access to vhost '/'
rabbit-1  | 2026-02-06 09:38:22.954749+00:00 [info] <0.1420.0> accepting AMQP connection <0.1420.0> (172.18.0.1:51508 -> 172.18.0.3:5672)
rabbit-1  | 2026-02-06 09:38:22.957052+00:00 [info] <0.1420.0> connection <0.1420.0> (172.18.0.1:51508 -> 172.18.0.3:5672): user 'guest' authenticated and granted access to vhost '/'
rabbit-1  | 2026-02-06 09:38:23.026444+00:00 [info] <0.1420.0> closing AMQP connection <0.1420.0> (172.18.0.1:51508 -> 172.18.0.3:5672, vhost: '/', user: 'guest')
rabbit-1  | 2026-02-06 09:38:23.041386+00:00 [info] <0.1505.0> accepting AMQP connection <0.1505.0> (172.18.0.1:51510 -> 172.18.0.3:5672)
rabbit-1  | 2026-02-06 09:38:23.043178+00:00 [info] <0.1505.0> connection <0.1505.0> (172.18.0.1:51510 -> 172.18.0.3:5672): user 'guest' authenticated and granted access to vhost '/'
rabbit-1  | 2026-02-06 09:38:36.119475+00:00 [info] <0.1395.0> closing AMQP connection <0.1395.0> (172.18.0.1:51500 -> 172.18.0.3:5672, vhost: '/', user: 'guest')
rabbit-1  | 2026-02-06 09:38:36.224116+00:00 [warning] <0.1505.0> closing AMQP connection <0.1505.0> (172.18.0.1:51510 -> 172.18.0.3:5672, vhost: '/', user: 'guest'):
rabbit-1  | 2026-02-06 09:38:36.224116+00:00 [warning] <0.1505.0> client unexpectedly closed TCP connection
rabbit-1  | 2026-02-06 09:38:36.224569+00:00 [warning] <0.1298.0> closing AMQP connection <0.1298.0> (172.18.0.1:37338 -> 172.18.0.3:5672, vhost: '/', user: 'guest'):
rabbit-1  | 2026-02-06 09:38:36.224569+00:00 [warning] <0.1298.0> client unexpectedly closed TCP connection
rabbit-1  | 2026-02-06 09:38:36.323387+00:00 [warning] <0.1281.0> closing AMQP connection <0.1281.0> (172.18.0.1:37330 -> 172.18.0.3:5672, vhost: '/', user: 'guest'):
rabbit-1  | 2026-02-06 09:38:36.323387+00:00 [warning] <0.1281.0> client unexpectedly closed TCP connection
```
</details>

The issue is not reproducable with RabbitMQ ≥4.0.1, as the RabbitMQ server will not interpret `x-death` headers being published by the client: [see the release notes for RabbitMQ 4.0.1](https://github.com/rabbitmq/rabbitmq-server/blob/76d891c10160b1a5803ba412e331f9c44b385259/release-notes/4.0.1.md?plain=1#L70-L80).

I'm also not able to reproduce the issue using a delay of 1 second, it seems only having the last death be the same queue as the current death prevents the cycle detection from occuring. Instead of a new death that would be appended to the x-death header, but the count for the existing death is incremented.  I'm not sure, but I suspect it's not possible to setup dead-lettering directly to the same queue in RabbitMQ, a different kind of cycle detection probably occurs in that case.  Using a delay of 3 seconds results in the message being routed to `celery_delayed_1` than `celery_delayed_0`, after a retry it ends up back in `celery_delayed_1` where the cycle is detected by RabbitMQ.

In order to run with RabbitMQ 3.13, this patch can be applied locally, and the docker container recreated:

<details>
<summary>Patch to use RabbitMQ 3.13</summary>

```diff
diff --git a/docker/docker-compose.yml b/docker/docker-compose.yml
index b9a29b1dd..8a9c2c0b5 100644
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - azurite

   rabbit:
-    image: rabbitmq:management
+    image: rabbitmq:3.13-management
     ports:
       - "15672:15672"
       - "5672:5672"
```
</details>

The instrumentation to see the message headers was done by applying this patch:

<details>
<summary>Patch to log message headers</summary>

```diff
diff --git a/celery/app/amqp.py b/celery/app/amqp.py
index 6caedc5c5..66a321fef 100644
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -556,6 +556,23 @@ class AMQP:
                     declare=declare, headers=headers2,
                     properties=properties, retry_policy=retry_policy,
                 )
+            # DEBUG: Log publishing details
+            import logging
+            import pprint
+            logger = logging.getLogger(__name__)
+            logger.info("=" * 80)
+            logger.info(f"PUBLISHING TASK: {name}")
+            logger.info(f"  Task ID: {headers2.get('id')}")
+            logger.info(f"  Exchange: {exchange}")
+            logger.info(f"  Routing Key: {routing_key}")
+            logger.info(f"  ETA: {headers2.get('eta')}")
+            logger.info(f"  Retries: {headers2.get('retries', 0)}")
+            if 'x-death' in headers2:
+                logger.info(f"  X-Death being sent in headers:")
+                logger.info(pprint.pformat(headers2['x-death']))
+            else:
+                logger.info("  NO X-Death headers being sent")
+            logger.info("=" * 80)
             ret = producer.publish(
                 body,
                 exchange=exchange,
diff --git a/celery/worker/strategy.py b/celery/worker/strategy.py
index 6a1c6225b..54952ee7d 100644
--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -142,6 +142,15 @@ def default(task, app, consumer,
             else:
                 body, headers, decoded, utc = proto1_to_proto2(message, body)
 
+        # DEBUG: Print message headers to see X-Death and other headers
+        import pprint
+        info("=" * 80)
+        info("MESSAGE HEADERS:")
+        info(pprint.pformat(dict(headers or {})))
+        info("MESSAGE PROPERTIES:")
+        info(pprint.pformat(getattr(message, 'properties', {})))
+        info("=" * 80)
+
         req = Req(
             message,
             on_ack=ack, on_reject=reject, app=app, hostname=hostname,
```
</details>

Despite the fact that this issue doesn't occur with non-EoL versions of RabbitMQ, it still affects us.  We have a shared RabbitMQ server used by several dozen microservices.  Historically we've relied on classic queue mirroring to provide high availability message brokering.  We're moving each critical use-case from mirrored classic queues to quorum queues, but the scope is too large to be done in a day.  We're unable to upgrade to RabbitMQ ≥4.0.1 until all services have been migrated.  This means we're stuck with the behavior of RabbitMQ 3.13 for the coming months.  Given that quorum queues support for Celery is relatively new, I doubt we are the only ones in this situation.

The integration test was importent to ensure we could reproduce the issue and resolve it when making a fix.   However, I'm not sure how useful it is to keep the integration test as the issue can not be reproduced with the RabbitMQ being used in the CI.  I propose either:

* Keep the test as it is despite requiring to run manually integration tests against an older version of RabbitMQ in order to test the failure case.
* Remove the integration test and rely solely on the unit test to ensure the correct header handling.
* Add a second RabbitMQ 3.13 version on a different port to be able to test this case correctly.
* Run the all the integration tests with a matrix of RabbitMQ versions.

Let me know which of these options you prefer.