### PR TITLE
fix: show user-friendly broker errors for remote CLI commands

### DIFF
--- a/celery/bin/events.py
+++ b/celery/bin/events.py
@@ -4,7 +4,8 @@ from functools import partial
 
 import click
 
-from celery.bin.base import LOG_LEVEL, CeleryDaemonCommand, CeleryOption, handle_preload_options
+from celery.bin.base import (LOG_LEVEL, CeleryDaemonCommand, CeleryOption, handle_preload_options,
+                             handle_remote_command_error)
 from celery.platforms import detached, set_process_title, strargv
 
 
@@ -82,13 +83,16 @@ def _run_evtop(app):
 def events(ctx, dump, camera, detach, frequency, maxrate, loglevel, **kwargs):
     """Event-stream utilities."""
     app = ctx.obj.app
-    if dump:
-        return _run_evdump(app)
+    try:
+        if dump:
+            return _run_evdump(app)
 
-    if camera:
-        return _run_evcam(camera, app=app, freq=frequency, maxrate=maxrate,
-                          loglevel=loglevel,
-                          detach=detach,
-                          **kwargs)
+        if camera:
+            return _run_evcam(camera, app=app, freq=frequency, maxrate=maxrate,
+                              loglevel=loglevel,
+                              detach=detach,
+                              **kwargs)
 
-    return _run_evtop(app)
+        return _run_evtop(app)
+    except Exception as exc:
+        handle_remote_command_error('events', exc)


### PR DESCRIPTION
## Summary
- Replace raw tracebacks from broker connection failures in remote CLI commands with concise, user-friendly errors.
- Add a shared remote-command error translator and apply it to `status`, `inspect`, `control`, `graph workers`, and `events` command paths.
- Keep non-connection CLI errors concise as command-scoped failures without traceback output.

## Test plan
- [x] `.venv/bin/python -m pytest t/unit/bin/test_control.py -q`
- [x] `.venv/bin/pre-commit run --files celery/bin/base.py celery/bin/control.py celery/bin/events.py celery/bin/graph.py t/unit/bin/test_control.py`
- [x] Manual check: `.venv/bin/celery --broker amqp://guest@127.0.0.1:5672// status -t 1`

issue #9722 
