### PR TITLE
Apply backend retry policy to all DatabaseBackend DB operations

### DIFF
--- a/celery/backends/database/__init__.py
+++ b/celery/backends/database/__init__.py
@@ -122,7 +122,7 @@ class DatabaseBackend(BaseBackend):
 
     def _create_tables(self):
         """Create the task and taskset tables."""
-        self.ResultSession()
+        self._ensure_retryable(self.ResultSession)
 
     def ResultSession(self, session_manager=None):
         if session_manager is None:
@@ -189,6 +189,10 @@ class DatabaseBackend(BaseBackend):
 
         .. versionadded:: 5.7.0
         """
+        return self._ensure_retryable(
+            self._task_result_exists, task_id=task_id)
+
+    def _task_result_exists(self, task_id):
         session = self.ResultSession()
         with session_cleanup(session):
             return session.query(self.task_cls).filter(
@@ -232,6 +236,9 @@ class DatabaseBackend(BaseBackend):
 
     def cleanup(self):
         """Delete expired meta-data."""
+        self._ensure_retryable(self._cleanup)
+
+    def _cleanup(self):
         session = self.ResultSession()
         expires = self.expires
         now = self.app.now()

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -225,6 +225,80 @@ class test_DatabaseBackend:
         assert call_count[0] == 2
         assert tb._sleep.call_count == 1
 
+    def test_cleanup_retries_on_database_error(self):
+        """Test that cleanup retries when database errors occur."""
+        from celery.backends.database import DatabaseError
+
+        self.app.conf.result_backend_always_retry = True
+        self.app.conf.result_backend_max_retries = 2
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tb._sleep = Mock()
+
+        original_cleanup = tb._cleanup
+        call_count = [0]
+
+        def failing_cleanup(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise DatabaseError("temporary failure", None, None)
+            return original_cleanup(*args, **kwargs)
+
+        tb._cleanup = failing_cleanup
+
+        tb.cleanup()
+        assert call_count[0] == 2
+        assert tb._sleep.call_count == 1
+
+    def test_task_result_exists_retries_on_database_error(self):
+        """Test that task_result_exists retries when database errors occur."""
+        from celery.backends.database import DatabaseError
+
+        self.app.conf.result_backend_always_retry = True
+        self.app.conf.result_backend_max_retries = 2
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tb._sleep = Mock()
+
+        tb.store_result('task_id_exists', {'result': 'value'}, states.SUCCESS)
+
+        original = tb._task_result_exists
+        call_count = [0]
+
+        def failing(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise DatabaseError("temporary failure", None, None)
+            return original(*args, **kwargs)
+
+        tb._task_result_exists = failing
+
+        assert tb.task_result_exists('task_id_exists') is True
+        assert call_count[0] == 2
+        assert tb._sleep.call_count == 1
+
+    def test_create_tables_retries_on_database_error(self):
+        """Test that _create_tables retries when ResultSession() fails."""
+        from celery.backends.database import DatabaseError
+
+        self.app.conf.result_backend_always_retry = True
+        self.app.conf.result_backend_max_retries = 2
+        tb = DatabaseBackend(self.uri, app=self.app)
+        tb._sleep = Mock()
+
+        original = tb.ResultSession
+        call_count = [0]
+
+        def failing(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise DatabaseError("engine init failure", None, None)
+            return original(*args, **kwargs)
+
+        tb.ResultSession = failing
+
+        tb._create_tables()
+        assert call_count[0] == 2
+        assert tb._sleep.call_count == 1
+
     def test_retries_respect_max_retries_config(self):
         """Test that retries stop after max_retries is reached."""
         from celery.backends.database import DatabaseError


### PR DESCRIPTION
## Summary

The SQLAlchemy `DatabaseBackend` already routes `_store_result`,
`_get_task_meta_for`, `_save_group`, `_restore_group`, `_delete_group`,
and `_forget` through `BaseBackend._ensure_retryable`, so they retry on
transient DB errors with exponential backoff and invalidate the session
via `on_backend_retryable_error`.

Three remaining methods that also open a session and run SQL were not
routed through the same retry path:

- `_create_tables` — called during `__init__` when
  `database_create_tables_at_setup` is enabled; an engine/connection
  hiccup at process start would propagate immediately.
- `task_result_exists` — runs a `SELECT` but had no
  retry coverage, unlike `get_task_meta` which retries.
- `cleanup` — runs two `DELETE` statements and a `commit`; a transient
  failure midway just bubbles up.

This PR wraps all three in `self._ensure_retryable(...)` so the full
public surface of `DatabaseBackend` honours the
`result_backend_always_retry` / `result_backend_max_retries` /
`result_backend_{base,max}_sleep_between_retries_ms` settings
consistently.

## Changes

- `celery/backends/database/__init__.py`
  - `_create_tables` now calls `self._ensure_retryable(self.ResultSession)`.
  - `task_result_exists` delegates the query to a new private
    `_task_result_exists` invoked through `_ensure_retryable`.
  - `cleanup` delegates the deletes to a new private `_cleanup`
    invoked through `_ensure_retryable`.
- `t/unit/backends/test_database.py`
  - Adds three tests (one per newly-wrapped method) following the
    existing `test_*_retries_on_database_error` pattern.

## Behaviour notes

- `DatabaseBackend.__init__` already overrides `always_retry=True` and
  `max_retries=3` to preserve historical behaviour, so default users
  immediately benefit from retry coverage on these three methods without
  any configuration change. Users who explicitly set
  `result_backend_always_retry=False` keep the old fail-fast semantics.
- No public API or signature changes.
- No new configuration settings.

## Tests

`python3 -m pytest t/unit/backends/test_database.py -q` → 77 passed
(74 existing + 3 new).

## Checklist

- [x] Includes tests covering the change.
- [x] No public API changes; no docs update required.
- [x] No new configuration settings.

Drafted-by: Claude Code (Opus 4.7)