### PR TITLE
Fix/10096 worker fails to reconnect after redis failover

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -1000,11 +1000,14 @@ class AsynPool(_pool.Pool):
         if self._state == TERMINATE:
             return
         # cancel all tasks that haven't been accepted so that NACK is sent
-        # if synack is enabled.
-        if self.synack:
-            for job in self._cache.values():
-                if not job._accepted:
+        # if synack is enabled, otherwise discard them from the cache
+        # since they will be redelivered by the broker.
+        for job in tuple(self._cache.values()):
+            if not job._accepted:
+                if self.synack:
                     job._cancel()
+                else:
+                    job.discard()
 
         # clear the outgoing buffer as the tasks will be redelivered by
         # the broker anyway.

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -472,7 +472,7 @@ class AsynPool(_pool.Pool):
 
         self.write_stats = Counter()
 
-        super().__init__(processes, *args, **kwargs)
+        super().__init__(processes, *args, synack=synack, **kwargs)
 
         for proc in self._pool:
             # create initial mappings, these will be updated

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -514,8 +514,7 @@ class test_AsynPool:
         assert proc._sentinel_poll is None
 
     @t.skip.if_pypy
-    @patch('billiard.pool.Pool._create_worker_process')
-    def test_flush_no_synack_discards_unaccepted_jobs(self, _create_worker_process):
+    def test_flush_no_synack_discards_unaccepted_jobs(self):
         """flush() should discard unaccepted jobs when synack is disabled.
 
         Previously, flush() only handled the synack case. Without synack,
@@ -543,8 +542,7 @@ class test_AsynPool:
         job2.discard.assert_not_called()
 
     @t.skip.if_pypy
-    @patch('billiard.pool.Pool._create_worker_process')
-    def test_flush_synack_cancels_unaccepted_jobs(self, _create_worker_process):
+    def test_flush_synack_cancels_unaccepted_jobs(self):
         """flush() should call _cancel() on unaccepted jobs when synack is enabled."""
         pool = asynpool.AsynPool(processes=1, synack=True, threads=False)
         pool._state = asynpool.RUN

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -514,7 +514,8 @@ class test_AsynPool:
         assert proc._sentinel_poll is None
 
     @t.skip.if_pypy
-    def test_flush_no_synack_discards_unaccepted_jobs(self):
+    @patch('billiard.pool.Pool._create_worker_process')
+    def test_flush_no_synack_discards_unaccepted_jobs(self, _create_worker_process):
         """flush() should discard unaccepted jobs when synack is disabled.
 
         Previously, flush() only handled the synack case. Without synack,
@@ -523,6 +524,7 @@ class test_AsynPool:
         """
         pool = asynpool.AsynPool(processes=1, synack=False, threads=False)
         pool._state = asynpool.RUN
+        pool.maintain_pool = Mock(name='maintain_pool')
 
         job1 = Mock(name='job1')
         job1._accepted = False
@@ -541,10 +543,12 @@ class test_AsynPool:
         job2.discard.assert_not_called()
 
     @t.skip.if_pypy
-    def test_flush_synack_cancels_unaccepted_jobs(self):
+    @patch('billiard.pool.Pool._create_worker_process')
+    def test_flush_synack_cancels_unaccepted_jobs(self, _create_worker_process):
         """flush() should call _cancel() on unaccepted jobs when synack is enabled."""
         pool = asynpool.AsynPool(processes=1, synack=True, threads=False)
         pool._state = asynpool.RUN
+        pool.maintain_pool = Mock(name='maintain_pool')
 
         job1 = Mock(name='job1')
         job1._accepted = False
@@ -563,6 +567,75 @@ class test_AsynPool:
         job1.discard.assert_not_called()
         job2._cancel.assert_not_called()
 
+    @t.skip.if_pypy
+    @patch('billiard.pool.Pool._create_worker_process')
+    def test_flush_dead_process_discards_active_writer(self, _create_worker_process):
+        """flush() must discard generator from _active_writers when process is dead.
+
+        Previously, when a process was dead, the generator was never removed
+        from _active_writers, causing an infinite loop in the while loop.
+        """
+        pool = asynpool.AsynPool(processes=1, synack=False, threads=False)
+        pool._state = asynpool.RUN
+        pool.maintain_pool = Mock(name='maintain_pool')
+
+        # Create a mock generator (already started, so not gen_not_started)
+        gen = Mock(name='gen')
+        gen.__name__ = '_write_job'
+        # Simulate a started generator
+        with patch.object(asynpool, 'gen_not_started', return_value=False):
+            proc = Mock(name='proc')
+            proc._is_alive.return_value = False  # Process is dead
+
+            job = Mock(name='job')
+            job._accepted = True
+            job._write_to = proc
+            job._writer.return_value = gen
+
+            pool._cache = {1: job}
+            pool._active_writers = {gen}
+            pool.outbound_buffer.clear()
+
+            pool.flush()
+
+        # Generator should have been removed from active_writers
+        assert gen not in pool._active_writers
+        # Job should have been discarded since process is dead
+        job.discard.assert_called()
+
+    @t.skip.if_pypy
+    @patch('billiard.pool.Pool._create_worker_process')
+    def test_flush_alive_process_flushes_writer(self, _create_worker_process):
+        """flush() should call _flush_writer when process is still alive."""
+        pool = asynpool.AsynPool(processes=1, synack=False, threads=False)
+        pool._state = asynpool.RUN
+        pool.maintain_pool = Mock(name='maintain_pool')
+
+        gen = Mock(name='gen')
+        gen.__name__ = '_write_job'
+
+        with patch.object(asynpool, 'gen_not_started', return_value=False):
+            proc = Mock(name='proc')
+            proc._is_alive.return_value = True
+
+            job = Mock(name='job')
+            job._accepted = True
+            job._write_to = proc
+            job._writer.return_value = gen
+
+            pool._cache = {1: job}
+            pool._active_writers = {gen}
+            pool.outbound_buffer.clear()
+
+            with patch.object(pool, '_flush_writer') as mock_flush:
+                # _flush_writer removes from _active_writers in its finally
+                def side_effect(p, g):
+                    pool._active_writers.discard(g)
+                mock_flush.side_effect = side_effect
+
+                pool.flush()
+
+            mock_flush.assert_called_once_with(proc, gen)
 
 
 @t.skip.if_win32

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -646,7 +646,7 @@ class test_AsynPool:
         and hangs the worker process waiting for the ack that never arrives.
         flush() must advance them to completion instead.
         """
