### PR TITLE
Database Backend filter unsupport sql engine arguments with nullpool #7355

### DIFF
--- a/celery/backends/database/session.py
+++ b/celery/backends/database/session.py
@@ -48,10 +48,10 @@ class SessionManager:
                 engine = self._engines[dburi] = create_engine(dburi, **kwargs)
                 return engine
         else:
-            unsupport_nullpool_kwargs = {'max_overflow'}
+            unsupported_nullpool_kwargs = {'max_overflow', 'echo_pool'}
             kwargs = {
                 k: v for k, v in kwargs.items()
-                if not k.startswith('pool') and k not in unsupport_nullpool_kwargs
+                if not k.startswith('pool') and k not in unsupported_nullpool_kwargs
             }
             return create_engine(dburi, poolclass=NullPool, **kwargs)
 

--- a/celery/backends/database/session.py
+++ b/celery/backends/database/session.py
@@ -48,8 +48,11 @@ class SessionManager:
                 engine = self._engines[dburi] = create_engine(dburi, **kwargs)
                 return engine
         else:
-            kwargs = {k: v for k, v in kwargs.items() if
-                      not k.startswith('pool')}
+            unsupport_nullpool_kwargs = {'max_overflow'}
+            kwargs = {
+                k: v for k, v in kwargs.items()
+                if not k.startswith('pool') and k not in unsupport_nullpool_kwargs
+            }
             return create_engine(dburi, poolclass=NullPool, **kwargs)
 
     def create_session(self, dburi, short_lived_sessions=False, **kwargs):

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -633,3 +633,22 @@ class test_SessionManager:
             manager.prepare_models(engine)
 
         assert mock_create_all.call_count == PREPARE_MODELS_MAX_RETRIES + 1
+
+    @patch('celery.backends.database.session.create_engine')
+    def test_get_engine_filters_nullpool_unsupported_kwargs(self, mock_create_engine):
+        """
+        Test that QueuePool-specific kwargs (like pool_size and max_overflow)
+        are filtered out when creating an engine with NullPool.
+        """
+        from celery.backends.database.session import NullPool
+
+        s = SessionManager()
+        s.forked = False  # Ensure we're in the non-forked code path
+
+        s.get_engine('dburi', echo=True, pool_size=10, max_overflow=5)
+
+        mock_create_engine.assert_called_once_with(
+            'dburi',
+            poolclass=NullPool,
+            echo=True
+        )

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -645,10 +645,9 @@ class test_SessionManager:
         s = SessionManager()
         s.forked = False  # Ensure we're in the non-forked code path
 
-        s.get_engine('dburi', echo=True, pool_size=10, max_overflow=5)
+        s.get_engine('dburi', echo_pool=True, pool_size=10, max_overflow=5)
 
         mock_create_engine.assert_called_once_with(
             'dburi',
             poolclass=NullPool,
-            echo=True
         )


### PR DESCRIPTION
## Description
Fixes #7355

### Background
When a Celery worker uses a database result backend and processes a task that doesn't require a new subprocess fork (e.g., discarding an expired task inline), it avoids creating a full connection pool by falling back to SQLAlchemy's `NullPool`. 

Previously, `get_engine` attempted to strip out `QueuePool`-specific arguments from `database_engine_options` by only filtering keys that started with `"pool"`. However, arguments like `max_overflow` (and `echo_pool`) bypass this filter. Passing these arguments to `NullPool` causes `create_engine` to raise a `TypeError`, leading to a worker crash mid-execution.

### Changes Made
* Updated the fallback logic in `celery.backends.database.session.SessionManager.get_engine`.
* Introduced an explicit exclusion set (`unsupported_nullpool_kwargs`) containing `'max_overflow'` and `'echo_pool'`.
* The dictionary comprehension now safely filters out both `pool*` prefixed arguments and the explicitly defined unsupported kwargs before initializing `NullPool`.
