### PR TITLE
docs: fix wording in Celery 5.3 worker pool notes

### DIFF
--- a/docs/history/whatsnew-5.3.rst
+++ b/docs/history/whatsnew-5.3.rst
@@ -251,7 +251,7 @@ Support for out-of-tree worker pool implementations
 Prior to version 5.3, Celery had a fixed notion of the worker pool types it supports.
 Celery v5.3.0 introduces the possibility of an out-of-tree worker pool implementation.
 This feature ensures that the current worker pool implementations consistently call into
-BasePool._get_info(), and enhance it to report the work pool class in use via the 
+BasePool._get_info(), and enhances it to report the worker pool class in use via the
 "celery inspect stats" command. For example:
 
 $ celery -A ... inspect stats


### PR DESCRIPTION
## Summary
- fix a duplicated word in the v5.3 worker pool section
- fix subject-verb agreement in the following sentence

## Guideline alignment
- guideline reference: https://docs.celeryq.dev/en/main/contributing.html
- docs-only wording cleanup in historical release notes
- no functional changes

## Validation
- docs-only change; standard CI/docs checks run in PR
