### PR TITLE
fix: respect task-level serializer and exec options in send_task

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -873,6 +873,15 @@ class Celery:
         options = router.route(
             options, route_name or name, args, kwargs, task_type)
 
+        # Apply task-level defaults for options not explicitly provided
+        try:
+            task = self.tasks[name]
+        except KeyError:
+            pass
+        else:
+            for key, value in task._get_exec_options().items():
+                options.setdefault(key, value)
+
         if eta or countdown:
             driver_type = self.producer_pool.connections.connection.transport.driver_type
             if detect_quorum_queues(self, driver_type)[0]:


### PR DESCRIPTION
## Summary

When calling `app.send_task('task_name')`, per-task attributes defined via the `@task()` decorator (such as `serializer`, `compression`, `queue`, `routing_key`, etc.) were silently ignored. The global config defaults were always used instead.

This meant that a task declared with `@app.task(serializer='json')` would still be serialized with `msgpack` (or whatever `task_serializer` is set to) when sent via `send_task`, even though `apply_async` correctly respects the task's own serializer.

## Changes

After routing resolves the target queue/exchange, look up the task from the registry by name and apply its `_get_exec_options()` as defaults via `setdefault` — so explicitly passed options still take precedence.

Fixes #8542