### PR TITLE
docs: fix duplicated word in bootsteps comment

### DIFF
--- a/celery/bootsteps.py
+++ b/celery/bootsteps.py
@@ -303,7 +303,7 @@ class Step(metaclass=StepType):
     #: Set this to true if the step is enabled based on some condition.
     conditional = False
 
-    #: List of other steps that that must be started before this step.
+    #: List of other steps that must be started before this step.
     #: Note that all dependencies must be in the same blueprint.
     requires = ()
 


### PR DESCRIPTION
## Summary
- fix duplicated wording in `celery/bootsteps.py`
- changed `steps that that must be started before this step.` -> `steps that must be started before this step.`

## Related issue
- N/A (trivial comment typo fix)

## Guideline alignment
- guideline reference: https://docs.celeryq.dev/en/main/contributing.html
- trivial docs/comment wording fix only
- no behavior or API changes

## Validation
- single-file text/comment/docs change