### PR TITLE
docs: clarify after_return behavior for retried tasks

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -1597,7 +1597,7 @@ The following diagram shows the exact order of execution:
     │     on_retry() OR       │                                     │
     │     on_failure()        │                                     │
     │  5. after_return()      ← Runs last on terminal states        │
-    │                          (skipped for RETRY/REJECTED/IGNORED) │
+    │                       (skipped for RETRY/REJECTED/IGNORED)    │
     └───────────────────────────────────────────────────────────────┘
 
 .. important::
@@ -1690,12 +1690,13 @@ Available handlers
     Handler called after the task returns.
 
     .. note::
-       Executes **after** ``on_success``/``on_retry``/``on_failure``. This is the
-       final hook in the task lifecycle when the task reaches a terminal state.
+        Executes after the outcome-specific handler when the task reaches a
+        terminal state.
 
-       It is not executed for ``RETRY``, ``REJECTED``, or ``IGNORED`` states. If a
-       hook is needed for every attempt, consider using the :signal:`task_postrun`
-       signal.
+        In practice, this means it runs after ``on_success`` or ``on_failure``.
+        It is not executed for ``RETRY``, ``REJECTED``, or ``IGNORED`` states.
+        If a hook is needed for every attempt, consider using the
+        :signal:`task_postrun` signal.
 
     :param status: Current task state.
     :param retval: Task return value/exception.


### PR DESCRIPTION
## Summary

This PR clarifies the documented behavior of `after_return`.

The previous wording could be interpreted as if `after_return` runs for every task attempt. In practice, it runs when the task reaches a terminal state and does not run for `RETRY`, `REJECTED`, or `IGNORED`.

The docs now also reference `task_postrun` for cases where a hook is needed on every attempt.

## Reason

This aligns the documentation with the current behavior and avoids implying a potentially backward-incompatible behavior change.
Related discussion: #10046