### PR TITLE
fix(utils): use bufmaxsize parameter in BufferMap.__init__

### DIFF
--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -776,7 +776,7 @@ class BufferMap(OrderedDict, Evictable):
         # type: (int, Iterable, int) -> None
         super().__init__()
         self.maxsize = maxsize
-        self.bufmaxsize = 1000
+        self.bufmaxsize = bufmaxsize
         if iterable:
             self.update(iterable)
         self.total = sum(len(buf) for buf in self.items())


### PR DESCRIPTION
## Summary

`BufferMap.__init__` accepts a `bufmaxsize` parameter but ignores it, always hardcoding `self.bufmaxsize = 1000`.

## Problem

```python
def __init__(self, maxsize, iterable=None, bufmaxsize=1000):
    super().__init__()
    self.maxsize = maxsize
    self.bufmaxsize = 1000  # <-- should be bufmaxsize
```

The parameter `bufmaxsize` is passed in but never assigned to the instance attribute. Instead, `1000` is hardcoded. This means any code passing a custom `bufmaxsize` value has no effect — buffers are always created with maxsize 1000.

## Fix

```python
self.bufmaxsize = bufmaxsize
```
