### PR TITLE
Remove redundant test_isa_mapping test (fixes #10077)

### DIFF
--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -128,10 +128,6 @@ class test_ConfigurationView:
         self.view.clear()
         assert len(self.view) == 2
 
-    def test_isa_mapping(self):
-        from collections.abc import Mapping
-        assert issubclass(ConfigurationView, Mapping)
-
     def test_isa_mutable_mapping(self):
         from collections.abc import MutableMapping
         assert issubclass(ConfigurationView, MutableMapping)


### PR DESCRIPTION
## Summary

Removes the redundant `test_isa_mapping` test in `t/unit/utils/test_collections.py`.

## Problem

As noted in #10077, the `test_isa_mapping` test checks that `ConfigurationView` is a subclass of `Mapping`, but this is already implied by the adjacent `test_isa_mutable_mapping` test which checks for `MutableMapping`. Since `MutableMapping` is a subclass of `Mapping`, the `Mapping` check is always `True` and fully redundant.

The inheritance chain: `ConfigurationView -> ChainMap -> MutableMapping -> Mapping`

## Changes

- Removed `test_isa_mapping` from `test_ConfigurationView` (4 lines)
- Kept `test_isa_mutable_mapping` which provides the stronger guarantee

## Testing

All 51 tests in `t/unit/utils/test_collections.py` pass.