-        pool = asynpool.AsynPool(processes=1, synack=False, threads=False)
+        pool = asynpool.AsynPool(processes=1, synack=True, threads=False)
         pool._state = asynpool.RUN
         pool.maintain_pool = Mock(name='maintain_pool')
 
@@ -672,7 +672,7 @@ class test_AsynPool:
     @patch('billiard.pool.Pool._create_worker_process')
     def test_flush_write_ack_coroutine_handles_oserror(self, _create_worker_process):
         """flush() should discard the coroutine if OSError is raised during next()."""
-        pool = asynpool.AsynPool(processes=1, synack=False, threads=False)
+        pool = asynpool.AsynPool(processes=1, synack=True, threads=False)
         pool._state = asynpool.RUN
         pool.maintain_pool = Mock(name='maintain_pool')
 
@@ -691,7 +691,7 @@ class test_AsynPool:
     @patch('billiard.pool.Pool._create_worker_process')
     def test_flush_write_ack_coroutine_handles_eoferror(self, _create_worker_process):
         """flush() should discard the coroutine if EOFError is raised during next()."""
-        pool = asynpool.AsynPool(processes=1, synack=False, threads=False)
+        pool = asynpool.AsynPool(processes=1, synack=True, threads=False)
         pool._state = asynpool.RUN
         pool.maintain_pool = Mock(name='maintain_pool')
 


### PR DESCRIPTION
# Fix: Worker fails to reconnect after Redis failover (regression from #9986 and #7273)

Fixes #10096

## Description

After upgrading to Celery 5.6.x, workers using Redis Sentinel as the broker fail to reconnect after a Redis failover. Running tasks appear permanently stuck in `active` state, no new tasks are consumed, and the worker becomes invisible to `celery inspect ping` / `active_queues`.

The root cause is a combination of two regressions introduced by #9986 and #7273 in `AsynPool.flush()` and `asynloop()`. This PR fixes all three bugs while preserving the intended behavior of both original PRs.

### Bug 1 — `hub.reset()` removed from `asynloop()` error path (regression from #9986)

PR #9986 removed the `hub.reset()` call from `asynloop()` to keep timers alive during graceful shutdown. However, this also removed the reset on the **error** path (e.g., broker connection loss), which means stale file descriptors and callbacks from the old connection remain registered in the hub. When the consumer restarts and re-registers with the event loop, these stale descriptors cause `EBADF` errors or 100% CPU poll loops, preventing the worker from reconnecting.

**Fix:** Wrap the event loop in `try/except Exception` and call `hub.reset()` only on error. This preserves the #9986 fix because:

- On **graceful shutdown**, the loop exits normally (no exception), so `hub.reset()` is **not** called — timers keep firing while the pool drains, exactly as #9986 intended.
- On **error** (connection loss, etc.), `hub.reset()` **is** called — stale fds and callbacks are cleaned up before the consumer restarts.
- `WorkerShutdown` / `WorkerTerminate` extend `SystemExit` (not `Exception`), so they pass through without triggering the reset.

> **Note:** The issue reporter's patch used `finally:` (unconditional reset), which would re-break #9986 / #5998. Using `except Exception:` is the correct approach — it targets only error-driven reconnection while leaving graceful shutdown intact.

### Bug 2 — Unaccepted jobs stuck in cache when `synack=False` (regression from #7273)

PR #7273 added logic in `AsynPool.flush()` to clear the `_cache` when there are no active writers. However, the cleanup of individual unaccepted jobs was only done when `synack=True`:

