### PR TITLE
Fix head_from_fun following __wrapped__ on Python 3.14+

### DIFF
--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -321,8 +321,18 @@ if sys.version_info >= (3, 14):
         # annotations here, so use Format.STRING to avoid evaluation.
         # For bound methods, use __func__ so that 'self' is included in args,
         # matching the behaviour of getfullargspec on older Python versions.
+        # Pass follow_wrapped=False to match inspect.getfullargspec's behaviour
+        # of introspecting the callable itself rather than following __wrapped__;
+        # this matters for tasks defined via functools.wraps over a variadic
+        # wrapper (e.g. dependency-injection decorators) where the wrapper's
+        # signature -- not the inner function's -- is what should be validated
+        # against caller-supplied args.
         target = getattr(fun, '__func__', fun)
-        sig = inspect.signature(target, annotation_format=_annotationlib.Format.STRING)
+        sig = inspect.signature(
+            target,
+            follow_wrapped=False,
+            annotation_format=_annotationlib.Format.STRING,
+        )
         args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults = [], None, None, [], [], {}
         for name, param in sig.parameters.items():
             kind = param.kind

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -384,6 +384,31 @@ class test_head_from_fun:
         g(1)
         g(1, 2)
 
+    def test_wraps_variadic_wrapper(self):
+        # Regression test: head_from_fun should introspect the callable it was
+        # handed, not the original function referenced via __wrapped__. This
+        # matters for tasks defined via functools.wraps over a variadic wrapper
+        # (a common pattern for DI decorators that inject extra kwargs at call
+        # time). inspect.getfullargspec ignores __wrapped__; inspect.signature
+        # follows it by default, so the Python 3.14 _getfullargspec shim must
+        # pass follow_wrapped=False to preserve the documented behaviour.
+        from functools import wraps
+
+        def inner(x, y, app, sa_session, kwarg=1):
+            pass
+
+        @wraps(inner)
+        def wrapper(*args, **kwds):
+            pass
+
+        g = head_from_fun(wrapper)
+        # The wrapper accepts anything; head_from_fun should see its signature,
+        # not inner's (which would require app/sa_session as positional args).
+        g()
+        g(1)
+        g(1, 2, 3)
+        g(anything=1, at=2, all=3)
+
 
 class test_fun_takes_argument:
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Follow-up to #10165. The `_getfullargspec` shim added for Python 3.14 calls
`inspect.signature(...)` to avoid eager PEP 649 annotation evaluation, but
`inspect.signature` follows `__wrapped__` by default while the
`inspect.getfullargspec` it replaced did not.

Tasks defined with `functools.wraps` over a variadic wrapper -- a common
dependency-injection pattern where the wrapper takes `*args, **kwds` and
the inner function expects extra framework-supplied params -- end up
validated against the inner function's signature. `apply_async`'s
`check_arguments` then raises `TypeError` for arguments the wrapper would
have accepted on 3.13 and earlier.

Minimal reproduction:

    from functools import wraps
    from celery import Celery

    app = Celery(broker='memory://')

    def decorator(func):
        @wraps(func)
        def wrapper(*args, **kwds):
            # framework injects extra kwargs here at call time
            return func(*args, injected='x', **kwds)
        return wrapper

    @app.task
    @decorator
    def my_task(arg, injected):
        return arg, injected

    my_task.apply_async(args=('hello',))
    # Python 3.13: works
    # Python 3.14 with celery 5.6.3: TypeError: my_task() missing 1 required
    #                                positional argument: 'injected'

Passing `follow_wrapped=False` restores `getfullargspec`'s documented
behaviour while preserving the PEP 649 fix from #10165.

## Test

Added `test_wraps_variadic_wrapper` in `t/unit/utils/test_functional.py`.
Fails without this patch on 3.14; passes with it. All existing tests
(including `test_type_checking_annotation`) continue to pass on both 3.13
and 3.14.