### PR TITLE
Bump codecov actions 5 -> 6

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
           sudo apt-get update
-          sudo apt-get install -f libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
+          sudo apt-get install -f libcurl4-openssl-dev libev-dev libssl-dev libgnutls28-dev httping expect libmemcached-dev
 
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
           sudo apt-get update
-          sudo apt-get install -f -y --no-install-recommends libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
+          sudo apt-get install -f libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
 
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install apt packages
         run: |
           sudo apt-get update
-          sudo apt-get install -f libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
+          sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
 
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,6 +48,7 @@ jobs:
     steps:
       - name: Install apt packages
         run: |
+          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
           sudo apt-get update
           sudo apt-get install -f -y --no-install-recommends libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,7 +48,8 @@ jobs:
     steps:
       - name: Install apt packages
         run: |
-          sudo apt-get update && sudo apt-get install -f libcurl4-openssl-dev libssl-dev libgnutls28-dev httping expect libmemcached-dev
+          sudo apt-get update
+          sudo apt-get install -f libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
 
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install apt packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
+          sudo apt-get install -f -y --no-install-recommends libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
 
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   linter:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
 
       - name: Checkout branch

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -81,7 +81,7 @@ jobs:
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/codecov-actions@v6
+      uses: codecov/codecov-action@v6
       with:
         report_type: test_results
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
         sudo apt-get update
-        sudo apt-get install -f -y --no-install-recommends libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
+        sudo apt-get install -f libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
 
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         tox --verbose --verbose
 
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@v6
       with:
         flags: unittests # optional
         fail_ci_if_error: true # optional (default = false)
@@ -81,8 +81,9 @@ jobs:
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/codecov-actions@v6
       with:
+        report_type: test_results
         token: ${{ secrets.CODECOV_TOKEN }}
 
   Integration-tests:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,6 +53,7 @@ jobs:
     - name: Install apt packages
       if: startsWith(matrix.os, 'blacksmith-4vcpu-ubuntu')
       run: |
+        echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
         sudo apt-get update
         sudo apt-get install -f -y --no-install-recommends libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
         sudo apt-get update
-        sudo apt-get install -f libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
+        sudo apt-get install -f libcurl4-openssl-dev libev-dev libssl-dev libgnutls28-dev httping expect libmemcached-dev
 
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,7 +54,7 @@ jobs:
       if: startsWith(matrix.os, 'blacksmith-4vcpu-ubuntu')
       run: |
         sudo apt-get update
-        sudo apt-get install -f libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
+        sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,7 +53,8 @@ jobs:
     - name: Install apt packages
       if: startsWith(matrix.os, 'blacksmith-4vcpu-ubuntu')
       run: |
-        sudo apt-get update && sudo apt-get install -f libcurl4-openssl-dev libssl-dev libgnutls28-dev httping expect libmemcached-dev
+        sudo apt-get update
+        sudo apt-get install -f libcurl4-openssl-dev libgnutls28-dev httping expect libmemcached-dev
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   semgrep:
     name: Scan
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
           sudo apt-get update
-          sudo apt-get install -f -y --no-install-recommends procps  # Install procps to enable sysctl
+          sudo apt-get install -f procps  # Install procps to enable sysctl
           sudo sysctl -w vm.overcommit_memory=1
 
       - uses: actions/checkout@v6

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Install apt packages
         run: |
+          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
           sudo apt-get update
           sudo apt-get install -f -y --no-install-recommends procps  # Install procps to enable sysctl
           sudo sysctl -w vm.overcommit_memory=1

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Install apt packages
         run: |
-          sudo apt update
-          sudo apt-get install -y procps  # Install procps to enable sysctl
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends procps  # Install procps to enable sysctl
           sudo sysctl -w vm.overcommit_memory=1
 
       - uses: actions/checkout@v6

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run tox for "${{ matrix.python-version }}-smoke-${{ inputs.module_name }}"
         uses: nick-fields/retry@v4
         with:
-          timeout_minutes: 20
+          timeout_minutes: 60
           max_attempts: 5
           retry_wait_seconds: 60
           command: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 60
-          max_attempts: 5
+          max_attempts: 3
           retry_wait_seconds: 60
           command: |
             tox --verbose --verbose -e "${{ matrix.python-version }}-smoke" -- -k ${{ inputs.module_name }} -n auto

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install apt packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends procps  # Install procps to enable sysctl
+          sudo apt-get install -f -y --no-install-recommends procps  # Install procps to enable sysctl
           sudo sysctl -w vm.overcommit_memory=1
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Description
Bumps codecov actions and replace deprecated codecov action.

See warning in current CI on main branch:
> This action is being deprecated in favor of 'codecov-action'. Please update CI accordingly to use 'codecov-action@v5' with 'report_type: test_results'. The 'codecov-action' should and can be run at least once for coverage and once for test results

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
