### PR TITLE
perf(examples): set a timeout on tasks HTTP calls

### DIFF
--- a/examples/eventlet/tasks.py
+++ b/examples/eventlet/tasks.py
@@ -5,10 +5,10 @@ from celery import shared_task
 
 @shared_task()
 def urlopen(url):
-    print(f'-open: {url}')
+    print(f"-open: {url}")
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=10.0)
     except requests.exceptions.RequestException as exc:
-        print(f'-url {url} gave error: {exc!r}')
+        print(f"-url {url} gave error: {exc!r}")
         return
     return len(response.text)


### PR DESCRIPTION
Found a `requests.get(url)` call in `examples/eventlet/tasks.py` with no timeout set. If the server is slow or unreachable this will hang indefinitely and block the thread. Added `timeout=10.0` - adjust to whatever makes sense for your use case.