### PR TITLE
fix(trace): dispatch chain/callbacks on dedup fast-path for redelivered tasks

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -94,6 +94,7 @@ jobs:
           'test_backend.py',
           'test_canvas.py',
           'test_database_backend.py',
+          'test_dedup_chain_dispatch.py',
           'test_inspect.py',
           'test_loader.py',
           'test_mem_leak_in_exception_handling.py',

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -459,16 +459,6 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                             stored_retval = r.result
                             _meta = r._get_task_meta()
                             _children = _meta.get('children')
-                            _chain = task_request.chain
-                            if _chain and not _children:
-                                _chsig = signature(_chain[-1], app=app)
-                                _chsig.apply_async(
-                                    (stored_retval,),
-                                    chain=_chain[:-1],
-                                    parent_id=uuid,
-                                    root_id=_root_id,
-                                    priority=_priority,
-                                )
                             _callbacks = task_request.callbacks
                             if _callbacks and not _children:
                                 if len(_callbacks) > 1:
@@ -497,6 +487,16 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                                         parent_id=uuid, root_id=_root_id,
                                         priority=_priority,
                                     )
+                            _chain = task_request.chain
+                            if _chain and not _children:
+                                _chsig = signature(_chain[-1], app=app)
+                                _chsig.apply_async(
+                                    (stored_retval,),
+                                    chain=_chain[:-1],
+                                    parent_id=uuid,
+                                    root_id=_root_id,
+                                    priority=_priority,
+                                )
                             successful_requests.add(task_request.id)
                         except MemoryError:
                             raise

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -452,6 +452,37 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                             'name': get_task_name(task_request, name),
                             'description': 'Task already completed successfully.'
                         })
+                        # tasks that were already completed by another worker.
+                        try:
+                            stored_retval = r.result
+                            _chain = task_request.chain
+                            if _chain:
+                                _chsig = signature(_chain[-1], app=app)
+                                _chsig.apply_async(
+                                    (stored_retval,),
+                                    chain=_chain[:-1],
+                                    parent_id=uuid,
+                                    root_id=task_request.root_id or uuid,
+                                    priority=(
+                                        task_request.delivery_info.get('priority')
+                                        if inherit_parent_priority else None
+                                    ),
+                                )
+                            _callbacks = task_request.callbacks
+                            if _callbacks:
+                                for cb in _callbacks:
+                                    signature(cb, app=app).apply_async(
+                                        (stored_retval,),
+                                        parent_id=uuid,
+                                        root_id=task_request.root_id or uuid,
+                                    )
+                        except Exception:
+                            logger.warning(
+                                'Failed to dispatch chain/callbacks for '
+                                'deduplicated task %s',
+                                task_request.id,
+                                exc_info=True,
+                            )
                         return trace_ok_t(R, I, T, Rstr)
 
             push_task(task)
@@ -541,9 +572,9 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                         # execute first task in chain
                         chain = task_request.chain
                         if chain:
-                            _chsig = signature(chain.pop(), app=app)
+                            _chsig = signature(chain[-1], app=app)
                             _chsig.apply_async(
-                                (retval,), chain=chain,
+                                (retval,), chain=chain[:-1],
                                 parent_id=uuid, root_id=root_id,
                                 priority=task_priority
                             )

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -457,8 +457,10 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                             inherit_parent_priority else None
                         try:
                             stored_retval = r.result
+                            _meta = r._get_task_meta()
+                            _children = _meta.get('children')
                             _chain = task_request.chain
-                            if _chain:
+                            if _chain and not _children:
                                 _chsig = signature(_chain[-1], app=app)
                                 _chsig.apply_async(
                                     (stored_retval,),
@@ -468,7 +470,7 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                                     priority=_priority,
                                 )
                             _callbacks = task_request.callbacks
-                            if _callbacks:
+                            if _callbacks and not _children:
                                 if len(_callbacks) > 1:
                                     sigs, groups = [], []
                                     for sig in _callbacks:

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -557,13 +557,14 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                             successful_requests.add(task_request.id)
                         except MemoryError:
                             raise
-                        except Exception:
+                        except Exception as exc:
                             logger.error(
                                 'Failed to dispatch chain/callbacks for '
                                 'deduplicated task %s',
                                 task_request.id,
                                 exc_info=True,
                             )
+                            raise Reject(exc, requeue=True)
                         return trace_ok_t(R, I, T, Rstr)
 
             push_task(task)
@@ -709,6 +710,8 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                                          exc_info=True)
         except MemoryError:
             raise
+        except Reject:
+            raise
         except Exception as exc:
             _signal_internal_error(task, uuid, args, kwargs, request, exc)
             if eager:
@@ -728,6 +731,8 @@ def trace_task(task, uuid, args, kwargs, request=None, **opts):
         if task.__trace__ is None:
             task.__trace__ = build_tracer(task.name, task, **opts)
         return task.__trace__(uuid, args, kwargs, request)
+    except Reject:
+        raise
     except Exception as exc:
         _signal_internal_error(task, uuid, args, kwargs, request, exc)
         return trace_ok_t(report_internal_error(task, exc), TraceInfo(FAILURE, exc), 0.0, None)

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -465,12 +465,14 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                                 # Mirror the normal success path by pushing task/request
                                 # context so dispatched signatures can register themselves
                                 # as children of this request.
-                                context_pushed = False
+                                task_pushed = False
+                                request_pushed = False
                                 try:
                                     try:
                                         push_task(task)
+                                        task_pushed = True
                                         push_request(task_request)
-                                        context_pushed = True
+                                        request_pushed = True
                                     except Exception:
                                         logger.error(
                                             'Failed to push task/request context for '
@@ -517,7 +519,7 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                                             priority=_priority,
                                         )
                                 finally:
-                                    if context_pushed:
+                                    if request_pushed:
                                         try:
                                             pop_request()
                                         except Exception:
@@ -527,6 +529,7 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                                                 task_request.id,
                                                 exc_info=True,
                                             )
+                                    if task_pushed:
                                         try:
                                             pop_task()
                                         except Exception:

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -460,43 +460,100 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                             _meta = r._get_task_meta()
                             _children = _meta.get('children')
                             _callbacks = task_request.callbacks
-                            if _callbacks and not _children:
-                                if len(_callbacks) > 1:
-                                    sigs, groups = [], []
-                                    for sig in _callbacks:
-                                        sig = signature(sig, app=app)
-                                        if isinstance(sig, group):
-                                            groups.append(sig)
-                                        else:
-                                            sigs.append(sig)
-                                    for group_ in groups:
-                                        group_.apply_async(
-                                            (stored_retval,),
-                                            parent_id=uuid, root_id=_root_id,
-                                            priority=_priority,
-                                        )
-                                    if sigs:
-                                        group(sigs, app=app).apply_async(
-                                            (stored_retval,),
-                                            parent_id=uuid, root_id=_root_id,
-                                            priority=_priority,
-                                        )
-                                else:
-                                    signature(_callbacks[0], app=app).apply_async(
-                                        (stored_retval,),
-                                        parent_id=uuid, root_id=_root_id,
-                                        priority=_priority,
-                                    )
                             _chain = task_request.chain
