### PR TITLE
docs: remove duplicated words in broker and routing docs

### DIFF
--- a/docs/getting-started/backends-and-brokers/rabbitmq.rst
+++ b/docs/getting-started/backends-and-brokers/rabbitmq.rst
@@ -223,7 +223,7 @@ To migrate from classic mirrored queues to quorum queues, please refer to Rabbit
 Limitations
 -----------
 
-Disabling global QoS means that the the per-channel QoS is now static.
+Disabling global QoS means that the per-channel QoS is now static.
 This means that some Celery features won't work when using Quorum Queues.
 
 Autoscaling relies on increasing and decreasing the prefetch count whenever a new process is instantiated

--- a/docs/getting-started/backends-and-brokers/redis.rst
+++ b/docs/getting-started/backends-and-brokers/redis.rst
@@ -268,7 +268,7 @@ Group result ordering
 
 Versions of Celery up to and including 4.4.6 used an unsorted list to store
 result objects for groups in the Redis backend. This can cause those results to
-be be returned in a different order to their associated tasks in the original
+be returned in a different order to their associated tasks in the original
 group instantiation. Celery 4.4.7 introduced an opt-in behaviour which fixes
 this issue and ensures that group results are returned in the same order the
 tasks were defined, matching the behaviour of other backends. In Celery 5.0

--- a/docs/userguide/routing.rst
+++ b/docs/userguide/routing.rst
@@ -276,7 +276,7 @@ This means that even though there are 10 (0-9) priority levels, these are
 consolidated into 4 levels by default to save resources. This means that a
 queue named celery will really be split into 4 queues.
 
-The highest priority queue will be named celery, and the the other queues will
+The highest priority queue will be named celery, and the other queues will
 have a separator (by default `\x06\x16`) and their priority number appended to
 the queue name.
 


### PR DESCRIPTION
## Summary
Fix three duplicated-word typos in docs:

- `the the` -> `the` in routing docs
- `the the` -> `the` in RabbitMQ backend docs
- `be be` -> `be` in Redis backend docs

## Scope
- docs only
- no behavior changes
