### PR TITLE
Continue to fire timers for heartbeat during thread pool shutdown

### DIFF
--- a/celery/concurrency/base.py
+++ b/celery/concurrency/base.py
@@ -3,10 +3,12 @@ import logging
 import os
 import sys
 import time
+from threading import Event, Thread
 from typing import Any, Dict
 
 from billiard.einfo import ExceptionInfo
 from billiard.exceptions import WorkerLostError
+from kombu.asynchronous import get_event_loop
 from kombu.utils.encoding import safe_repr
 
 from celery.exceptions import WorkerShutdown, WorkerTerminate, reraise
@@ -14,7 +16,7 @@ from celery.utils import timer2
 from celery.utils.log import get_logger
 from celery.utils.text import truncate
 
-__all__ = ('BasePool', 'apply_target')
+__all__ = ('AsyncPoolShutdownMixin', 'BasePool', 'apply_target')
 
 logger = get_logger('celery.pool')
 
@@ -178,3 +180,44 @@ class BasePool:
     @property
     def num_processes(self):
         return self.limit
+
+
+class AsyncPoolShutdownMixin:
+    """
+    Provides a utility method for async pool (e.g. prefork, threads) shutdown.
+
+    These pools must start their own timer thread to continue firing timer events
+    during pool shutdown. This allows heartbeats to continue to be sent while
+    long-running tasks drain from the pool.
+    """
+
+    def start_timer_event_loop(self, pool_type: str) -> tuple[Event, Thread] | None:
+        # Keep firing timers (for heartbeats on async transports) while
+        # the pool drains. If not using an async transport, no hub exists
+        # and the timer thread is not created.
+        hub = get_event_loop()
+        if hub is not None:
+            shutdown_event = Event()
+
+            def fire_timers_loop():
+                while not shutdown_event.is_set():
+                    try:
+                        hub.fire_timers()
+                    except Exception:
+                        logger.warning(
+                            f"Exception in timer thread during {pool_type} on_stop()",
+                            exc_info=True,
+                        )
+                    # 0.5 seconds was chosen as a balance between joining quickly
+                    # after the thread/pool join is complete and sleeping long enough to
+                    # avoid excessive CPU usage.
+                    time.sleep(0.5)
+
+            timer_thread = Thread(
+                target=fire_timers_loop,
+                daemon=True,
+                name=f"{pool_type}-timer-shutdown",
+            )
+            timer_thread.start()
+
+            return shutdown_event, timer_thread

--- a/celery/concurrency/base.py
+++ b/celery/concurrency/base.py
@@ -4,7 +4,7 @@ import os
 import sys
 import time
 from threading import Event, Thread
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 from billiard.einfo import ExceptionInfo
 from billiard.exceptions import WorkerLostError
@@ -191,7 +191,8 @@ class AsyncPoolShutdownMixin:
     long-running tasks drain from the pool.
     """
 
-    def start_timer_event_loop(self, pool_type: str) -> tuple[Event, Thread] | None:
+    @staticmethod
+    def start_timer_event_loop(*, pool_type: str) -> tuple[Event, Thread] | None:
         # Keep firing timers (for heartbeats on async transports) while
         # the pool drains. If not using an async transport, no hub exists
         # and the timer thread is not created.
@@ -221,3 +222,21 @@ class AsyncPoolShutdownMixin:
             timer_thread.start()
 
             return shutdown_event, timer_thread
+
+    @classmethod
+    def shutdown_with_timer_loop(cls, *, pool_type: str, shutdown_function: Callable):
+        if event_loop_started := cls.start_timer_event_loop(pool_type=pool_type):
+            shutdown_event, timer_thread = event_loop_started
+
+            try:
+                shutdown_function()
+            finally:
+                shutdown_event.set()
+                timer_thread.join(timeout=1.0)
+
+                if timer_thread.is_alive():
+                    logger.warning(
+                        f"Timer thread in {pool_type} on_stop() did not terminate cleanly"
+                    )
+        else:
+            shutdown_function()

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -3,19 +3,16 @@
 Pool implementation using :mod:`multiprocessing`.
 """
 import os
