### PR TITLE
Fix mock connection interfaces to prevent `TypeError` during exception handling

### DIFF
--- a/t/unit/worker/test_bootsteps.py
+++ b/t/unit/worker/test_bootsteps.py
@@ -122,6 +122,8 @@ class test_ConsumerStep:
     def test_start_stop_shutdown(self):
         consumer = Mock()
         self.connection = Mock()
+        self.connection.connection_errors = ()
+        self.connection.channel_errors = ()
 
         class Step(bootsteps.ConsumerStep):
 
@@ -141,6 +143,8 @@ class test_ConsumerStep:
 
     def test_start_no_consumers(self):
         self.connection = Mock()
+        self.connection.connection_errors = ()
+        self.connection.channel_errors = ()
 
         class Step(bootsteps.ConsumerStep):
 

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -534,6 +534,8 @@ class test_Consumer(ConsumerTestCase):
         consumer.controller.max_concurrency = None
         consumer.initial_prefetch_count = 16
         consumer.connection = Mock()
+        consumer.connection.connection_errors = ()
+        consumer.connection.channel_errors = ()
         consumer.connection.default_channel = Mock()
         consumer.connection.transport = Mock()
         consumer.connection.transport.driver_type = 'redis'
@@ -571,6 +573,8 @@ class test_Consumer(ConsumerTestCase):
         consumer.controller.max_concurrency = None
         consumer.initial_prefetch_count = 16
         consumer.connection = Mock()
+        consumer.connection.connection_errors = ()
+        consumer.connection.channel_errors = ()
         consumer.connection.default_channel = Mock()
         consumer.connection.transport = Mock()
         consumer.connection.transport.driver_type = 'redis'
@@ -611,6 +615,8 @@ class test_Consumer(ConsumerTestCase):
         consumer.controller.max_concurrency = None
         consumer.initial_prefetch_count = 16
         consumer.connection = Mock()
+        consumer.connection.connection_errors = ()
+        consumer.connection.channel_errors = ()
         consumer.connection.default_channel = Mock()
         consumer.connection.transport = Mock()
         consumer.connection.transport.driver_type = 'redis'
@@ -651,6 +657,8 @@ class test_Consumer(ConsumerTestCase):
         consumer.controller.max_concurrency = 2  # Lower than pool processes
         consumer.initial_prefetch_count = 16
         consumer.connection = Mock()
+        consumer.connection.connection_errors = ()
+        consumer.connection.channel_errors = ()
         consumer.connection.default_channel = Mock()
         consumer.connection.transport = Mock()
         consumer.connection.transport.driver_type = 'redis'
@@ -691,6 +699,8 @@ class test_Consumer(ConsumerTestCase):
         consumer.controller.max_concurrency = None
         consumer.initial_prefetch_count = 16
         consumer.connection = Mock()
+        consumer.connection.connection_errors = ()
+        consumer.connection.channel_errors = ()
         consumer.connection.default_channel = Mock()
         consumer.connection.transport = Mock()
         consumer.connection.transport.driver_type = 'amqp'  # RabbitMQ

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -111,6 +111,8 @@ class test_Consumer(ConsumerCase):
         c.task_consumer = Mock(name='.task_consumer')
         c.qos = QoS(c.task_consumer.qos, 10)
         c.connection = Mock(name='.connection')
+        c.connection.connection_errors = ()
+        c.connection.channel_errors = ()
         c.controller = c.app.WorkController()
         c.heart = Mock(name='.heart')
         c.controller.consumer = c
@@ -249,6 +251,8 @@ class test_Consumer(ConsumerCase):
         c.task_consumer = Mock()
         c.event_dispatcher = mock_event_dispatcher()
         c.connection = Mock(name='.connection')
+        c.connection.connection_errors = ()
+        c.connection.channel_errors = ()
         c.connection.get_heartbeat_interval.return_value = 0
         c.connection.drain_events.side_effect = WorkerShutdown()
 


### PR DESCRIPTION
## Description

Fixes #10177. Relates to kombu PR #2473.

Several unit tests passed a bare `Mock()` as the broker connection object, leaving `connection_errors` and `channel_errors` as auto-generated `Mock` attributes rather than tuples. Kombu's `ignore_errors` helper (and similar exception-handling paths) performs tuple concatenation (`connection_errors + channel_errors`), which results in:

```
TypeError: unsupported operand type(s) for +: 'Mock' and 'Mock'
```

This was recently exposed by kombu PR #2473 and broke Celery CI.

Explicitly set `connection_errors = ()` and `channel_errors = ()` on mock connection objects in three test files:

**`t/unit/worker/test_bootsteps.py`**
- `test_start_stop_shutdown` and `test_start_no_consumers` — both had bare `Mock()` connections missing `connection_errors` and `channel_errors`.

**`t/unit/worker/test_consumer.py`**
- Five `test_disable_prefetch_*` test methods — all used `consumer.connection = Mock()` without the error tuple attributes.

**`t/unit/worker/test_worker.py`**
- `LoopConsumer()` helper — shared by the majority of `test_Consumer` tests.
- `_get_on_message()` helper — also shared across multiple tests.

Fixing the mocks directly is more robust than relying solely on lazy evaluation inside Kombu (proposed in kombu #2478). If any Celery test legitimately triggers an exception path that evaluates those attributes, the bare `Mock()` approach would crash with the same `TypeError`. Explicit empty tuples correctly reflect the Kombu `Connection` interface contract and make the intent clear to future readers.
