### PR TITLE
Improve on_after_finalize signal documentation

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -311,8 +311,9 @@ class Celery:
 
     #: Signal sent after the app has been finalized (i.e., all pending
     #: task decorators have been evaluated, built-in tasks loaded, and
-    #: every task has been bound to the app).  This is the earliest point
-    #: at which the full task registry is available.
+    #: every currently registered task has been bound to the app).  This is
+    #: the earliest point at which the task registry is initialized/stable
+    #: and safe to inspect for tasks currently registered with this app.
     on_after_finalize = None
 
     #: Signal sent by every new process after fork.

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -309,7 +309,10 @@ class Celery:
     #: Signal sent after app has prepared the configuration.
     on_after_configure = None
 
-    #: Signal sent after app has been finalized.
+    #: Signal sent after the app has been finalized (i.e., all pending
+    #: task decorators have been evaluated, built-in tasks loaded, and
+    #: every task has been bound to the app).  This is the earliest point
+    #: at which the full task registry is available.
     on_after_finalize = None
 
     #: Signal sent by every new process after fork.

--- a/docs/reference/celery.rst
+++ b/docs/reference/celery.rst
@@ -126,7 +126,14 @@ and creating Celery applications.
 
     .. data:: on_after_finalize
 
-        Signal sent after app has been finalized.
+        Signal sent after the app has been finalized — that is, after all
+        pending task decorators have been evaluated, built-in tasks loaded,
+        and every task has been bound to the app.  This is the earliest
+        point at which the full task registry is available, making it safe
+        to import and inspect task objects.
+
+        See :meth:`~celery.Celery.finalize` for more details on what
+        finalization does.
 
     .. data:: on_after_fork
 

--- a/docs/reference/celery.rst
+++ b/docs/reference/celery.rst
@@ -128,9 +128,9 @@ and creating Celery applications.
 
         Signal sent after the app has been finalized — that is, after all
         pending task decorators have been evaluated, built-in tasks loaded,
-        and every task has been bound to the app.  This is the earliest
-        point at which the full task registry is available, making it safe
-        to import and inspect task objects.
+        and every task registered at that point has been bound to the app.
+        At this stage the task registry is initialized and stable enough to
+        import and inspect task objects reliably.
 
         See :meth:`~celery.Celery.finalize` for more details on what
         finalization does.


### PR DESCRIPTION
## Description

The existing documentation for `on_after_finalize` just says "Signal sent after app has been finalized" — which essentially repeats the signal name without explaining what "finalized" actually means. This is confusing for users trying to understand the app lifecycle (as reported in #7280).

This PR updates both the class attribute docstring in `celery/app/base.py` and the reference docs in `docs/reference/celery.rst` to explain that finalization:

- Evaluates all pending task decorators
- Loads built-in tasks
- Binds every task to the app

This makes `on_after_finalize` the earliest point at which the full task registry is available, which is the key information users need when choosing between `on_after_configure` and `on_after_finalize`.

Fixes #7280