### PR TITLE
fix: respect custom default exchange with direct type

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -535,7 +535,11 @@ class AMQP:
                     exchange_type = 'direct'
 
             # convert to anon-exchange, when exchange not set and direct ex.
-            if (not exchange or not routing_key) and exchange_type == 'direct':
+            # Only use the anonymous exchange when no custom default_exchange
+            # is configured (fixes #9940).
+            if ((not exchange or not routing_key)
+                    and exchange_type == 'direct'
+                    and not default_exchange.name):
                 exchange, routing_key = '', qname
             elif exchange is None:
                 # not topic exchange, and exchange not undefined

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -277,7 +277,9 @@ class test_AMQP(test_AMQP_Base):
         )
         kwargs = prod.publish.call_args[1]
         assert kwargs['routing_key'] == 'foo'
-        assert kwargs['exchange'] == ''
+        # When a custom default_exchange is configured, the queue's
+        # exchange should be used instead of the anonymous exchange (#9940).
+        assert kwargs['exchange'] == 'foo'
 
     def test_send_task_message__broadcast_without_exchange(self):
         from kombu.common import Broadcast
@@ -300,8 +302,10 @@ class test_AMQP(test_AMQP_Base):
         )
         prod.publish.assert_called()
         pub = prod.publish.call_args[1]
-        assert pub['routing_key'] == 'bar'
-        assert pub['exchange'] == ''
+        # When a custom default_exchange is configured, explicitly-set
+        # exchanges should be respected, not overridden to anon-exchange (#9940).
+        assert pub['exchange'] == 'xyz'
+        assert pub['routing_key'] is None
 
     def test_send_event_exchange_direct_with_routing_key(self):
         prod = Mock(name='prod')
@@ -311,8 +315,10 @@ class test_AMQP(test_AMQP_Base):
         )
         prod.publish.assert_called()
         pub = prod.publish.call_args[1]
-        assert pub['routing_key'] == 'bar'
-        assert pub['exchange'] == ''
+        # When a custom default_exchange is configured, the explicitly-set
+        # routing_key should be respected and the queue's exchange used (#9940).
+        assert pub['routing_key'] == 'xyb'
+        assert pub['exchange'] == 'bar'
 
     def test_send_event_exchange_string(self):
         evd = Mock(name='evd')


### PR DESCRIPTION
When task_default_exchange was configured with a direct exchange type,
Celery ignored the custom exchange and published to the AMQP anonymous
exchange instead.

The condition in _create_task_sender() unconditionally converted to the
anonymous exchange when exchange_type == "direct", without checking
whether a custom task_default_exchange was configured.

Fix: only apply the anonymous exchange optimization when no custom default
exchange name is configured.

Fixes #9940