### PR TITLE
Removed socket.timeout from reconnection conditions

### DIFF
--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -347,6 +347,11 @@ class BaseResultConsumer:
         """
         try:
             yield
+        except socket.timeout:
+            # socket.timeout (builtin TimeoutError) from drain_events(timeout=N)
+            # is normal polling behavior, not a connection error.
+            # Let it bubble up to be caught by the Drainer.
+            raise
         except self._connection_errors:
             try:
                 self._reconnect()

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -350,7 +350,8 @@ class BaseResultConsumer:
         except socket.timeout:
             # socket.timeout (builtin TimeoutError) from drain_events(timeout=N)
             # is normal polling behavior, not a connection error.
-            # Let it bubble up to be caught by the Drainer.
+            # Let it propagate as an expected polling timeout for the caller
+            # to handle.
             raise
         except self._connection_errors:
             try:

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -1,3 +1,4 @@
+import socket
 import uuid
 from unittest.mock import Mock, patch
 
@@ -84,6 +85,30 @@ class test_RPCResultConsumer:
         # The new Consumer should have been created with both old queues.
         new_consumer_call = consumer.Consumer.call_args
         assert list(new_consumer_call[0][1]) == [queue1, queue2]
+
+    def test_drain_events_timeout_swallowed(self):
+        """socket.timeout from drain_events should NOT trigger reconnection."""
+        consumer = self.get_consumer()
+        mock_conn = Mock(name='connection')
+        mock_conn.connection_errors = (OSError,)
+        mock_conn.channel_errors = ()
+        # Simulate a normal polling timeout (no messages within timeout period)
+        mock_conn.drain_events.side_effect = socket.timeout()
+        consumer._connection = mock_conn
+        consumer._connection_errors = mock_conn.connection_errors + mock_conn.channel_errors
+
+        mock_consumer = Mock(name='consumer')
+        mock_consumer.queues = [Mock(name='queue1')]
+        consumer._consumer = mock_consumer
+
+        # drain_events should raise socket.timeout, NOT trigger reconnection.
+        # socket.timeout should bubble up so the Drainer can catch it.
+        with pytest.raises(socket.timeout):
+            consumer.drain_events(timeout=1)
+
+        # Verify that NO reconnection occurred:
+        # - Connection should NOT be closed
+        mock_conn.close.assert_not_called()
 
     def test_drain_events_no_reconnect_on_other_errors(self):
         consumer = self.get_consumer()

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -86,7 +86,7 @@ class test_RPCResultConsumer:
         new_consumer_call = consumer.Consumer.call_args
         assert list(new_consumer_call[0][1]) == [queue1, queue2]
 
-    def test_drain_events_timeout_swallowed(self):
+    def test_drain_events_timeout_does_not_trigger_reconnect(self):
         """socket.timeout from drain_events should NOT trigger reconnection."""
         consumer = self.get_consumer()
         mock_conn = Mock(name='connection')

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -86,7 +86,7 @@ class test_RPCResultConsumer:
         new_consumer_call = consumer.Consumer.call_args
         assert list(new_consumer_call[0][1]) == [queue1, queue2]
 
-    def test_drain_events_timeout_does_not_trigger_reconnect(self):
+    def test_drain_events_socket_timeout_does_not_trigger_reconnect(self):
         """socket.timeout from drain_events should NOT trigger reconnection."""
         consumer = self.get_consumer()
         mock_conn = Mock(name='connection')


### PR DESCRIPTION
## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

Fixes a regression introduced in 5.6.3 where the 1 second polling timeouts were considered connection errors and triggered a reconnect, described in #10284 