-                            if _chain and not _children:
-                                _chsig = signature(_chain[-1], app=app)
-                                _chsig.apply_async(
-                                    (stored_retval,),
-                                    chain=_chain[:-1],
-                                    parent_id=uuid,
-                                    root_id=_root_id,
-                                    priority=_priority,
-                                )
+                            if (_callbacks or _chain) and not _children:
+                                # Mirror the normal success path by pushing task/request
+                                # context so dispatched signatures can register themselves
+                                # as children of this request.
+                                context_pushed = False
+                                try:
+                                    try:
+                                        push_task(task)
+                                        push_request(task_request)
+                                        context_pushed = True
+                                    except Exception:
+                                        logger.error(
+                                            'Failed to push task/request context for '
+                                            'deduplicated task %s',
+                                            task_request.id,
+                                            exc_info=True,
+                                        )
+                                    # Dispatch callbacks (if any) under the pushed context.
+                                    if _callbacks:
+                                        if len(_callbacks) > 1:
+                                            sigs, groups = [], []
+                                            for sig in _callbacks:
+                                                sig = signature(sig, app=app)
+                                                if isinstance(sig, group):
+                                                    groups.append(sig)
+                                                else:
+                                                    sigs.append(sig)
+                                            for group_ in groups:
+                                                group_.apply_async(
+                                                    (stored_retval,),
+                                                    parent_id=uuid, root_id=_root_id,
+                                                    priority=_priority,
+                                                )
+                                            if sigs:
+                                                group(sigs, app=app).apply_async(
+                                                    (stored_retval,),
+                                                    parent_id=uuid, root_id=_root_id,
+                                                    priority=_priority,
+                                                )
+                                        else:
+                                            signature(_callbacks[0], app=app).apply_async(
+                                                (stored_retval,),
+                                                parent_id=uuid, root_id=_root_id,
+                                                priority=_priority,
+                                            )
+                                    # Dispatch chain (if any) under the same context.
+                                    if _chain:
+                                        _chsig = signature(_chain[-1], app=app)
+                                        _chsig.apply_async(
+                                            (stored_retval,),
+                                            chain=_chain[:-1],
+                                            parent_id=uuid,
+                                            root_id=_root_id,
+                                            priority=_priority,
+                                        )
+                                finally:
+                                    if context_pushed:
+                                        try:
+                                            pop_request()
+                                        except Exception:
+                                            logger.error(
+                                                'Failed to pop request context for '
+                                                'deduplicated task %s',
+                                                task_request.id,
+                                                exc_info=True,
+                                            )
+                                        try:
+                                            pop_task()
+                                        except Exception:
+                                            logger.error(
+                                                'Failed to pop task context for '
+                                                'deduplicated task %s',
+                                                task_request.id,
+                                                exc_info=True,
+                                            )
+                                # If children were registered during dispatch, persist them
+                                # in the backend meta so future redeliveries see them.
+                                if getattr(task_request, 'children', None):
+                                    _meta['children'] = task_request.children
+                                    try:
+                                        app.backend.store_result(
+                                            task_request.id,
+                                            stored_retval,
+                                            states.SUCCESS,
+                                            request=task_request,
+                                        )
+                                    except Exception:
+                                        logger.error(
+                                            'Failed to persist children for '
+                                            'deduplicated task %s',
+                                            task_request.id,
+                                            exc_info=True,
+                                        )
                             successful_requests.add(task_request.id)
                         except MemoryError:
                             raise

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -414,8 +414,14 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
     ):
         """Dispatch callbacks and chain for a completed task.
 
-        Shared by both the normal success path and the dedup fast-path
-        to keep dispatch logic in one place.
+        Dispatches link callbacks and then the next chain step.
+        Does NOT fire task lifecycle signals (on_success, task_postrun)
+        or call mark_as_done — callers handle those separately.
+
+        Note: dispatch is not atomic.  If callbacks succeed but the
+        chain step fails (or vice-versa), a Reject + redeliver may
+        re-dispatch the already-sent callbacks.  This is acceptable
+        under Celery's at-least-once delivery model.
         """
         if callbacks:
             if len(callbacks) > 1:
@@ -499,8 +505,14 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                         _priority = task_request.delivery_info.get('priority') if \
                             inherit_parent_priority else None
                         try:
-                            stored_retval = r.result
-                            _children = r._get_task_meta().get('children')
+                            _meta = r._get_task_meta()
+                            stored_retval = _meta.get('result')
+                            # Children are populated by mark_as_done on the
+                            # original execution.  If present, callbacks were
+                            # already dispatched — skip to avoid duplicates.
+                            # Requires the backend to persist extended result
+                            # metadata (result_extended=True).
+                            _children = _meta.get('children')
                             _callbacks = task_request.callbacks
                             _chain = task_request.chain
                             if (_callbacks or _chain) and not _children:
@@ -513,6 +525,10 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                         except MemoryError:
                             raise
                         except Exception as exc:
+                            # Permanent failures (malformed signature, etc.)
+                            # will requeue indefinitely.  Broker-level
+                            # dead-letter / max-delivery-count policies are
+                            # the intended circuit-breaker.
                             logger.error(
                                 'Failed to dispatch chain/callbacks for '
                                 'deduplicated task %s',

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -409,6 +409,49 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
         )
         return I, R, I.state, I.retval
 
+    def _dispatch_callbacks_and_chain(
+        retval, callbacks, chain, parent_id, root_id, priority,
+    ):
+        """Dispatch callbacks and chain for a completed task.
+
+        Shared by both the normal success path and the dedup fast-path
+        to keep dispatch logic in one place.
+        """
+        if callbacks:
+            if len(callbacks) > 1:
+                sigs, groups = [], []
+                for sig in callbacks:
+                    sig = signature(sig, app=app)
+                    if isinstance(sig, group):
+                        groups.append(sig)
+                    else:
+                        sigs.append(sig)
+                for group_ in groups:
+                    group_.apply_async(
+                        (retval,),
+                        parent_id=parent_id, root_id=root_id,
+                        priority=priority,
+                    )
+                if sigs:
+                    group(sigs, app=app).apply_async(
+                        (retval,),
+                        parent_id=parent_id, root_id=root_id,
+                        priority=priority,
+                    )
+            else:
+                signature(callbacks[0], app=app).apply_async(
+                    (retval,),
+                    parent_id=parent_id, root_id=root_id,
+                    priority=priority,
+                )
+        if chain:
+            _chsig = signature(chain[-1], app=app)
+            _chsig.apply_async(
+                (retval,), chain=chain[:-1],
+                parent_id=parent_id, root_id=root_id,
+                priority=priority,
+            )
+
     def trace_task(uuid, args, kwargs, request=None):
         # R      - is the possibly prepared return value.
         # I      - is the Info object.
