### PR TITLE
Revert "fix(defaults): default to exclusive queues for RabbitMQ 4.3.0 compatibility"

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -151,7 +151,7 @@ NAMESPACES = Namespace(
     control=Namespace(
         queue_ttl=Option(300.0, type='float'),
         queue_expires=Option(10.0, type='float'),
-        queue_exclusive=Option(True, type='bool'),
+        queue_exclusive=Option(False, type='bool'),
         queue_durable=Option(False, type='bool'),
         exchange=Option('celery', type='string'),
     ),
@@ -182,7 +182,7 @@ NAMESPACES = Namespace(
         queue_expires=Option(60.0, type='float'),
         queue_ttl=Option(5.0, type='float'),
         queue_prefix=Option('celeryev'),
-        queue_exclusive=Option(True, type='bool'),
+        queue_exclusive=Option(False, type='bool'),
         queue_durable=Option(False, type='bool'),
         serializer=Option('json'),
         exchange=Option('celeryev', type='string'),

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -390,7 +390,7 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
     def binding(self):
         return self.Queue(
             self.oid, self.exchange, self.oid,
-            durable=True,
+            durable=False,
             auto_delete=True,
             expires=self.expires,
         )

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -242,7 +242,7 @@ class test_RPCBackend:
         assert queue.name == self.b.oid
         assert queue.exchange == self.b.exchange
         assert queue.routing_key == self.b.oid
-        assert queue.durable
+        assert not queue.durable
         assert queue.auto_delete
 
     def test_create_binding(self):


### PR DESCRIPTION
Reverts celery/celery#10287