### PR TITLE
Replace remaining deprecated datetime.utcnow() calls

### DIFF
--- a/celery/backends/gcs.py
+++ b/celery/backends/gcs.py
@@ -1,6 +1,6 @@
 """Google Cloud Storage result store backend for Celery."""
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from os import getpid
 from threading import RLock
 
@@ -95,7 +95,7 @@ class GCSBackendBase(KeyValueStoreBackend):
         key = bytes_to_str(key)
         blob = self._get_blob(key)
         if self.ttl:
-            blob.custom_time = datetime.utcnow() + timedelta(seconds=self.ttl)
+            blob.custom_time = datetime.now(timezone.utc) + timedelta(seconds=self.ttl)
         blob.upload_from_string(value, retry=self._retry_policy)
 
     def delete(self, key):
@@ -344,7 +344,7 @@ class GCSBackend(GCSBackendBase):
         Firestore ttl data is typically deleted within 24 hours after its
         expiration date.
         """
-        val_expires = datetime.utcnow() + timedelta(seconds=expires)
+        val_expires = datetime.now(timezone.utc) + timedelta(seconds=expires)
         doc = self._firestore_document(key)
         doc.set({self._field_expires: val_expires}, merge=True)
 

--- a/celery/events/cursesmon.py
+++ b/celery/events/cursesmon.py
@@ -3,7 +3,7 @@
 import curses
 import sys
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import count
 from math import ceil
 from textwrap import wrap
@@ -322,8 +322,8 @@ class CursesMonitor:  # pragma: no cover
         attr = curses.A_NORMAL
         if task.uuid == self.selected_task:
             attr = curses.A_STANDOUT
-        timestamp = datetime.utcfromtimestamp(
-            task.timestamp or time(),
+        timestamp = datetime.fromtimestamp(
+            task.timestamp or time(), tz=timezone.utc,
         )
         timef = timestamp.strftime('%H:%M:%S')
         hostname = task.worker.hostname if task.worker else '*NONE*'

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -415,7 +415,7 @@ class test_Scheduler:
         scheduler = mScheduler(app=self.app)
 
         now_ts = 1514797200.2
-        now = datetime.utcfromtimestamp(now_ts)
+        now = datetime.fromtimestamp(now_ts, tz=timezone.utc)
         schedule_half = schedule(timedelta(seconds=0.5), nowfun=lambda: now)
         scheduler.add(name='half_second_schedule', schedule=schedule_half)
 

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -115,8 +115,8 @@ class test_schedule:
         assert s1 == s2
 
 
-# This is needed for test_crontab_parser because datetime.utcnow doesn't pickle
-# in python 2
+# This is needed for test_crontab_parser because datetime.utcnow doesn't
+# serialize in python 2
 def utcnow():
     return datetime.now(timezone.utc)
 

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -115,8 +115,8 @@ class test_schedule:
         assert s1 == s2
 
 
-# This is needed for test_crontab_parser because datetime.utcnow doesn't
-# serialize in python 2
+# Module-level helper used as crontab(nowfun=...) in pickling tests.
+# Defined at top level so it is picklable/serializable.
 def utcnow():
     return datetime.now(timezone.utc)
 

--- a/t/unit/backends/test_gcs.py
+++ b/t/unit/backends/test_gcs.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
@@ -141,7 +141,7 @@ class test_GCSBackend:
             'testvalue', retry=backend._retry_policy
         )
         if gcs_ttl:
-            assert mock_blob.custom_time >= datetime.utcnow()
+            assert mock_blob.custom_time >= datetime.now(timezone.utc)
 
     @patch.object(GCSBackend, '_get_blob')
     @patch.object(GCSBackend, '_is_firestore_ttl_policy_enabled')
@@ -441,7 +441,7 @@ class test_GCSBackend:
         expires = 86400
         mock_document = MagicMock()
         mock_firestore_document.return_value = mock_document
-        expected_expiry = datetime.utcnow() + timedelta(seconds=expires)
+        expected_expiry = datetime.now(timezone.utc) + timedelta(seconds=expires)
 
         backend = GCSBackend(app=self.app)
         backend._expire_chord_key(key, expires)


### PR DESCRIPTION
## Summary

Replace deprecated `datetime.utcnow()` and `datetime.utcfromtimestamp()` calls with their timezone-aware equivalents.

These methods have been deprecated since Python 3.12 (see [PEP 728](https://docs.python.org/3/whatsnew/3.12.html#deprecated)) and will be removed in a future Python version. Most of the codebase was already updated in #8726, but a few occurrences remained:

**Production code:**
- `celery/backends/gcs.py` — 2 occurrences of `datetime.utcnow()`
- `celery/events/cursesmon.py` — 1 occurrence of `datetime.utcfromtimestamp()`

**Test code:**
- `t/unit/backends/test_gcs.py` — 2 occurrences
- `t/unit/app/test_beat.py` — 1 occurrence
- `t/unit/app/test_schedules.py` — stale comment referencing the old pattern

## Changes

- `datetime.utcnow()` → `datetime.now(timezone.utc)`
- `datetime.utcfromtimestamp(ts)` → `datetime.fromtimestamp(ts, tz=timezone.utc)`
- Added `timezone` to import statements where needed