### PR TITLE
Fix O(K²) message bloat in a chain of chords

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -992,13 +992,13 @@ class _chain(Signature):
                     sig.tasks[-2].body = sig.tasks[-2].body | sig.tasks[-1]
                     sig.tasks = sig.tasks[:-1]
                 return sig
-            elif self.tasks and isinstance(self.tasks[-1], chord):
-                # CHAIN [last item is chord] -> chain with chord body.
+            elif self.tasks and isinstance(self.tasks[-1], chord) and not isinstance(other, chord):
+                # CHAIN [last item is chord] | TASK -> chain with chord body.
                 sig = self.clone()
                 sig.tasks[-1].body = sig.tasks[-1].body | other
                 return sig
             else:
-                # chain | task -> chain
+                # chain | task/chord -> chain
                 # use type(self) for _chain subclasses
                 return type(self)(seq_concat_item(
                     self.unchain_tasks(), other), app=self._app)

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -441,6 +441,48 @@ class test_chain:
         assert res.get(timeout=TIMEOUT) == 12
 
     @flaky
+    def test_chain_of_explicit_chords(self, manager):
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.args[0])
+
+        c1 = chain(
+            chord(group(add.si(1, 0), add.si(1, 0)), tsum.s()),
+            chord(group(add.s(1), add.s(1)), tsum.s()),
+            chord(group(add.s(0), add.s(0)), tsum.s()),
+        )
+        c2 = chain(
+            chord(group(add.s(10), add.s(10)), tsum.s()),
+            chord(group(add.s(0), add.s(0)), tsum.s()),
+            chord(group(add.s(1), add.s(1)), tsum.s()),
+        )
+        c = c1 | c2
+        res = c()
+        assert res.get(timeout=TIMEOUT) == 178
+
+    @flaky
+    def test_chain_of_six_chords(self, manager):
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.args[0])
+
+        c = chain(
+            chord(group(add.si(1, 0), add.si(1, 0), add.si(1, 0)), tsum.s()),
+            chord(group(add.s(1), add.s(1), add.s(1)), tsum.s()),
+            chord(group(add.s(1), add.s(1), add.s(1)), tsum.s()),
+            chord(group(add.s(1), add.s(1), add.s(1)), tsum.s()),
+            chord(group(add.s(1), add.s(1), add.s(1)), tsum.s()),
+            chord(group(add.s(1), add.s(1), add.s(1)), tsum.s()),
+            chord(group(add.s(1), add.s(1), add.s(1)), tsum.s()),
+            chord(group(add.s(1), add.s(1), add.s(1)), tsum.s()),
+            chord(group(add.s(0), add.s(0), add.s(0)), tsum.s()),
+        )
+        res = c()
+        assert res.get(timeout=TIMEOUT) == 29520
+
+    @flaky
     def test_chain_of_a_chord_and_a_group_with_two_tasks(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -462,7 +462,7 @@ class test_chain:
         assert res.get(timeout=TIMEOUT) == 178
 
     @flaky
-    def test_chain_of_six_chords(self, manager):
+    def test_chain_of_nine_chords(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()
         except NotImplementedError as e:

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -615,8 +615,8 @@ class test_chain(CanvasCase):
         c = chain(*chords)
         assert isinstance(c, _chain)
         sizes = [len(json.dumps(task.__json__())) for task in c.tasks]
-        assert sizes[0] == sizes[-1], (
-            f"First chord ({sizes[0]} bytes) should equal last chord ({sizes[-1]} bytes)"
+        assert max(sizes) == min(sizes), (
+            f"Chord sizes not constant across chain: {sizes}"
         )
 
     def test_chord_or_task_still_nests(self):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -592,6 +592,40 @@ class test_chain(CanvasCase):
         ), "Chord followed by a group should be upgraded to a single chord with chained body."
         assert len(c.tasks) == 6
 
+    def test_chain_of_chords_stays_flat(self):
+        c = chain(
+            chord([signature('h1'), signature('h2')], signature('b1'), app=self.app),
+            chord([signature('h3'), signature('h4')], signature('b2'), app=self.app),
+            chord([signature('h5'), signature('h6')], signature('b3'), app=self.app),
+        )
+        assert isinstance(c, _chain)
+        assert len(c.tasks) == 3
+        for task in c.tasks:
+            assert isinstance(task, chord)
+        assert not isinstance(c.tasks[0].body, _chain)
+        assert not isinstance(c.tasks[1].body, _chain)
+        assert not isinstance(c.tasks[2].body, _chain)
+
+    def test_chain_of_chords_serialized_size_constant(self):
+        chords = [
+            chord([signature(f'h{i}_{j}') for j in range(3)],
+                  signature(f'b{i}'), app=self.app)
+            for i in range(6)
+        ]
+        c = chain(*chords)
+        assert isinstance(c, _chain)
+        sizes = [len(json.dumps(task.__json__())) for task in c.tasks]
+        assert sizes[0] == sizes[-1], (
+            f"First chord ({sizes[0]} bytes) should equal last chord ({sizes[-1]} bytes)"
+        )
+
+    def test_chord_or_task_still_nests(self):
+        c = chord([signature('h1')], signature('b1'), app=self.app)
+        t = signature('t1')
+        result = chain(c) | t
+        assert isinstance(result, _chain)
+        assert isinstance(result.tasks[0].body, _chain)
+
     def test_apply_options(self):
 
         class static(Signature):


### PR DESCRIPTION
This PR fixes O(K²) message bloat which was caused by submitting a chain of chords.

Currently, chain(chord_A, chord_B, chord_C) goes through `reduce(operator.or_, ...)` which hits `_chain.__or__` line 995, and every chord | chord nests the right chord into the left chord's body. So we get one giant chord with everything inside. 5 chords each having 10 noop tasks would require 120MB. 6 chords of the same width will require 1.4GB.

With this update, chord | chord appends flat to the chain list instead. 5 chords with 10 noop tasks require 25KB; 6 chords — 31KB.

Script to reproduce:
```python
import argparse
import json

from celery import Celery, chain, chord, group

app = Celery("repro", backend="cache+memory://")
app.conf.update(
    task_serializer="json",
    result_serializer="json",
    accept_content=["json"],
)


@app.task
def noop(x=None):
    return None


def build_chain_of_chords(num_layers: int, tasks_per_layer: int):
    """Build chain(chord_0, chord_1, ..., chord_N) — the problematic pattern."""
    layers = []
    for _ in range(num_layers):
        header = group(noop.si() for _ in range(tasks_per_layer))
        body = noop.si()
        layers.append(chord(header, body))
    return chain(*layers)


def measure_serialized_sizes(num_layers: int, tasks_per_layer: int):
    canvas = build_chain_of_chords(num_layers, tasks_per_layer)
    canvas.freeze()

    total_bytes = 0
    print(f"\n{'Layer':<8} {'Size (bytes)':<15} {'chain entries'}")
    print("-" * 40)

    for i, task in enumerate(canvas.tasks):
        size = len(json.dumps(task.__json__()))
        total_bytes += size
        chain_entries = len(task.options.get("chain", []))
        print(f"{i:<8} {size:<15,} {chain_entries}")

    print("-" * 40)
    print(f"Total: {total_bytes:,} bytes across {len(canvas.tasks)} tasks")

    if len(canvas.tasks) >= 2:
        first = len(json.dumps(canvas.tasks[0].__json__()))
        last = len(json.dumps(canvas.tasks[-1].__json__()))
        print(f"First: {first:,}  Last: {last:,}  Ratio: {first / max(last, 1):.1f}x")


if __name__ == "__main__":
    parser = argparse.ArgumentParser(description="Measure chord-chain message sizes")
    parser.add_argument("--layers", type=int, default=8, help="Number of chord layers")
    parser.add_argument("--tasks-per-layer", type=int, default=3, help="Parallel tasks per layer")
    args = parser.parse_args()

    measure_serialized_sizes(args.layers, args.tasks_per_layer)
```