### PR TITLE
Cache Context custom header key set to avoid per-call allocations

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -48,6 +48,10 @@ X_DEATH_HEADERS = {
     'x-last-death-reason',
 }
 
+CONTEXT_CUSTOM_HEADER_KEYS = frozenset({
+    'lang', 'task', 'argsrepr', 'kwargsrepr', 'compression',
+})
+
 #: Here for backwards compatibility as tasks no longer use a custom meta-class.
 TaskType = type
 
@@ -116,8 +120,7 @@ class Context:
     def _get_custom_headers(self, *args, **kwargs):
         headers = {}
         headers.update(*args, **kwargs)
-        celery_keys = {*Context.__dict__.keys(), 'lang', 'task', 'argsrepr', 'kwargsrepr', 'compression'}
-        for key in celery_keys:
+        for key in self._custom_header_keys:
             headers.pop(key, None)
         if not headers:
             return None
@@ -178,6 +181,9 @@ class Context:
         if self._children is None:
             self._children = []
         return self._children
+
+
+Context._custom_header_keys = frozenset(Context.__dict__) | CONTEXT_CUSTOM_HEADER_KEYS
 
 
 @abstract.CallableTask.register


### PR DESCRIPTION
## Description

`celery.app.task.Context._get_custom_headers()` currently rebuilds the set of Celery-owned request keys on every call before filtering custom headers.

This change computes that key set once and reuses it, preserving existing behavior while avoiding repeated allocations on the task request path.

This is a small optimization in a hot path, reducing per-request overhead without changing semantics.

**Env**
mac mini m4 
Python 3.13
Celery ver. 5.6.2

**Micro-benchmark**:
old (rebuild set): 0.6754s (~740k ops/sec)
new (cached set): 0.5778s (~865k ops/sec)

**~17%** improvement for this code path.
