### PR TITLE
Remove dependency on unmaintained click-plugins package (#9719)

### DIFF
--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -320,6 +320,49 @@ class LogLevel(click.Choice):
         value = super().convert(value, param, ctx)
         return mlevel(value)
 
+class BrokenCommand(click.Command):
+    """Placeholder for a CLI plugin that could not be loaded.
+
+    Rather than crash the CLI when a broken plugin is loaded, this class provides a help message informing the user that the plugin is broken
+    and they should contact the author.
+    """
+
+    def __init__(self, name):
+        click.Command.__init__(self, name)
+        import os
+        import traceback
+        util_name = os.path.basename(__import__('sys').argv and __import__('sys').argv[0] or __file__)
+        self.help = (
+            "\nWarning: entry point could not be loaded. Contact "
+            "its author for help.\n\n\b\n" + traceback.format_exc()
+        )
+        self.short_help = (
+            "\u2020 Warning: could not load plugin. See `%s %s --help`."
+            % (util_name, self.name)
+        )
+
+    def invoke(self, ctx):
+        click.echo(self.help, color=ctx.color)
+        ctx.exit(1)
+
+    def parse_args(self, ctx, args):
+        return args
+
+
+def with_plugins(plugins):
+    """Decorator to register entry-point plugins on a :class:`click.Group`.
+
+    Replaces the unmaintained ``click-plugins`` package.
+    """
+    def decorator(group):
+        for ep in plugins or ():
+            try:
+                group.add_command(ep.load())
+            except Exception:
+                group.add_command(BrokenCommand(ep.name))
+        return group
+    return decorator
+
 
 JSON_ARRAY = JsonArray()
 JSON_OBJECT = JsonObject()

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -8,12 +8,11 @@ from importlib.metadata import entry_points
 import click
 import click.exceptions
 from click_didyoumean import DYMGroup
-from celery.bin.base import BrokenCommand, with_plugins
 
 from celery import VERSION_BANNER
 from celery.app.utils import find_app
 from celery.bin.amqp import amqp
-from celery.bin.base import CeleryCommand, CeleryOption, CLIContext
+from celery.bin.base import BrokenCommand, CeleryCommand, CeleryOption, CLIContext, with_plugins
 from celery.bin.beat import beat
 from celery.bin.call import call
 from celery.bin.control import control, inspect, status

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -8,7 +8,7 @@ from importlib.metadata import entry_points
 import click
 import click.exceptions
 from click_didyoumean import DYMGroup
-from click_plugins import with_plugins
+from celery.bin.base import BrokenCommand, with_plugins
 
 from celery import VERSION_BANNER
 from celery.app.utils import find_app

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -4,7 +4,6 @@ vine>=5.1.0,<6.0
 click>=8.1.2,<9.0
 click-didyoumean>=0.3.0
 click-repl>=0.2.0
-click-plugins>=1.1.1
 python-dateutil>=2.8.2
 exceptiongroup>=1.3.0; python_version < '3.11'
 tzlocal

--- a/t/unit/bin/test_base.py
+++ b/t/unit/bin/test_base.py
@@ -1,0 +1,71 @@
+"""Tests for celery.bin.base — specifically the plugin loading utilities."""
+import click
+import pytest
+from unittest.mock import MagicMock
+
+from celery.bin.base import BrokenCommand, with_plugins
+
+
+class test_with_plugins:
+    def test_registers_valid_plugin(self):
+        @click.command()
+        def my_plugin():
+            """A test plugin."""
+
+        ep = MagicMock()
+        ep.name = "my_plugin"
+        ep.load.return_value = my_plugin
+
+        @with_plugins([ep])
+        @click.group()
+        def cli():
+            pass
+
+        assert "my-plugin" in cli.commands
+
+    def test_broken_plugin_registers_broken_command(self):
+        ep = MagicMock()
+        ep.name = "broken_plugin"
+        ep.load.side_effect = Exception("plugin load failed")
+
+        @with_plugins([ep])
+        @click.group()
+        def cli():
+            pass
+
+        assert "broken_plugin" in cli.commands
+        assert isinstance(cli.commands["broken_plugin"], BrokenCommand)
+
+    def test_none_plugins_is_handled(self):
+        @with_plugins(None)
+        @click.group()
+        def cli():
+            pass
+
+        assert cli.commands == {}
+
+    def test_empty_plugins_is_handled(self):
+        @with_plugins([])
+        @click.group()
+        def cli():
+            pass
+
+        assert cli.commands == {}
+
+
+class test_broken_command:
+    def test_short_help_contains_warning(self):
+        cmd = BrokenCommand("bad_plugin")
+        assert "Warning" in cmd.short_help
+
+    def test_invoke_exits_with_error(self):
+        from click.testing import CliRunner
+
+        @click.group()
+        def cli():
+            pass
+
+        cli.add_command(BrokenCommand("bad_plugin"))
+        runner = CliRunner()
+        result = runner.invoke(cli, ["bad_plugin"])
+        assert result.exit_code == 1

--- a/t/unit/bin/test_base.py
+++ b/t/unit/bin/test_base.py
@@ -1,7 +1,8 @@
 """Tests for celery.bin.base — specifically the plugin loading utilities."""
+from unittest.mock import MagicMock
+
 import click
 import pytest
-from unittest.mock import MagicMock
 
 from celery.bin.base import BrokenCommand, with_plugins
 


### PR DESCRIPTION
Fixes #9719

## Problem
`click-plugins` has been unmaintained for 6+ years and is incompatible with click 8.2.0, blocking users from upgrading click past 8.1.x.

## Fix
Inline the `with_plugins()` decorator and `BrokenCommand` class directly into `celery/bin/base.py`, alongside the other Click customizations that already live there (`CeleryCommand`, `CeleryOption`, etc.). Import from there in `celery/bin/celery.py`.

The implementation is functionally identical to `click-plugins`:
- `with_plugins()` iterates entry points and registers them as subcommands
- `BrokenCommand` gracefully handles plugins that fail to load

Removes `click-plugins` from `requirements/default.txt`.

## Tests
Added `t/unit/bin/test_base.py` with 6 tests covering:
- Valid plugin registration
- Broken plugin graceful handling  
- None/empty plugin iterables
- BrokenCommand help text and exit code