### PR TITLE
fix(defaults,rpc): RabbitMQ 4.3.0 compatibility

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -151,7 +151,7 @@ NAMESPACES = Namespace(
     control=Namespace(
         queue_ttl=Option(300.0, type='float'),
         queue_expires=Option(10.0, type='float'),
-        queue_exclusive=Option(False, type='bool'),
+        queue_exclusive=Option(True, type='bool'),
         queue_durable=Option(False, type='bool'),
         exchange=Option('celery', type='string'),
     ),
@@ -182,7 +182,7 @@ NAMESPACES = Namespace(
         queue_expires=Option(60.0, type='float'),
         queue_ttl=Option(5.0, type='float'),
         queue_prefix=Option('celeryev'),
-        queue_exclusive=Option(False, type='bool'),
+        queue_exclusive=Option(True, type='bool'),
         queue_durable=Option(False, type='bool'),
         serializer=Option('json'),
         exchange=Option('celeryev', type='string'),

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -390,7 +390,7 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
     def binding(self):
         return self.Queue(
             self.oid, self.exchange, self.oid,
-            durable=False,
+            durable=True,
             auto_delete=True,
             expires=self.expires,
         )

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3797,9 +3797,15 @@ If enabled, the event receiver's queue will be marked as *durable*, meaning it w
 :transports supported: ``amqp``
 .. versionadded:: 5.6
 
-Default: ``False``
+Default: ``True``
 
 If enabled, the event queue will be *exclusive* to the current connection and automatically deleted when the connection closes.
+
+.. versionchanged:: 5.7
+
+   The default was changed from ``False`` to ``True`` for compatibility with RabbitMQ 4.3.0,
+   which no longer permits transient non-exclusive queues by default.
+   See `RabbitMQ Deprecated Features List <https://www.rabbitmq.com/release-information/deprecated-features-list>`_.
 
 .. warning::
 
@@ -3977,10 +3983,16 @@ If set to ``True``, the control exchange and queue will be durable — they will
 ``control_queue_exclusive``
 ---------------------------
 
-- **Default:** ``False``
+- **Default:** ``True``
 - **Type:** ``bool``
 
-If set to ``True``, the control queue will be exclusive to a single connection. This is generally not recommended in distributed environments.
+If set to ``True``, the control queue will be exclusive to a single connection.
+
+.. versionchanged:: 5.7
+
+   The default was changed from ``False`` to ``True`` for compatibility with RabbitMQ 4.3.0,
+   which no longer permits transient non-exclusive queues by default.
+   See `RabbitMQ Deprecated Features List <https://www.rabbitmq.com/release-information/deprecated-features-list>`_.
 
 .. warning::
 

--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -839,7 +839,7 @@ Advanced users can configure the behavior of this mailbox by customizing how it 
 The following parameters are now supported by `Mailbox`:
 
 - ``durable`` (default: ``False``): If set to ``True``, the control exchanges will survive broker restarts.
-- ``exclusive`` (default: ``False``): If set to ``True``, the exchanges will be usable by only one connection.
+- ``exclusive`` (default: ``True``): If set to ``True``, the exchanges will be usable by only one connection.
 
 .. warning::
 

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -242,7 +242,7 @@ class test_RPCBackend:
         assert queue.name == self.b.oid
         assert queue.exchange == self.b.exchange
         assert queue.routing_key == self.b.oid
-        assert not queue.durable
+        assert queue.durable
         assert queue.auto_delete
 
     def test_create_binding(self):


### PR DESCRIPTION
## Description

RabbitMQ 4.3.0 disables transient non-exclusive queues by default. Celery's control and event queues are declared with `durable=False, exclusive=False`, which RabbitMQ 4.3.0 rejects with `(541) INTERNAL_ERROR`.

### RabbitMQ References

- [**Release Notes (Broadcom TechDocs)**](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/open-source-rabbitmq/4-3/opn-src-rabbitmq/site-release-notes.html): *"Deprecated Features are Now Disabled by Default — This includes non-durable (transient) non-exclusive queues: attempts to declare a queue with that property combination are rejected by default. Use durable queues, transient exclusive queues, or durable queues with a queue TTL instead."*
- [**Deprecated Features List**](https://www.rabbitmq.com/release-information/deprecated-features-list): `transient_nonexcl_queues` — *"Covers queues that are both non-durable and non-exclusive, this combination should be avoided. Use durable queues or non-durable exclusive queues."*
- [**Deprecation Announcement (August 2021)**](https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements): Original deprecation notice for RabbitMQ 4.0+

### Fix

Change the defaults for `control_queue_exclusive` and `event_queue_exclusive` from `False` to `True` in `celery/app/defaults.py`.

### Before → After

| Setting | Before | After |
|---|---|---|
| `control_queue_exclusive` | `False` | `True` |
| `event_queue_exclusive` | `False` | `True` |

All affected queues are per-connection, transient state — they exist only while the declaring connection is active and should be auto-deleted on disconnect. `exclusive=True` matches the intended lifecycle and is RabbitMQ's recommended alternative for the deprecated transient non-exclusive pattern.

---

Replaces https://github.com/celery/celery/pull/10287 reverted in https://github.com/celery/celery/pull/10289