### PR TITLE
Fix worker consuming unexpected queues after connection loss

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -81,7 +81,7 @@ class Queues(dict):
         for name, q in queues.items():
             self.add(q) if isinstance(q, Queue) else self.add_compat(name, **q)
         # The default set of queues to consume from if no -Q option is set.
-        self._consume_from = {**self}
+        self._default_consume_from = {**self}
 
     def __getitem__(self, name):
         try:
@@ -165,6 +165,8 @@ class Queues(dict):
         q = self.add(queue, **kwargs)
         if self._consume_from is not None:
             self._consume_from[q.name] = q
+        else:
+            self._default_consume_from[q.name] = q
         return q
 
     def select(self, include):
@@ -215,7 +217,7 @@ class Queues(dict):
     def consume_from(self):
         if self._consume_from is not None:
             return self._consume_from
-        return self
+        return self._default_consume_from
 
 
 class AMQP:

--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -80,6 +80,8 @@ class Queues(dict):
         queues = queues or {}
         for name, q in queues.items():
             self.add(q) if isinstance(q, Queue) else self.add_compat(name, **q)
+        # The default set of queues to consume from if no -Q option is set.
+        self._consume_from = {**self}
 
     def __getitem__(self, name):
         try:

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -95,6 +95,12 @@ class test_Queues:
         q.select_add('baz')
         assert sorted(q._consume_from.keys()) == ['bar', 'baz', 'foo']
 
+    def test_select_add_without_selection_extends_default(self):
+        q = Queues([Queue('default')])
+        q.select_add('worker.dq2')
+        assert q._consume_from is None
+        assert sorted(q.consume_from.keys()) == ['default', 'worker.dq2']
+
     def test_deselect(self):
         q = Queues()
         q.select(['foo', 'bar'])

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -641,23 +641,21 @@ class test_Consumer(ConsumerTestCase):
                     c.ensure_connected(conn)
 
     def test_recreated_task_consumer_does_not_consume_late_added_queue(self):
-        self.app.conf.worker_detect_quorum_queues = False
         default_queue = self.app.conf.task_default_queue
-        consumer = Mock()
-        consumer.app = self.app
-        consumer.initial_prefetch_count = 16
-        consumer.update_strategies = Mock()
-        consumer.on_decode_error = Mock()
 
-        tasks = Tasks(consumer)
-        with self.app.pool.acquire(block=True) as con:
-            consumer.connection = con
-            tasks.start(consumer)
-            assert {q.name for q in consumer.task_consumer.queues} == {default_queue}
+        def _fake_consumer(channel, *, accept=None, queues=None, **kwargs):
+            c = Mock()
+            c.queues = queues
+            return c
 
-            self.app.amqp.queues.add('next')
-            tasks.start(consumer)
-            assert {q.name for q in consumer.task_consumer.queues} == {default_queue}
+        with patch.object(self.app.amqp, 'Consumer', side_effect=_fake_consumer):
+            with self.app.pool.acquire(block=True) as con:
+                task_consumer = self.app.amqp.TaskConsumer(con)
+                assert {q.name for q in task_consumer.queues} == {default_queue}
+
+                self.app.amqp.queues.add('next')
+                task_consumer = self.app.amqp.TaskConsumer(con)
+                assert {q.name for q in task_consumer.queues} == {default_queue}
 
     def test_disable_prefetch_not_enabled(self):
         """Test that disable_prefetch doesn't affect behavior when disabled"""

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -640,6 +640,25 @@ class test_Consumer(ConsumerTestCase):
                 with pytest.raises(ConnectionError):
                     c.ensure_connected(conn)
 
+    def test_recreated_task_consumer_does_not_consume_late_added_queue(self):
+        self.app.conf.worker_detect_quorum_queues = False
+        default_queue = self.app.conf.task_default_queue
+        consumer = Mock()
+        consumer.app = self.app
+        consumer.initial_prefetch_count = 16
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+
+        tasks = Tasks(consumer)
+        with self.app.pool.acquire(block=True) as con:
+            consumer.connection = con
+            tasks.start(consumer)
+            assert {q.name for q in consumer.task_consumer.queues} == {default_queue}
+
+            self.app.amqp.queues.add('next')
+            tasks.start(consumer)
+            assert {q.name for q in consumer.task_consumer.queues} == {default_queue}
+
     def test_disable_prefetch_not_enabled(self):
         """Test that disable_prefetch doesn't affect behavior when disabled"""
         self.app.conf.worker_disable_prefetch = False


### PR DESCRIPTION
## Description

Fixes https://github.com/celery/celery/issues/9462

When the connection to the broker is disconnected, the worker will try to recreate a `TaskConsumer` and looks up the queues to consume from:
```python
@property
def consume_from(self):
    if self._consume_from is not None:
        return self._consume_from
    return self
```
However, if no `-Q` option is set, `self._consume_from` would be None and `app.amqp.queues` is returned, which can include queues added only for routing.