### PR TITLE
perf(examples): set a timeout on tasks HTTP calls

### DIFF
--- a/examples/eventlet/tasks.py
+++ b/examples/eventlet/tasks.py
@@ -5,10 +5,10 @@ from celery import shared_task
 
 @shared_task()
 def urlopen(url):
-    print(f'-open: {url}')
+    print(f"-open: {url}")
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=10.0)
     except requests.exceptions.RequestException as exc:
-        print(f'-url {url} gave error: {exc!r}')
+        print(f"-url {url} gave error: {exc!r}")
         return
     return len(response.text)


### PR DESCRIPTION
## What

This caught my eye while tracing through `examples/eventlet/tasks.py`. Set a timeout on tasks HTTP calls.

## Why

Without a `timeout` argument, `requests` (and `httpx`) will wait indefinitely for a response. Under slow or unreachable endpoints this blocks the calling thread forever, eventually starving thread pools or hanging the process.

## Fix

Added `timeout=10.0` (seconds) to the call. Feel free to adjust the value to whatever fits your use-case — the important thing is that *some* bound exists.

## References

- https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts

## Files changed

- `examples/eventlet/tasks.py`

## Validation

The patch was generated automatically and validated with `py_compile` before being submitted. Please review the diff carefully — if this fix doesn't fit your codebase, feel free to close the PR.