### PR TITLE
chore(testing): disable management plugin in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,10 +37,9 @@ jobs:
           REDIS_HOST: localhost
           REDIS_PORT: 6379
       rabbitmq:
-        image: rabbitmq:management
+        image: rabbitmq:latest
         ports:
           - 5672:5672
-          - 15672:15672
         env:
           RABBITMQ_DEFAULT_USER: guest
           RABBITMQ_DEFAULT_PASS: guest


### PR DESCRIPTION
## Description

The management plugin was enabled in both `docker-compose.yml` and in the GHA integration tests [here](https://github.com/celery/celery/pull/9959/changes#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593).  This shouldn't be needed since https://github.com/celery/celery/pull/10239.  However, I think it's useful to keep the management UI in docker-compose.yml, as this can make debugging locally easier and only comes with the disadvantage of a very small memory footprint.

As the integration tests will not run without modifying [certain patterns](https://github.com/celery/celery/blob/72e9240aa1e22b5a124534f6b469d32629a066e2/.github/workflows/python-package.yml#L10-L22), I've created this PR to force a run of the integration tests and ensure that they still work with the management UI disabled:
https://github.com/celery/celery/pull/10250