### PR TITLE
docs: fix duplicated wording in 3.1 changelog entry

### DIFF
--- a/docs/history/changelog-3.1.rst
+++ b/docs/history/changelog-3.1.rst
@@ -1031,7 +1031,7 @@ News
 - **Beat**: No longer attempts to upgrade a newly created database file
   (Issue #1923).
 
-- **Beat**: New setting :setting:``CELERYBEAT_SYNC_EVERY`` can be be used
+- **Beat**: New setting :setting:``CELERYBEAT_SYNC_EVERY`` can be used
   to control file sync by specifying the number of tasks to send between
   each sync.
 


### PR DESCRIPTION
## Summary
- remove a duplicated word (`be be`) in the Celery 3.1 changelog entry for `CELERYBEAT_SYNC_EVERY`

## Guideline alignment
- guideline reference: https://docs.celeryq.dev/en/main/contributing.html
- docs-only wording correction in historical release notes
- no functional changes

## Validation
- docs-only change