@@ -457,106 +500,15 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                             inherit_parent_priority else None
                         try:
                             stored_retval = r.result
-                            _meta = r._get_task_meta()
-                            _children = _meta.get('children')
+                            _children = r._get_task_meta().get('children')
                             _callbacks = task_request.callbacks
                             _chain = task_request.chain
                             if (_callbacks or _chain) and not _children:
-                                # Mirror the normal success path by pushing task/request
-                                # context so dispatched signatures can register themselves
-                                # as children of this request.
-                                task_pushed = False
-                                request_pushed = False
-                                try:
-                                    try:
-                                        push_task(task)
-                                        task_pushed = True
-                                        push_request(task_request)
-                                        request_pushed = True
-                                    except Exception:
-                                        logger.error(
-                                            'Failed to push task/request context for '
-                                            'deduplicated task %s',
-                                            task_request.id,
-                                            exc_info=True,
-                                        )
-                                    # Dispatch callbacks (if any) under the pushed context.
-                                    if _callbacks:
-                                        if len(_callbacks) > 1:
-                                            sigs, groups = [], []
-                                            for sig in _callbacks:
-                                                sig = signature(sig, app=app)
-                                                if isinstance(sig, group):
-                                                    groups.append(sig)
-                                                else:
-                                                    sigs.append(sig)
-                                            for group_ in groups:
-                                                group_.apply_async(
-                                                    (stored_retval,),
-                                                    parent_id=uuid, root_id=_root_id,
-                                                    priority=_priority,
-                                                )
-                                            if sigs:
-                                                group(sigs, app=app).apply_async(
-                                                    (stored_retval,),
-                                                    parent_id=uuid, root_id=_root_id,
-                                                    priority=_priority,
-                                                )
-                                        else:
-                                            signature(_callbacks[0], app=app).apply_async(
-                                                (stored_retval,),
-                                                parent_id=uuid, root_id=_root_id,
-                                                priority=_priority,
-                                            )
-                                    # Dispatch chain (if any) under the same context.
-                                    if _chain:
-                                        _chsig = signature(_chain[-1], app=app)
-                                        _chsig.apply_async(
-                                            (stored_retval,),
-                                            chain=_chain[:-1],
-                                            parent_id=uuid,
-                                            root_id=_root_id,
-                                            priority=_priority,
-                                        )
-                                finally:
-                                    if request_pushed:
-                                        try:
-                                            pop_request()
-                                        except Exception:
-                                            logger.error(
-                                                'Failed to pop request context for '
-                                                'deduplicated task %s',
-                                                task_request.id,
-                                                exc_info=True,
-                                            )
-                                    if task_pushed:
-                                        try:
-                                            pop_task()
-                                        except Exception:
-                                            logger.error(
-                                                'Failed to pop task context for '
-                                                'deduplicated task %s',
-                                                task_request.id,
-                                                exc_info=True,
-                                            )
-                                # If children were registered during dispatch, persist them
-                                # in the backend meta so future redeliveries see them.
-                                if getattr(task_request, 'children', None):
-                                    _meta['children'] = task_request.children
-                                    try:
-                                        app.backend.store_result(
-                                            task_request.id,
-                                            stored_retval,
-                                            states.SUCCESS,
-                                            request=task_request,
-                                        )
-                                    except Exception:
-                                        logger.error(
-                                            'Failed to persist children for '
-                                            'deduplicated task %s',
-                                            task_request.id,
-                                            exc_info=True,
-                                        )
+                                _dispatch_callbacks_and_chain(
+                                    stored_retval, _callbacks, _chain,
+                                    parent_id=uuid, root_id=_root_id,
+                                    priority=_priority,
+                                )
                             successful_requests.add(task_request.id)
                         except MemoryError:
                             raise
@@ -626,43 +578,12 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                         # separately, so need to call them separately
                         # so that the trail's not added multiple times :(
                         # (Issue #1936)
-                        callbacks = task.request.callbacks
-                        if callbacks:
-                            if len(task.request.callbacks) > 1:
-                                sigs, groups = [], []
-                                for sig in callbacks:
-                                    sig = signature(sig, app=app)
-                                    if isinstance(sig, group):
-                                        groups.append(sig)
-                                    else:
-                                        sigs.append(sig)
-                                for group_ in groups:
-                                    group_.apply_async(
-                                        (retval,),
-                                        parent_id=uuid, root_id=root_id,
-                                        priority=task_priority
-                                    )
-                                if sigs:
-                                    group(sigs, app=app).apply_async(
-                                        (retval,),
-                                        parent_id=uuid, root_id=root_id,
-                                        priority=task_priority
-                                    )
-                            else:
-                                signature(callbacks[0], app=app).apply_async(
-                                    (retval,), parent_id=uuid, root_id=root_id,
-                                    priority=task_priority
-                                )
-
-                        # execute first task in chain
-                        chain = task_request.chain
-                        if chain:
-                            _chsig = signature(chain[-1], app=app)
-                            _chsig.apply_async(
-                                (retval,), chain=chain[:-1],
-                                parent_id=uuid, root_id=root_id,
-                                priority=task_priority
-                            )
+                        _dispatch_callbacks_and_chain(
+                            retval, task.request.callbacks,
+                            task_request.chain,
+                            parent_id=uuid, root_id=root_id,
+                            priority=task_priority,
+                        )
                         task.backend.mark_as_done(
                             uuid, retval, task_request, publish_result,
                         )

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 from celery.contrib.pytest import celery_app, celery_session_worker
 from celery.contrib.testing.manager import Manager
+from celery.exceptions import TimeoutError
 from t.integration.tasks import get_redis_connection
 
 # we have to import the pytest plugin fixtures here,
@@ -20,9 +21,25 @@ logger = logging.getLogger(__name__)
 TEST_BROKER = os.environ.get('TEST_BROKER', 'pyamqp://')
 TEST_BACKEND = os.environ.get('TEST_BACKEND', 'redis://')
 
+RETRYABLE_EXCEPTIONS = (OSError, ConnectionError, TimeoutError)
+
+
+def is_retryable_exception(exc):
+    return isinstance(exc, RETRYABLE_EXCEPTIONS)
+
+
+_flaky = pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
+_timeout = pytest.mark.timeout(timeout=300)
+
+
+def flaky(fn):
+    return _timeout(_flaky(fn))
+
+
 __all__ = (
     'celery_app',
     'celery_session_worker',
+    'flaky',
     'get_active_redis_channels',
 )
 

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -522,6 +522,29 @@ if LEGACY_TASKS_DISABLED:
         self.replace(signature(replace_with))
 
 
