### PR TITLE
Update the docker build environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING=UTF-8
@@ -67,7 +67,9 @@ USER $CELERY_USER
 RUN curl https://pyenv.run | bash
 
 # Install required Python versions
-RUN pyenv install 3.13 && \
+
+RUN pyenv install 3.14 && \
+    pyenv install 3.13 && \
     pyenv install 3.12 && \
     pyenv install 3.11 && \
     pyenv install 3.10 && \
@@ -75,7 +77,7 @@ RUN pyenv install 3.13 && \
 
 
 # Set global Python versions
-RUN pyenv global 3.13 3.12 3.11 3.10 pypy3.11
+RUN pyenv global 3.14 3.13 3.12 3.11 3.10 pypy3.11
 
 # Install celery
 WORKDIR $HOME
@@ -84,9 +86,10 @@ COPY --chown=1000:1000 docker/entrypoint /entrypoint
 RUN chmod gu+x /entrypoint
 
 # Define the local pyenvs
-RUN pyenv local 3.13 3.12 3.11 3.10 pypy3.11
+RUN pyenv local 3.14 3.13 3.12 3.11 3.10 pypy3.11
 
 RUN --mount=type=cache,target=/home/$CELERY_USER/.cache/pip \
+    pyenv exec python3.14 -m pip install --upgrade pip setuptools wheel && \
     pyenv exec python3.13 -m pip install --upgrade pip setuptools wheel && \
     pyenv exec python3.12 -m pip install --upgrade pip setuptools wheel && \
     pyenv exec python3.11 -m pip install --upgrade pip setuptools wheel && \
@@ -95,6 +98,18 @@ RUN --mount=type=cache,target=/home/$CELERY_USER/.cache/pip \
 
 # Install requirements first to leverage Docker layer caching
 # Split into separate RUN commands to reduce memory pressure and improve layer caching
+
+RUN --mount=type=cache,target=/home/$CELERY_USER/.cache/pip \
+    pyenv exec python3.14 -m pip install -r requirements/default.txt \
+    -r requirements/dev.txt \
+    -r requirements/docs.txt \
+    -r requirements/pkgutils.txt \
+    -r requirements/test-ci-base.txt \
+    -r requirements/test-ci-default.txt \
+    -r requirements/test-integration.txt \
+    -r requirements/test.txt \
+    --build-constraint requirements/constraints.txt
+
 RUN --mount=type=cache,target=/home/$CELERY_USER/.cache/pip \
     pyenv exec python3.13 -m pip install -r requirements/default.txt \
     -r requirements/dev.txt \
@@ -154,6 +169,7 @@ COPY --chown=1000:1000 . $HOME/celery
 
 # Install celery in editable mode (dependencies already installed above)
 RUN --mount=type=cache,target=/home/$CELERY_USER/.cache/pip \
+    pyenv exec python3.14 -m pip install --no-deps -e $HOME/celery && \
     pyenv exec python3.13 -m pip install --no-deps -e $HOME/celery && \
     pyenv exec python3.12 -m pip install --no-deps -e $HOME/celery && \
     pyenv exec python3.11 -m pip install --no-deps -e $HOME/celery && \


### PR DESCRIPTION
Update to Debian 13 (trixie-slim), and add pyenv 3.14 support.

I plan to refactore entirly the `Dockerfile` to use python base images. Will do this ASAP.