### PR TITLE
fix: honor request-level ignore_result overrides

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -162,6 +162,7 @@ class Context:
             'retries': self.retries,
             'reply_to': self.reply_to,
             'replaced_task_nesting': self.replaced_task_nesting,
+            'ignore_result': self.ignore_result,
             'origin': self.origin,
         }
         if hasattr(self, 'stamps') and hasattr(self, 'stamped_headers'):

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -125,7 +125,9 @@ class Request:
         self._eventer = eventer
         self._connection_errors = connection_errors or ()
         self._task = task or self._app.tasks[self._type]
-        self._ignore_result = self._request_dict.get('ignore_result', False)
+        self._ignore_result = self._request_dict.get(
+            'ignore_result', self._task.ignore_result,
+        )
 
         # timezone means the message is timezone-aware, and the only timezone
         # supported at this point is UTC.
@@ -287,7 +289,7 @@ class Request:
 
     @property
     def store_errors(self):
-        return (not self.task.ignore_result or
+        return (not self.ignore_result or
                 self.task.store_errors_even_if_ignored)
 
     @property

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -471,6 +471,12 @@ class test_task_retries(TasksCase):
         sig = self.retry_task.signature_from_request()
         assert sig.options['shadow'] == 'test'
 
+    def test_signature_from_request__passes_ignore_result(self):
+        self.retry_task.push_request()
+        self.retry_task.request.ignore_result = True
+        sig = self.retry_task.signature_from_request()
+        assert sig.options['ignore_result'] is True
+
     def test_retry_kwargs_can_be_empty(self):
         self.retry_task_mockapply.push_request()
         try:

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -248,6 +248,11 @@ class test_Request(RequestCase):
                                    exclude_headers=['shadow'])
         assert request.name == 't.unit.worker.test_request.add'
 
+    def test_ignore_result_defaults_to_task_setting_when_header_missing(self):
+        self.add.ignore_result = True
+        request = self.get_request(self.add.s(2, 2))
+        assert request.ignore_result is True
+
     def test_invalid_eta_raises_InvalidTaskError(self):
         with pytest.raises(InvalidTaskError):
             self.get_request(self.add.s(2, 2).set(eta='12345'))
@@ -450,6 +455,9 @@ class test_Request(RequestCase):
         self.mytask.ignore_result = True
         job = self.xRequest()
         assert not job.store_errors
+
+        job = self.xRequest(ignore_result=False)
+        assert job.store_errors
 
         self.mytask.store_errors_even_if_ignored = True
         job = self.xRequest()


### PR DESCRIPTION
## Summary
- Honor `apply_async(ignore_result=...)` at execution time by resolving `ignore_result` from the request context in trace/worker paths instead of only task defaults.
- Propagate request `ignore_result` through execution options so retries/signature reconstruction keep the effective value.
- Add regression tests covering request-level overrides for result publishing and error storage behavior.

## Test plan
- [x] `.venv/bin/python -m pytest t/unit/tasks/test_trace.py t/unit/worker/test_request.py t/unit/tasks/test_tasks.py -q`
- [x] `.venv/bin/pre-commit run --files celery/app/task.py celery/app/trace.py celery/worker/request.py t/unit/tasks/test_tasks.py t/unit/tasks/test_trace.py t/unit/worker/test_request.py`

issue: #9654 