-import threading
-import time
 
 from billiard import forking_enable
 from billiard.common import REMAP_SIGTERM, TERM_SIGNAME
 from billiard.pool import CLOSE, RUN
 from billiard.pool import Pool as BlockingPool
-from kombu.asynchronous import get_event_loop
 
 from celery import platforms, signals
 from celery._state import _set_task_join_will_block, set_default_app
 from celery.app import trace
-from celery.concurrency.base import BasePool
+from celery.concurrency.base import AsyncPoolShutdownMixin, BasePool
 from celery.utils.functional import noop
 from celery.utils.log import get_logger
 
@@ -92,7 +89,7 @@ def process_destructor(pid, exitcode):
     )
 
 
-class TaskPool(BasePool):
+class TaskPool(BasePool, AsyncPoolShutdownMixin):
     """Multiprocessing Pool implementation."""
 
     Pool = AsynPool
@@ -144,34 +141,8 @@ class TaskPool(BasePool):
         if self._pool is not None and self._pool._state in (RUN, CLOSE):
             self._pool.close()
 
-            # Keep firing timers (for heartbeats on async transports) while
-            # the pool drains. If not using an async transport, no hub exists
-            # and the timer thread is not created.
-            hub = get_event_loop()
-            if hub is not None:
-                shutdown_event = threading.Event()
-
-                def fire_timers_loop():
-                    while not shutdown_event.is_set():
-                        try:
-                            hub.fire_timers()
-                        except Exception:
-                            logger.warning(
-                                "Exception in timer thread during prefork on_stop()",
-                                exc_info=True,
-                            )
-                        # 0.5 seconds was chosen as a balance between joining quickly
-                        # after the pool join is complete and sleeping long enough to
-                        # avoid excessive CPU usage.
-                        time.sleep(0.5)
-
-                timer_thread = threading.Thread(
-                    target=fire_timers_loop,
-                    daemon=True,
-                    name="prefork-timer-shutdown",
-                )
-                timer_thread.start()
-
+            if event_loop_started := self.start_timer_event_loop(pool_type="prefork"):
+                shutdown_event, timer_thread = event_loop_started
                 try:
                     self._pool.join()
                 finally:

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -14,7 +14,6 @@ from celery._state import _set_task_join_will_block, set_default_app
 from celery.app import trace
 from celery.concurrency.base import AsyncPoolShutdownMixin, BasePool
 from celery.utils.functional import noop
-from celery.utils.log import get_logger
 
 from .asynpool import AsynPool
 
@@ -30,9 +29,6 @@ if REMAP_SIGTERM:
     WORKER_SIGIGNORE = {'SIGINT', TERM_SIGNAME}
 else:
     WORKER_SIGIGNORE = {'SIGINT'}
-
-logger = get_logger(__name__)
-warning, debug = logger.warning, logger.debug
 
 
 def process_initializer(app, hostname):
@@ -140,22 +136,9 @@ class TaskPool(BasePool, AsyncPoolShutdownMixin):
         """Gracefully stop the pool."""
         if self._pool is not None and self._pool._state in (RUN, CLOSE):
             self._pool.close()
-
-            if event_loop_started := self.start_timer_event_loop(pool_type="prefork"):
-                shutdown_event, timer_thread = event_loop_started
-                try:
-                    self._pool.join()
-                finally:
-                    shutdown_event.set()
-                    timer_thread.join(timeout=1.0)
-
-                    if timer_thread.is_alive():
-                        logger.warning(
-                            "Timer thread in prefork on_stop() did not terminate cleanly"
-                        )
-            else:
-                self._pool.join()
-
+            self.shutdown_with_timer_loop(
+                pool_type="prefork", shutdown_function=self._pool.join
+            )
             self._pool = None
 
     def on_terminate(self):

--- a/celery/concurrency/thread.py
+++ b/celery/concurrency/thread.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from typing import TYPE_CHECKING, Any, Callable
 
-from celery.utils.log import get_logger
-
 from .base import AsyncPoolShutdownMixin, BasePool, apply_target
 
 __all__ = ('TaskPool',)
@@ -18,8 +16,6 @@ if TYPE_CHECKING:
     # `TargetFunction` should be a Protocol that represents fast_trace_task and
     # trace_task_ret.
     TargetFunction = Callable[..., Any]
