### PR TITLE
Fix warm shutdown RuntimeError with eventlet>=0.37.0 (#10083)

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -15,6 +15,13 @@ from collections import namedtuple
 # Lazy loading
 from . import local
 
+# Save original os.write before eventlet/gevent can monkey-patch it.
+# This is needed for signal handlers (e.g., SIGINT) which may run inside
+# the eventlet hub's event loop. Using the patched os.write from within
+# the hub causes: RuntimeError('do not call blocking functions from the mainloop')
+# See: https://github.com/celery/celery/issues/10083
+_original_os_write = os.write
+
 SERIES = 'recovery'
 
 __version__ = '5.6.2'
@@ -169,4 +176,5 @@ old_module, new_module = local.recreate_module(  # pragma: no cover
     version_info=version_info,
     maybe_patch_concurrency=maybe_patch_concurrency,
     _find_option_with_arg=_find_option_with_arg,
+    _original_os_write=_original_os_write,
 )


### PR DESCRIPTION
## Description

Fixes #10083 - Celery warm shutdown fails with `RuntimeError: do not call blocking functions from the mainloop` when using `celery>=5.5.0b3` and `eventlet>=0.37.0`.

## Problem

When pressing Ctrl+C to initiate a warm shutdown with the eventlet pool, users encounter:

```
RuntimeError: do not call blocking functions from the mainloop
```


### Root Cause

1. **PR #9222** changed `safe_say()` to use `os.write()` instead of `print()` for signal-safe output
2. **Eventlet 0.37.0** ([PR #975](https://github.com/eventlet/eventlet/pull/975)) changed `os.write()` to use cooperative I/O via `hubs.trampoline()`
3. When SIGINT is received, the signal handler runs **inside** eventlet's hub event loop
4. Calling the patched `os.write()` from within the hub triggers the RuntimeError

### Call Stack

```
SIGINT received →
  hub.run() [eventlet mainloop] →
    _handle_request() →
      on_SIGINT() →
        safe_say() →
          os.write() [eventlet-patched] →
            hubs.trampoline() →
              RuntimeError: do not call blocking functions from the mainloop
```

## Solution

Save the original `os.write` function in `celery/__init__.py` **before** `maybe_patch_concurrency()` is called (which triggers eventlet's monkey-patching), and import it in `celery/apps/worker.py` for use in `safe_say()`:

```python
# celery/__init__.py - after all imports, before maybe_patch_concurrency
_original_os_write = os.write

# celery/apps/worker.py
from celery import _original_os_write

def safe_say(msg, f=sys.__stderr__):
    if hasattr(f, 'fileno') and f.fileno() is not None:
        _original_os_write(f.fileno(), f'\n{msg}\n'.encode())
```

### Why This Works

- `celery/__init__.py` is imported **before** `maybe_patch_concurrency()` is called
- `maybe_patch_concurrency()` calls `eventlet.monkey_patch()` which patches `os.write`
- `celery/apps/worker.py` is imported **after** monkey-patching, but it uses the pre-saved original
- The original `os.write()` is async-signal-safe and non-blocking
- It doesn't interact with eventlet's hub/greenlet scheduler
- Signal handlers can safely call it without triggering hub conflicts

## Changes

- **`celery/__init__.py`**:
  - Save `_original_os_write = os.write` at module level after all imports
  - Export via `local.recreate_module()` for lazy loading compatibility
  - Add comment explaining the purpose

- **`celery/apps/worker.py`**:
  - Import `_original_os_write` from `celery`
  - Update `safe_say()` to use `_original_os_write` instead of `os.write`
  - Add docstring explaining the rationale

## Testing

### Manual Testing

1. Install eventlet>=0.37.0
2. Start worker: `celery -A myapp worker --pool=eventlet`
3. Press Ctrl+C
4. **Before fix**: RuntimeError
5. **After fix**: Clean warm shutdown message

### Reproduction Script

Create a test file to reproduce the issue:

```python
# test_eventlet_shutdown.py
"""Simple Celery app for testing eventlet warm shutdown fix."""
from celery import Celery

# Create a simple Celery app
app = Celery('test_eventlet_shutdown')

# Configure broker (using memory transport for simplicity)
app.conf.update(
    broker_url='memory://',
    result_backend='cache+memory://',
    task_always_eager=False,  # Don't execute tasks immediately
    worker_prefetch_multiplier=1,
    task_acks_late=True,
)

@app.task
def simple_task(x, y):
    """A simple task that adds two numbers."""
    import time
    time.sleep(2)  # Simulate some work
    return x + y

@app.task
def long_running_task():
    """A longer task to test shutdown during execution."""
    import time
    print("Starting long running task...")
    for i in range(10):
        print(f"Working... {i+1}/10")
        time.sleep(1)
    print("Long running task completed!")
    return "done"

if __name__ == '__main__':
    app.start()
```

### Testing Steps

```bash
# Step 1: Install eventlet (ensure version >= 0.37.0)
pip install eventlet>=0.37.0

# Step 2: Start worker with eventlet pool
python -m celery -A test_eventlet_shutdown worker --pool=eventlet --concurrency=4 --loglevel=info

# Step 3: Press Ctrl+C once worker is ready
# Expected (AFTER fix): Clean warm shutdown
# Expected (BEFORE fix): RuntimeError: do not call blocking functions from the mainloop
```

<img width="1040" height="568" alt="image" src="https://github.com/user-attachments/assets/600aabe1-aa3b-4d52-ae66-0603a4636994" />


## Backward Compatibility

✅ **Fully backward compatible**

- No API changes
- No configuration changes
- Works with all eventlet versions (including those without the patch)
- Works with gevent (same pattern applies)
- Works without any concurrency pool (original `os.write` is used either way)

## Related Issues

- Fixes #10083
- Related to #9222 (original change that introduced `os.write` in `safe_say`)

## Checklist

- [x] I have verified that the fix works against the `main` branch of Celery.
- [x] I have added comments explaining why this change is necessary.
- [x] The fix is backward compatible.
- [x] No new dependencies are introduced.
- [x] I have added/updated tests (if applicable).
- [x] I have read the [contribution guide](https://docs.celeryq.dev/en/main/contributing.html).
