### PR TITLE
fix: handle spring-forward DST gap in make_aware() (#10322)

### DIFF
--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -335,6 +335,15 @@ def _can_detect_ambiguous(tz: tzinfo) -> bool:
     return isinstance(tz, ZoneInfo) or hasattr(tz, "is_ambiguous")
 
 
+def _is_nonexistent(dt: datetime, tz: tzinfo) -> bool:
+    """Helper to determine if a datetime falls in a spring-forward DST gap.
+
+    Returns False if the timezone cannot detect non-existent times, or if the
+    datetime exists, otherwise True. Mirrors _is_ambiguous() but uses
+    dateutil.datetime_exists() which returns False for DST gap times.
+    """
+    return _can_detect_ambiguous(tz) and not dateutil_tz.datetime_exists(dt)
+
 def _is_ambiguous(dt: datetime, tz: tzinfo) -> bool:
     """Helper function to determine if a timezone is ambiguous using python's dateutil module.
 
@@ -354,6 +363,10 @@ def make_aware(dt: datetime, tz: tzinfo) -> datetime:
     dt = dt.replace(tzinfo=tz)
     if _is_ambiguous(dt, tz):
         dt = min(dt.replace(fold=0), dt.replace(fold=1))
+    elif _is_nonexistent(dt, tz):
+        # Spring-forward gap: this local time does not exist.
+        # Advance to the post-transition instant by using fold=1.
+        dt = dt.replace(fold=1)
     return dt
 
 

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -12,9 +12,10 @@ else:
     from backports.zoneinfo import ZoneInfo
 
 from celery.utils.iso8601 import parse_iso8601
-from celery.utils.time import (LocalTimezone, delta_resolution, ffwd, get_exponential_backoff_interval,
-                               humanize_seconds, localize, make_aware, maybe_iso8601, maybe_make_aware,
-                               maybe_timedelta, rate, remaining, timezone, utcoffset, _is_nonexistent)
+from celery.utils.time import (LocalTimezone, _is_nonexistent, delta_resolution, ffwd,
+                               get_exponential_backoff_interval, humanize_seconds, localize, make_aware,
+                               maybe_iso8601, maybe_make_aware, maybe_timedelta, rate, remaining, timezone,
+                               utcoffset)
 
 
 class test_LocalTimezone:

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -14,7 +14,7 @@ else:
 from celery.utils.iso8601 import parse_iso8601
 from celery.utils.time import (LocalTimezone, delta_resolution, ffwd, get_exponential_backoff_interval,
                                humanize_seconds, localize, make_aware, maybe_iso8601, maybe_make_aware,
-                               maybe_timedelta, rate, remaining, timezone, utcoffset)
+                               maybe_timedelta, rate, remaining, timezone, utcoffset, _is_nonexistent)
 
 
 class test_LocalTimezone:
@@ -256,6 +256,22 @@ class test_make_aware:
         assert maybe_make_aware(eastern).tzinfo is tz
         utcnow = datetime.now()
         assert maybe_make_aware(utcnow, 'UTC').tzinfo is ZoneInfo("UTC")
+
+    def test_spring_forward_dst_gap(self):
+        """make_aware() should advance non-existent times to post-transition."""
+        tz = ZoneInfo("US/Eastern")
+        # March 10, 2024: clocks spring forward at 2:00 AM -> 3:00 AM
+        # 2:30 AM does not exist in US/Eastern on this date
+        non_existent_dt = datetime(2024, 3, 10, 2, 30, 0)
+        result = make_aware(non_existent_dt, tz)
+        # After fix, fold=1 gives EDT offset (-04:00), not EST (-05:00)
+        offset = result.utcoffset()
+        assert offset == timedelta(hours=-4), (
+            f"Expected EDT offset (-04:00) for spring-forward gap, got {offset}"
+        )
+        # UTC equivalent: 2:30 EDT (fold=1) = 06:30 UTC
+        utc_result = result.astimezone(_timezone.utc)
+        assert utc_result.hour == 6, f"Expected UTC hour 6, got {utc_result.hour}"
 
 
 class test_localize:


### PR DESCRIPTION
## Problem

`make_aware()` in `celery/utils/time.py` silently mishandles spring-forward DST gaps. When a naive datetime falls in a spring-forward gap (e.g., 2:30 AM on March 10, 2024 in US/Eastern where clocks jump 2:00→3:00 AM), `dt.replace(tzinfo=tz)` attaches the timezone with no correction. ZoneInfo uses `fold=0` (default), which applies the pre-transition UTC offset (EST -05:00) instead of the correct post-transition offset (EDT -04:00). This causes the datetime to be shifted 1 hour wrong in UTC.

**Impact:** crontab schedules can skip or fire 1 hour late during spring-forward DST transitions.

## Root Cause

`make_aware()` handles fall-back DST (ambiguous times) via `_is_ambiguous()` but has NO check for spring-forward DST gaps (non-existent times).

## Fix

1. Add `_is_nonexistent()` helper function mirroring `_is_ambiguous()` but using `dateutil_tz.datetime_exists()` (negated) to detect non-existent times.
2. Add `elif _is_nonexistent(dt, tz)` branch in `make_aware()` that applies `fold=1` to advance to the post-transition instant.
3. Add conformant regression test `test_spring_forward_dst_gap()` in `test_make_aware` class.

## Files Changed
- `celery/utils/time.py` — source fix (add `_is_nonexistent()` + elif branch)
- `t/unit/utils/test_time.py` — conformant regression test

## Testing
- New test verifies EDT offset (-04:00) is used for spring-forward gap times
- Existing tests preserved (no behavior change for valid times or fall-back DST)