### PR TITLE
fix: add explicit encoding to open() calls for cross-platform portability

### DIFF
--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -163,7 +163,7 @@ class Pidfile:
     def read_pid(self):
         """Read and return the current pid."""
         with ignore_errno('ENOENT'):
-            with open(self.path) as fh:
+            with open(self.path, encoding="utf-8") as fh:
                 line = fh.readline()
                 if line.strip() == line:  # must contain '\n'
                     raise ValueError(
@@ -229,7 +229,7 @@ class Pidfile:
         finally:
             pidfile.close()
 
-        rfh = open(self.path)
+        rfh = open(self.path, encoding="utf-8")
         try:
             if rfh.read() != content:
                 raise LockFailed(

--- a/celery/security/__init__.py
+++ b/celery/security/__init__.py
@@ -64,8 +64,8 @@ def setup_security(allowed_serializers=None, key=None, key_password=None, cert=N
     if not (key and cert and store):
         raise ImproperlyConfigured(SECURITY_SETTING_MISSING)
 
-    with open(key) as kf:
-        with open(cert) as cf:
+    with open(key, encoding="utf-8") as kf:
+        with open(cert, encoding="utf-8") as cf:
             register_auth(kf.read(), key_password, cf.read(), store, digest, serializer)
     registry._set_default_serializer('auth')
 

--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -105,7 +105,7 @@ class FSCertStore(CertStore):
         if os.path.isdir(path):
             path = os.path.join(path, '*')
         for p in glob.glob(path):
-            with open(p) as f:
+            with open(p, encoding="utf-8") as f:
                 cert = Certificate(f.read())
                 if cert.has_expired():
                     raise SecurityError(


### PR DESCRIPTION
Python open() uses locale-dependent encoding by default. On systems with non-UTF-8 locale (e.g. Windows cp1252), reading PID files, certificates, and auth keys can fail or produce corrupted data.

Fixed 3 files in celery/production code:
- platforms.py: PID file read/write (2 calls)
- security/certificate.py: PEM certificate loading (1 call)
- security/__init__.py: SSL key and cert loading (2 calls)