### PR TITLE
fix(worker): guard heartbeat control command against None event_dispatcher

### DIFF
--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -345,6 +345,8 @@ def election(state, id, topic, action=None, **kwargs):
 def enable_events(state):
     """Tell worker(s) to send task-related events."""
     dispatcher = state.consumer.event_dispatcher
+    if dispatcher is None:
+        return nok('event dispatcher unavailable')
     if dispatcher.groups and 'task' not in dispatcher.groups:
         dispatcher.groups.add('task')
         logger.info('Events of group {task} enabled by remote.')
@@ -356,6 +358,8 @@ def enable_events(state):
 def disable_events(state):
     """Tell worker(s) to stop sending task-related events."""
     dispatcher = state.consumer.event_dispatcher
+    if dispatcher is None:
+        return nok('event dispatcher unavailable')
     if 'task' in dispatcher.groups:
         dispatcher.groups.discard('task')
         logger.info('Events of group {task} disabled by remote.')

--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -368,7 +368,8 @@ def heartbeat(state):
     """Tell worker(s) to send event heartbeat immediately."""
     logger.debug('Heartbeat requested by remote.')
     dispatcher = state.consumer.event_dispatcher
-    dispatcher.send('worker-heartbeat', freq=5, **worker_state.SOFTWARE_INFO)
+    if dispatcher:
+        dispatcher.send('worker-heartbeat', freq=5, **worker_state.SOFTWARE_INFO)
 
 
 # -- Worker

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -246,6 +246,13 @@ class test_ControlPanel:
         panel.handle('heartbeat')
         assert ('worker-heartbeat',) in event_dispatcher.send.call_args
 
+    def test_heartbeat_no_dispatcher(self):
+        consumer = Consumer(self.app)
+        consumer.event_dispatcher = None
+        panel = self.create_panel(consumer=consumer)
+        # Should not raise AttributeError when dispatcher is None (#9489).
+        panel.handle('heartbeat')
+
     def test_time_limit(self):
         panel = self.create_panel(consumer=Mock())
         r = panel.handle('time_limit', arguments={

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -163,6 +163,20 @@ class test_ControlPanel:
         assert 'task' not in evd.groups
         assert 'already disabled' in panel.handle('disable_events')['ok']
 
+    def test_enable_events_no_dispatcher(self):
+        consumer = Consumer(self.app)
+        consumer.event_dispatcher = None
+        panel = self.create_panel(consumer=consumer)
+        # Should not raise AttributeError when dispatcher is None (#9489).
+        assert 'unavailable' in panel.handle('enable_events')['error']
+
+    def test_disable_events_no_dispatcher(self):
+        consumer = Consumer(self.app)
+        consumer.event_dispatcher = None
+        panel = self.create_panel(consumer=consumer)
+        # Should not raise AttributeError when dispatcher is None (#9489).
+        assert 'unavailable' in panel.handle('disable_events')['error']
+
     def test_clock(self):
         consumer = Consumer(self.app)
         panel = self.create_panel(consumer=consumer)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

The `heartbeat` control command in `celery/worker/control.py` accesses `state.consumer.event_dispatcher` and immediately calls `.send(...)` on it. When the dispatcher is `None` (e.g. transient state during broker reconnect, or workers started with `--without-heartbeat`), this raises `AttributeError: 'NoneType' object has no attribute 'send'` and surfaces as `pidbox command error` in the worker logs.

The adjacent code paths in `celery/worker/consumer/consumer.py` (`_flush_events`, line 621/697) and `celery/worker/consumer/events.py` (line 55) already use the `if self.event_dispatcher:` pattern. This PR extends the same guard to the `heartbeat` control command and adds a regression test asserting `panel.handle('heartbeat')` does not raise when `event_dispatcher is None`.

Fixes #9489.