### PR TITLE
Upgrade pytest-celery to >=1.3.0 and adopt PYTEST_CELERY_PKG build arg

### DIFF
--- a/requirements/extras/pytest.txt
+++ b/requirements/extras/pytest.txt
@@ -1,1 +1,1 @@
-pytest-celery[all]>=1.2.0,<1.3.0
+pytest-celery[all]>=1.3.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 pytest==9.0.2
-pytest-celery[all]>=1.2.0,<1.3.0
+pytest-celery[all]>=1.3.0
 pytest-rerunfailures>=15.0; python_version >= "3.9"
 pytest-subtests>=0.14.1; python_version >= "3.9"
 pytest-timeout==2.4.0

--- a/t/smoke/workers/docker/dev
+++ b/t/smoke/workers/docker/dev
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y build-essential \
 ARG CELERY_LOG_LEVEL=INFO
 ARG CELERY_WORKER_NAME=celery_dev_worker
 ARG CELERY_WORKER_QUEUE=celery
+ARG PYTEST_CELERY_PKG="pytest-celery"
 ENV LOG_LEVEL=$CELERY_LOG_LEVEL
 ENV WORKER_NAME=$CELERY_WORKER_NAME
 ENV WORKER_QUEUE=$CELERY_WORKER_QUEUE
@@ -39,7 +40,7 @@ COPY --chown=test_user:test_user . /celery
 RUN pip install --no-cache-dir --upgrade \
     pip \
     -e /celery[redis,pymemcache,pydantic,sqs] \
-    pytest-celery>=1.1.3
+    "${PYTEST_CELERY_PKG}"
 
 # The workdir must be /app
 WORKDIR /app

--- a/t/smoke/workers/docker/pypi
+++ b/t/smoke/workers/docker/pypi
@@ -24,6 +24,7 @@ ARG CELERY_VERSION=""
 ARG CELERY_LOG_LEVEL=INFO
 ARG CELERY_WORKER_NAME=celery_tests_worker
 ARG CELERY_WORKER_QUEUE=celery
+ARG PYTEST_CELERY_PKG="pytest-celery"
 ENV PIP_VERSION=$CELERY_VERSION
 ENV LOG_LEVEL=$CELERY_LOG_LEVEL
 ENV WORKER_NAME=$CELERY_WORKER_NAME
@@ -38,7 +39,7 @@ EXPOSE 5678
 RUN pip install --no-cache-dir --upgrade \
     pip \
     celery[redis,pymemcache]${CELERY_VERSION:+==$CELERY_VERSION} \
-    pytest-celery[sqs]>=1.1.3 \
+    "${PYTEST_CELERY_PKG}" \
     pydantic>=2.4
 
 # The workdir must be /app


### PR DESCRIPTION
- Update pytest-celery version pin to >=1.3.0 (no upper bound) in requirements/test.txt and requirements/extras/pytest.txt
- Adopt PYTEST_CELERY_PKG build arg pattern in smoke test Dockerfiles (dev and pypi) for configurable install source