### PR TITLE
Add Google Cloud PubSub dependency group

### DIFF
--- a/requirements/extras/gcpubsub.txt
+++ b/requirements/extras/gcpubsub.txt
@@ -1,0 +1,1 @@
+kombu[gcpubsub]>=5.5.0

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ EXTENSIONS = (
     'dynamodb',
     'elasticsearch',
     'eventlet',
+    'gcpubsub',
     'gevent',
     'gcs',
     'librabbitmq',


### PR DESCRIPTION
## Description

Adds the `gcpubsub` dependency group [as described in the documentation](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/gcpubsub.html). 

Closes #10215
relates to  discussion https://github.com/celery/celery/discussions/9681
