### PR TITLE
fix(events): stop leaking exceptions and cancel stale Heart timers

### DIFF
--- a/celery/events/dispatcher.py
+++ b/celery/events/dispatcher.py
@@ -156,10 +156,10 @@ class EventDispatcher:
                 headers=self.headers,
                 delivery_mode=self.delivery_mode,
             )
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception:
             if not self.buffer_while_offline:
                 raise
-            self._outbound_buffer.append((event, routing_key, exc))
+            self._outbound_buffer.append((event, routing_key))
 
     def send(self, type, blind=False, utcoffset=utcoffset, retry=False,
              retry_policy=None, Event=Event, **fields):
@@ -204,7 +204,7 @@ class EventDispatcher:
             buf = list(self._outbound_buffer)
             try:
                 with self.mutex:
-                    for event, routing_key, _ in buf:
+                    for event, routing_key in buf:
                         self._publish(event, self.producer, routing_key)
             finally:
                 self._outbound_buffer.clear()

--- a/celery/worker/consumer/events.py
+++ b/celery/worker/consumer/events.py
@@ -60,7 +60,7 @@ class Events(bootsteps.StartStopStep):
             # close custom connection
             if dispatcher.connection:
                 ignore_errors(c, dispatcher.connection.close)
-            ignore_errors(c, dispatcher.close)
+            ignore_errors(c, dispatcher.disable)
             c.event_dispatcher = None
             return dispatcher
 

--- a/t/unit/events/test_events.py
+++ b/t/unit/events/test_events.py
@@ -145,6 +145,51 @@ class test_EventDispatcher:
         eventer.send('worker-heartbeat')
         assert len(eventer._outbound_buffer) == 0
 
+    def test_buffered_entries_do_not_retain_exception(self):
+        # Follow-up for #10273. The buffer used to hold
+        # (event, routing_key, exc); the retained exception kept its
+        # traceback and ~6 frames alive per failed publish, leaking
+        # hundreds of MiB in long-lived workers. flush() already
+        # discards the exception, so the entry is now 2-tuple only.
+        producer = MockProducer()
+        producer.connection = self.app.connection_for_write()
+        producer.raise_on_publish = True
+        connection = Mock()
+        connection.transport.driver_type = 'amqp'
+        eventer = self.app.events.Dispatcher(connection, enabled=False,
+                                             buffer_while_offline=True)
+        eventer.producer = producer
+        eventer.enabled = True
+        eventer.send('task-received', uuid=1)
+        assert len(eventer._outbound_buffer) == 1
+        entry = eventer._outbound_buffer[0]
+        assert len(entry) == 2
+        event, routing_key = entry
+        assert routing_key == 'task.received'
+        assert event['type'] == 'task-received'
+
+    def test_flush_replays_buffered_entries_after_tuple_shape_change(self):
+        # flush() must still successfully replay events buffered during
+        # an outage once the producer is restored. Guards the unpack
+        # change in flush() against regressions.
+        producer = MockProducer()
+        producer.connection = self.app.connection_for_write()
+        producer.raise_on_publish = True
+        connection = Mock()
+        connection.transport.driver_type = 'amqp'
+        eventer = self.app.events.Dispatcher(connection, enabled=False,
+                                             buffer_while_offline=True)
+        eventer.producer = producer
+        eventer.enabled = True
+        for name in ('Event 1', 'Event 2', 'Event 3'):
+            eventer.send(name)
+        assert len(eventer._outbound_buffer) == 3
+        producer.raise_on_publish = False
+        eventer.flush()
+        for name in ('Event 1', 'Event 2', 'Event 3'):
+            assert producer.has_event(name)
+        assert len(eventer._outbound_buffer) == 0
+
     def test_enter_exit(self):
         with self.app.connection_for_write() as conn:
             d = self.app.events.Dispatcher(conn)

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -183,7 +183,7 @@ class test_Consumer(ConsumerCase):
         Events.shutdown(c)
         Heart = find_step(c, consumer.Heart)
         Heart.shutdown(c)
-        event_dispatcher.close.assert_called()
+        event_dispatcher.disable.assert_called()
         heart.stop.assert_called_with()
 
     @patch('celery.worker.consumer.consumer.warn')


### PR DESCRIPTION
## Description
                                                                                                                                                                                                                                  
  Follow-up to #10277 addressing the two remaining review comments on that PR. Both changes target root causes of the memory leak reported in #10273 — the previous PR only closed the immediate symptom via an early return in   
  `_publish()`.
                                                                                                                                                                                                                                  
  **1. `EventDispatcher._outbound_buffer` no longer retains the exception object.**                                                                                                                                               
  
  `_publish()` used to buffer `(event, routing_key, exc)` when a publish failed under `buffer_while_offline`. The retained exception pinned its traceback and ~6 local frames per failure — for any long-lived dispatcher hitting 
  repeated publish errors (network blips, broker pauses, etc.) this was the real source of the memory leak. `flush()` already discards the exception via `_`, so the entry is now `(event, routing_key)` and `flush()` unpacking
  is updated accordingly. `extend_buffer()` is shape-agnostic so no change is needed there.                                                                                                                                       
                                                            
  **2. `Events._close()` now calls `dispatcher.disable()` instead of `dispatcher.close()`.**                                                                                                                                      
  
  `close()` only nulls the producer; it does not fire `on_disabled`. `Heart` registers its timer-cancel callback on `on_disabled`, so under the old code the stale heartbeat `tref` kept firing against a dead dispatcher after   
  every broker reconnect. `disable()` invokes the callback chain (`enabled = False` → `close()` → callbacks) while still performing the producer cleanup, so the stale heartbeat is cancelled at its source rather than merely    
  becoming a no-op publish. `dispatcher.close()` has no external callers outside this module, so there is no compatibility impact.
                                                                                                                                                                                                                                  
  Added regression tests:                                   

  - `test_buffered_entries_do_not_retain_exception` — asserts `_outbound_buffer` entries are 2-tuples with no exception reference.
  - `test_flush_replays_buffered_entries_after_tuple_shape_change` — guards `flush()` unpack against regressions.                                                                                                                 
  - `test_close_connection__heart_shutdown` (existing) updated to assert `disable()` is called on the dispatcher.                                                                                                                 
                                                                                                                                                                                                                                  
  Verified against the reproduction in #10273 (RabbitMQ paused 20 s to force reconnect, `gc.get_objects()` delta measured after):                                                                                                 
                                                                                                                                                                                                                                  
  | Wait | Delta | Dispatcher #2 state |                    
  |---|---|---|                                                                                                                                                                                                                   
  | 30 s | `AE=+1 frames=+5` | `enabled=False` |            
  | 90 s | `AE=+1 frames=+5` | `enabled=False` |                                                                                                                                                                                  
                                                                                                                                                                                                                                  
  The delta is constant regardless of wait time — no linear growth. The residual `+1/+5` comes from an unrelated AMQP heartbeat path (`celery/worker/loops.py:40 tick()` → `kombu.connection.Connection.heartbeat_check()`) firing
   once during the reconnection transition; that is a distinct issue outside the scope of #10273. `Dispatcher #2: enabled=False` in the measurement output confirms `on_disabled` now fires on reconnect — previously `enabled`   
  stayed `True` because `close()` never flipped it.         
                                                                                                                                                                                                                                  
  See: #10273, #10277    