### PR TITLE
fix(worker): skip Broadcast queues in native delayed delivery binding

### DIFF
--- a/celery/worker/consumer/delayed_delivery.py
+++ b/celery/worker/consumer/delayed_delivery.py
@@ -11,6 +11,7 @@ if sys.version_info < (3, 11):  # pragma: no cover
     from exceptiongroup import ExceptionGroup
 
 from kombu import Connection, Queue
+from kombu.common import Broadcast
 from kombu.transport.native_delayed_delivery import (bind_queue_to_native_delayed_delivery_exchange,
                                                      declare_native_delayed_delivery_exchanges_and_queues)
 from kombu.utils.functional import retry_over_time
@@ -165,6 +166,8 @@ class DelayedDelivery(bootsteps.StartStopStep):
 
         exceptions: list[Exception] = []
         for queue in queues:
+            if isinstance(queue, Broadcast):
+                continue
             try:
                 logger.debug("Binding queue %r to delayed delivery exchange", queue.name)
                 bind_queue_to_native_delayed_delivery_exchange(connection, queue)

--- a/t/unit/worker/test_native_delayed_delivery.py
+++ b/t/unit/worker/test_native_delayed_delivery.py
@@ -469,3 +469,25 @@ class test_DelayedDelivery:
         assert "attempt 1/" in retry_warnings[0].message
         assert "Connection refused" in retry_warnings[1].message
         assert "attempt 2/" in retry_warnings[1].message
+
+    @patch('celery.worker.consumer.delayed_delivery.bind_queue_to_native_delayed_delivery_exchange')
+    def test_bind_queues_skips_broadcast_queues(self, mock_bind):
+        """Broadcast queues are auto-delete/ephemeral and should not be
+        bound to the delayed delivery exchange."""
+        from kombu.common import Broadcast
+
+        consumer_mock = MagicMock()
+        consumer_mock.app.conf.broker_native_delayed_delivery_queue_type = 'classic'
+        consumer_mock.app.conf.broker_url = 'amqp://'
+        consumer_mock.app.amqp.queues = {
+            'celery':        Queue('celery', exchange=Exchange('celery', type='topic')),
+            'celery.pidbox': Broadcast('celery.pidbox'),   # <-- the problematic one
+        }
+
+        delayed_delivery = DelayedDelivery(consumer_mock)
+        delayed_delivery.start(consumer_mock)
+
+        # bind should only be called for the regular queue, not the Broadcast one
+        assert mock_bind.call_count == 1
+        bound_queue = mock_bind.call_args[0][1]
+        assert bound_queue.name == 'celery'


### PR DESCRIPTION
## Description

Skip `Broadcast` queues in `DelayedDelivery._bind_queues` during worker startup.

Broadcast queues (e.g. `celery.pidbox`) are auto-delete and ephemeral — they may not
exist on the broker when the worker starts. Attempting to bind them to the
`celery_delayed_delivery` exchange produces spurious `NOT_FOUND` errors and an
`ExceptionGroup` on every startup. Since Broadcast queues use a fanout exchange and
are not eligible for delayed delivery by design, they should be silently skipped.

Adds `Broadcast` import from `kombu.common` and a unit test covering the skip behavior.

Fixes #9699
