### PR TITLE
Add exists() method to AsyncResult

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -750,6 +750,8 @@ class Backend:
     def task_result_exists(self, task_id):
         """Check if a result exists in the backend for the given task ID.
 
+        .. versionadded:: 5.7.0
+
         Returns:
             bool: :const:`True` if the backend has a result for the task,
                 :const:`False` otherwise.
@@ -1133,6 +1135,8 @@ class BaseKeyValueStoreBackend(Backend):
         the existence of the key in the store, which is more accurate
         than checking the status since tasks stored with PENDING status
         would still be detected.
+
+        .. versionadded:: 5.7.0
 
         Returns:
             bool: :const:`True` if the backend has a result for the task,

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -747,6 +747,15 @@ class Backend:
         """Reload task result, even if it has been previously fetched."""
         self._cache[task_id] = self.get_task_meta(task_id, cache=False)
 
+    def task_result_exists(self, task_id):
+        """Check if a result exists in the backend for the given task ID.
+
+        Returns:
+            bool: :const:`True` if the backend has a result for the task,
+                :const:`False` otherwise.
+        """
+        return self._get_task_meta_for(task_id)["status"] != states.PENDING
+
     def reload_group_result(self, group_id):
         """Reload group result, even if it has been previously fetched."""
         self._cache[group_id] = self.get_group_meta(group_id, cache=False)
@@ -1116,6 +1125,20 @@ class BaseKeyValueStoreBackend(Backend):
         if not meta:
             return {'status': states.PENDING, 'result': None}
         return self.decode_result(meta)
+
+    def task_result_exists(self, task_id):
+        """Check if a result exists in the backend for the given task ID.
+
+        This overrides the base implementation to directly check for
+        the existence of the key in the store, which is more accurate
+        than checking the status since tasks stored with PENDING status
+        would still be detected.
+
+        Returns:
+            bool: :const:`True` if the backend has a result for the task,
+                :const:`False` otherwise.
+        """
+        return bool(self.get(self.get_key_for_task(task_id)))
 
     def _restore_group(self, group_id):
         """Get task meta-data for a task by id."""

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -175,7 +175,10 @@ class DatabaseBackend(BaseBackend):
             return self.meta_from_decoded(data)
 
     def task_result_exists(self, task_id):
-        """Check if a result exists in the database for the given task ID."""
+        """Check if a result exists in the database for the given task ID.
+
+        .. versionadded:: 5.7.0
+        """
         session = self.ResultSession()
         with session_cleanup(session):
             return session.query(self.task_cls).filter(

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -174,6 +174,17 @@ class DatabaseBackend(BaseBackend):
                 data['kwargs'] = self.decode(data['kwargs'])
             return self.meta_from_decoded(data)
 
+    def task_result_exists(self, task_id):
+        """Check if a result exists in the database for the given task ID."""
+        session = self.ResultSession()
+        with session_cleanup(session):
+            return bool(
+                session.query(self.task_cls)
+                .filter(self.task_cls.task_id == task_id)
+                .count()
+            )
+
+    @retry
     def _save_group(self, group_id, result):
         """Store the result of an executed group."""
         session = self.ResultSession()

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -178,11 +178,9 @@ class DatabaseBackend(BaseBackend):
         """Check if a result exists in the database for the given task ID."""
         session = self.ResultSession()
         with session_cleanup(session):
-            return bool(
-                session.query(self.task_cls)
-                .filter(self.task_cls.task_id == task_id)
-                .count()
-            )
+            return session.query(self.task_cls).filter(
+                self.task_cls.task_id == task_id
+            ).first() is not None
 
     @retry
     def _save_group(self, group_id, result):

--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -182,7 +182,6 @@ class DatabaseBackend(BaseBackend):
                 self.task_cls.task_id == task_id
             ).first() is not None
 
-    @retry
     def _save_group(self, group_id, result):
         """Store the result of an executed group."""
         session = self.ResultSession()

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -224,6 +224,10 @@ class MongoBackend(BaseBackend):
             })
         return {'status': states.PENDING, 'result': None}
 
+    def task_result_exists(self, task_id):
+        """Check if a result exists in MongoDB for the given task ID."""
+        return bool(self.collection.find_one({"_id": task_id}))
+
     def _save_group(self, group_id, result):
         """Save the group result."""
         meta = {

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -225,7 +225,10 @@ class MongoBackend(BaseBackend):
         return {'status': states.PENDING, 'result': None}
 
     def task_result_exists(self, task_id):
-        """Check if a result exists in MongoDB for the given task ID."""
+        """Check if a result exists in MongoDB for the given task ID.
+
+        .. versionadded:: 5.7.0
+        """
         return bool(self.collection.find_one({"_id": task_id}))
 
     def _save_group(self, group_id, result):

--- a/celery/result.py
+++ b/celery/result.py
@@ -351,6 +351,8 @@ class AsyncResult(ResultBase):
         Without this method, both cases return ``PENDING`` as the state,
         making them indistinguishable.
 
+        .. versionadded:: 5.7.0
+
         Returns:
             bool: :const:`True` if the backend has a result stored for
                 this task ID, :const:`False` otherwise.

--- a/celery/result.py
+++ b/celery/result.py
@@ -341,6 +341,22 @@ class AsyncResult(ResultBase):
                 if is_incomplete_stream:
                     raise IncompleteStream()
 
+    def exists(self):
+        """Return :const:`True` if a result exists in the backend for this task.
+
+        This can be used to distinguish between a task that is truly
+        pending (waiting for execution) and a task ID that has never
+        been submitted or whose result has been forgotten/expired.
+
+        Without this method, both cases return ``PENDING`` as the state,
+        making them indistinguishable.
+
+        Returns:
+            bool: :const:`True` if the backend has a result stored for
+                this task ID, :const:`False` otherwise.
+        """
+        return self.backend.task_result_exists(self.id)
+
     def ready(self):
         """Return :const:`True` if the task has executed.
 

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -494,6 +494,27 @@ class test_BaseBackend_dict:
         self.b.serializer = 'pickle'
         assert isinstance(self.b.prepare_value(g), self.app.GroupResult)
 
