### PR TITLE
docs: remove duplicated words in history notes

### DIFF
--- a/docs/history/changelog-3.1.rst
+++ b/docs/history/changelog-3.1.rst
@@ -1031,7 +1031,7 @@ News
 - **Beat**: No longer attempts to upgrade a newly created database file
   (Issue #1923).
 
-- **Beat**: New setting :setting:``CELERYBEAT_SYNC_EVERY`` can be be used
+- **Beat**: New setting :setting:``CELERYBEAT_SYNC_EVERY`` can be used
   to control file sync by specifying the number of tasks to send between
   each sync.
 

--- a/docs/history/whatsnew-5.3.rst
+++ b/docs/history/whatsnew-5.3.rst
@@ -249,7 +249,7 @@ A switch have been made to zoneinfo for handling timezone data instead of pytz.
 Support for out-of-tree worker pool implementations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Prior to version 5.3, Celery had a fixed notion of the worker pool types it supports.
-Celery v5.3.0 introduces the the possibility of an out-of-tree worker pool implementation.
+Celery v5.3.0 introduces the possibility of an out-of-tree worker pool implementation.
 This feature ensure that the current worker pool implementations consistently call into
 BasePool._get_info(), and enhance it to report the work pool class in use via the 
 "celery inspect stats" command. For example:
@@ -345,7 +345,6 @@ Known Issues
 ------------
 Canvas header stamping has issues in a hybrid Celery 4.x. & Celery 5.3.x 
 environment and is not safe for production use at the moment.
-
 
 
 


### PR DESCRIPTION
## Description
Fix duplicated words in Celery history docs:
- `the the` -> `the`
- `can be be` -> `can be`

Docs-only change with no runtime impact.
