### PR TITLE
git commit -m "Remove unused code identified by Skylos"

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -71,12 +71,6 @@ EXTRA_INFO_FMT = """
 """
 
 
-def active_thread_count():
-    from threading import enumerate
-    return sum(1 for t in enumerate()
-               if not t.name.startswith('Dummy-'))
-
-
 def safe_say(msg, f=sys.__stderr__):
     """
     Uses the original (unpatched) os.write to avoid issues with eventlet/gevent

--- a/celery/bin/graph.py
+++ b/celery/bin/graph.py
@@ -48,7 +48,6 @@ def workers(ctx):
                                    node._label.split('://')[0])
 
     class Node:
-        force_label = None
         scheme = {}
 
         def __init__(self, label, pos=None):

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -1195,41 +1195,11 @@ class AsynPool(_pool.Pool):
             }
         }
 
-    def _process_cleanup_queues(self, proc):
-        """Called to clean up queues after process exit."""
-        if not proc.dead:
-            try:
-                self._queues[self._find_worker_queues(proc)] = None
-            except (KeyError, ValueError):
-                pass
-
-    @staticmethod
-    def _stop_task_handler(task_handler):
-        """Called at shutdown to tell processes that we're shutting down."""
-        for proc in task_handler.pool:
-            try:
-                setblocking(proc.inq._writer, 1)
-            except OSError:
-                pass
-            else:
-                try:
-                    proc.inq.put(None)
-                except OSError as exc:
-                    if exc.errno != errno.EBADF:
-                        raise
-
     def create_result_handler(self):
         return super().create_result_handler(
             fileno_to_outq=self._fileno_to_outq,
             on_process_alive=self.on_process_alive,
         )
-
-    def _process_register_queues(self, proc, queues):
-        """Mark new ownership for ``queues`` to update fileno indices."""
-        assert queues in self._queues
-        b = len(self._queues)
-        self._queues[queues] = proc
-        assert b == len(self._queues)
 
     def _find_worker_queues(self, proc):
         """Find the queues owned by ``proc``."""
@@ -1238,16 +1208,6 @@ class AsynPool(_pool.Pool):
                         if owner == proc)
         except StopIteration:
             raise ValueError(proc)