+@shared_task(bind=True, acks_late=True)
+def store_success_then_reject(self):
+    """First delivery: store SUCCESS manually, then Reject to trigger redelivery.
+    Second delivery: dedup finds SUCCESS, dispatches chain."""
+    from celery.backends.base import states
+    from celery.exceptions import Reject
+    if not self.request.delivery_info.get('redelivered'):
+        self.backend.store_result(self.request.id, 'first-pass', states.SUCCESS)
+        raise Reject(requeue=True)
+    # When dedup is enabled the fast-path intercepts before reaching here,
+    # so 'dedup-pass' is only returned when dedup is disabled.
+    return 'dedup-pass'
+
+
+@shared_task(bind=True, acks_late=True)
+def reject_then_succeed(self):
+    """First delivery: Reject(requeue=True). Second delivery: succeed normally."""
+    from celery.exceptions import Reject
+    if not self.request.delivery_info.get('redelivered'):
+        raise Reject(requeue=True)
+    return 'second-pass'
+
+
 @shared_task(soft_time_limit=2, time_limit=1)
 def soft_time_limit_must_exceed_time_limit():
     pass

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from celery import Signature, Task, chain, chord, group, shared_task
 from celery.canvas import signature
-from celery.exceptions import SoftTimeLimitExceeded
+from celery.exceptions import Reject, SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
 
 LEGACY_TASKS_DISABLED = True
@@ -527,7 +527,6 @@ def store_success_then_reject(self):
     """First delivery: store SUCCESS manually, then Reject to trigger redelivery.
     Second delivery: dedup finds SUCCESS, dispatches chain."""
     from celery.backends.base import states
-    from celery.exceptions import Reject
     if not self.request.delivery_info.get('redelivered'):
         self.backend.store_result(self.request.id, 'first-pass', states.SUCCESS)
         raise Reject(requeue=True)
@@ -539,7 +538,6 @@ def store_success_then_reject(self):
 @shared_task(bind=True, acks_late=True)
 def reject_then_succeed(self):
     """First delivery: Reject(requeue=True). Second delivery: succeed normally."""
-    from celery.exceptions import Reject
     if not self.request.delivery_info.get('redelivered'):
         raise Reject(requeue=True)
     return 'second-pass'

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -10,6 +10,7 @@ import pytest
 from celery import chain, chord, group, signature
 from celery.backends.base import BaseKeyValueStoreBackend
 from celery.canvas import StampingVisitor
+from celery.contrib.testing.worker import start_worker
 from celery.exceptions import ImproperlyConfigured, TimeoutError
 from celery.result import AsyncResult, GroupResult, ResultSet
 from celery.signals import before_task_publish, task_received
@@ -20,9 +21,10 @@ from .tasks import (ExpectedException, StampOnReplace, add, add_chord_to_chord, 
                     add_to_all_to_chord, build_chain_inside_task, collect_ids, delayed_sum,
                     delayed_sum_with_soft_guard, errback_new_style, errback_old_style, fail, fail_replaced, identity,
                     ids, mul, print_unicode, raise_error, redis_count, redis_echo, redis_echo_group_id,
-                    replace_with_chain, replace_with_chain_which_raises, replace_with_empty_chain,
-                    replace_with_stamped_task, retry_once, return_exception, return_priority, second_order_replace1,
-                    tsum, write_to_file_and_return_int, xsum)
+                    reject_then_succeed, replace_with_chain, replace_with_chain_which_raises,
+                    replace_with_empty_chain, replace_with_stamped_task, retry_once, return_exception,
+                    return_priority, second_order_replace1, store_success_then_reject, tsum,
+                    write_to_file_and_return_int, xsum)
 
 RETRYABLE_EXCEPTIONS = (OSError, ConnectionError, TimeoutError)
 
@@ -3744,3 +3746,78 @@ class test_stamping_mechanism:
         with subtests.test(msg="Expect canvas to fail"):
             with pytest.raises(ExpectedException):
                 canvas.apply_async().get(timeout=TIMEOUT)
+
+
+class test_dedup_chain_dispatch:
+    """Integration tests for chain/callback dispatch on the dedup fast-path.
+
+    See https://github.com/celery/celery/issues/9835
+    """
+
+    @pytest.fixture()
+    def dedup_app(self):
+        """Standalone Celery app with dedup enabled.
+
+        Uses its own event hub so it doesn't conflict with the session
+        worker.  We use TEST_BACKEND (Redis) as both broker and backend
+        so the tests only need Redis — no RabbitMQ dependency.
+        """
+        from celery import Celery
+        app = Celery('test_dedup',
+                     broker=TEST_BACKEND,
+                     backend=TEST_BACKEND)
+        app.conf.update(
+            worker_deduplicate_successful_tasks=True,
+            task_acks_late=True,
+            result_extended=True,
+            worker_hijack_root_logger=False,
+        )
+        app.config_from_object({'include': ['t.integration.tasks']})
+        yield app
+        app.close()
+
+    @flaky
+    def test_chain_completes_with_dedup_enabled(self, dedup_app):
+        """Smoke test: a normal chain works when dedup is on."""
+        q = f'dedup-test-{uuid.uuid4().hex[:8]}'
+        with start_worker(dedup_app, pool='solo', concurrency=1, queues=[q],
+                          perform_ping_check=False, shutdown_timeout=TIMEOUT):
+            c = chain(add.s(2, 3).set(queue=q), add.s(5).set(queue=q))
+            assert c.apply_async().get(timeout=TIMEOUT) == 10
+
+    @flaky
+    def test_reject_requeue_completes_chain(self, dedup_app):
+        """Reject passthrough: chain completes after rejection + redelivery."""
+        q = f'dedup-test-{uuid.uuid4().hex[:8]}'
+        with start_worker(dedup_app, pool='solo', concurrency=1, queues=[q],
+                          perform_ping_check=False, shutdown_timeout=TIMEOUT):
+            c = chain(
+                reject_then_succeed.s().set(queue=q),
+                identity.s().set(queue=q),
+            )
+            assert c.apply_async().get(timeout=TIMEOUT) == 'second-pass'
+
+    @flaky
+    def test_dedup_dispatches_chain_on_redelivery(self, dedup_app):
+        """Core test: dedup fast-path dispatches the chain."""
+        q = f'dedup-test-{uuid.uuid4().hex[:8]}'
+        with start_worker(dedup_app, pool='solo', concurrency=1, queues=[q],
+                          perform_ping_check=False, shutdown_timeout=TIMEOUT):
+            c = chain(
+                store_success_then_reject.s().set(queue=q),
+                identity.s().set(queue=q),
+            )
+            assert c.apply_async().get(timeout=TIMEOUT) == 'first-pass'
+
+    @flaky
+    def test_dedup_dispatches_callback_on_redelivery(self, dedup_app):
+        """Dedup fast-path dispatches link callbacks."""
+        q = f'dedup-test-{uuid.uuid4().hex[:8]}'
+        with start_worker(dedup_app, pool='solo', concurrency=1, queues=[q],
+                          perform_ping_check=False, shutdown_timeout=TIMEOUT):
+            cb_id = uuid.uuid4().hex
+            sig = store_success_then_reject.s().set(queue=q)
+            sig.link(identity.s().set(queue=q, task_id=cb_id))
+            sig.apply_async()
+            cb_result = AsyncResult(cb_id, app=dedup_app)
+            assert cb_result.get(timeout=TIMEOUT) == 'first-pass'

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -20,10 +20,9 @@ from .tasks import (ExpectedException, StampOnReplace, add, add_chord_to_chord, 
                     add_to_all_to_chord, build_chain_inside_task, collect_ids, delayed_sum,
                     delayed_sum_with_soft_guard, errback_new_style, errback_old_style, fail, fail_replaced, identity,
                     ids, mul, print_unicode, raise_error, redis_count, redis_echo, redis_echo_group_id,
-                    replace_with_chain, replace_with_chain_which_raises,
-                    replace_with_empty_chain, replace_with_stamped_task, retry_once, return_exception,
-                    return_priority, second_order_replace1, tsum,
-                    write_to_file_and_return_int, xsum)
+                    replace_with_chain, replace_with_chain_which_raises, replace_with_empty_chain,
+                    replace_with_stamped_task, retry_once, return_exception, return_priority, second_order_replace1,
+                    tsum, write_to_file_and_return_int, xsum)
 
 TIMEOUT = 60
 

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -3730,5 +3730,3 @@ class test_stamping_mechanism:
         with subtests.test(msg="Expect canvas to fail"):
             with pytest.raises(ExpectedException):
                 canvas.apply_async().get(timeout=TIMEOUT)
