### PR TITLE
fix(beat): correct argument order in Service.__reduce__

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -627,8 +627,8 @@ class Service:
         self._is_stopped = Event()
 
     def __reduce__(self):
-        return self.__class__, (self.max_interval, self.schedule_filename,
-                                self.scheduler_cls, self.app)
+        return self.__class__, (self.app, self.max_interval,
+                                self.schedule_filename, self.scheduler_cls)
 
     def start(self, embedded_process=False):
         info('beat: Starting...')


### PR DESCRIPTION
## Summary

`Service.__reduce__` in `celery/beat.py` returns arguments in the wrong positional order, causing deserialization to fail when pickling/unpickling the beat `Service` instance.

## Problem

`Service.__init__` signature is:
```python
def __init__(self, app, max_interval=None, schedule_filename=None, scheduler_cls=None):
```

But `__reduce__` was returning:
```python
return self.__class__, (self.max_interval, self.schedule_filename, self.scheduler_cls, self.app)
```

This means on unpickling, `app` receives `self.max_interval` (an int/float), `max_interval` receives `self.schedule_filename` (a string), etc. This would blow up whenever the Service object is pickled and then unpickled — for example when beat is embedded in a multiprocessing child.

## Fix

Reorder the tuple to match the `__init__` signature:
```python
return self.__class__, (self.app, self.max_interval, self.schedule_filename, self.scheduler_cls)
```
