### PR TITLE
fix(backends): catch exceptions from new-style errbacks to prevent chain halt

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -262,7 +262,14 @@ class Backend:
                         not isinstance(errback.type.__header__, partial) and
                         arity_greater(errback.type.__header__, 1)
                 ):
-                    errback(request, exc, traceback)
+                    try:
+                        errback(request, exc, traceback)
+                    except Exception as inner_exc:
+                        logger.error(
+                            'Error calling errback %r: %r',
+                            errback, inner_exc,
+                            exc_info=True,
+                        )
                 else:
                     old_signature.append(errback)
             except NotRegistered:

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -264,6 +264,10 @@ class Backend:
                 ):
                     try:
                         errback(request, exc, traceback)
+                    except NotRegistered:
+                        # Let NotRegistered bubble up so the outer handler can
+                        # append this errback to old_signature and forward it.
+                        raise
                     except Exception as inner_exc:
                         logger.error(
                             'Error calling errback %r: %r',

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -568,6 +568,39 @@ class test_BaseBackend_dict:
         b.mark_as_failure('id', exc, request=request)
         assert self.errback.last_result == 5
 
+    def test_new_style_errback_exception_is_logged_and_does_not_halt_remaining(self):
+        # A failing new-style errback must not prevent subsequent errbacks
+        # from running. The error should be logged instead of propagating.
+        call_order = []
+
+        @self.app.task(shared=False)
+        def failing_errback(request, exc, traceback):
+            call_order.append('failing')
+            raise RuntimeError('errback failure')
+
+        @self.app.task(shared=False)
+        def succeeding_errback(request, exc, traceback):
+            call_order.append('succeeding')
+
+        b = BaseBackend(app=self.app)
+        b._store_result = Mock()
+        request = Mock(name='request')
+        request.errbacks = [
+            failing_errback.s(),
+            succeeding_errback.s(),
+        ]
+        exc = KeyError('original')
+
+        with patch('celery.backends.base.logger') as mock_logger:
+            b.mark_as_failure('id', exc, request=request)
+
+        assert 'failing' in call_order
+        assert 'succeeding' in call_order
+        assert call_order.index('failing') < call_order.index('succeeding')
+        mock_logger.error.assert_called_once()
+        log_args = mock_logger.error.call_args[0]
+        assert 'errback' in log_args[0]
+
     @patch('celery.backends.base.group')
     def test_class_based_task_can_be_used_as_error_callback(self, mock_group):
         b = BaseBackend(app=self.app)


### PR DESCRIPTION
## What

In `_call_task_errbacks`, new-style errbacks (those with `__header__` and arity > 1) were called with no exception handling at all. If such an errback raised any exception other than `NotRegistered`, the exception propagated out of the loop and all subsequent errbacks were silently skipped.

Old-style errbacks (dispatched via `group`) already have defensive error handling at the group/apply layer. New-style ones had none.

## Fix

Wrap the `errback(request, exc, traceback)` call in a `try/except Exception` block. On failure, log an error with `exc_info=True` and continue to the next errback.

```python
try:
    errback(request, exc, traceback)
except Exception as inner_exc:
    logger.error(
        'Error calling errback %r: %r',
        errback, inner_exc,
        exc_info=True,
    )
```

## Test

Added `test_new_style_errback_exception_is_logged_and_does_not_halt_remaining` to `t/unit/backends/test_base.py` that:

- Registers two new-style errbacks where the first raises `RuntimeError`
- Asserts both errbacks are called (in order)
- Asserts `logger.error` is called once with an 'errback' reference in the message

Closes #10195

## Test run

```
python -m pytest t/unit/backends/test_base.py -x -q --timeout=60
132 passed in 2.11s
```