-
-    def _setup_queues(self):
-        # this is only used by the original pool that used a shared
-        # queue for all processes.
-        self._quick_put = None
-
-        # these attributes are unused by this class, but we'll still
-        # have to initialize them for compatibility.
-        self._inqueue = self._outqueue = \
-            self._quick_get = self._poll_result = None
 
     def process_flush_queues(self, proc):
         """Flush all queues.
@@ -1345,41 +1305,6 @@ class AsynPool(_pool.Pool):
         size = len(body)
         header = pack('>I', size)
         return header, body, size
-
-    @classmethod
-    def _set_result_sentinel(cls, _outqueue, _pool):
-        # unused
-        pass
-
-    def _help_stuff_finish_args(self):
-        # Pool._help_stuff_finished is a classmethod so we have to use this
-        # trick to modify the arguments passed to it.
-        return (self._pool,)
-
-    @classmethod
-    def _help_stuff_finish(cls, pool):
-        # pylint: disable=arguments-differ
-        debug(
-            'removing tasks from inqueue until task handler finished',
-        )
-        fileno_to_proc = {}
-        inqR = set()
-        for w in pool:
-            try:
-                fd = w.inq._reader.fileno()
-                inqR.add(fd)
-                fileno_to_proc[fd] = w
-            except OSError:
-                pass
-        while inqR:
-            readable, _, again = _select(inqR, timeout=0.5)
-            if again:
-                continue
-            if not readable:
-                break
-            for fd in readable:
-                fileno_to_proc[fd].inq._reader.recv()
-            sleep(0)
 
     @property
     def timers(self):

--- a/celery/contrib/rdb.py
+++ b/celery/contrib/rdb.py
@@ -85,7 +85,6 @@ class Rdb(Pdb):
     """Remote debugger."""
 
     me = 'Remote Debugger'
-    _prev_outs = None
     _sock = None
 
     def __init__(self, host=CELERY_RDB_HOST, port=CELERY_RDB_PORT,

--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -192,30 +192,6 @@ def _start_worker_thread(app: Celery,
         state.should_terminate = None
 
 
-@contextmanager
-def _start_worker_process(app,
-                          concurrency=1,
-                          pool='solo',
-                          loglevel=WORKER_LOGLEVEL,
-                          logfile=None,
-                          **kwargs):
-    # type (Celery, int, str, Union[int, str], str, **Any) -> Iterable
-    """Start worker in separate process.
-
-    Yields:
-        celery.app.worker.Worker: worker instance.
-    """
-    from celery.apps.multi import Cluster, Node
-
-    app.set_current()
-    cluster = Cluster([Node('testworker1@%h')])
-    cluster.start()
-    try:
-        yield
-    finally:
-        cluster.stopwait()
-
-
 def setup_app_for_worker(app: Celery, loglevel: Union[str, int], logfile: str) -> None:
     """Setup the app to be used for starting an embedded worker."""
     app.finalize()

--- a/celery/local.py
+++ b/celery/local.py
@@ -447,10 +447,6 @@ class class_property:
         return self.__class__(self.__get, setter)
 
 
-def reclassmethod(method):
-    return classmethod(fun_of_method(method))
-
-
 class LazyModule(ModuleType):
     _compat_modules = ()
     _all_by_module = {}

--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -153,12 +153,3 @@ def load_extension_class_names(namespace):
         yield ep.name, ep.value
 
 
-def load_extension_classes(namespace):
-    for name, class_name in load_extension_class_names(namespace):
-        try:
-            cls = symbol_by_name(class_name)
-        except (ImportError, SyntaxError) as exc:
-            warnings.warn(
-                f'Cannot load {namespace} extension {class_name!r}: {exc!r}')
-        else:
-            yield name, cls

--- a/celery/utils/log.py
+++ b/celery/utils/log.py
@@ -21,7 +21,6 @@ __all__ = (
     'get_multiprocessing_logger', 'reset_multiprocessing_logger', 'LOG_LEVELS'
 )
 
-_process_aware = False
 _in_sighandler = False
 
 MP_LOG = os.environ.get('MP_LOG', False)

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -62,8 +62,6 @@ TIME_UNITS = (
 
 ZERO = timedelta(0)
 
-_local_timezone = None
-
 
 class LocalTimezone(tzinfo):
     """Local time implementation. Provided in _Zone to the app when `enable_utc` is disabled.


### PR DESCRIPTION
Hi! Celery user here, and just decided to do some cleanup. Removed fifteen internal items that are defined but never referenced anywhere in the codebase:

- `reclassmethod()` in `local.py`: utility function with zero callers
- `load_extension_classes()` in `utils/imports.py`: utility function with zero callers
- `active_thread_count()` in `apps/worker.py`: utility function with zero callers
- `_start_worker_process()` in `contrib/testing/worker.py`: unused context manager, superseded by `_start_worker_thread()`
- `_local_timezone` in `utils/time.py`: variable initialized to None, never assigned or read
- `_process_aware` in `utils/log.py`: variable initialized to False, never read
- `force_label` in `bin/graph.py`: class attribute never used
- `_prev_outs` in `contrib/rdb.py`:  class attribute never assigned or read
- `_process_cleanup_queues`, `_stop_task_handler`, `_process_register_queues`, `_setup_queues`, `_set_result_sentinel` (marked "# unused"), `_help_stuff_finish_args`, `_help_stuff_finish`: unused methods on `AsynPool` in `concurrency/asynpool.py`

We verified with grep across all file types.. each appears only at its definition.

Found during static and agentic analysis with Skylos.