### PR TITLE
ci: declare explicit read-only token permissions in workflow jobs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,6 +2,9 @@ name: Linter
 
 on: [pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   linter:
     runs-on: blacksmith-4vcpu-ubuntu-2204

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,6 +12,10 @@ on:
   workflow_dispatch:
 
 name: Semgrep
+
+permissions:
+  contents: read
+
 jobs:
   semgrep:
     name: Scan

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -13,6 +13,9 @@ on:
         type: string
         default: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]'
 
+permissions:
+  contents: read
+
 jobs:
   testing-with:
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
## Summary
Add explicit `GITHUB_TOKEN` permissions to three workflows that currently rely on defaults:

- `.github/workflows/linter.yml`
- `.github/workflows/smoke-tests.yml`
- `.github/workflows/semgrep.yml`

All three now declare:

```yaml
permissions:
  contents: read
```

## Why
These workflows only require repository read access (checkout + CI commands). Declaring explicit permissions improves least-privilege security and avoids implicit default scopes.