-
-logger = get_logger(__name__)
 
 
 class ApplyResult:
@@ -43,23 +39,9 @@ class TaskPool(BasePool, AsyncPoolShutdownMixin):
         self.executor = ThreadPoolExecutor(max_workers=self.limit)
 
     def on_stop(self) -> None:
-        if event_loop_started := self.start_timer_event_loop(pool_type="thread"):
-            shutdown_event, timer_thread = event_loop_started
-
-            try:
-                self.executor.shutdown()
-            finally:
-                shutdown_event.set()
-                timer_thread.join(timeout=1.0)
-
-                if timer_thread.is_alive():
-                    logger.warning(
-                        "Timer thread in thread on_stop() did not terminate cleanly"
-                    )
-
-        else:
-            self.executor.shutdown()
-
+        self.shutdown_with_timer_loop(
+            pool_type="threads", shutdown_function=self.executor.shutdown
+        )
         super().on_stop()
 
     def on_apply(

--- a/celery/concurrency/thread.py
+++ b/celery/concurrency/thread.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from typing import TYPE_CHECKING, Any, Callable
 
-from .base import BasePool, apply_target
+from celery.utils.log import get_logger
+
+from .base import AsyncPoolShutdownMixin, BasePool, apply_target
 
 __all__ = ('TaskPool',)
 
@@ -17,6 +19,8 @@ if TYPE_CHECKING:
     # trace_task_ret.
     TargetFunction = Callable[..., Any]
 
+logger = get_logger(__name__)
+
 
 class ApplyResult:
     def __init__(self, future: Future) -> None:
@@ -27,7 +31,7 @@ class ApplyResult:
         wait([self.f], timeout)
 
 
-class TaskPool(BasePool):
+class TaskPool(BasePool, AsyncPoolShutdownMixin):
     """Thread Task Pool."""
     limit: int
 
@@ -39,7 +43,23 @@ class TaskPool(BasePool):
         self.executor = ThreadPoolExecutor(max_workers=self.limit)
 
     def on_stop(self) -> None:
-        self.executor.shutdown()
+        if event_loop_started := self.start_timer_event_loop(pool_type="thread"):
+            shutdown_event, timer_thread = event_loop_started
+
+            try:
+                self.executor.shutdown()
+            finally:
+                shutdown_event.set()
+                timer_thread.join(timeout=1.0)
+
+                if timer_thread.is_alive():
+                    logger.warning(
+                        "Timer thread in thread on_stop() did not terminate cleanly"
+                    )
+
+        else:
+            self.executor.shutdown()
+
         super().on_stop()
 
     def on_apply(

--- a/t/integration/test_async_pool_shutdown.py
+++ b/t/integration/test_async_pool_shutdown.py
@@ -1,10 +1,9 @@
-"""Integration tests for prefork pool shutdown behaviour.
+"""Integration tests for prefork/thread pool shutdown behaviour.
 
-These tests verify that the prefork pool gracefully shuts down and maintains
+These tests verify that the pool gracefully shuts down and maintains
 heartbeats during the shutdown process, preventing connection loss during
 worker drain.
 """
-
 from time import sleep
 
 import pytest
@@ -23,9 +22,10 @@ LONG_TASK_DURATION = 10
 TIMEOUT = LONG_TASK_DURATION * 2
 
 
-@pytest.fixture
-def heartbeat_worker(celery_session_app):
+@pytest.fixture(params=["prefork", "threads"])
+def heartbeat_worker(request, celery_session_app):
     """Worker with short heartbeat for testing purposes."""
+    pool_type = request.param
 
     # Temporarily lower heartbeat for this test
     original_heartbeat = celery_session_app.conf.broker_heartbeat
@@ -34,34 +34,40 @@ def heartbeat_worker(celery_session_app):
     original_acks_late = celery_session_app.conf.task_acks_late
     celery_session_app.conf.task_acks_late = True
 
-    with start_worker(
-        celery_session_app,
-        pool="prefork",
-        without_heartbeat=False,
-        concurrency=4,
-        shutdown_timeout=TIMEOUT,
-        perform_ping_check=False,
-    ) as worker:
-        # Verify that low heartbeat is configured correctly
-        assert worker.consumer.amqheartbeat == TEST_HEARTBEAT
+    try:
+        with start_worker(
+            celery_session_app,
+            pool=pool_type,
+            without_heartbeat=False,
+            concurrency=4,
+            shutdown_timeout=TIMEOUT,
+            perform_ping_check=False,
+        ) as worker:
+            # Verify that low heartbeat is configured correctly
+            assert worker.consumer.amqheartbeat == TEST_HEARTBEAT
 
-        yield worker
+            yield worker
 
-    celery_session_app.conf.broker_heartbeat = original_heartbeat
-    celery_session_app.conf.task_acks_late = original_acks_late
+    finally:
+        state.should_stop = False
+        state.should_terminate = False
+
+        celery_session_app.conf.broker_heartbeat = original_heartbeat
+        celery_session_app.conf.task_acks_late = original_acks_late
 
 
-class test_prefork_shutdown:
-    """Test prefork shutdown with heartbeat maintenance."""
+class test_async_pool_shutdown:
+    """Test pool shutdown with heartbeat maintenance."""
 
     # Test timeout should be longer than worker timeout
     @pytest.mark.timeout(timeout=TIMEOUT * 2)
     @pytest.mark.usefixtures("heartbeat_worker")
     def test_shutdown_with_long_running_tasks(self):
-        """Test that graceful shutdown completes long-running tasks without
+        """
+        Test that graceful shutdown completes long-running tasks without
         connection loss.
 
-        This test verifies that when the prefork pool is shutting down with
+        This test verifies that when the pool is shutting down with
         long-running tasks, heartbeats continue to be sent to maintain the
         broker connection.
 

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -812,8 +812,8 @@ class test_TaskPool:
         pool.on_close()
         pool._pool.close.assert_not_called()
 
-    @patch('celery.concurrency.prefork.get_event_loop')
-    @patch('celery.concurrency.prefork.threading.Thread')
+    @patch('celery.concurrency.base.get_event_loop')
+    @patch('celery.concurrency.base.Thread')
     def test_on_stop_with_hub_fires_timers(self, mock_thread, mock_get_event_loop):
         pool = TaskPool(10)
         mock_pool = Mock(name='pool')
@@ -835,9 +835,9 @@ class test_TaskPool:
         mock_timer_thread.start.assert_called_once()
         mock_timer_thread.join.assert_called_once_with(timeout=1.0)
 
-    @patch('celery.concurrency.prefork.get_event_loop')
-    @patch('celery.concurrency.prefork.threading.Thread')
-    @patch('celery.concurrency.prefork.threading.Event')
+    @patch('celery.concurrency.base.get_event_loop')
+    @patch('celery.concurrency.base.Thread')
+    @patch('celery.concurrency.base.Event')
     def test_on_stop_timer_thread_handles_exceptions(
         self,
         mock_event_class,
@@ -870,13 +870,13 @@ class test_TaskPool:
 
         pool.on_stop()
 
-        with patch('celery.concurrency.prefork.time.sleep'):
+        with patch('celery.concurrency.base.time.sleep'):
             thread_target()
 
         # Should match number of loop iterations allowed by mock_shutdown_event.is_set.side_effect
         assert mock_hub.fire_timers.call_count == 2
 
-    @patch('celery.concurrency.prefork.get_event_loop')
+    @patch('celery.concurrency.base.get_event_loop')
     def test_on_stop_no_hub(self, mock_get_event_loop):
         pool = TaskPool(10)
         mock_pool = Mock(name='pool')


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
This extends the fix to the issue of broker heartbeats not being sent on worker shutdown, reported in Issue #5998 and fixed by @weetster in PR #9986 the context of the default `prefork` pool type.  Here this fix is applied to the `threads` pool type, which still exhibits the bug, and an integration test is added to validate the fix.

I have refactored the code as far as possible to avoid code duplication, and have used pytest fixtures to apply the same test to both `prefork` and `threads` pool types (this test refactor is the only part of the PR for which I used AI assistance, with Claude Opus helping me with the fixture syntax and debugging a thread-locking problem in the test).

It is possible that the issue persists in the context of `eventlet` and/or `gevent` async pool types, but my understanding of these pool types is insufficient to allow me to propose a fix for them.