### PR TITLE
Clarify gevent pool selection in 5.x upgrade docs

### DIFF
--- a/docs/history/whatsnew-5.0.rst
+++ b/docs/history/whatsnew-5.0.rst
@@ -123,6 +123,19 @@ Instead, they must be positioned as an option for the `celery` command like so::
 If you were using our :ref:`daemonizing` guide to deploy Celery in production,
 you should revisit it for updates.
 
+If you use the gevent or eventlet worker pool, select it on the worker
+command line too, for example::
+
+    celery --app path.to.app worker --pool=gevent
+
+Do not rely on calling ``gevent.monkey.patch_all()`` or
+``eventlet.monkey_patch()`` from your application as a substitute for
+``-P gevent``/``--pool=gevent`` or ``-P eventlet``/``--pool=eventlet``.
+The worker needs the pool selection during startup so Celery can apply the
+required patches before worker components are imported. If you launch Celery
+through a wrapper, apply any manual monkey patches before importing Celery and
+still select the matching worker pool with ``-P``/``--pool``.
+
 Step 2: Update your configuration with the new setting names
 ------------------------------------------------------------
 

--- a/docs/history/whatsnew-5.1.rst
+++ b/docs/history/whatsnew-5.1.rst
@@ -144,6 +144,19 @@ Instead, they must be positioned as an option for the `celery` command like so::
 If you were using our :ref:`daemonizing` guide to deploy Celery in production,
 you should revisit it for updates.
 
+If you use the gevent or eventlet worker pool, select it on the worker
+command line too, for example::
+
+    celery --app path.to.app worker --pool=gevent
+
+Do not rely on calling ``gevent.monkey.patch_all()`` or
+``eventlet.monkey_patch()`` from your application as a substitute for
+``-P gevent``/``--pool=gevent`` or ``-P eventlet``/``--pool=eventlet``.
+The worker needs the pool selection during startup so Celery can apply the
+required patches before worker components are imported. If you launch Celery
+through a wrapper, apply any manual monkey patches before importing Celery and
+still select the matching worker pool with ``-P``/``--pool``.
+
 Step 2: Update your configuration with the new setting names
 ------------------------------------------------------------
 

--- a/docs/history/whatsnew-5.3.rst
+++ b/docs/history/whatsnew-5.3.rst
@@ -106,6 +106,19 @@ Instead, they must be positioned as an option for the `celery` command like so::
 If you were using our :ref:`daemonizing` guide to deploy Celery in production,
 you should revisit it for updates.
 
+If you use the gevent or eventlet worker pool, select it on the worker
+command line too, for example::
+
+    celery --app path.to.app worker --pool=gevent
+
+Do not rely on calling ``gevent.monkey.patch_all()`` or
+``eventlet.monkey_patch()`` from your application as a substitute for
+``-P gevent``/``--pool=gevent`` or ``-P eventlet``/``--pool=eventlet``.
+The worker needs the pool selection during startup so Celery can apply the
+required patches before worker components are imported. If you launch Celery
+through a wrapper, apply any manual monkey patches before importing Celery and
+still select the matching worker pool with ``-P``/``--pool``.
+
 Step 2: Update your configuration with the new setting names
 ------------------------------------------------------------
 

--- a/docs/history/whatsnew-5.4.rst
+++ b/docs/history/whatsnew-5.4.rst
@@ -106,6 +106,19 @@ Instead, they must be positioned as an option for the `celery` command like so::
 If you were using our :ref:`daemonizing` guide to deploy Celery in production,
 you should revisit it for updates.
 
+If you use the gevent or eventlet worker pool, select it on the worker
+command line too, for example::
+
+    celery --app path.to.app worker --pool=gevent
+
+Do not rely on calling ``gevent.monkey.patch_all()`` or
+``eventlet.monkey_patch()`` from your application as a substitute for
+``-P gevent``/``--pool=gevent`` or ``-P eventlet``/``--pool=eventlet``.
+The worker needs the pool selection during startup so Celery can apply the
+required patches before worker components are imported. If you launch Celery
+through a wrapper, apply any manual monkey patches before importing Celery and
+still select the matching worker pool with ``-P``/``--pool``.
+
 Step 2: Update your configuration with the new setting names
 ------------------------------------------------------------
 

--- a/docs/history/whatsnew-5.5.rst
+++ b/docs/history/whatsnew-5.5.rst
@@ -97,6 +97,19 @@ Instead, they must be positioned as an option for the `celery` command like so::
 If you were using our :ref:`daemonizing` guide to deploy Celery in production,
 you should revisit it for updates.
 
+If you use the gevent or eventlet worker pool, select it on the worker
+command line too, for example::
+
+    celery --app path.to.app worker --pool=gevent
+
+Do not rely on calling ``gevent.monkey.patch_all()`` or
+``eventlet.monkey_patch()`` from your application as a substitute for
+``-P gevent``/``--pool=gevent`` or ``-P eventlet``/``--pool=eventlet``.
+The worker needs the pool selection during startup so Celery can apply the
+required patches before worker components are imported. If you launch Celery
+through a wrapper, apply any manual monkey patches before importing Celery and
+still select the matching worker pool with ``-P``/``--pool``.
+
 Step 2: Update your configuration with the new setting names
 ------------------------------------------------------------
 

--- a/docs/history/whatsnew-5.6.rst
+++ b/docs/history/whatsnew-5.6.rst
@@ -96,6 +96,19 @@ Instead, they must be positioned as an option for the `celery` command like so::
 If you were using our :ref:`daemonizing` guide to deploy Celery in production,
 you should revisit it for updates.
 
+If you use the gevent or eventlet worker pool, select it on the worker
+command line too, for example::
+
+    celery --app path.to.app worker --pool=gevent
+
+Do not rely on calling ``gevent.monkey.patch_all()`` or
+``eventlet.monkey_patch()`` from your application as a substitute for
+``-P gevent``/``--pool=gevent`` or ``-P eventlet``/``--pool=eventlet``.
+The worker needs the pool selection during startup so Celery can apply the
+required patches before worker components are imported. If you launch Celery
+through a wrapper, apply any manual monkey patches before importing Celery and
+still select the matching worker pool with ``-P``/``--pool``.
+
 Step 2: Update your configuration with the new setting names
 ------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #10067.

Clarifies in the 5.x upgrade guides that gevent/eventlet worker pools still need to be selected with `-P`/`--pool` at worker startup. It also notes that application-level monkey patching does not replace selecting the worker pool.

## Tests

- `git diff --check`

Not run: full docs build.
