### PR TITLE
fix(defaults): default to exclusive queues for RabbitMQ 4.3.0 compatibility

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -151,7 +151,7 @@ NAMESPACES = Namespace(
     control=Namespace(
         queue_ttl=Option(300.0, type='float'),
         queue_expires=Option(10.0, type='float'),
-        queue_exclusive=Option(False, type='bool'),
+        queue_exclusive=Option(True, type='bool'),
         queue_durable=Option(False, type='bool'),
         exchange=Option('celery', type='string'),
     ),
@@ -182,7 +182,7 @@ NAMESPACES = Namespace(
         queue_expires=Option(60.0, type='float'),
         queue_ttl=Option(5.0, type='float'),
         queue_prefix=Option('celeryev'),
-        queue_exclusive=Option(False, type='bool'),
+        queue_exclusive=Option(True, type='bool'),
         queue_durable=Option(False, type='bool'),
         serializer=Option('json'),
         exchange=Option('celeryev', type='string'),

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -392,6 +392,7 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
             self.oid, self.exchange, self.oid,
             durable=False,
             auto_delete=True,
+            exclusive=True,
             expires=self.expires,
         )
 

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -390,9 +390,8 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
     def binding(self):
         return self.Queue(
             self.oid, self.exchange, self.oid,
-            durable=False,
+            durable=True,
             auto_delete=True,
-            exclusive=True,
             expires=self.expires,
         )
 

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -242,7 +242,7 @@ class test_RPCBackend:
         assert queue.name == self.b.oid
         assert queue.exchange == self.b.exchange
         assert queue.routing_key == self.b.oid
-        assert not queue.durable
+        assert queue.durable
         assert queue.auto_delete
 
     def test_create_binding(self):


### PR DESCRIPTION
## Description

RabbitMQ 4.3.0 disables transient non-exclusive queues by default. Celery's control and event queues are declared with `durable=False, exclusive=False`, which RabbitMQ 4.3.0 rejects with `(541) INTERNAL_ERROR`.

### RabbitMQ References

- [**Release Notes (Broadcom TechDocs)**](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/open-source-rabbitmq/4-3/opn-src-rabbitmq/site-release-notes.html): *"Deprecated Features are Now Disabled by Default — This includes non-durable (transient) non-exclusive queues: attempts to declare a queue with that property combination are rejected by default. Use durable queues, transient exclusive queues, or durable queues with a queue TTL instead."*
- [**Deprecated Features List**](https://www.rabbitmq.com/release-information/deprecated-features-list): `transient_nonexcl_queues` — *"Covers queues that are both non-durable and non-exclusive, this combination should be avoided. Use durable queues or non-durable exclusive queues."*
- [**Deprecation Announcement (August 2021)**](https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements): Original deprecation notice for RabbitMQ 4.0+

### Fix

Change the defaults for `control_queue_exclusive` and `event_queue_exclusive` from `False` to `True` in `celery/app/defaults.py`.

### Before → After

| Setting | Before | After |
|---|---|---|
| `control_queue_exclusive` | `False` | `True` |
| `event_queue_exclusive` | `False` | `True` |

All affected queues are per-connection, transient state — they exist only while the declaring connection is active and should be auto-deleted on disconnect. `exclusive=True` matches the intended lifecycle and is RabbitMQ's recommended alternative for the deprecated transient non-exclusive pattern.