### PR TITLE
Fix new-style errbacks: add exception handling to prevent chain halt

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -271,6 +271,12 @@ class Backend:
                 # If the task is not registered there, the worker will raise
                 # NotRegistered.
                 old_signature.append(errback)
+            except Exception:
+                # Log and continue so that one failing errback does not
+                # prevent subsequent errbacks from running.
+                self._logger.exception(
+                    'errback %r raised exception', errback,
+                )
 
         if old_signature:
             # Previously errback was called as a task so we still


### PR DESCRIPTION
## Problem

New-style errbacks (with `__header__` and arity > 1) in `_call_task_errbacks` are called without exception handling. If an errback raises any exception other than `NotRegistered`, it propagates uncaught and **prevents all subsequent errbacks from running**.

Old-style errbacks already have defensive try/except handling. New-style should match.

## Fix

Add a broad `except Exception` handler that logs the error and continues to the next errback. 6 lines added.

Closes #10195