-
-

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -10,37 +10,22 @@ import pytest
 from celery import chain, chord, group, signature
 from celery.backends.base import BaseKeyValueStoreBackend
 from celery.canvas import StampingVisitor
-from celery.contrib.testing.worker import start_worker
 from celery.exceptions import ImproperlyConfigured, TimeoutError
 from celery.result import AsyncResult, GroupResult, ResultSet
 from celery.signals import before_task_publish, task_received
 
 from . import tasks
-from .conftest import TEST_BACKEND, check_for_logs, get_active_redis_channels, get_redis_connection
+from .conftest import TEST_BACKEND, check_for_logs, flaky, get_active_redis_channels, get_redis_connection
 from .tasks import (ExpectedException, StampOnReplace, add, add_chord_to_chord, add_replaced, add_to_all,
                     add_to_all_to_chord, build_chain_inside_task, collect_ids, delayed_sum,
                     delayed_sum_with_soft_guard, errback_new_style, errback_old_style, fail, fail_replaced, identity,
                     ids, mul, print_unicode, raise_error, redis_count, redis_echo, redis_echo_group_id,
-                    reject_then_succeed, replace_with_chain, replace_with_chain_which_raises,
+                    replace_with_chain, replace_with_chain_which_raises,
                     replace_with_empty_chain, replace_with_stamped_task, retry_once, return_exception,
-                    return_priority, second_order_replace1, store_success_then_reject, tsum,
+                    return_priority, second_order_replace1, tsum,
                     write_to_file_and_return_int, xsum)
 
-RETRYABLE_EXCEPTIONS = (OSError, ConnectionError, TimeoutError)
-
-
-def is_retryable_exception(exc):
-    return isinstance(exc, RETRYABLE_EXCEPTIONS)
-
-
 TIMEOUT = 60
-
-_flaky = pytest.mark.flaky(reruns=5, reruns_delay=1, cause=is_retryable_exception)
-_timeout = pytest.mark.timeout(timeout=300)
-
-
-def flaky(fn):
-    return _timeout(_flaky(fn))
 
 
 def await_redis_echo(expected_msgs, redis_key="redis-echo", timeout=TIMEOUT):
@@ -3748,76 +3733,3 @@ class test_stamping_mechanism:
                 canvas.apply_async().get(timeout=TIMEOUT)
 
 
-class test_dedup_chain_dispatch:
-    """Integration tests for chain/callback dispatch on the dedup fast-path.
-
-    See https://github.com/celery/celery/issues/9835
-    """
-
-    @pytest.fixture()
-    def dedup_app(self):
-        """Standalone Celery app with dedup enabled.
-
-        Uses its own event hub so it doesn't conflict with the session
-        worker.  We use TEST_BACKEND (Redis) as both broker and backend
-        so the tests only need Redis — no RabbitMQ dependency.
-        """
-        from celery import Celery
-        app = Celery('test_dedup',
-                     broker=TEST_BACKEND,
-                     backend=TEST_BACKEND)
-        app.conf.update(
-            worker_deduplicate_successful_tasks=True,
-            task_acks_late=True,
-            result_extended=True,
-            worker_hijack_root_logger=False,
-        )
-        app.config_from_object({'include': ['t.integration.tasks']})
-        yield app
-        app.close()
-
-    @flaky
-    def test_chain_completes_with_dedup_enabled(self, dedup_app):
-        """Smoke test: a normal chain works when dedup is on."""
-        q = f'dedup-test-{uuid.uuid4().hex[:8]}'
-        with start_worker(dedup_app, pool='solo', concurrency=1, queues=[q],
-                          perform_ping_check=False, shutdown_timeout=TIMEOUT):
-            c = chain(add.s(2, 3).set(queue=q), add.s(5).set(queue=q))
-            assert c.apply_async().get(timeout=TIMEOUT) == 10
-
-    @flaky
-    def test_reject_requeue_completes_chain(self, dedup_app):
-        """Reject passthrough: chain completes after rejection + redelivery."""
-        q = f'dedup-test-{uuid.uuid4().hex[:8]}'
-        with start_worker(dedup_app, pool='solo', concurrency=1, queues=[q],
-                          perform_ping_check=False, shutdown_timeout=TIMEOUT):
-            c = chain(
-                reject_then_succeed.s().set(queue=q),
-                identity.s().set(queue=q),
-            )
-            assert c.apply_async().get(timeout=TIMEOUT) == 'second-pass'
-
-    @flaky
-    def test_dedup_dispatches_chain_on_redelivery(self, dedup_app):
-        """Core test: dedup fast-path dispatches the chain."""
-        q = f'dedup-test-{uuid.uuid4().hex[:8]}'
-        with start_worker(dedup_app, pool='solo', concurrency=1, queues=[q],
-                          perform_ping_check=False, shutdown_timeout=TIMEOUT):
-            c = chain(
-                store_success_then_reject.s().set(queue=q),
-                identity.s().set(queue=q),
-            )
-            assert c.apply_async().get(timeout=TIMEOUT) == 'first-pass'
-
-    @flaky
-    def test_dedup_dispatches_callback_on_redelivery(self, dedup_app):
-        """Dedup fast-path dispatches link callbacks."""
-        q = f'dedup-test-{uuid.uuid4().hex[:8]}'
-        with start_worker(dedup_app, pool='solo', concurrency=1, queues=[q],
-                          perform_ping_check=False, shutdown_timeout=TIMEOUT):
-            cb_id = uuid.uuid4().hex
-            sig = store_success_then_reject.s().set(queue=q)
-            sig.link(identity.s().set(queue=q, task_id=cb_id))
-            sig.apply_async()
-            cb_result = AsyncResult(cb_id, app=dedup_app)
-            assert cb_result.get(timeout=TIMEOUT) == 'first-pass'

