### PR TITLE
fix(worker): add hub.reset() to synloop on connection error

### DIFF
--- a/celery/worker/loops.py
+++ b/celery/worker/loops.py
@@ -143,8 +143,23 @@ def synloop(obj, connection, consumer, blueprint, hub, qos,
             if blueprint.state == RUN:
                 raise
 
-    while blueprint.state == RUN and obj.connection:
-        try:
-            state.maybe_shutdown()
-        finally:
-            _loop_cycle()
+    try:
+        while blueprint.state == RUN and obj.connection:
+            try:
+                state.maybe_shutdown()
+            finally:
+                _loop_cycle()
+    except Exception:
+        # Reset the hub on error (e.g. connection loss) to clean up
+        # stale state from the old connection, matching the cleanup
+        # already done in asynloop.  Without this, the synloop
+        # (used by gevent/eventlet pools) could leave stale callbacks
+        # that prevent consumer re-registration after reconnection.
+        # See: https://github.com/celery/celery/issues/9191
+        if hub is not None:
+            try:
+                hub.reset()
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.exception(
+                    'Error cleaning up after sync event loop: %r', exc)
+        raise

--- a/t/unit/worker/test_loops.py
+++ b/t/unit/worker/test_loops.py
@@ -609,11 +609,21 @@ class test_synloop:
 
     def test_hub_reset_error_is_logged(self):
         x = X(self.app)
-        x.hub.reset = Mock(name='hub.reset()', side_effect=RuntimeError('reset failed'))
+        reset_error = RuntimeError('reset failed')
+        x.hub.reset = Mock(name='hub.reset()', side_effect=reset_error)
         x.timeout_then_error(x.connection.drain_events)
         with pytest.raises(socket.error):
             synloop(*x.args)
         x.hub.reset.assert_called_once()
+
+    def test_hub_reset_error_logs_exception(self, caplog):
+        x = X(self.app)
+        reset_error = RuntimeError('reset failed')
+        x.hub.reset = Mock(name='hub.reset()', side_effect=reset_error)
+        x.timeout_then_error(x.connection.drain_events)
+        with pytest.raises(socket.error):
+            synloop(*x.args)
+        assert 'Error cleaning up after sync event loop' in caplog.text
 
 
 class test_quick_drain:

--- a/t/unit/worker/test_loops.py
+++ b/t/unit/worker/test_loops.py
@@ -582,6 +582,31 @@ class test_synloop:
 
         x.obj.timer.call_repeatedly.assert_not_called()
 
+    def test_hub_reset_on_connection_error(self):
+        x = X(self.app)
+        x.hub.reset = Mock(name='hub.reset()')
+        x.timeout_then_error(x.connection.drain_events)
+        with pytest.raises(socket.error):
+            synloop(*x.args)
+        x.hub.reset.assert_called_once()
+
+    def test_hub_not_reset_on_graceful_shutdown(self):
+        x = X(self.app)
+        x.hub.reset = Mock(name='hub.reset()')
+
+        def drain_events(timeout):
+            x.blueprint.state = CLOSE
+        x.connection.drain_events.side_effect = drain_events
+        synloop(*x.args)
+        x.hub.reset.assert_not_called()
+
+    def test_hub_reset_with_none_hub(self):
+        x = X(self.app)
+        x.args[4] = None  # hub is None
+        x.timeout_then_error(x.connection.drain_events)
+        with pytest.raises(socket.error):
+            synloop(*x.args)
+
 
 class test_quick_drain:
 

--- a/t/unit/worker/test_loops.py
+++ b/t/unit/worker/test_loops.py
@@ -607,6 +607,14 @@ class test_synloop:
         with pytest.raises(socket.error):
             synloop(*x.args)
 
+    def test_hub_reset_error_is_logged(self):
+        x = X(self.app)
+        x.hub.reset = Mock(name='hub.reset()', side_effect=RuntimeError('reset failed'))
+        x.timeout_then_error(x.connection.drain_events)
+        with pytest.raises(socket.error):
+            synloop(*x.args)
+        x.hub.reset.assert_called_once()
+
 
 class test_quick_drain:
 


### PR DESCRIPTION
## Summary

Add `hub.reset()` cleanup to the `synloop` (used by gevent/eventlet pools) when a connection error occurs, matching the cleanup already present in `asynloop`.

## Root cause

When a broker connection drops during `asynloop`, `hub.reset()` is called in the `except Exception` block (loops.py:107-108), cleaning up stale file descriptors and callbacks. The `synloop` lacked this cleanup entirely. With gevent/eventlet pools, stale state from the old connection persisted across reconnection attempts, preventing proper consumer re-registration.

This is especially problematic because gevent disables `broker_connection_timeout` (consumer.py:230-234), meaning a silent Redis death can leave the worker stuck in `drain_events` indefinitely. When it eventually reconnects, the stale hub state prevents the new consumers from registering properly.

## Fix

Wrap the `synloop` main loop in `try/except Exception` and call `hub.reset()` on error, matching the `asynloop` pattern. The hub is guarded against `None` since it may not always be available in the sync path.

## Companion PR

- **Kombu**: celery/kombu#2492 — fixes the race condition in Redis transport `_on_disconnect` that removes the `on_poll_start` callback from `on_tick`, preventing consumer re-registration after reconnection.

Together, these two PRs address the "catatonic worker" problem from both sides:
1. **Kombu** (this PR's companion): prevents the race condition that removes the poll callback
2. **Celery** (this PR): ensures stale state is cleaned up in the gevent/eventlet code path

## Related issues

- Fixes #9191 — gevent-specific catatonic worker (open)
- Related: #8030 — original report (closed but not fully fixed)
- Related: #9631 — Redis + HAProxy variant (open)
- Related: #9095 — Discussion with reports through Nov 2025 on Celery 5.5.3

## Test plan

- [x] `test_hub_reset_on_connection_error` — verifies `hub.reset()` is called on `socket.error`
- [x] `test_hub_not_reset_on_graceful_shutdown` — verifies no reset on normal exit
- [x] `test_hub_reset_with_none_hub` — verifies safe handling when hub is `None`
- [x] All 48 loop tests pass (asynloop + synloop + quick_drain)