### PR TITLE
Fix NameError with TYPE_CHECKING annotations on Python 3.14+ (PEP 649)

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -58,6 +58,18 @@ __all__ = ('Celery',)
 
 logger = get_logger(__name__)
 
+if sys.version_info >= (3, 14):
+    import annotationlib
+
+    def _get_annotations(fun):
+        # In Python 3.14+, annotations are deferred by default (PEP 649).
+        # Accessing fun.__annotations__ evaluates them, raising NameError for
+        # types only available under TYPE_CHECKING. Use STRING format instead.
+        return inspect.get_annotations(fun, format=annotationlib.Format.STRING)
+else:
+    def _get_annotations(fun):
+        return fun.__annotations__
+
 BUILTIN_FIXUPS = {
     'celery.fixups.django:fixup',
 }
@@ -595,7 +607,7 @@ class Celery:
                 '_decorated': True,
                 '__doc__': fun.__doc__,
                 '__module__': fun.__module__,
-                '__annotations__': fun.__annotations__,
+                '__annotations__': _get_annotations(fun),
                 '__header__': self.type_checker(fun, bound=bind),
                 '__wrapped__': run}, **options))()
             # for some reason __qualname__ cannot be set in type()

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -63,9 +63,15 @@ if sys.version_info >= (3, 14):
 
     def _get_annotations(fun):
         # In Python 3.14+, annotations are deferred by default (PEP 649).
-        # Accessing fun.__annotations__ evaluates them, raising NameError for
-        # types only available under TYPE_CHECKING. Use STRING format instead.
-        return inspect.get_annotations(fun, format=annotationlib.Format.STRING)
+        # Accessing fun.__annotations__ (or inspect.get_annotations without a
+        # format) evaluates them and may raise NameError for types only
+        # available under TYPE_CHECKING. To preserve previous behavior, first
+        # try to return evaluated annotations; if that fails with NameError,
+        # fall back to returning stringified annotations instead.
+        try:
+            return inspect.get_annotations(fun)
+        except NameError:
+            return inspect.get_annotations(fun, format=annotationlib.Format.STRING)
 else:
     def _get_annotations(fun):
         return fun.__annotations__

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -1,5 +1,6 @@
 """Functional-style utilities."""
 import inspect
+import sys
 from collections import UserList
 from functools import partial
 from itertools import islice, tee, zip_longest
@@ -311,6 +312,46 @@ def _argsfromspec(spec, replace_defaults=True):
     ]))
 
 
+if sys.version_info >= (3, 14):
+    import annotationlib as _annotationlib
+
+    def _getfullargspec(fun):
+        # In Python 3.14+, inspect.getfullargspec evaluates annotations by default
+        # (PEP 649). This raises NameError for types only imported under TYPE_CHECKING,
+        # which getfullargspec then wraps as TypeError('unsupported callable').
+        # We don't need annotations here, so fall back to reading the code object directly.
+        try:
+            return inspect.getfullargspec(fun)
+        except TypeError:
+            pass
+
+        # Bound methods need their underlying function's code object.
+        func = getattr(fun, '__func__', fun)
+        code = func.__code__
+        CO_VARARGS = 0x04
+        CO_VARKEYWORDS = 0x08
+        nargs = code.co_argcount
+        nkwonly = code.co_kwonlyargcount
+        varnames = code.co_varnames
+        args = list(varnames[:nargs])
+        kwonlyargs = list(varnames[nargs:nargs + nkwonly])
+        offset = nargs + nkwonly
+        varargs = varnames[offset] if code.co_flags & CO_VARARGS else None
+        offset += bool(code.co_flags & CO_VARARGS)
+        varkw = varnames[offset] if code.co_flags & CO_VARKEYWORDS else None
+        return inspect.FullArgSpec(
+            args=args,
+            varargs=varargs,
+            varkw=varkw,
+            defaults=func.__defaults__,
+            kwonlyargs=kwonlyargs,
+            kwonlydefaults=func.__kwdefaults__,
+            annotations={},
+        )
+else:
+    _getfullargspec = inspect.getfullargspec
+
+
 def head_from_fun(fun: Callable[..., Any], bound: bool = False) -> str:
     """Generate signature function from actual function."""
     # we could use inspect.Signature here, but that implementation
@@ -329,7 +370,7 @@ def head_from_fun(fun: Callable[..., Any], bound: bool = False) -> str:
         name = fun.__name__
     definition = FUNHEAD_TEMPLATE.format(
         fun_name=name,
-        fun_args=_argsfromspec(inspect.getfullargspec(fun)),
+        fun_args=_argsfromspec(_getfullargspec(fun)),
         fun_value=1,
     )
     logger.debug(definition)

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -313,37 +313,38 @@ def _argsfromspec(spec, replace_defaults=True):
 
 
 if sys.version_info >= (3, 14):
+    import annotationlib as _annotationlib
+
     def _getfullargspec(fun):
         # In Python 3.14+, inspect.getfullargspec evaluates annotations by default