--- a/t/integration/test_dedup_chain_dispatch.py
+++ b/t/integration/test_dedup_chain_dispatch.py
@@ -1,0 +1,86 @@
+"""Integration tests for chain/callback dispatch on the dedup fast-path.
+
+When ``deduplicate_successful_tasks=True`` and ``acks_late=True``, a
+redelivered task that hits the dedup fast-path in ``trace.py`` must still
+dispatch its chain and link callbacks.
+
+See https://github.com/celery/celery/issues/9835
+"""
+
+import pytest
+
+from celery import chain
+from celery.contrib.testing.worker import start_worker
+from celery.result import AsyncResult
+
+from .conftest import flaky
+from .tasks import add, identity, reject_then_succeed, store_success_then_reject
+
+TIMEOUT = 60
+
+
+@pytest.fixture()
+def dedup_worker(celery_session_app):
+    """Solo worker with dedup enabled.
+
+    Temporarily enables ``worker_deduplicate_successful_tasks`` on the
+    session app, starts a solo worker, and restores the original
+    setting on teardown.
+    """
+    if not celery_session_app.backend.persistent:
+        raise pytest.skip('Requires a persistent result backend.')
+
+    orig_dedup = celery_session_app.conf.worker_deduplicate_successful_tasks
+    orig_acks_late = celery_session_app.conf.task_acks_late
+    celery_session_app.conf.worker_deduplicate_successful_tasks = True
+    celery_session_app.conf.task_acks_late = True
+
+    try:
+        with start_worker(
+            celery_session_app,
+            pool='solo',
+            concurrency=1,
+            perform_ping_check=False,
+            shutdown_timeout=TIMEOUT,
+        ) as worker:
+            yield worker
+    finally:
+        celery_session_app.conf.worker_deduplicate_successful_tasks = orig_dedup
+        celery_session_app.conf.task_acks_late = orig_acks_late
+
+
+class test_dedup_chain_dispatch:
+    """Test chain/callback dispatch on the dedup fast-path."""
+
+    @flaky
+    @pytest.mark.usefixtures('dedup_worker')
+    def test_chain_completes_with_dedup_enabled(self):
+        """Smoke test: a normal chain works when dedup is on."""
+        c = chain(add.s(2, 3), add.s(5))
+        assert c().get(timeout=TIMEOUT) == 10
+
+    @flaky
+    @pytest.mark.usefixtures('dedup_worker')
+    def test_reject_requeue_completes_chain(self):
+        """Reject passthrough: chain completes after rejection + redelivery."""
+        c = chain(reject_then_succeed.s(), identity.s())
+        assert c().get(timeout=TIMEOUT) == 'second-pass'
+
+    @flaky
+    @pytest.mark.usefixtures('dedup_worker')
+    def test_dedup_dispatches_chain_on_redelivery(self):
+        """Core test: dedup fast-path dispatches the chain."""
+        c = chain(store_success_then_reject.s(), identity.s())
+        assert c().get(timeout=TIMEOUT) == 'first-pass'
+
+    @flaky
+    @pytest.mark.usefixtures('dedup_worker')
+    def test_dedup_dispatches_callback_on_redelivery(self, celery_session_app):
+        """Dedup fast-path dispatches link callbacks."""
+        import uuid as _uuid
+        cb_id = _uuid.uuid4().hex
+        sig = store_success_then_reject.s()
+        sig.link(identity.s().set(task_id=cb_id))
+        sig.apply_async()
+        cb_result = AsyncResult(cb_id, app=celery_session_app)
+        assert cb_result.get(timeout=TIMEOUT) == 'first-pass'

--- a/t/integration/test_dedup_chain_dispatch.py
+++ b/t/integration/test_dedup_chain_dispatch.py
@@ -1,8 +1,9 @@
 """Integration tests for chain/callback dispatch on the dedup fast-path.
 
-When ``deduplicate_successful_tasks=True`` and ``acks_late=True``, a
-redelivered task that hits the dedup fast-path in ``trace.py`` must still
-dispatch its chain and link callbacks.
+When ``worker_deduplicate_successful_tasks=True`` and
+``task_acks_late=True``, a redelivered task that hits the dedup
+fast-path in ``trace.py`` must still dispatch its chain and link
+callbacks.
 
 See https://github.com/celery/celery/issues/9835
 """

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -597,6 +597,7 @@ class test_trace(TraceCase):
             assert call_args[1]['parent_id'] == task_id
             assert 'root_id' in call_args[1]
 
+        successful_requests.discard(task_id)
         self.app.conf.worker_deduplicate_successful_tasks = False
 
     def test_deduplicate_successful_tasks__backend_dedup_multi_element_chain(self):
@@ -632,6 +633,7 @@ class test_trace(TraceCase):
             call_args = mock_apply.call_args
             assert call_args[1]['chain'] == [step3]
 
+        successful_requests.discard(task_id)
         self.app.conf.worker_deduplicate_successful_tasks = False
 
     def test_deduplicate_successful_tasks__backend_dedup_adds_to_successful_requests(self):
@@ -742,13 +744,14 @@ class test_trace(TraceCase):
 
         chain_list = [self.add.s(10), self.add.s(20)]
         original_length = len(chain_list)
+        task_id = str(uuid4())
         request = {
-            'id': str(uuid4()),
+            'id': task_id,
             'delivery_info': {'redelivered': False},
             'chain': chain_list,
         }
 
-        trace(self.app, add, (1, 1), request=request)
+        trace(self.app, add, (1, 1), task_id=task_id, request=request)
         assert len(chain_list) == original_length
 
     def test_deduplicate_successful_tasks__backend_dedup_dispatches_callbacks(self):
@@ -783,6 +786,7 @@ class test_trace(TraceCase):
             assert call_args[0] == ((2,),)
             assert call_args[1]['parent_id'] == task_id
 
+        successful_requests.discard(task_id)
         self.app.conf.worker_deduplicate_successful_tasks = False
 
     def test_deduplicate_successful_tasks__backend_dedup_chain_and_callbacks(self):
