### PR TITLE
fix: skip empty groups in chain prepare_steps

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1187,6 +1187,8 @@ class _chain(Signature):
             if not isinstance(task, abstract.CallableSignature):
                 task = from_dict(task, app=app)
             if isinstance(task, group):
+                if not task.tasks:
+                    continue
                 # when groups are nested, they are unrolled - all tasks within
                 # groups should be called in parallel
                 task = maybe_unroll_group(task)


### PR DESCRIPTION
## Summary
- `chain(group([task1, task2]), group(), group())` crashes with `AttributeError: 'NoneType' object has no attribute 'parent'`
- Empty groups in a chain produce `None` results that break the parent traversal loop

## Root Cause
In `prepare_steps`, empty `group()` calls are not filtered out before processing. When an empty group is encountered, it eventually produces a `None` result object, and the `while node.parent:` loop at line 1277 crashes.

## Fix
Skip empty groups (groups with no tasks) early in the `prepare_steps` loop with a `continue` statement, before they can be processed into chords or produce invalid results.

## Testing
- Verified the fix handles `chain(group([t1, t2]), group(), group())` without crash
- Empty groups are silently skipped, preserving the chain's remaining tasks

Fixes #9772

Made with [Cursor](https://cursor.com)