-        # (PEP 649). This raises NameError for types only imported under TYPE_CHECKING,
-        # which getfullargspec then wraps as TypeError('unsupported callable').
-        # We don't need annotations here, so fall back to reading the code object directly.
-        try:
-            return inspect.getfullargspec(fun)
-        except TypeError:
-            pass
-
-        # Bound methods need their underlying function's code object.
-        func = getattr(fun, '__func__', fun)
-        code = func.__code__
-        CO_VARARGS = 0x04
-        CO_VARKEYWORDS = 0x08
-        nargs = code.co_argcount
-        nkwonly = code.co_kwonlyargcount
-        varnames = code.co_varnames
-        args = list(varnames[:nargs])
-        kwonlyargs = list(varnames[nargs:nargs + nkwonly])
-        offset = nargs + nkwonly
-        varargs = varnames[offset] if code.co_flags & CO_VARARGS else None
-        offset += bool(code.co_flags & CO_VARARGS)
-        varkw = varnames[offset] if code.co_flags & CO_VARKEYWORDS else None
+        # (PEP 649), raising NameError for TYPE_CHECKING-only types. We don't need
+        # annotations here, so use Format.STRING to avoid evaluation.
+        # For bound methods, use __func__ so that 'self' is included in args,
+        # matching the behaviour of getfullargspec on older Python versions.
+        target = getattr(fun, '__func__', fun)
+        sig = inspect.signature(target, annotation_format=_annotationlib.Format.STRING)
+        args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults = [], None, None, [], [], {}
+        for name, param in sig.parameters.items():
+            kind = param.kind
+            if kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
+                args.append(name)
+                if param.default is not param.empty:
+                    defaults.append(param.default)
+            elif kind == param.VAR_POSITIONAL:
+                varargs = name
+            elif kind == param.KEYWORD_ONLY:
+                kwonlyargs.append(name)
+                if param.default is not param.empty:
+                    kwonlydefaults[name] = param.default
+            elif kind == param.VAR_KEYWORD:
+                varkw = name
         return inspect.FullArgSpec(
             args=args,
             varargs=varargs,
             varkw=varkw,
-            defaults=func.__defaults__,
+            defaults=tuple(defaults) or None,
             kwonlyargs=kwonlyargs,
-            kwonlydefaults=func.__kwdefaults__,
+            kwonlydefaults=kwonlydefaults or None,
             annotations={},
         )
 else:

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -313,8 +313,6 @@ def _argsfromspec(spec, replace_defaults=True):
 
 
 if sys.version_info >= (3, 14):
-    import annotationlib as _annotationlib
-
     def _getfullargspec(fun):
         # In Python 3.14+, inspect.getfullargspec evaluates annotations by default
         # (PEP 649). This raises NameError for types only imported under TYPE_CHECKING,

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -831,6 +831,25 @@ class test_App:
             assert typing.get_type_hints(foo) == {
                 'parameter': int, 'return': type(None)}
 
+    def test_task_with_type_checking_annotation(self):
+        # Regression test for https://github.com/celery/celery/discussions/10099
+        # On Python 3.14+, annotations are deferred (PEP 649). Registering a task
+        # whose annotations reference TYPE_CHECKING-only types must not raise NameError.
+        local = {}
+        exec(
+            'def foo(args: Sequence[str], x: int = 0): return args',
+            {'app': None},
+            local,
+        )
+        raw_fun = local['foo']
+
+        with self.Celery() as app:
+            task = app.task(raw_fun)
+            result = task.apply(args=(['hello'],))
+            assert result.result == ['hello']
+            # Annotations should be stored as strings, not evaluated
+            assert task.__annotations__['args'] == 'Sequence[str]'
+
     def test_annotate_decorator(self):
         from celery.app.task import Task
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -831,6 +831,7 @@ class test_App:
             assert typing.get_type_hints(foo) == {
                 'parameter': int, 'return': type(None)}
 
+    @pytest.mark.skipif(sys.version_info < (3, 14), reason="PEP 649 deferred annotations require Python 3.14+")
     def test_task_with_type_checking_annotation(self):
         # Regression test for https://github.com/celery/celery/discussions/10099
         # On Python 3.14+, annotations are deferred (PEP 649). Registering a task

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -1,4 +1,5 @@
 import collections
+import sys
 
 import pytest
 from kombu.utils.functional import lazy
@@ -368,6 +369,7 @@ class test_head_from_fun:
 
         g(b=3)
 
+    @pytest.mark.skipif(sys.version_info < (3, 14), reason="PEP 649 deferred annotations require Python 3.14+")
     def test_type_checking_annotation(self):
         # Regression test for https://github.com/celery/celery/discussions/10099
         # On Python 3.14+, annotations are deferred (PEP 649). Functions with

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -368,6 +368,20 @@ class test_head_from_fun:
 
         g(b=3)
 
+    def test_type_checking_annotation(self):
+        # Regression test for https://github.com/celery/celery/discussions/10099
+        # On Python 3.14+, annotations are deferred (PEP 649). Functions with
+        # annotations referencing TYPE_CHECKING-only types must not raise NameError.
+        local = {}
+        exec('def f(args: Sequence[str], x: int = 0): return args', {}, local)
+        f = local['f']
+
+        g = head_from_fun(f)
+        with pytest.raises(TypeError):
+            g()
+        g(1)
+        g(1, 2)
+
 
 class test_fun_takes_argument:
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Fix NameError when registering tasks whose annotations reference types only imported under TYPE_CHECKING on Python 3.14+.

In Python 3.14, annotations are deferred by default ([PEP 649](https://peps.python.org/pep-0649/)). Accessing fun.__annotations__ triggers lazy evaluation, which raises NameError for types only imported under TYPE_CHECKING. Two sites in Celery eagerly triggered this evaluation:

celery/app/base.py — _task_from_fun: Replaced direct fun.__annotations__ access with inspect.get_annotations(fun, format=annotationlib.Format.STRING) on Python 3.14+, which returns annotations as strings without evaluating them.

celery/utils/functional.py — head_from_fun: inspect.getfullargspec internally evaluates annotations on 3.14+ and raises NameError for TYPE_CHECKING-only types. Added a _getfullargspec wrapper on Python 3.14+ that calls inspect.signature(..., annotation_format=annotationlib.Format.STRING) and reconstructs a FullArgSpec with annotations omitted, since head_from_fun never uses annotations anyway.

Fixes https://github.com/celery/celery/discussions/10099