```python
# Before (only handles synack=True)
if self.synack:
    for job in self._cache.values():
        if not job._accepted:
            job._cancel()
```

When `synack=False` (the default), unaccepted jobs were never removed from `_cache`. After a broker reconnection, these orphaned entries make the worker think it still has active tasks, blocking new task consumption (especially with `worker_concurrency=1`).

**Fix:** Iterate over all unaccepted jobs regardless of `synack`. When `synack=True`, call `job._cancel()` (sends NACK). When `synack=False`, call `job.discard()` (removes from cache; broker will redeliver). Uses `tuple()` to safely copy the dict during iteration.

### Bug 3 — Infinite loop in `flush()` when worker process is dead (latent bug in #7273)

In the `while self._active_writers` loop of `flush()`, when a writer generator had already started but its target process was dead:

1. `_flush_writer()` was skipped (process not alive)
2. `job.discard()` was called
3. **But the generator was never removed from `_active_writers`**

This caused the `while` loop to spin forever, hanging the worker on connection loss.

Additionally, the original code had a shortcut `if not self._active_writers: self._cache.clear()` that aggressively cleared the **entire** cache, including jobs that were already accepted and actively executing in worker processes.

**Fix:**
- Always call `self._active_writers.discard(gen)` in the `else` branch, regardless of whether the process is alive or dead.
- Remove the `self._cache.clear()` shortcut — jobs should only be discarded individually based on their actual state.
- When a process is dead, explicitly discard the job from cache since it will never complete.

## How these bugs interact (the #10096 scenario)

The issue reporter's environment: Redis Sentinel broker, `worker_concurrency=1`, `task_acks_late=False`.

1. A task is running when Redis fails over → connection to old master is lost.
2. `asynloop()` gets an exception from the broken connection.
3. **Without Bug 1 fix:** `hub.reset()` is never called → stale fds remain → consumer cannot cleanly re-register with the event loop → worker becomes invisible (`inspect ping` fails).
4. **Without Bug 2 fix:** The in-flight task completes, but its job entry remains in `_cache` → worker thinks it still has 1 active task → with `concurrency=1`, no new tasks are accepted.
5. **Without Bug 3 fix:** If `flush()` is called while a writer targets a dead process, the worker hangs in an infinite loop.

All three fixes are needed for full recovery. The reporter confirmed that versions prior to 5.6.1 only needed the `asynpool.py` fix (Bugs 2+3), and from 5.6.1 onwards the `loops.py` fix (Bug 1) became necessary as well — matching the timeline of #9986 being merged.

## Changes

| File | Change |
|------|--------|
| `celery/worker/loops.py` | Add `try/except Exception` around event loop; call `hub.reset()` on error only |
| `celery/concurrency/asynpool.py` | Discard unaccepted jobs when `synack=False`; fix infinite loop by always removing dead-process writers from `_active_writers`; remove unsafe `_cache.clear()` shortcut |
| `t/unit/worker/test_loops.py` | 5 new tests for hub reset behavior |
| `t/unit/concurrency/test_prefork.py` | 4 new tests for `flush()` behavior |

## Test coverage

### `asynloop` hub reset tests (`t/unit/worker/test_loops.py`)

| Test | Verifies |
|------|----------|
| `test_hub_reset_on_connection_error` | `hub.reset()` called when poll raises `socket.error` |
| `test_hub_not_reset_on_graceful_shutdown` | `hub.reset()` **not** called on normal CLOSE transition |
| `test_hub_not_reset_on_worker_shutdown` | `hub.reset()` **not** called for `WorkerShutdown` (extends `SystemExit`) |
| `test_hub_not_reset_on_worker_terminate` | `hub.reset()` **not** called for `WorkerTerminate` (extends `SystemExit`) |
| `test_hub_reset_error_still_reraises_original` | Original exception propagates even if `hub.reset()` itself fails |

### `AsynPool.flush()` tests (`t/unit/concurrency/test_prefork.py`)

| Test | Verifies |
|------|----------|
| `test_flush_no_synack_discards_unaccepted_jobs` | `job.discard()` called for unaccepted jobs when `synack=False` |
| `test_flush_synack_cancels_unaccepted_jobs` | `job._cancel()` called for unaccepted jobs when `synack=True` |
| `test_flush_dead_process_discards_active_writer` | Generator removed from `_active_writers` when process is dead (no infinite loop) |
| `test_flush_alive_process_flushes_writer` | `_flush_writer()` called when process is still alive |

## Backwards compatibility

- No user-facing API changes.
- No configuration changes.
- Graceful shutdown behavior from #9986 is preserved (timers keep firing during pool drain).
- Memory leak fix from #7273 is preserved (jobs are still discarded from cache on flush).
- The only behavioral change is that `hub.reset()` is now called on connection errors (restoring pre-#9986 behavior for the error path only), and unaccepted jobs are properly cleaned up regardless of `synack` setting.
