### PR TITLE
ci: add Integration-tests-integrity job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -111,6 +111,53 @@ jobs:
     with:
       module_name: ${{ matrix.module }}
 
+  Integration-tests-integrity:
+    needs: [Unit]
+    if: needs.Unit.result == 'success'
+    timeout-minutes: 240
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: 6379
+      rabbitmq:
+        image: rabbitmq:management
+        ports:
+          - 5672:5672
+          - 15672:15672
+        env:
+          RABBITMQ_DEFAULT_USER: guest
+          RABBITMQ_DEFAULT_PASS: guest
+
+    steps:
+      - name: Install apt packages
+        run: |
+          sudo apt-get update && sudo apt-get install -f libcurl4-openssl-dev libssl-dev libgnutls28-dev httping expect libmemcached-dev
+
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.14
+        uses: useblacksmith/setup-python@v6
+        with:
+          python-version: '3.14'
+          allow-prereleases: true
+          cache: 'pip'
+          cache-dependency-path: '**/setup.py'
+      - name: Install tox
+        run: python -m pip install --upgrade pip 'tox' tox-gh-actions
+      - name: Run all integration tests in a single session
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 60
+          max_attempts: 5
+          retry_wait_seconds: 0
+          command: |
+            tox --verbose --verbose -e "3.14-integration-rabbitmq_redis"
+
   Smoke-tests:
     needs: [Unit]
     if: needs.Unit.result == 'success'


### PR DESCRIPTION
Runs all integration tests in a single pytest session (Python 3.14, rabbitmq_redis) to catch cross-module test pollution 