### PR TITLE
feat(redis): support configuring additional connection errors

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -324,12 +324,24 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             else ((), ()))
         additional = self._transport_options.get(
             'additional_connection_errors', ())
+        # Normalize common scalar misconfigurations (single str/type) to a 1-tuple.
+        if isinstance(additional, (str, type)):
+            additional = (additional,)
         if additional:
-            extra = tuple(
-                symbol_by_name(cls) if isinstance(cls, str) else cls
-                for cls in additional
-            )
-            self.connection_errors = self.connection_errors + extra
+            extra = []
+            for cls in additional:
+                resolved = symbol_by_name(cls) if isinstance(cls, str) else cls
+                # Ensure we only add valid exception classes; skip invalid entries.
+                if isinstance(resolved, type) and issubclass(resolved, BaseException):
+                    extra.append(resolved)
+                else:
+                    logger.warning(
+                        "Ignoring invalid additional_connection_errors entry %r: "
+                        "expected an exception class or dotted path to one.",
+                        resolved,
+                    )
+            if extra:
+                self.connection_errors = self.connection_errors + tuple(extra)
         self.result_consumer = self.ResultConsumer(
             self, self.app, self.accept,
             self._pending_results, self._pending_messages,

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -322,7 +322,9 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         self.connection_errors, self.channel_errors = (
             get_redis_error_classes() if get_redis_error_classes
             else ((), ()))
-        additional = self._transport_options.get(
+        transport_options = self.app.conf.get(
+            'result_backend_transport_options', {})
+        additional = transport_options.get(
             'additional_connection_errors', ())
         if isinstance(additional, (str, type)):
             additional = (additional,)

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -324,24 +324,36 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             else ((), ()))
         additional = self._transport_options.get(
             'additional_connection_errors', ())
-        # Normalize common scalar misconfigurations (single str/type) to a 1-tuple.
         if isinstance(additional, (str, type)):
             additional = (additional,)
         if additional:
             extra = []
             for cls in additional:
-                resolved = symbol_by_name(cls) if isinstance(cls, str) else cls
-                # Ensure we only add valid exception classes; skip invalid entries.
-                if isinstance(resolved, type) and issubclass(resolved, BaseException):
+                try:
+                    resolved = (
+                        symbol_by_name(cls)
+                        if isinstance(cls, str) else cls
+                    )
+                except (ImportError, AttributeError) as exc:
+                    logger.warning(
+                        'Ignoring unresolvable'
+                        ' additional_connection_errors'
+                        ' entry %r: %r', cls, exc,
+                    )
+                    continue
+                if (isinstance(resolved, type)
+                        and issubclass(resolved, BaseException)):
                     extra.append(resolved)
                 else:
                     logger.warning(
-                        "Ignoring invalid additional_connection_errors entry %r: "
-                        "expected an exception class or dotted path to one.",
-                        resolved,
+                        'Ignoring invalid additional_connection_errors'
+                        ' entry %r: expected an exception class or'
+                        ' dotted path to one.', resolved,
                     )
             if extra:
-                self.connection_errors = self.connection_errors + tuple(extra)
+                self.connection_errors = (
+                    self.connection_errors + tuple(extra)
+                )
         self.result_consumer = self.ResultConsumer(
             self, self.app, self.accept,
             self._pending_results, self._pending_messages,

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -322,6 +322,14 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
         self.connection_errors, self.channel_errors = (
             get_redis_error_classes() if get_redis_error_classes
             else ((), ()))
+        additional = self._transport_options.get(
+            'additional_connection_errors', ())
+        if additional:
+            extra = tuple(
+                symbol_by_name(cls) if isinstance(cls, str) else cls
+                for cls in additional
+            )
+            self.connection_errors = self.connection_errors + extra
         self.result_consumer = self.ResultConsumer(
             self, self.app, self.accept,
             self._pending_results, self._pending_messages,

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -344,13 +344,14 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
                     )
                     continue
                 if (isinstance(resolved, type)
-                        and issubclass(resolved, BaseException)):
+                        and issubclass(resolved, Exception)):
                     extra.append(resolved)
                 else:
                     logger.warning(
                         'Ignoring invalid additional_connection_errors'
-                        ' entry %r: expected an exception class or'
-                        ' dotted path to one.', resolved,
+                        ' entry %r (resolved: %r): expected an'
+                        ' exception class or dotted path to one.',
+                        cls, resolved,
                     )
             if extra:
                 self.connection_errors = (

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -313,8 +313,15 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
             'result_backend_transport_options', {})
         additional = transport_options.get(
             'additional_connection_errors', ())
-        if isinstance(additional, (str, type)):
+        if additional is None:
+            additional = ()
+        elif isinstance(additional, (str, type)):
             additional = (additional,)
+        else:
+            try:
+                iter(additional)
+            except TypeError:
+                additional = (additional,)
         if additional:
             extra = []
             for cls in additional:

--- a/docs/getting-started/backends-and-brokers/redis.rst
+++ b/docs/getting-started/backends-and-brokers/redis.rst
@@ -143,6 +143,27 @@ To configure the connection timeouts for the Redis result backend, use the ``ret
 
 See :func:`~kombu.utils.functional.retry_over_time` for the possible retry policy options.
 
+.. _redis-result-backend-additional-connection-errors:
+
+Additional connection errors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some Redis proxies or cloud providers may raise custom exceptions that Celery
+does not recognize as connection errors. To have these retried automatically,
+use the ``additional_connection_errors`` key under
+:setting:`result_backend_transport_options`:
+
+
+.. code-block:: python
+
+    app.conf.result_backend_transport_options = {
+        'additional_connection_errors': (
+            'my_redis_proxy.CustomConnectionError',
+        ),
+    }
+
+Both dotted import strings and exception classes are supported.
+
 .. _redis-serverless:
 
 Serverless

--- a/docs/getting-started/backends-and-brokers/redis.rst
+++ b/docs/getting-started/backends-and-brokers/redis.rst
@@ -148,6 +148,8 @@ See :func:`~kombu.utils.functional.retry_over_time` for the possible retry polic
 Additional connection errors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. versionadded:: 5.7
+
 Some Redis proxies or cloud providers may raise custom exceptions that Celery
 does not recognize as connection errors. To have these retried automatically,
 use the ``additional_connection_errors`` key under

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -847,6 +847,39 @@ class test_RedisBackend(basetest_RedisBackend):
         b = self.Backend(app=self.app)
         assert ConnectionError not in b.connection_errors
 
+    def test_additional_connection_errors_scalar_class(self):
+        self.app.conf.result_backend_transport_options = dict(
+            additional_connection_errors=ConnectionError,
+        )
+        b = self.Backend(app=self.app)
+        assert ConnectionError in b.connection_errors
+
+    def test_additional_connection_errors_scalar_string(self):
+        self.app.conf.result_backend_transport_options = dict(
+            additional_connection_errors=(
+                't.unit.backends.test_redis.ConnectionError'
+            ),
+        )
+        b = self.Backend(app=self.app)
+        assert ConnectionError in b.connection_errors
+
+    def test_additional_connection_errors_non_exception_ignored(self):
+        self.app.conf.result_backend_transport_options = dict(
+            additional_connection_errors=(ConnectionError, int),
+        )
+        b = self.Backend(app=self.app)
+        assert ConnectionError in b.connection_errors
+        assert int not in b.connection_errors
+
+    def test_additional_connection_errors_bad_import_ignored(self):
+        self.app.conf.result_backend_transport_options = dict(
+            additional_connection_errors=(
+                ConnectionError, 'no.such.module.Error',
+            ),
+        )
+        b = self.Backend(app=self.app)
+        assert ConnectionError in b.connection_errors
+
     def test_incr(self):
         self.b.client = Mock(name='client')
         self.b.incr('foo')

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -871,6 +871,13 @@ class test_RedisBackend(basetest_RedisBackend):
         assert ConnectionError in b.connection_errors
         assert int not in b.connection_errors
 
+    def test_additional_connection_errors_non_type_ignored(self):
+        self.app.conf.result_backend_transport_options = dict(
+            additional_connection_errors=(ConnectionError, 42),
+        )
+        b = self.Backend(app=self.app)
+        assert ConnectionError in b.connection_errors
+
     def test_additional_connection_errors_bad_import_ignored(self):
         self.app.conf.result_backend_transport_options = dict(
             additional_connection_errors=(


### PR DESCRIPTION
Allow users to configure additional exception classes as connection errors for the Redis backend via `result_backend_transport_options`. This lets `exception_safe_to_retry()` recognize custom errors from Redis proxies or cloud providers. Supports both class objects and dotted import strings.

Fixes #10119