### PR TITLE
fix(events): skip publish when producer is None to stop memory leak after broker reconnect

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -307,3 +307,4 @@ Colin Watson, 2025/03/01
 Lucas Infante, 2025/05/15
 Diego Margoni, 2025/07/01
 Brian Helba, 2026/01/12
+송준호, 2026/04/22

--- a/celery/events/dispatcher.py
+++ b/celery/events/dispatcher.py
@@ -141,6 +141,8 @@ class EventDispatcher:
 
     def _publish(self, event, producer, routing_key, retry=False,
                  retry_policy=None, utcoffset=utcoffset):
+        if producer is None:
+            return
         exchange = self.exchange
         try:
             producer.publish(

--- a/t/unit/events/test_events.py
+++ b/t/unit/events/test_events.py
@@ -131,6 +131,17 @@ class test_EventDispatcher:
         eventer = self.app.events.Dispatcher(Mock())
         eventer.flush(errors=False, groups=False)
 
+    def test_publish_skipped_when_producer_is_none(self):
+        connection = Mock()
+        connection.transport.driver_type = 'amqp'
+        eventer = self.app.events.Dispatcher(connection, enabled=False,
+                                             buffer_while_offline=True)
+        eventer.producer = None
+        eventer._publish(
+            {'type': 'worker-heartbeat'}, None, 'worker.heartbeat',
+        )
+        assert len(eventer._outbound_buffer) == 0
+
     def test_enter_exit(self):
         with self.app.connection_for_write() as conn:
             d = self.app.events.Dispatcher(conn)

--- a/t/unit/events/test_events.py
+++ b/t/unit/events/test_events.py
@@ -131,15 +131,18 @@ class test_EventDispatcher:
         eventer = self.app.events.Dispatcher(Mock())
         eventer.flush(errors=False, groups=False)
 
-    def test_publish_skipped_when_producer_is_none(self):
+    def test_send_skipped_after_close_when_producer_is_none(self):
+        # Regression for #10273. After close() during a broker reconnect
+        # the dispatcher's producer is cleared but ``enabled`` stays True,
+        # so stale heartbeat timers still call send(). That must be a
+        # no-op, not an AttributeError buffered into _outbound_buffer.
         connection = Mock()
         connection.transport.driver_type = 'amqp'
         eventer = self.app.events.Dispatcher(connection, enabled=False,
                                              buffer_while_offline=True)
+        eventer.enabled = True
         eventer.producer = None
-        eventer._publish(
-            {'type': 'worker-heartbeat'}, None, 'worker.heartbeat',
-        )
+        eventer.send('worker-heartbeat')
         assert len(eventer._outbound_buffer) == 0
 
     def test_enter_exit(self):


### PR DESCRIPTION
Fixes #10273. Regression of #5047.
                                                                                                   
  ## Description                                            

  After a broker reconnect the previous `EventDispatcher` is closed (`producer` set to `None`) but 
  stale timers — notably `Heart`'s heartbeat timer, wired up via `on_enabled` on the old dispatcher
   — keep calling its `_publish()`. Each call raised an `AttributeError: 'NoneType' object has no attribute 'publish'` that `_publish()` caught under `buffer_while_offline=True` and appended to
  `_outbound_buffer` together with the exception object. The retained exception pinned its
  traceback and frame locals, leaking ~6 frame objects and a full `AttributeError` per failed
  publish (~every 2s, the default heartbeat interval).

  A long-lived gevent worker accumulated hundreds of MiB of unreclaimable memory after a single    
  broker blip. Production measurement cited in #10273 (Python 3.14, Celery 5.6.3, gevent pool, 3.8
  days after one reconnect):                                                                       
                                                            
  ```
  99,138 AttributeError objects (never GC'd)
  99,191 traceback objects (1 per exception)                                                       
  594,908 frame objects (~6 per exception)
  _outbound_buffer: 99,139 events accumulated                                                      
  Process RSS: 677 MiB (started at 192 MiB)                                                        
  ```