### PR TITLE
Fix: wrap new-style errback calls in try/except to prevent silent chain halt

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -262,7 +262,13 @@ class Backend:
                         not isinstance(errback.type.__header__, partial) and
                         arity_greater(errback.type.__header__, 1)
                 ):
-                    errback(request, exc, traceback)
+                    try:
+                        errback(request, exc, traceback)
+                    except Exception:
+                        logger.exception(
+                            'Errback %r raised an exception',
+                            errback.name,
+                        )
                 else:
                     old_signature.append(errback)
             except NotRegistered:

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -597,6 +597,34 @@ class test_BaseBackend_dict:
         b.mark_as_failure('id', exc, request=request)
         mock_group.assert_called_once_with(request.errbacks, app=self.app)
 
+    def test_new_style_errback_exception_does_not_halt_chain(self):
+        """Test that a new-style errback raising an exception is caught
+        and does not prevent subsequent errbacks from being called."""
+        b = BaseBackend(app=self.app)
+        b._store_result = Mock()
+
+        @self.app.task(shared=False, bind=True)
+        def failing_errback(self, request, exc, traceback):
+            raise RuntimeError('errback failed')
+
+        @self.app.task(shared=False)
+        def ok_errback(arg1):
+            ok_errback.called = True
+
+        ok_errback.called = False
+
+        request = Mock(name='request')
+        request.delivery_info = {'is_eager': True}
+        request.errbacks = [
+            failing_errback.subtask(immutable=True),
+            ok_errback.subtask(args=[1], immutable=True),
+        ]
+        exc = KeyError()
+        # Should not raise — the RuntimeError from failing_errback is caught
+        b.mark_as_failure('id', exc, request=request)
+        # The old-style errback (ok_errback) should still have been dispatched
+        assert ok_errback.called
+
     def test_mark_as_failure__chord(self):
         b = BaseBackend(app=self.app)
         b._store_result = Mock()

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -603,27 +603,27 @@ class test_BaseBackend_dict:
         b = BaseBackend(app=self.app)
         b._store_result = Mock()
 
-        @self.app.task(shared=False, bind=True)
-        def failing_errback(self, request, exc, traceback):
+        errback_calls = []
+
+        @self.app.task(shared=False)
+        def failing_errback(request, exc, traceback):
+            errback_calls.append('failing')
             raise RuntimeError('errback failed')
 
         @self.app.task(shared=False)
-        def ok_errback(arg1):
-            ok_errback.called = True
-
-        ok_errback.called = False
+        def ok_errback(request, exc, traceback):
+            errback_calls.append('ok')
 
         request = Mock(name='request')
-        request.delivery_info = {'is_eager': True}
         request.errbacks = [
-            failing_errback.subtask(immutable=True),
-            ok_errback.subtask(args=[1], immutable=True),
+            failing_errback.subtask(),
+            ok_errback.subtask(),
         ]
         exc = KeyError()
-        # Should not raise — the RuntimeError from failing_errback is caught
+        # Should not raise — the RuntimeError from failing_errback is
+        # caught and logged, and the next new-style errback still runs.
         b.mark_as_failure('id', exc, request=request)
-        # The old-style errback (ok_errback) should still have been dispatched
-        assert ok_errback.called
+        assert errback_calls == ['failing', 'ok']
 
     def test_mark_as_failure__chord(self):
         b = BaseBackend(app=self.app)


### PR DESCRIPTION
## Description

Fixes #10195

New-style errbacks (those with `__header__` and arity > 1) in `_call_task_errbacks` are invoked directly with no surrounding try/except. If one errback raises any exception other than `NotRegistered`, that exception propagates uncaught and **subsequent errbacks in the chain are never called**.

This wraps the new-style errback call in a try/except that:
- Catches any `Exception`
- Logs the error with `logger.exception` (including the errback name)
- Continues to the next errback in the chain

This matches the defensive behavior already present in the old-style errback path (where group execution failures don't halt the process).

## Changes

- `celery/backends/base.py`: Added try/except around `errback(request, exc, traceback)` call (3 lines of new code)
- `t/unit/backends/test_base.py`: Added test `test_new_style_errback_exception_does_not_halt_chain` that verifies a failing new-style errback doesn't prevent subsequent errbacks from running

## Testing

All existing errback-related tests pass. The new test confirms:
1. A new-style errback that raises `RuntimeError` is caught and logged
2. Subsequent errbacks in the chain still execute normally