### PR TITLE
Fix #10180: Cancel prefetched tasks on warm shutdown with thread-pool

### DIFF
--- a/celery/concurrency/thread.py
+++ b/celery/concurrency/thread.py
@@ -39,7 +39,7 @@ class TaskPool(BasePool):
         self.executor = ThreadPoolExecutor(max_workers=self.limit)
 
     def on_stop(self) -> None:
-        self.executor.shutdown()
+        self.executor.shutdown(cancel_futures=True)
         super().on_stop()
 
     def on_apply(


### PR DESCRIPTION
## Summary
- Fixes warm shutdown not cancelling prefetched tasks when using thread-pool concurrency
- Prefetched tasks are now properly cancelled during warm shutdown

## Test plan
- Verify warm shutdown cancels prefetched tasks with thread-pool
- Existing test suite passes

Generated by [OwlMind](https://owlmind.dev) — 96.67% on SWE-bench Lite