### PR TITLE
Extract `reconnect_on_error` to `BaseResultConsumer`

### DIFF
--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -5,6 +5,7 @@ import socket
 import threading
 import time
 from collections import deque
+from contextlib import contextmanager
 from queue import Empty
 from time import sleep
 from weakref import WeakKeyDictionary
@@ -13,9 +14,17 @@ from kombu.utils.compat import detect_environment
 
 from celery import states
 from celery.exceptions import TimeoutError
+from celery.utils.log import get_logger
 from celery.utils.threads import THREAD_TIMEOUT_MAX
 
 E_CELERY_RESTART_REQUIRED = "Celery must be restarted because a shutdown signal was detected."
+
+E_RETRY_LIMIT_EXCEEDED = """
+Retry limit exceeded while trying to reconnect to the Celery result store
+backend. The Celery application must be restarted.
+"""
+
+logger = get_logger(__name__)
 
 __all__ = (
     'AsyncBackendMixin', 'BaseResultConsumer', 'Drainer',
@@ -307,6 +316,11 @@ class AsyncBackendMixin:
 class BaseResultConsumer:
     """Manager responsible for consuming result messages."""
 
+    #: Tuple of transport-layer exceptions that signal a lost connection.
+    #: Subclasses should override this with the appropriate exception types
+    #: so that :meth:`reconnect_on_error` can catch and recover from them.
+    _connection_errors = ()
+
     def __init__(self, backend, app, accept,
                  pending_results, pending_messages):
         self.backend = backend
@@ -320,6 +334,34 @@ class BaseResultConsumer:
 
     def start(self, initial_task_id, **kwargs):
         raise NotImplementedError()
+
+    @contextmanager
+    def reconnect_on_error(self):
+        """Context manager that catches connection errors and reconnects.
+
+        Wraps a block of code so that any :attr:`_connection_errors` raised
+        inside it trigger a call to :meth:`_reconnect`.  If reconnection
+        itself raises a connection error the consumer is considered
+        unrecoverable and a :exc:`RuntimeError` is raised to signal that
+        the Celery application must be restarted.
+        """
+        try:
+            yield
+        except self._connection_errors:
+            try:
+                self._reconnect()
+            except self._connection_errors as exc:
+                logger.critical(E_RETRY_LIMIT_EXCEEDED)
+                raise RuntimeError(E_RETRY_LIMIT_EXCEEDED) from exc
+
+    def _reconnect(self):
+        """Re-establish the backend connection.
+
+        Subclasses must override this method to perform the transport-specific
+        reconnection logic that should be executed when a connection error is
+        caught by :meth:`reconnect_on_error`.
+        """
+        pass
 
     def stop(self):
         pass

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -1,6 +1,5 @@
 """Redis result store backend."""
 import time
-from contextlib import contextmanager
 from functools import partial
 from ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
 from urllib.parse import unquote
@@ -72,11 +71,6 @@ CERT_REQUIRED, CERT_OPTIONAL, or CERT_NONE
 
 E_LOST = 'Connection to Redis lost: Retry (%s/%s) %s.'
 
-E_RETRY_LIMIT_EXCEEDED = """
-Retry limit exceeded while trying to reconnect to the Celery redis result \
-store backend. The Celery application must be restarted.
-"""
-
 logger = get_logger(__name__)
 
 
@@ -122,16 +116,9 @@ class ResultConsumer(BaseResultConsumer):
             # The on_connect callback will re-subscribe to any channels we previously subscribed to.
             self._pubsub.connection.register_connect_callback(self._pubsub.on_connect)
 
-    @contextmanager
-    def reconnect_on_error(self):
-        try:
-            yield
-        except self._connection_errors:
-            try:
-                self._ensure(self._reconnect_pubsub, ())
-            except self._connection_errors as e:
-                logger.critical(E_RETRY_LIMIT_EXCEEDED)
-                raise RuntimeError(E_RETRY_LIMIT_EXCEEDED) from e
+    def _reconnect(self):
+        """Re-establish the Redis pub/sub connection with retry."""
+        self._ensure(self._reconnect_pubsub, ())
 
     def _maybe_cancel_ready_task(self, meta):
         if meta['status'] in states.READY_STATES:

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -4,7 +4,6 @@ RPC-style result backend, using reply-to and one queue per client.
 """
 import logging
 import time
-from contextlib import contextmanager
 
 import kombu
 from kombu.common import maybe_declare
@@ -53,6 +52,10 @@ class ResultConsumer(BaseResultConsumer):
     def start(self, initial_task_id, no_ack=True, **kwargs):
         self._no_ack = no_ack
         self._connection = self.app.connection()
+        self._connection_errors = (
+            self._connection.connection_errors
+            + self._connection.channel_errors
+        )
         initial_queue = self._create_binding(initial_task_id)
         self._consumer = self.Consumer(
             self._connection.default_channel, [initial_queue],
@@ -60,22 +63,9 @@ class ResultConsumer(BaseResultConsumer):
             accept=self.accept)
         self._consumer.consume()
 
-    @contextmanager
-    def _handle_connection_errors(self):
-        """Context manager that catches broker connection/channel errors and reconnects."""
-        try:
-            yield
-        except (self._connection.connection_errors
-                + self._connection.channel_errors) as exc:
-            logger.warning(
-                'RPC result consumer: connection lost (%s), '
-                'attempting to reconnect...', exc,
-            )
-            self._reconnect()
-
     def drain_events(self, timeout=None):
         if self._connection:
-            with self._handle_connection_errors():
+            with self.reconnect_on_error():
                 return self._connection.drain_events(timeout=timeout)
         elif timeout:
             time.sleep(timeout)
@@ -86,6 +76,9 @@ class ResultConsumer(BaseResultConsumer):
         Re-subscribes to every queue that the old consumer was listening on
         so that pending results can still be drained.
         """
+        logger.warning(
+            'RPC result consumer: connection lost, attempting to reconnect...',
+        )
         old_queues = []
         if self._consumer is not None:
             old_queues = list(self._consumer.queues)

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -78,6 +78,7 @@ class ResultConsumer(BaseResultConsumer):
         """
         logger.warning(
             'RPC result consumer: connection lost, attempting to reconnect...',
+            exc_info=True,
         )
         old_queues = []
         if self._consumer is not None:
@@ -104,6 +105,10 @@ class ResultConsumer(BaseResultConsumer):
 
         # Establish a fresh connection and consumer.
         self._connection = self.app.connection()
+        self._connection_errors = (
+            self._connection.connection_errors
+            + self._connection.channel_errors
+        )
         self._consumer = self.Consumer(
             self._connection.default_channel,
             old_queues,

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -9,8 +9,7 @@ from unittest.mock import Mock, patch
 import pytest
 from vine import promise
 
-from celery.backends.asynchronous import (E_CELERY_RESTART_REQUIRED, E_RETRY_LIMIT_EXCEEDED, BaseResultConsumer,
-                                          greenletDrainer)
+from celery.backends.asynchronous import E_CELERY_RESTART_REQUIRED, BaseResultConsumer, greenletDrainer
 from celery.backends.base import Backend
 from celery.utils import cached_property
 
@@ -712,4 +711,3 @@ class test_BaseResultConsumer_reconnect:
         consumer = self._make_consumer(app)
 
         assert consumer._reconnect() is None
-

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -9,7 +9,8 @@ from unittest.mock import Mock, patch
 import pytest
 from vine import promise
 
-from celery.backends.asynchronous import E_CELERY_RESTART_REQUIRED, BaseResultConsumer, greenletDrainer
+from celery.backends.asynchronous import (E_CELERY_RESTART_REQUIRED, E_RETRY_LIMIT_EXCEEDED, BaseResultConsumer,
+                                          greenletDrainer)
 from celery.backends.base import Backend
 from celery.utils import cached_property
 
@@ -633,3 +634,82 @@ class test_GeventDrainer(GreenletDrainerTests):
     def teardown_thread(self, thread):
         import gevent
         gevent.wait([thread])
+
+
+class test_BaseResultConsumer_reconnect:
+
+    def _make_consumer(self, app):
+        return _make_consumer(app)
+
+    def test_reconnect_on_error_no_exception_passes_through(self, app):
+        consumer = self._make_consumer(app)
+        result = []
+        with consumer.reconnect_on_error():
+            result.append('ok')
+        assert result == ['ok']
+
+    def test_reconnect_on_error_ignores_non_connection_error(self, app):
+        consumer = self._make_consumer(app)
+        with pytest.raises(ValueError):
+            with consumer.reconnect_on_error():
+                raise ValueError('unrelated')
+
+    def test_reconnect_on_error_default_connection_errors_empty(self, app):
+        consumer = self._make_consumer(app)
+        assert consumer._connection_errors == ()
+
+        class FakeConnError(Exception):
+            pass
+
+        with pytest.raises(FakeConnError):
+            with consumer.reconnect_on_error():
+                raise FakeConnError('dropped')
+
+    def test_reconnect_on_error_calls_reconnect_on_connection_error(self, app):
+        consumer = self._make_consumer(app)
+
+        class FakeConnError(Exception):
+            pass
+
+        consumer._connection_errors = (FakeConnError,)
+        consumer._reconnect = Mock()
+
+        with consumer.reconnect_on_error():
+            raise FakeConnError('dropped')
+
+        consumer._reconnect.assert_called_once_with()
+
+    def test_reconnect_on_error_raises_runtime_when_reconnect_also_fails(self, app):
+        consumer = self._make_consumer(app)
+
+        class FakeConnError(Exception):
+            pass
+
+        consumer._connection_errors = (FakeConnError,)
+        consumer._reconnect = Mock(side_effect=FakeConnError('still down'))
+
+        with pytest.raises(RuntimeError, match='Retry limit exceeded'):
+            with consumer.reconnect_on_error():
+                raise FakeConnError('dropped')
+
+    def test_reconnect_on_error_runtime_chained_from_connection_error(self, app):
+        consumer = self._make_consumer(app)
+
+        class FakeConnError(Exception):
+            pass
+
+        consumer._connection_errors = (FakeConnError,)
+        original = FakeConnError('still down')
+        consumer._reconnect = Mock(side_effect=original)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            with consumer.reconnect_on_error():
+                raise FakeConnError('dropped')
+
+        assert exc_info.value.__cause__ is original
+
+    def test_reconnect_base_implementation_is_noop(self, app):
+        consumer = self._make_consumer(app)
+
+        assert consumer._reconnect() is None
+

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -39,6 +39,8 @@ class test_RPCResultConsumer:
         # Patch app.connection() to return a fresh mock connection
         # and Consumer to return a mock consumer.
         new_conn = Mock(name='new_connection')
+        new_conn.connection_errors = (OSError,)
+        new_conn.channel_errors = ()
         new_kombu_consumer = Mock(name='new_kombu_consumer')
         consumer.app = Mock()
         consumer.app.connection.return_value = new_conn
@@ -71,6 +73,8 @@ class test_RPCResultConsumer:
         consumer._consumer = mock_consumer
 
         new_conn = Mock(name='new_connection')
+        new_conn.connection_errors = (ConnectionError,)
+        new_conn.channel_errors = ()
         consumer.app = Mock()
         consumer.app.connection.return_value = new_conn
         consumer.Consumer = Mock(return_value=Mock(name='new_kombu_consumer'))
@@ -88,6 +92,7 @@ class test_RPCResultConsumer:
         mock_conn.channel_errors = ()
         mock_conn.drain_events.side_effect = RuntimeError('unexpected')
         consumer._connection = mock_conn
+        consumer._connection_errors = mock_conn.connection_errors + mock_conn.channel_errors
 
         with pytest.raises(RuntimeError, match='unexpected'):
             consumer.drain_events(timeout=1)
@@ -104,6 +109,8 @@ class test_RPCResultConsumer:
         consumer._consumer = mock_consumer
 
         new_conn = Mock(name='new_connection')
+        new_conn.connection_errors = (OSError,)
+        new_conn.channel_errors = ()
         new_kombu_consumer = Mock(name='new_kombu_consumer')
         consumer.app = Mock()
         consumer.app.connection.return_value = new_conn
@@ -129,6 +136,8 @@ class test_RPCResultConsumer:
         consumer._consumer = mock_consumer
 
         new_conn = Mock(name='new_connection')
+        new_conn.connection_errors = ()
+        new_conn.channel_errors = (KeyError,)
         consumer.app = Mock()
         consumer.app.connection.return_value = new_conn
         consumer.Consumer = Mock(return_value=Mock(name='new_kombu_consumer'))
@@ -136,6 +145,29 @@ class test_RPCResultConsumer:
         consumer.drain_events(timeout=1)
 
         assert consumer._connection is new_conn
+
+    def test_drain_events_raises_runtime_when_reconnect_also_fails(self):
+        consumer = self.get_consumer()
+
+        class FakeConnError(Exception):
+            pass
+
+        mock_conn = Mock(name='connection')
+        mock_conn.connection_errors = (FakeConnError,)
+        mock_conn.channel_errors = ()
+        mock_conn.drain_events.side_effect = FakeConnError('dropped')
+        consumer._connection = mock_conn
+        consumer._connection_errors = mock_conn.connection_errors + mock_conn.channel_errors
+
+        mock_consumer = Mock(name='consumer')
+        mock_consumer.queues = []
+        consumer._consumer = mock_consumer
+
+        consumer.app = Mock()
+        consumer.app.connection.side_effect = FakeConnError('still down')
+
+        with pytest.raises(RuntimeError, match='Retry limit exceeded'):
+            consumer.drain_events(timeout=1)
 
 
 class test_RPCBackend:

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -30,6 +30,7 @@ class test_RPCResultConsumer:
             'Server unexpectedly closed connection'
         )
         consumer._connection = mock_conn
+        consumer._connection_errors = mock_conn.connection_errors + mock_conn.channel_errors
 
         mock_consumer = Mock(name='consumer')
         mock_consumer.queues = [Mock(name='queue1')]
@@ -62,6 +63,7 @@ class test_RPCResultConsumer:
         mock_conn.channel_errors = ()
         mock_conn.drain_events.side_effect = ConnectionError('reset')
         consumer._connection = mock_conn
+        consumer._connection_errors = mock_conn.connection_errors + mock_conn.channel_errors
 
         queue1, queue2 = Mock(name='q1'), Mock(name='q2')
         mock_consumer = Mock(name='consumer')
@@ -120,6 +122,7 @@ class test_RPCResultConsumer:
         mock_conn.channel_errors = (KeyError,)
         mock_conn.drain_events.side_effect = KeyError('channel closed')
         consumer._connection = mock_conn
+        consumer._connection_errors = mock_conn.connection_errors + mock_conn.channel_errors
 
         mock_consumer = Mock(name='consumer')
         mock_consumer.queues = []


### PR DESCRIPTION
- celery/celery#10179
- celery/celery#10188

---

## Context

[PR #10179](https://github.com/celery/celery/pull/10179) fixed the immediate
bug (RPC producer can't fetch results after RabbitMQ restart) by adding a
local `_handle_connection_errors()` context manager and `_reconnect()` to
`rpc.ResultConsumer`, plus `OSError` guards in the drainer loop.

After that fix, two independent reconnect context managers coexist:

| Location | Context manager | Error source |
|---|---|---|
| `redis.ResultConsumer` | `reconnect_on_error()` | `self._connection_errors` (class/instance attr) |
| `rpc.ResultConsumer` | `_handle_connection_errors()` | `self._connection.connection_errors + channel_errors` (live object) |

This PR lifts the shared skeleton into `BaseResultConsumer` so all backends
can rely on one well-tested hook.

---

## What changed and why

### `celery/backends/asynchronous.py`

| What | Detail |
|---|---|
| New import | `from contextlib import contextmanager` |
| New import | `from celery.utils.log import get_logger` |
| New constant | `E_RETRY_LIMIT_EXCEEDED` — generic "retry limit exceeded" message (previously Redis-only) |
| New module-level | `logger = get_logger(__name__)` |
| `BaseResultConsumer._connection_errors` | Class attribute `= ()`.  Catches nothing by default — zero behaviour change for RPC or any other backend. |
| `BaseResultConsumer.reconnect_on_error()` | `@contextmanager` — catches `_connection_errors`, calls `_reconnect()`, raises `RuntimeError` on retry exhaustion. |
| `BaseResultConsumer._reconnect()` | No-op hook; subclasses override with transport-specific logic. |

### `celery/backends/redis.py`

| What | Detail |
|---|---|
| Removed import | `from contextlib import contextmanager` (now unused) |
| Removed constant | `E_RETRY_LIMIT_EXCEEDED` (moved to `asynchronous.py`) |
| Removed method | `ResultConsumer.reconnect_on_error` (now inherited from base class) |
| New method | `ResultConsumer._reconnect()` — delegates to `self._ensure(self._reconnect_pubsub, ())` |

`self._connection_errors` continues to be set in `ResultConsumer.__init__` (unchanged).

### `celery/backends/rpc.py`

| What | Detail |
|---|---|
| Removed import | `from contextlib import contextmanager` (now unused) |
| Removed method | `ResultConsumer._handle_connection_errors()` (replaced by `reconnect_on_error()` from base class) |
| `ResultConsumer.start()` | Now populates `self._connection_errors` from the live connection after connecting |
| `ResultConsumer.drain_events()` | Uses `reconnect_on_error()` instead of `_handle_connection_errors()` |
| `ResultConsumer._reconnect()` | Warning log now includes `exc_info=True` to preserve original exception context; also refreshes `_connection_errors` from the new connection after reconnect |

**Behaviour change:** reconnect failures in the RPC consumer now raise `RuntimeError(E_RETRY_LIMIT_EXCEEDED)` (consistent with Redis). Previously a failing `_reconnect()` would propagate the raw connection exception.

---

## Behaviour

- **Redis backend**: identical to before. `_connection_errors` is set from `self.backend.connection_errors`; `_reconnect()` calls `_ensure(self._reconnect_pubsub, ())`.
- **RPC backend**: `_handle_connection_errors()` removed; now uses `reconnect_on_error()` from base class. `_connection_errors` populated in `start()` from the live connection and refreshed on each `_reconnect()`. **Reconnect failure now raises `RuntimeError`** instead of propagating the raw connection exception.
- **New backends**: opt-in by setting `_connection_errors` and overriding `_reconnect()`.

---

## Follow-up

- Align `rpc.ResultConsumer._handle_connection_errors()` → `reconnect_on_error()` now that the base class owns the skeleton. Requires deciding how `_connection_errors` is populated for RPC (connection is created lazily in `start()`).
- Add unit tests in `t/unit/backends/test_asynchronous.py`:
  - `reconnect_on_error()` yields normally when no error.
  - `reconnect_on_error()` calls `_reconnect()` on a matching exception.
  - `reconnect_on_error()` raises `RuntimeError` when `_reconnect()` also raises.
  - `reconnect_on_error()` is a no-op when `_connection_errors = ()`.

---

## Checklist

- [x] No behaviour change for existing backends
- [x] `contextmanager` import removed from `redis.py`
- [x] Unused `E_RETRY_LIMIT_EXCEEDED` removed from `redis.py`
- [x] `_connection_errors = ()` default preserves RPC behaviour
- [x] `rpc.ResultConsumer._handle_connection_errors()` from #10179 left untouched
- [x] All existing unit tests pass
- [x] New unit tests for `BaseResultConsumer.reconnect_on_error`
- [x] RPC `_handle_connection_errors` → `reconnect_on_error` alignment
- [x] `rpc._reconnect()` logs original exception via `exc_info=True`
- [x] `rpc._reconnect()` refreshes `_connection_errors` from new connection
- [x] Test: RPC `RuntimeError` path when `_reconnect()` also fails
