### PR TITLE
Database Backend: Add missing index on date_done (Fixes #10097)

### DIFF
--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -25,7 +25,7 @@ class Task(ResultModelBase):
     status = sa.Column(sa.String(50), default=states.PENDING)
     result = sa.Column(PickleType, nullable=True)
     date_done = sa.Column(sa.DateTime, default=datetime.now(timezone.utc),
-                          onupdate=datetime.now(timezone.utc), nullable=True)
+                          onupdate=datetime.now(timezone.utc), nullable=True, index=True)
     traceback = sa.Column(sa.Text, nullable=True)
 
     def __init__(self, task_id):
@@ -87,7 +87,7 @@ class TaskSet(ResultModelBase):
     taskset_id = sa.Column(sa.String(155), unique=True)
     result = sa.Column(PickleType, nullable=True)
     date_done = sa.Column(sa.DateTime, default=datetime.now(timezone.utc),
-                          nullable=True)
+                          nullable=True, index=True)
 
     def __init__(self, taskset_id, result):
         self.taskset_id = taskset_id

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -995,6 +995,21 @@ strings (this is the part of the URI that comes after the ``db+`` prefix).
 .. _`Connection String`:
     http://www.sqlalchemy.org/docs/core/engines.html#database-urls
 
+.. note::
+
+    If you are upgrading from Celery 5.6 or earlier, the ``date_done`` column
+    in ``celery_taskmeta`` and ``celery_tasksetmeta`` tables does not have a
+    database index. The built-in periodic task ``celery.backend_cleanup``
+    queries on ``date_done`` to delete expired task results, so adding an
+    index significantly improves cleanup performance on large tables.
+    Since SQLAlchemy's ``create_all()`` will not alter existing tables, you
+    should add the indexes manually:
+
+    .. code-block:: sql
+
+        CREATE INDEX ix_celery_taskmeta_date_done ON celery_taskmeta (date_done);
+        CREATE INDEX ix_celery_tasksetmeta_date_done ON celery_tasksetmeta (date_done);
+
 .. setting:: database_create_tables_at_setup
 
 ``database_create_tables_at_setup``

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1002,8 +1002,25 @@ strings (this is the part of the URI that comes after the ``db+`` prefix).
     database index. The built-in periodic task ``celery.backend_cleanup``
     queries on ``date_done`` to delete expired task results, so adding an
     index significantly improves cleanup performance on large tables.
+
     Since SQLAlchemy's ``create_all()`` will not alter existing tables, you
-    should add the indexes manually:
+    will need to update your database schema. If you are using Alembic for
+    schema migrations, you can generate an empty revision and apply the
+    following operations:
+
+    .. code-block:: python
+
+        from alembic import op
+
+        def upgrade():
+            op.create_index('ix_celery_taskmeta_date_done', 'celery_taskmeta', ['date_done'])
+            op.create_index('ix_celery_tasksetmeta_date_done', 'celery_tasksetmeta', ['date_done'])
+
+        def downgrade():
+            op.drop_index('ix_celery_tasksetmeta_date_done', table_name='celery_tasksetmeta')
+            op.drop_index('ix_celery_taskmeta_date_done', table_name='celery_taskmeta')
+
+    Otherwise, you can add the indexes manually using SQL:
 
     .. code-block:: sql
 

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -66,6 +66,19 @@ class test_ModelsIdFieldTypeVariations:
 
 
 @skip.if_pypy
+class test_DateDoneIndex:
+    """Test that date_done columns have index=True on Task and TaskSet models."""
+
+    def test_task_date_done_has_index(self):
+        col = Task.__table__.columns['date_done']
+        assert col.index is True, "Task.date_done should have index=True"
+
+    def test_taskset_date_done_has_index(self):
+        col = TaskSet.__table__.columns['date_done']
+        assert col.index is True, "TaskSet.date_done should have index=True"
+
+
+@skip.if_pypy
 class test_DatabaseBackend:
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
## What is the purpose of this change?

This PR adds a database index to the `date_done` column in the `Task` and `TaskSet` models of the Database Backend.

Fixes #10097

## Brief Changelog

* Add `index=True` to `Task.date_done` in `celery/backends/database/models.py`
* Add `index=True` to `TaskSet.date_done` in `celery/backends/database/models.py`

## Significant changes

As detailed in Issue #10097, the `cleanup()` method performs a `DELETE` operation based on `date_done`. Without an index, this causes a full table scan and locks the entire table (especially in MySQL/InnoDB), causing `Lock Wait Timeout Exceeded` errors for concurrent workers trying to store results.

Adding this index allows the database to lock only the relevant rows during cleanup, significantly improving performance and stability in high-throughput environments.

## Note to existing users
Since SQLAlchemy's `create_all` does not update existing tables, users upgrading to this version will need to manually add the index using:
```sql
CREATE INDEX ix_celery_taskmeta_date_done ON celery_taskmeta(date_done);
CREATE INDEX ix_celery_tasksetmeta_date_done ON celery_tasksetmeta(date_done);
```