+    def test_task_result_exists_true(self):
+        b = DictBackend(app=self.app)
+        b._get_task_meta_for = Mock(return_value={
+            'status': states.SUCCESS, 'result': 42,
+        })
+        assert b.task_result_exists('task-exists') is True
+
+    def test_task_result_exists_false(self):
+        b = DictBackend(app=self.app)
+        b._get_task_meta_for = Mock(return_value={
+            'status': states.PENDING, 'result': None,
+        })
+        assert b.task_result_exists('task-missing') is False
+
+    def test_task_result_exists_failure_state(self):
+        b = DictBackend(app=self.app)
+        b._get_task_meta_for = Mock(return_value={
+            'status': states.FAILURE, 'result': None,
+        })
+        assert b.task_result_exists('task-failed') is True
+
     def test_is_cached(self):
         b = BaseBackend(app=self.app, max_cached_results=1)
         b._cache['foo'] = 1
@@ -1386,6 +1407,31 @@ class test_KeyValueStoreBackend:
 
     def test_restore_missing_group(self):
         assert self.b.restore_group('xxx-nonexistant') is None
+
+    def test_task_result_exists_after_store(self):
+        tid = uuid()
+        self.b.mark_as_done(tid, 'result')
+        assert self.b.task_result_exists(tid) is True
+
+    def test_task_result_exists_missing(self):
+        assert self.b.task_result_exists('xxx-nonexistant') is False
+
+    def test_task_result_exists_after_failure(self):
+        tid = uuid()
+        self.b.mark_as_failure(tid, RuntimeError('failed'), traceback='tb')
+        assert self.b.task_result_exists(tid) is True
+
+    def test_task_result_exists_after_retry(self):
+        tid = uuid()
+        self.b.mark_as_retry(tid, RuntimeError('retry'), traceback='tb')
+        assert self.b.task_result_exists(tid) is True
+
+    def test_task_result_exists_after_forget(self):
+        tid = uuid()
+        self.b.mark_as_done(tid, 'result')
+        assert self.b.task_result_exists(tid) is True
+        self.b.forget(tid)
+        assert self.b.task_result_exists(tid) is False
 
 
 class test_KeyValueStoreBackend_interface:

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -415,6 +415,23 @@ class test_DatabaseBackend:
         assert meta['result'] is None
         assert meta['traceback'] is None
 
