### PR TITLE
Fix connection retry with purge option at startup (#10102)

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -129,9 +129,8 @@ class Worker(WorkController):
             sender=self.hostname, instance=self, conf=app.conf,
         )
 
-        if self.purge:
-            self.purge_messages()
-
+        # Purge is deferred to Consumer's Connection step so it runs after
+        # broker connection is established (with retry). See #10102.
         if not self.quiet:
             self.emit_banner()
 
@@ -185,9 +184,19 @@ class Worker(WorkController):
 
     def purge_messages(self):
         with self.app.connection_for_write() as connection:
-            count = self.app.control.purge(connection=connection)
-            if count:  # pragma: no cover
-                print(f"purge: Erased {count} {pluralize(count, 'message')} from the queue.\n", flush=True)
+            self._do_purge(connection)
+
+    def purge_messages_with_connection(self, connection):
+        """Purge queue using an already-established connection (e.g. from Consumer).
+
+        Used when --purge is passed so purge runs after broker connection retry.
+        """
+        self._do_purge(connection)
+
+    def _do_purge(self, connection):
+        count = self.app.control.purge(connection=connection)
+        if count:  # pragma: no cover
+            print(f"purge: Erased {count} {pluralize(count, 'message')} from the queue.\n", flush=True)
 
     def tasklist(self, include_builtins=True, sep='\n', int_='celery.'):
         return sep.join(

--- a/celery/worker/consumer/connection.py
+++ b/celery/worker/consumer/connection.py
@@ -20,6 +20,10 @@ class Connection(bootsteps.StartStopStep):
     def start(self, c):
         c.connection = c.connect()
         info('Connected to %s', c.connection.as_uri())
+        # Run purge after connection is established so broker_connection_retry
+        # on startup is respected (fixes #10102).
+        if getattr(c.controller, 'purge', False):
+            c.controller.purge_messages_with_connection(c.connection)
 
     def shutdown(self, c):
         # We must set self.connection to None here, so


### PR DESCRIPTION
When --purge is used, purge was called in Worker.on_start() before the Consumer established the broker connection, so it failed immediately instead of respecting broker_connection_retry_on_startup.

- Defer purge until after Consumer's Connection step has connected (with retry). Run purge from Connection.start() when controller.purge is set, using the established connection.
- Add purge_messages_with_connection() and _do_purge() on Worker so purge can run with an existing connection.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Fixes #10102

## Summary
With `--purge`, the worker called purge in `on_start()` before the Consumer had a broker connection, so it failed immediately instead of using `broker_connection_retry_on_startup`. Purge now runs after the Consumer’s Connection step has established the connection (with retry), using that connection.

## Changes
- **celery/apps/worker.py**: Removed purge from `on_start()`. Added `purge_messages_with_connection(connection)` and `_do_purge(connection)` so purge can run with an existing connection.
- **celery/worker/consumer/connection.py**: After `c.connect()`, if `c.controller.purge` is set, call `c.controller.purge_messages_with_connection(c.connection)`.