@@ -815,6 +819,7 @@ class test_trace(TraceCase):
             trace(self.app, add, (1, 1), task_id=task_id, request=request_both)
             assert mock_apply.call_count == 2
 
+        successful_requests.discard(task_id)
         self.app.conf.worker_deduplicate_successful_tasks = False
 
     def test_deduplicate_successful_tasks__backend_dedup_dispatch_failure_logged(self):

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -751,7 +751,11 @@ class test_trace(TraceCase):
             'chain': chain_list,
         }
 
-        trace(self.app, add, (1, 1), task_id=task_id, request=request)
+        with patch('celery.canvas.maybe_signature') as mock_signature:
+            mock_signature.return_value.apply_async = Mock()
+            trace(self.app, add, (1, 1), task_id=task_id, request=request)
+            call_args = mock_signature.return_value.apply_async.call_args
+            assert call_args[1]['chain'] == chain_list[:-1]
         assert len(chain_list) == original_length
 
     def test_deduplicate_successful_tasks__backend_dedup_dispatches_callbacks(self):

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -12,6 +12,7 @@ from celery.app.trace import (TraceInfo, build_tracer, fast_trace_task, get_log_
                               log_policy_unexpected, reset_worker_optimizations, setup_worker_optimizations,
                               trace_task, trace_task_ret, traceback_clear)
 from celery.backends.base import BaseDictBackend
+from celery.result import AsyncResult
 from celery.backends.cache import CacheBackend
 from celery.exceptions import BackendGetMetaError, Ignore, Reject, Retry
 from celery.states import PENDING
@@ -1026,6 +1027,56 @@ class test_trace(TraceCase):
             mock_signature.return_value.apply_async = mock_apply
             trace(self.app, add, (1, 1), task_id=task_id, request=request_empty_chain)
             mock_apply.assert_not_called()
+
+        successful_requests.discard(task_id)
+        self.app.conf.worker_deduplicate_successful_tasks = False
+
+    def test_deduplicate_successful_tasks__backend_read_failure_rejects(self):
+        """When _get_task_meta() fails after state==SUCCESS, the exception
+        is caught and re-raised as Reject(requeue=True)."""
+        @self.app.task(shared=False)
+        def add(x, y):
+            return x + y
+
+        backend = CacheBackend(app=self.app, backend='memory')
+        add.backend = backend
+        add.store_eager_result = True
+        add.ignore_result = False
+        add.acks_late = True
+
+        self.app.conf.worker_deduplicate_successful_tasks = True
+        task_id = str(uuid4())
+        request = {'id': task_id, 'delivery_info': {'redelivered': True}}
+
+        trace(self.app, add, (1, 1), task_id=task_id, request=request)
+
+        successful_requests.discard(task_id)
+
+        request_with_chain = {
+            'id': task_id,
+            'delivery_info': {'redelivered': True},
+            'chain': [self.add.s(10)],
+        }
+
+        # First call to _get_task_meta (from r.state) returns normally;
+        # second call (line 508 in trace.py) raises to simulate a
+        # transient backend failure during dispatch.
+        original = AsyncResult._get_task_meta
+        call_count = 0
+
+        def fail_on_second_call(self_):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise ConnectionError('redis gone')
+            return original(self_)
+
+        with patch.object(AsyncResult, '_get_task_meta', fail_on_second_call):
+            with patch('celery.app.trace.logger'):
+                with pytest.raises(Reject):
+                    trace(self.app, add, (1, 1), task_id=task_id, request=request_with_chain)
+
+        assert task_id not in successful_requests
 
         successful_requests.discard(task_id)
         self.app.conf.worker_deduplicate_successful_tasks = False

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -900,6 +900,70 @@ class test_trace(TraceCase):
 
         self.app.conf.worker_deduplicate_successful_tasks = False
 
+    def test_deduplicate_successful_tasks__backend_dedup_memory_error_propagates(self):
+        @self.app.task(shared=False)
+        def add(x, y):
+            return x + y
+
+        backend = CacheBackend(app=self.app, backend='memory')
+        add.backend = backend
+        add.store_eager_result = True
+        add.ignore_result = False
+        add.acks_late = True
+
+        self.app.conf.worker_deduplicate_successful_tasks = True
+        task_id = str(uuid4())
+        request = {'id': task_id, 'delivery_info': {'redelivered': True}}
+
+        trace(self.app, add, (1, 1), task_id=task_id, request=request)
+
+        request_with_chain = {
+            'id': task_id,
+            'delivery_info': {'redelivered': True},
+            'chain': [self.add.s(10)],
+        }
+
+        with patch('celery.canvas.maybe_signature') as mock_signature:
+            mock_signature.return_value.apply_async.side_effect = MemoryError()
+            with pytest.raises(MemoryError):
+                trace(self.app, add, (1, 1), task_id=task_id, request=request_with_chain)
+
+        successful_requests.discard(task_id)
+        self.app.conf.worker_deduplicate_successful_tasks = False
+
+    def test_deduplicate_successful_tasks__reject_propagates_through_trace_task(self):
+        @self.app.task(shared=False)
+        def add(x, y):
+            return x + y
+
+        backend = CacheBackend(app=self.app, backend='memory')
+        add.backend = backend
+        add.store_eager_result = True
+        add.ignore_result = False
+        add.acks_late = True
+
+        self.app.conf.worker_deduplicate_successful_tasks = True
+        task_id = str(uuid4())
+        request = {'id': task_id, 'delivery_info': {'redelivered': True}}
+
+        trace(self.app, add, (1, 1), task_id=task_id, request=request)
+
+        request_with_chain = {
+            'id': task_id,
+            'delivery_info': {'redelivered': True},
+            'chain': [self.add.s(10)],
+        }
+
+        add.__trace__ = None
+        with patch('celery.canvas.maybe_signature') as mock_signature:
+            mock_signature.return_value.apply_async.side_effect = RuntimeError('broker down')
+            with patch('celery.app.trace.logger'):
+                with pytest.raises(Reject):
+                    trace_task(add, task_id, (1, 1), {}, request=request_with_chain, app=self.app)
+
+        successful_requests.discard(task_id)
+        self.app.conf.worker_deduplicate_successful_tasks = False
+
 
 class test_TraceInfo(TraceCase):
     class TI(TraceInfo):

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -595,7 +595,7 @@ class test_trace(TraceCase):
             call_args = mock_apply.call_args
             assert call_args[0] == ((2,),)
             assert call_args[1]['parent_id'] == task_id
-            assert 'root_id' in call_args[1]
+            assert call_args[1]['root_id'] == task_id
 
         successful_requests.discard(task_id)
         self.app.conf.worker_deduplicate_successful_tasks = False
@@ -960,6 +960,72 @@ class test_trace(TraceCase):
             with patch('celery.app.trace.logger'):
                 with pytest.raises(Reject):
                     trace_task(add, task_id, (1, 1), {}, request=request_with_chain, app=self.app)