+    def test_task_result_exists_for_missing_task(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        assert tb.task_result_exists('xxx-does-not-exist') is False
+
+    def test_task_result_exists_after_mark_as_done(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tid = uuid()
+        assert tb.task_result_exists(tid) is False
+        tb.mark_as_done(tid, 42)
+        assert tb.task_result_exists(tid) is True
+
+    def test_task_result_exists_after_mark_as_failure(self):
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tid = uuid()
+        tb.mark_as_failure(tid, RuntimeError('fail'), traceback='tb')
+        assert tb.task_result_exists(tid) is True
+
     def test_mark_as_done(self):
         tb = DatabaseBackend(self.uri, app=self.app)
 

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -482,6 +482,30 @@ class test_MongoBackend:
         assert {'status': states.PENDING, 'result': None} == ret_val
 
     @patch('celery.backends.mongodb.MongoBackend._get_database')
+    def test_task_result_exists_found(self, mock_get_database):
+        self.backend.taskmeta_collection = MONGODB_COLLECTION
+        mock_database = MagicMock(spec=['__getitem__', '__setitem__'])
+        mock_collection = Mock()
+        mock_collection.find_one.return_value = {'_id': sentinel.task_id, 'status': 'SUCCESS'}
+        mock_get_database.return_value = mock_database
+        mock_database.__getitem__.return_value = mock_collection
+
+        assert self.backend.task_result_exists(sentinel.task_id) is True
+        mock_collection.find_one.assert_called_once_with({"_id": sentinel.task_id})
+
+    @patch('celery.backends.mongodb.MongoBackend._get_database')
+    def test_task_result_exists_not_found(self, mock_get_database):
+        self.backend.taskmeta_collection = MONGODB_COLLECTION
+        mock_database = MagicMock(spec=['__getitem__', '__setitem__'])
+        mock_collection = Mock()
+        mock_collection.find_one.return_value = None
+        mock_get_database.return_value = mock_database
+        mock_database.__getitem__.return_value = mock_collection
+
+        assert self.backend.task_result_exists(sentinel.task_id) is False
+        mock_collection.find_one.assert_called_once_with({"_id": sentinel.task_id})
+
+    @patch('celery.backends.mongodb.MongoBackend._get_database')
     def test_save_group(self, mock_get_database):
         self.backend.groupmeta_collection = MONGODB_GROUP_COLLECTION
 

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -390,6 +390,17 @@ class test_AsyncResult:
 
         assert not self.app.AsyncResult(uuid()).ready()
 
+    def test_exists(self):
+        """Test that exists() returns True for stored results and False for unknown IDs."""
+        # Tasks with stored results should exist
+        assert self.app.AsyncResult(self.task1["id"]).exists()
+        assert self.app.AsyncResult(self.task2["id"]).exists()
+        assert self.app.AsyncResult(self.task3["id"]).exists()
+
+        # A random/unknown task ID should not exist
+        assert not self.app.AsyncResult(uuid()).exists()
+
+
     @pytest.mark.skipif(
         platform.python_implementation() == "PyPy",
         reason="Mocking here doesn't play well with PyPy",

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -392,14 +392,27 @@ class test_AsyncResult:
 
     def test_exists(self):
         """Test that exists() returns True for stored results and False for unknown IDs."""
-        # Tasks with stored results should exist
+        # Tasks with stored results should exist (SUCCESS, FAILURE, RETRY)
         assert self.app.AsyncResult(self.task1["id"]).exists()
         assert self.app.AsyncResult(self.task2["id"]).exists()
         assert self.app.AsyncResult(self.task3["id"]).exists()
 
+        # RETRY state should also exist
+        assert self.app.AsyncResult(self.task4["id"]).exists()
+
         # A random/unknown task ID should not exist
         assert not self.app.AsyncResult(uuid()).exists()
 
+        # Multiple unknown IDs should all return False
+        assert not self.app.AsyncResult(uuid()).exists()
+        assert not self.app.AsyncResult("totally-fake-id").exists()
+
+    def test_exists_returns_bool(self):
+        """Test that exists() returns a proper boolean type."""
+        result_exists = self.app.AsyncResult(self.task1["id"]).exists()
+        result_missing = self.app.AsyncResult(uuid()).exists()
+        assert isinstance(result_exists, bool)
+        assert isinstance(result_missing, bool)
 
     @pytest.mark.skipif(
         platform.python_implementation() == "PyPy",


### PR DESCRIPTION
Right now if you do `AsyncResult('some-random-id').state`, you get `PENDING` — same as an actual pending task. There's no way to tell if a task result actually exists in the backend or if you're just looking up a bogus ID.

This adds an `exists()` method to `AsyncResult` that checks whether the backend has a stored result for the task ID. Returns `True` if there's something stored, `False` if the ID is unknown.

```python
res = AsyncResult('nonexistent-id')
res.state      # 'PENDING' — misleading
res.exists()   # False — now we know it's not a real task

res2 = my_task.delay()
res2.exists()  # True
```

Changes:
- `AsyncResult.exists()` delegates to backend
- `Backend.task_result_exists()` base implementation checks if status != PENDING
- `BaseKeyValueStoreBackend` override does a direct key lookup (more accurate)
- `DatabaseBackend` override queries the DB table
- `MongoBackend` override checks the collection

Tests included — all existing tests pass.

Closes #3596