### PR TITLE
fix dusk_astronomical horizon sign (+18 -> -18)

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -764,7 +764,7 @@ class solar(BaseSchedule):
         'sunset': '-0:34',
         'dusk_civil': '-6',
         'dusk_nautical': '-12',
-        'dusk_astronomical': '18',
+        'dusk_astronomical': '-18',
     }
     _methods = {
         'dawn_astronomical': 'next_rising',

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -76,6 +76,16 @@ class test_solar:
         with pytest.raises(ValueError):
             solar('asdqwewqew', 60, 60, app=self.app)
 
+    def test_dusk_horizons_are_negative(self):
+        """All dusk events should have negative horizons (sun below horizon)."""
+        for event in ('dusk_civil', 'dusk_nautical', 'dusk_astronomical'):
+            s = solar(event, 50, 10, app=self.app)
+            horizon = float(s.cal.horizon)
+            assert horizon < 0, (
+                f"{event} horizon should be negative (below horizon), "
+                f"got {s.cal.horizon}"
+            )
+
     def test_event_uses_center(self):
         s = solar('solar_noon', 60, 60, app=self.app)
         for ev, is_center in s._use_center_l.items():


### PR DESCRIPTION
Fixes #10101

The `dusk_astronomical` event had its horizon set to `'18'` (18 degrees *above* the horizon) instead of `'-18'` (18 degrees below). This caused `next_setting` in ephem to compute when the sun drops below +18 degrees altitude, which is basically just regular sunset — not astronomical dusk at all.

For comparison, `dawn_astronomical` was correctly set to `'-18'`, and the other dusk events (`dusk_civil: '-6'`, `dusk_nautical: '-12'`) were also correct. This was just a missing minus sign on `dusk_astronomical`.

Added a test that verifies all dusk horizons are negative.