### PR TITLE
Wrap new-style errback calls in try/except (#10195)

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -262,7 +262,13 @@ class Backend:
                         not isinstance(errback.type.__header__, partial) and
                         arity_greater(errback.type.__header__, 1)
                 ):
-                    errback(request, exc, traceback)
+                    try:
+                        errback(request, exc, traceback)
+                    except Exception as inner_exc:
+                        logger.exception(
+                            'Error in new-style errback %s: %r',
+                            errback.task, inner_exc
+                        )
                 else:
                     old_signature.append(errback)
             except NotRegistered:

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -266,8 +266,8 @@ class Backend:
                         errback(request, exc, traceback)
                     except Exception as inner_exc:
                         logger.exception(
-                            'Error in new-style errback %s: %r',
-                            errback.task, inner_exc
+                            'Error in new-style errback %s for task %s: %r',
+                            errback.task, request.id, inner_exc
                         )
                 else:
                     old_signature.append(errback)

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -589,8 +589,7 @@ class test_BaseBackend_dict:
             good_errback.s(),
         ]
         b.mark_as_failure('id', KeyError(), request=request)
-        assert 'bad' in call_order
-        assert 'good' in call_order
+        assert call_order == ['bad', 'good']
 
     @patch('celery.backends.base.group')
     def test_class_based_task_can_be_used_as_error_callback(self, mock_group):

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -583,7 +583,7 @@ class test_BaseBackend_dict:
         def good_errback(request, exc, traceback):
             call_order.append('good')
 
-        request = Mock(name='request')
+        request = Mock(name='request', id='test-task-id')
         request.errbacks = [
             bad_errback.s(),
             good_errback.s(),

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -568,6 +568,30 @@ class test_BaseBackend_dict:
         b.mark_as_failure('id', exc, request=request)
         assert self.errback.last_result == 5
 
+    def test_new_style_errback_exception_does_not_halt_others(self):
+        b = BaseBackend(app=self.app)
+        b._store_result = Mock()
+
+        call_order = []
+
+        @self.app.task(shared=False)
+        def bad_errback(request, exc, traceback):
+            call_order.append('bad')
+            raise RuntimeError('errback broke')
+
+        @self.app.task(shared=False)
+        def good_errback(request, exc, traceback):
+            call_order.append('good')
+
+        request = Mock(name='request')
+        request.errbacks = [
+            bad_errback.s(),
+            good_errback.s(),
+        ]
+        b.mark_as_failure('id', KeyError(), request=request)
+        assert 'bad' in call_order
+        assert 'good' in call_order
+
     @patch('celery.backends.base.group')
     def test_class_based_task_can_be_used_as_error_callback(self, mock_group):
         b = BaseBackend(app=self.app)

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -588,7 +588,7 @@ class test_BaseBackend_dict:
             bad_errback.s(),
             good_errback.s(),
         ]
-        b.mark_as_failure('id', KeyError(), request=request)
+        b.mark_as_failure('test-task-id', KeyError(), request=request)
         assert call_order == ['bad', 'good']
 
     @patch('celery.backends.base.group')


### PR DESCRIPTION
New-style errbacks in _call_task_errbacks are called without any exception handling, so if one errback blows up, the rest never run. Old-style errbacks already have a defensive try/except, but the new-style path was missing it.

This just wraps the call the same way and logs the error with the task id so its easier to track down.

Test included -- registers two errbacks where the first raises, checks the second still runs.