+
+        successful_requests.discard(task_id)
+        self.app.conf.worker_deduplicate_successful_tasks = False
+
+    def test_deduplicate_successful_tasks__root_id_fallback(self):
+        @self.app.task(shared=False)
+        def add(x, y):
+            return x + y
+
+        backend = CacheBackend(app=self.app, backend='memory')
+        add.backend = backend
+        add.store_eager_result = True
+        add.ignore_result = False
+        add.acks_late = True
+
+        self.app.conf.worker_deduplicate_successful_tasks = True
+        task_id = str(uuid4())
+        request = {'id': task_id, 'delivery_info': {'redelivered': True}}
+
+        trace(self.app, add, (1, 1), task_id=task_id, request=request)
+
+        request_no_root_id = {
+            'id': task_id,
+            'delivery_info': {'redelivered': True},
+            'chain': [self.add.s(10)],
+        }
+
+        with patch('celery.canvas.maybe_signature') as mock_signature:
+            mock_apply = Mock()
+            mock_signature.return_value.apply_async = mock_apply
+            trace(self.app, add, (1, 1), task_id=task_id, request=request_no_root_id)
+            call_args = mock_apply.call_args
+            assert call_args[1]['root_id'] == task_id
+
+        successful_requests.discard(task_id)
+        self.app.conf.worker_deduplicate_successful_tasks = False
+
+    def test_deduplicate_successful_tasks__empty_chain_skips_dispatch(self):
+        @self.app.task(shared=False)
+        def add(x, y):
+            return x + y
+
+        backend = CacheBackend(app=self.app, backend='memory')
+        add.backend = backend
+        add.store_eager_result = True
+        add.ignore_result = False
+        add.acks_late = True
+
+        self.app.conf.worker_deduplicate_successful_tasks = True
+        task_id = str(uuid4())
+        request = {'id': task_id, 'delivery_info': {'redelivered': True}}
+
+        trace(self.app, add, (1, 1), task_id=task_id, request=request)
+
+        request_empty_chain = {
+            'id': task_id,
+            'delivery_info': {'redelivered': True},
+            'chain': [],
+            'callbacks': [],
+        }
+
+        with patch('celery.canvas.maybe_signature') as mock_signature:
+            mock_apply = Mock()
+            mock_signature.return_value.apply_async = mock_apply
+            trace(self.app, add, (1, 1), task_id=task_id, request=request_empty_chain)
+            mock_apply.assert_not_called()
 
         successful_requests.discard(task_id)
         self.app.conf.worker_deduplicate_successful_tasks = False

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -694,7 +694,8 @@ class test_trace(TraceCase):
         with patch('celery.canvas.maybe_signature') as mock_signature:
             mock_signature.return_value.apply_async.side_effect = RuntimeError('broker down')
             with patch('celery.app.trace.logger'):
-                trace(self.app, add, (1, 1), task_id=task_id, request=request_with_chain)
+                with pytest.raises(Reject):
+                    trace(self.app, add, (1, 1), task_id=task_id, request=request_with_chain)
 
         assert task_id not in successful_requests
 
@@ -892,7 +893,8 @@ class test_trace(TraceCase):
         with patch('celery.canvas.maybe_signature') as mock_signature:
             mock_signature.return_value.apply_async.side_effect = RuntimeError('broker down')
             with patch('celery.app.trace.logger') as mock_logger:
-                trace(self.app, add, (1, 1), task_id=task_id, request=request_with_chain)
+                with pytest.raises(Reject):
+                    trace(self.app, add, (1, 1), task_id=task_id, request=request_with_chain)
                 mock_logger.error.assert_called_once()
                 assert 'deduplicated task' in mock_logger.error.call_args[0][0]
 

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -12,9 +12,9 @@ from celery.app.trace import (TraceInfo, build_tracer, fast_trace_task, get_log_
                               log_policy_unexpected, reset_worker_optimizations, setup_worker_optimizations,
                               trace_task, trace_task_ret, traceback_clear)
 from celery.backends.base import BaseDictBackend
-from celery.result import AsyncResult
 from celery.backends.cache import CacheBackend
 from celery.exceptions import BackendGetMetaError, Ignore, Reject, Retry
+from celery.result import AsyncResult
 from celery.states import PENDING
 from celery.worker.state import successful_requests
 


### PR DESCRIPTION
## Description

Fixes #9835

When using `acks_late=True` with `worker_deduplicate_successful_tasks=True`, the deduplication fast-path in `build_tracer()` returns immediately for redelivered tasks that are already `SUCCESS` in the backend — without dispatching the chain or callbacks. If the original worker crashed after storing `SUCCESS` but before the broker ack, the redelivered message hits this fast-path and the chain is permanently lost.

Additionally, `chain.pop()` mutates `task_request.chain` in-place, which can lose chain steps on retry or redelivery within the same worker process.

## Changes

**`celery/app/trace.py`**

- **Dedup fast-path dispatches chain/callbacks**: When the backend-dedup path detects `SUCCESS` for a redelivered task, it now retrieves the stored result and dispatches any pending callbacks and chain steps using the same logic as the normal success path (callbacks first, then chain).
- **Children guard**: Checks `_get_task_meta().get('children')` before dispatching — if children are already recorded, the original execution already dispatched successfully, so re-dispatch is skipped.
- **`successful_requests` guard**: Adds the task to `successful_requests` only after successful dispatch, so a dispatch failure allows retry on next redelivery.
- **Non-mutating chain access**: Replaces `chain.pop()` with `chain[-1]` / `chain[:-1]` to avoid mutating `task_request.chain` in-place.

**`t/unit/tasks/test_trace.py`**

- 11 new tests covering: backend-dedup chain dispatch, multi-element chains, callback dispatch, combined chain+callbacks, in-memory dedup (correctly skips), chain mutation, children guard, dispatch failure logging, and `successful_requests` bookkeeping.

## Checklist

- [x] Make sure any change or new feature has a unit and/or integration test.
      11 new unit tests added in `t/unit/tasks/test_trace.py`, 55 total pass.
- [x] Make sure unit test coverage does not decrease.
      `pytest --cov=celery.app.trace` reports **91%** on `celery/app/trace.py`.
- [x] Run `pre-commit` against the code.
      `pre-commit run --all-files` — all hooks pass (pyupgrade, flake8, yesqa, codespell, isort, mypy).
- [x] Build api docs to make sure everything is OK.
      No new public API added — changes are internal to `build_tracer()` closure.
- [x] Build configcheck.
      No new configuration options added.
- [x] Run `bandit` to make sure there's no security issues.
      `bandit -b bandit.json celery/app/trace.py` — no issues identified.
- [x] Confirm `isort` on any new or modified imports.
      `isort celery/app/trace.py t/unit/tasks/test_trace.py --diff` — no changes needed.