### PR TITLE
Fix#10106 onupdate col use lambda func

### DIFF
--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -10,7 +10,18 @@ from .session import ResultModelBase
 
 __all__ = ('Task', 'TaskExtended', 'TaskSet')
 
+
 DialectSpecificInteger = sa.Integer().with_variant(sa.BigInteger, 'mssql')
+
+
+def _get_utc_now():
+    """Return current UTC datetime.
+
+    This helper is used as a callable for SQLAlchemy column defaults
+    to ensure the timestamp is evaluated at INSERT/UPDATE time,
+    not at module import time.
+    """
+    return datetime.now(timezone.utc)
 
 
 class Task(ResultModelBase):
@@ -24,8 +35,8 @@ class Task(ResultModelBase):
     task_id = sa.Column(sa.String(155), unique=True)
     status = sa.Column(sa.String(50), default=states.PENDING)
     result = sa.Column(PickleType, nullable=True)
-    date_done = sa.Column(sa.DateTime, default=lambda: datetime.now(timezone.utc),
-                          onupdate=lambda: datetime.now(timezone.utc), nullable=True)
+    date_done = sa.Column(sa.DateTime, default=_get_utc_now,
+                          onupdate=_get_utc_now, nullable=True)
     traceback = sa.Column(sa.Text, nullable=True)
 
     def __init__(self, task_id):
@@ -86,7 +97,7 @@ class TaskSet(ResultModelBase):
                    autoincrement=True, primary_key=True)
     taskset_id = sa.Column(sa.String(155), unique=True)
     result = sa.Column(PickleType, nullable=True)
-    date_done = sa.Column(sa.DateTime, default=lambda: datetime.now(timezone.utc),
+    date_done = sa.Column(sa.DateTime, default=_get_utc_now,
                           nullable=True)
 
     def __init__(self, taskset_id, result):

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -24,8 +24,8 @@ class Task(ResultModelBase):
     task_id = sa.Column(sa.String(155), unique=True)
     status = sa.Column(sa.String(50), default=states.PENDING)
     result = sa.Column(PickleType, nullable=True)
-    date_done = sa.Column(sa.DateTime, default=datetime.now(timezone.utc),
-                          onupdate=datetime.now(timezone.utc), nullable=True)
+    date_done = sa.Column(sa.DateTime, default=lambda: datetime.now(timezone.utc),
+                          onupdate=lambda: datetime.now(timezone.utc), nullable=True)
     traceback = sa.Column(sa.Text, nullable=True)
 
     def __init__(self, task_id):
@@ -86,7 +86,7 @@ class TaskSet(ResultModelBase):
                    autoincrement=True, primary_key=True)
     taskset_id = sa.Column(sa.String(155), unique=True)
     result = sa.Column(PickleType, nullable=True)
-    date_done = sa.Column(sa.DateTime, default=datetime.now(timezone.utc),
+    date_done = sa.Column(sa.DateTime, default=lambda: datetime.now(timezone.utc),
                           nullable=True)
 
     def __init__(self, taskset_id, result):

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -66,6 +66,36 @@ class test_ModelsIdFieldTypeVariations:
 
 
 @skip.if_pypy
+class test_DateDoneColumnDefaults:
+    """Test that date_done column defaults are callables, not fixed values.
+
+    The default and onupdate values must be callables (lambdas) so that
+    datetime.now() is evaluated per-row at INSERT/UPDATE time, not once
+    at module import time.
+    """
+
+    def test_task_date_done_default_is_callable(self):
+        """Task.date_done default should be a callable (lambda)."""
+        col = Task.__table__.columns['date_done']
+        assert callable(col.default.arg), \
+            "Task.date_done default should be a callable, not a fixed datetime"
+
+    def test_task_date_done_onupdate_is_callable(self):
+        """Task.date_done onupdate should be a callable (lambda)."""
+        col = Task.__table__.columns['date_done']
+        assert col.onupdate is not None, \
+            "Task.date_done should have an onupdate"
+        assert callable(col.onupdate.arg), \
+            "Task.date_done onupdate should be a callable, not a fixed datetime"
+
+    def test_taskset_date_done_default_is_callable(self):
+        """TaskSet.date_done default should be a callable (lambda)."""
+        col = TaskSet.__table__.columns['date_done']
+        assert callable(col.default.arg), \
+            "TaskSet.date_done default should be a callable, not a fixed datetime"
+
+
+@skip.if_pypy
 class test_DatabaseBackend:
 
     @pytest.fixture(autouse=True)

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -75,8 +75,10 @@ class test_DateDoneColumnDefaults:
     """
 
     def test_task_date_done_default_is_callable(self):
-        """Task.date_done default should be a callable (lambda)."""
+        """Task.date_done default should be a callable."""
         col = Task.__table__.columns['date_done']
+        assert col.default is not None, \
+            "Task.date_done should have a default"
         assert callable(col.default.arg), \
             "Task.date_done default should be a callable, not a fixed datetime"
 
@@ -89,8 +91,10 @@ class test_DateDoneColumnDefaults:
             "Task.date_done onupdate should be a callable, not a fixed datetime"
 
     def test_taskset_date_done_default_is_callable(self):
-        """TaskSet.date_done default should be a callable (lambda)."""
+        """TaskSet.date_done default should be a callable."""
         col = TaskSet.__table__.columns['date_done']
+        assert col.default is not None, \
+            "TaskSet.date_done should have a default"
         assert callable(col.default.arg), \
             "TaskSet.date_done default should be a callable, not a fixed datetime"
 


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
Fix `date_done` column defaults to use callables instead of fixed timestamps evaluated at module import time. (Fixes #10106)

## Problem
The `date_done` column in `Task` and `TaskSet` models used bare function calls as defaults:
```
date_done = sa.Column(sa.DateTime, default=datetime.now(timezone.utc), ...)
```

`datetime.now(timezone.utc)` executes once when the module is imported, and that fixed timestamp is reused for every row. This causes:

1. All `TaskSet` rows created by the same worker process share identical `date_done` values (the worker's startup time)
2. The `celery.backend_cleanup` periodic task queries `WHERE date_done < (now - expires)` — stale timestamps may cause premature or delayed cleanup of group results. 

## Solution
Changed the defaults to callables (lambdas) so SQLAlchemy evaluates them fresh for each INSERT/UPDATE:
```
# Task
date_done = sa.Column(sa.DateTime, 
                      default=lambda: datetime.now(timezone.utc),
                      onupdate=lambda: datetime.now(timezone.utc), 
                      nullable=True)

# TaskSet
date_done = sa.Column(sa.DateTime, 
                      default=lambda: datetime.now(timezone.utc),
                      nullable=True)
```

See [SQLAlchemy docs — Python-Executed Functions.](https://docs.sqlalchemy.org/en/20/core/defaults.html#python-executed-functions)

## Changes
`models.py`: Changed `Task.date_done` default and onupdate, and `TaskSet.date_done` default to use lambda functions
`test_database.py`: Added `test_DateDoneColumnDefaults` test class with 3 tests to ensure the defaults remain callables

**Notes**
While `Task.date_done` is typically overridden by `DatabaseBackend._update_result()` via `_get_result_meta()`, this fix is still applied defensively. `TaskSet` does not override the default, so this bug directly affects group result cleanup.

