### PR TITLE
`prefork` is not safe anymore

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -352,6 +352,7 @@ NAMESPACES = Namespace(
         pool=Option(DEFAULT_POOL),
         pool_putlocks=Option(True, type='bool'),
         pool_restarts=Option(False, type='bool'),
+        pool_start_method=Option('fork', type='string'),
         proc_alive_timeout=Option(4.0, type='float'),
         prefetch_multiplier=Option(4, type='int'),
         eta_task_limit=Option(None, type='int'),

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -236,6 +236,16 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
               help_group="Pool Options",
               help="Maximum number of tasks a pool worker can execute before "
                    "it's terminated and replaced by a new worker.")
+@click.option('--pool-start-method',
+              type=click.Choice(['fork', 'spawn']),
+              cls=CeleryOption,
+              help_group="Pool Options",
+              help="Start method used to create prefork pool child "
+                   "processes. 'fork' (default) is faster and shares memory "
+                   "copy-on-write but is unsafe with threads/C-extensions; "
+                   "'spawn' starts each child in a fresh interpreter. "
+                   "'spawn' is not supported with the asynchronous prefork "
+                   "pool.")
 @click.option('--max-memory-per-child',
               type=int,
               cls=CeleryOption,

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -6,7 +6,7 @@ import os
 import threading
 import time
 
-from billiard import forking_enable
+from billiard import forking_enable, set_start_method
 from billiard.common import REMAP_SIGTERM, TERM_SIGNAME
 from billiard.pool import CLOSE, RUN
 from billiard.pool import Pool as BlockingPool
@@ -102,7 +102,15 @@ class TaskPool(BasePool):
     write_stats = None
 
     def on_start(self):
-        forking_enable(self.forking_enable)
+        if self.forking_enable:
+            forking_enable(True)
+        else:
+            # billiard's forking_enable(False) maps to the legacy execv
+            # mechanism, which depends on the optional _billiard C extension
+            # and is unavailable on CPython 3 (always warns and silently
+            # stays on fork). Use the modern 'spawn' start method instead,
+            # which is implemented in pure Python and actually takes effect.
+            set_start_method('spawn', force=True)
         Pool = (self.BlockingPool if self.options.get('threads', True)
                 else self.Pool)
         proc_alive_timeout = (

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -110,6 +110,14 @@ class TaskPool(BasePool):
             # and is unavailable on CPython 3 (always warns and silently
             # stays on fork). Use the modern 'spawn' start method instead,
             # which is implemented in pure Python and actually takes effect.
+            #
+            # Each spawned child is a fresh interpreter and therefore must
+            # re-run the worker optimizations (task registry shortcut used by
+            # fast_trace_task, Django model validation, etc.). The rest of
+            # Celery keys this "fresh interpreter" behavior off the
+            # FORKED_BY_MULTIPROCESSING environment variable (historically set
+            # by billiard's execv path), so set it for the spawned children.
+            os.environ['FORKED_BY_MULTIPROCESSING'] = '1'
             set_start_method('spawn', force=True)
         Pool = (self.BlockingPool if self.options.get('threads', True)
                 else self.Pool)

--- a/celery/worker/components.py
+++ b/celery/worker/components.py
@@ -141,6 +141,14 @@ class Pool(bootsteps.StartStopStep):
         if w.app.conf.worker_pool in GREEN_POOLS:  # pragma: no cover
             warnings.warn(UserWarning(W_POOL_SETTING), stacklevel=2)
         threaded = not w.use_eventloop or IS_WINDOWS
+        # The async pool (AsynPool) cannot start its children with the
+        # 'spawn' start method, so reject the combination as early as
+        # possible instead of failing later with an opaque error.
+        if not threaded and w.pool_start_method == 'spawn':
+            raise ImproperlyConfigured(
+                "worker_pool_start_method='spawn' is not supported when the "
+                "asynchronous prefork pool is used (broker transport with an "
+                "event loop). Use worker_pool_start_method='fork' instead.")
         procs = w.min_concurrency
         w.process_task = w._process_task
         if not threaded:
@@ -163,7 +171,7 @@ class Pool(bootsteps.StartStopStep):
             threads=threaded,
             max_restarts=max_restarts,
             allow_restart=allow_restart,
-            forking_enable=True,
+            forking_enable=w.pool_start_method == 'fork',
             semaphore=semaphore,
             sched_strategy=self.optimization,
             app=w.app,

--- a/celery/worker/worker.py
+++ b/celery/worker/worker.py
@@ -368,7 +368,8 @@ class WorkController:
                        max_tasks_per_child=None,
                        prefetch_multiplier=None, disable_rate_limits=None,
                        worker_lost_wait=None,
-                       max_memory_per_child=None, **_kw):
+                       max_memory_per_child=None,
+                       pool_start_method=None, **_kw):
         either = self.app.either
         self.loglevel = loglevel
         self.logfile = logfile
@@ -385,6 +386,13 @@ class WorkController:
         self.autoscaler_cls = either('worker_autoscaler', autoscaler_cls)
         self.pool_putlocks = either('worker_pool_putlocks', pool_putlocks)
         self.pool_restarts = either('worker_pool_restarts', pool_restarts)
+        self.pool_start_method = either(
+            'worker_pool_start_method', pool_start_method,
+        )
+        if self.pool_start_method not in ('fork', 'spawn'):
+            raise ImproperlyConfigured(
+                "worker_pool_start_method must be 'fork' or 'spawn', "
+                f"got {self.pool_start_method!r}.")
         self.statedb = either('worker_state_db', statedb, state_db)
         self.schedule_filename = either(
             'beat_schedule_filename', schedule_filename,

--- a/docs/getting-started/backends-and-brokers/gcpubsub.rst
+++ b/docs/getting-started/backends-and-brokers/gcpubsub.rst
@@ -110,6 +110,23 @@ using the :setting:`broker_transport_options` setting::
 
     broker_transport_options = {'queue_name_prefix': 'kombu-'}
 
+.. _gcpubsub-pool-start-method:
+
+Pool start method
+-----------------
+
+The Pub/Sub driver uses gRPC, which starts background C threads that are
+**not fork-safe**. With the default ``fork`` start method a child process can
+inherit corrupted gRPC/TLS state -- for example after a hard
+:setting:`task_time_limit` kill, the replacement child may hang. It is
+therefore recommended to start the prefork pool children with the ``spawn``
+method so each child gets a clean interpreter::
+
+    worker_pool_start_method = "spawn"
+
+See :setting:`worker_pool_start_method` and
+:ref:`optimizing-pool-start-method` for the trade-offs.
+
 .. _gcpubsub-results-configuration:
 
 Results

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -4184,6 +4184,36 @@ Default: Disabled by default.
 If enabled the worker pool can be restarted using the
 :control:`pool_restart` remote control command.
 
+.. setting:: worker_pool_start_method
+
+``worker_pool_start_method``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.6
+
+Default: ``"fork"``.
+
+Start method used to create the child processes of the prefork pool. Only
+meaningful for the prefork pool; ignored by the eventlet/gevent/solo pools.
+
+- ``"fork"`` (default): children are created with ``fork()``. This is fast,
+  and shares the parent's already-imported modules and memory copy-on-write,
+  but is **unsafe** when the parent process has started threads or uses
+  C-extensions that are not fork-safe (for example gRPC, ``psycopg`` or
+  CUDA), and can deadlock or corrupt state in the children.
+- ``"spawn"``: each child is started in a fresh Python interpreter. This is
+  safe in the presence of threads and fork-unsafe C-extensions, at the cost
+  of slower start-up, higher memory usage, and the requirement that the app
+  and task arguments are picklable and that your entry point is guarded by
+  ``if __name__ == '__main__':``.
+
+.. warning::
+
+    ``"spawn"`` is **not supported** when the asynchronous prefork pool is
+    used (i.e. when the broker transport drives the event loop, which is the
+    common case for AMQP/Redis). The worker raises
+    :exc:`~celery.exceptions.ImproperlyConfigured` at start-up in that case.
+
 .. setting:: worker_autoscaler
 
 ``worker_autoscaler``

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -4189,7 +4189,7 @@ If enabled the worker pool can be restarted using the
 ``worker_pool_start_method``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.6
+.. versionadded:: 5.7
 
 Default: ``"fork"``.
 

--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -220,6 +220,42 @@ only be able to process a maximum of 60 tasks per minute (assuming the task ran
 instantly). A similar issue can occur when your tasks always exceed
 :setting:`worker_max_memory_per_child`.
 
+.. _optimizing-pool-start-method:
+
+Pool start method (fork vs spawn)
+---------------------------------
+
+By default the prefork pool creates its child processes with ``fork()``
+(:setting:`worker_pool_start_method` set to ``"fork"``). Forking is fast and
+lets children share the parent's already-imported modules and memory through
+copy-on-write, which is why it is the default and the right choice for most
+deployments.
+
+Forking is, however, **unsafe when the parent process has started threads or
+relies on C-extensions that are not fork-safe**. Common offenders are gRPC
+(used by some Google Cloud client libraries), ``psycopg`` and CUDA. After a
+``fork()`` only the forking thread survives in the child, while locks held by
+other threads remain locked forever, which typically shows up as children that
+hang, deadlock, or crash with corrupted internal state -- especially after a
+hard :setting:`task_time_limit` kill replaces a child.
+
+If you hit these problems, set :setting:`worker_pool_start_method` to
+``"spawn"`` so each child starts in a fresh interpreter::
+
+    worker_pool_start_method = "spawn"
+
+The trade-offs of ``"spawn"`` are slower start-up, higher memory usage (no
+copy-on-write sharing), and the requirement that your app and task arguments
+are picklable and that your worker entry point is guarded by
+``if __name__ == '__main__':``.
+
+.. note::
+
+    ``"spawn"`` only works with the synchronous prefork pool. When the broker
+    transport drives the event loop (the asynchronous prefork pool, used by
+    AMQP/Redis), the worker refuses to start with
+    :setting:`worker_pool_start_method` set to ``"spawn"``.
+
 
 .. rubric:: Footnotes
 

--- a/t/unit/app/test_defaults.py
+++ b/t/unit/app/test_defaults.py
@@ -43,9 +43,8 @@ class test_defaults:
         assert find('task_default_exchange')[2] is None
 
     def test_worker_pool_start_method_default(self):
-        find = self.defaults.find
-
-        assert find('worker_pool_start_method')[2].default == 'fork'
+        assert self.defaults.NAMESPACES['worker']['pool_start_method'].default == 'fork'
+        assert self.defaults.DEFAULTS['worker_pool_start_method'] == 'fork'
 
     @property
     def defaults(self):

--- a/t/unit/app/test_defaults.py
+++ b/t/unit/app/test_defaults.py
@@ -42,6 +42,11 @@ class test_defaults:
         assert find('default_queue')[2].default == 'celery'
         assert find('task_default_exchange')[2] is None
 
+    def test_worker_pool_start_method_default(self):
+        find = self.defaults.find
+
+        assert find('worker_pool_start_method')[2].default == 'fork'
+
     @property
     def defaults(self):
         return import_module('celery.app.defaults')

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -942,3 +942,23 @@ class test_TaskPool:
         pool = TaskPool(4, app=app)
         pool.on_start()
         assert pool._pool._proc_alive_timeout == 8.0
+
+    @patch('celery.concurrency.prefork.set_start_method')
+    @patch('celery.concurrency.prefork.forking_enable')
+    def test_on_start_fork(self, _forking_enable, _set_start_method):
+        app = Mock(conf=AttributeDict(DEFAULTS))
+        pool = TaskPool(4, app=app, forking_enable=True)
+        pool.BlockingPool = Mock()
+        pool.on_start()
+        _forking_enable.assert_called_once_with(True)
+        _set_start_method.assert_not_called()
+
+    @patch('celery.concurrency.prefork.set_start_method')
+    @patch('celery.concurrency.prefork.forking_enable')
+    def test_on_start_spawn(self, _forking_enable, _set_start_method):
+        app = Mock(conf=AttributeDict(DEFAULTS))
+        pool = TaskPool(4, app=app, forking_enable=False)
+        pool.BlockingPool = Mock()
+        pool.on_start()
+        _set_start_method.assert_called_once_with('spawn', force=True)
+        _forking_enable.assert_not_called()

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -953,12 +953,17 @@ class test_TaskPool:
         _forking_enable.assert_called_once_with(True)
         _set_start_method.assert_not_called()
 
+    @patch.dict(os.environ, clear=False)
     @patch('celery.concurrency.prefork.set_start_method')
     @patch('celery.concurrency.prefork.forking_enable')
     def test_on_start_spawn(self, _forking_enable, _set_start_method):
+        os.environ.pop('FORKED_BY_MULTIPROCESSING', None)
         app = Mock(conf=AttributeDict(DEFAULTS))
         pool = TaskPool(4, app=app, forking_enable=False)
         pool.BlockingPool = Mock()
         pool.on_start()
         _set_start_method.assert_called_once_with('spawn', force=True)
         _forking_enable.assert_not_called()
+        # spawned children must be flagged as fresh interpreters so they
+        # re-run setup_worker_optimizations in process_initializer.
+        assert os.environ.get('FORKED_BY_MULTIPROCESSING') == '1'

--- a/t/unit/worker/test_components.py
+++ b/t/unit/worker/test_components.py
@@ -81,6 +81,41 @@ class test_Pool:
 
         assert comp.instantiate.call_args[1]['max_memory_per_child'] == 32
 
+    @t.skip.if_win32
+    def test_create_forking_enable_fork(self):
+        w = Mock()
+        w.use_eventloop = w.pool_putlocks = w.pool_cls.uses_semaphore = True
+        w.pool_start_method = 'fork'
+        comp = Pool(w)
+        comp.instantiate = Mock()
+
+        comp.create(w)
+
+        assert comp.instantiate.call_args[1]['forking_enable'] is True
+
+    def test_create_forking_enable_spawn(self):
+        w = Mock()
+        w.use_eventloop = False
+        w.pool_putlocks = w.pool_cls.uses_semaphore = True
+        w.pool_start_method = 'spawn'
+        comp = Pool(w)
+        comp.instantiate = Mock()
+
+        comp.create(w)
+
+        assert comp.instantiate.call_args[1]['forking_enable'] is False
+
+    @t.skip.if_win32
+    def test_create_spawn_with_async_pool_raises(self):
+        w = Mock()
+        w.use_eventloop = w.pool_putlocks = w.pool_cls.uses_semaphore = True
+        w.pool_start_method = 'spawn'
+        comp = Pool(w)
+        comp.instantiate = Mock()
+
+        with pytest.raises(ImproperlyConfigured):
+            comp.create(w)
+
 
 class test_Beat:
 

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -726,6 +726,17 @@ class test_WorkController(ConsumerCase):
     def test_on_consumer_ready(self):
         self.worker.on_consumer_ready(Mock())
 
+    def test_pool_start_method_default(self):
+        assert self.worker.pool_start_method == 'fork'
+
+    def test_pool_start_method_spawn(self):
+        worker = self.create_worker(pool_start_method='spawn')
+        assert worker.pool_start_method == 'spawn'
+
+    def test_pool_start_method_invalid(self):
+        with pytest.raises(ImproperlyConfigured):
+            self.create_worker(pool_start_method='forkserver')
+
     def test_setup_queues_worker_direct(self):
         self.app.conf.worker_direct = True
         self.app.amqp.__dict__['queues'] = Mock()


### PR DESCRIPTION
#  `prefork` is not safe anymore

Table of content:
 - A proof/reproducer showing that `prefork` is unsafe
 - Why `prefork` is no longer safe
 - Why this trade-off was fine before, and why it is not anymore
 - `prefork` can be safe again
 -  How this PR partially fixes the issue
 - Testing the PR on the reproducer

## A proof/reproducer showing that `prefork` is unsafe

Setup a test env:

```bash
mkdir /tmp/celery-gcpubsub && cd /tmp/celery-gcpubsub
uv init
uv add celery[gcpubsub] google-cloud-iam google-cloud-monitoring google-cloud-pubsub
```

Some info about the environment:

```
celery 5.6.3 (recovery)
Python 3.10.19
uv 0.10.2
Linux lheureduthe 6.12.73 #1-NixOS SMP PREEMPT_DYNAMIC Mon Feb 16 16:09:13 UTC 2026 x86_64 GNU/Linux
```

Write `tasks.py`:

```python
from celery import Celery
import random
import time
import faulthandler, signal

faulthandler.register(signal.SIGUSR2, all_threads=True)

app = Celery('tasks', broker='gcpubsub://projects/consio-development/')
app.conf.task_default_queue = 'a_qdu_reproducer'
app.conf.task_default_exchange = 'a_qdu_reproducer'
app.conf.task_default_routing_key = 'a_qdu_reproducer'

@app.task
def dummy():
    print("dummy task")

@app.task(time_limit=2, acks_late=True)
def complex():
    print("progress is made...")
    dummy.delay()
    time.sleep(3600)
```

Write `main.py`

```python
from tasks import dummy, complex, app
import logging
import time

def main():
    print("Hello from gcpubsub!")
    for i in range(100):
        print(complex.delay())
    time.sleep(50)

if __name__ == "__main__":
    main()
```

Start worker following [official grpc recommendations](https://github.com/grpc/grpc/blob/master/doc/fork_support.md):

```bash
export GRPC_POLL_STRATEGY=poll
export GRPC_ENABLE_FORK_SUPPORT=true
uv run celery -A tasks worker \
  --without-gossip \
  --without-mingle \
  --without-heartbeat  \
  --loglevel=DEBUG \
  --concurrency 1
```

Send tasks to worker:

```
uv run main.py
```

Note that the worker becomes stuck with this log (no more progress is made, worker can't process tasks anymore):

```
I0603 16:40:02.202568  154246 fork_posix.cc:71] Other threads are currently calling into gRPC, skipping fork() handlers
I0603 16:40:02.208759  154425 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(20, generation: 1)
I0603 16:40:02.208894  154425 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(18, generation: 1)
I0603 16:40:02.208916  154425 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(16, generation: 1)
I0603 16:40:02.208929  154425 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(14, generation: 1)
```

<details><summary> Full trace </summary>

```
[2026-06-03 16:39:59,182: INFO/MainProcess] Task tasks.complex[730876e3-52c8-49ab-843b-50d1dec25994] received
[2026-06-03 16:39:59,182: DEBUG/MainProcess] TaskPool: Apply <function fast_trace_task at 0x7fffe8b09bd0> (args:('tasks.complex', '730876e3-52c8-49ab-843b-50d1dec25994', {'lang': 'py', 'task': 'tasks.complex', 'id': '730876e3-52c8-49ab-843b-50d1dec25994', 'shadow': None, 'eta': None, 'expires': None, 'group': None, 'group_index': None, 'retries': 0, 'timelimit': [2, None], 'root_id': '730876e3-52c8-49ab-843b-50d1dec25994', 'parent_id': None, 'argsrepr': '()', 'kwargsrepr': '{}', 'origin': 'gen151142@lheureduthe', 'ignore_result': False, 'replaced_task_nesting': 0, 'stamped_headers': None, 'stamps': {}, 'properties': {'correlation_id': '730876e3-52c8-49ab-843b-50d1dec25994', 'reply_to': '5cfba92a-eb5b-384e-ae2a-ac9216a34e38', 'delivery_mode': 2, 'delivery_info': {'exchange': '', 'routing_key': 'a_qdu_reproducer', 'gcpubsub_message': {'queue': 'kombu-a_qdu_reproducer', 'ack_id': 'UAYWLF1GSFE3GQhoUQ5PXiM_NSAoRRcECBQFfH13Ulh1WFkaB1ENGXJ8aCBiDkYAChZTLVVaEw5iXE5EB0mC0MKcV1dLWxoIAEZUeVdfGAVsXVtzAVglp82fhZSBqQEbOX3ct--6LS2K7dpZZiI9XxJLLD5-PD9FQV5AEkw3CkRJUytDCypYEU4EISE-MD5FU0Q', 'message_id': '19923778438417669',... kwargs:{})
[2026-06-03 16:39:59,182: WARNING/ForkPoolWorker-1] progress is made...
[2026-06-03 16:39:59,185: INFO/ForkPoolWorker-1] new GCP pub/sub channel: gcpubsub://projects/consio-development/
[2026-06-03 16:39:59,185: INFO/ForkPoolWorker-1] unacked deadline extension thread: [154354] started
[2026-06-03 16:39:59,186: DEBUG/ForkPoolWorker-1] binding queue: kombu-a_qdu_reproducer to direct exchange: a_qdu_reproducer with routing_key: a_qdu_reproducer
[2026-06-03 16:40:01,606: ERROR/MainProcess] Task handler raised error: TimeLimitExceeded(2)
Traceback (most recent call last):
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/billiard/pool.py", line 684, in on_hard_timeout
    raise TimeLimitExceeded(job._timeout)
billiard.einfo.ExceptionWithTraceback:
"""
Traceback (most recent call last):
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/billiard/pool.py", line 684, in on_hard_timeout
    raise TimeLimitExceeded(job._timeout)
billiard.exceptions.TimeLimitExceeded: TimeLimitExceeded(2,)
"""
[2026-06-03 16:40:01,607: ERROR/MainProcess] Hard time limit (2s) exceeded for tasks.complex[ce54d38c-ece0-4e4e-a22d-8c75c4fce3be]
[2026-06-03 16:40:01,610: DEBUG/ForkPoolWorker-1] closing channel
[2026-06-03 16:40:01,610: INFO/ForkPoolWorker-1] unacked deadline extension thread [154354] stopped
[2026-06-03 16:40:02,200: ERROR/MainProcess] Process 'ForkPoolWorker-1' pid:154245 exited with 'signal 15 (SIGTERM)'
I0603 16:40:02.202568  154246 fork_posix.cc:71] Other threads are currently calling into gRPC, skipping fork() handlers
I0603 16:40:02.208759  154425 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(20, generation: 1)
I0603 16:40:02.208894  154425 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(18, generation: 1)
I0603 16:40:02.208916  154425 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(16, generation: 1)
I0603 16:40:02.208929  154425 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(14, generation: 1)
[2026-06-03 16:40:02,211: DEBUG/MainProcess] consuming message from queue: a_qdu_reproducer
[2026-06-03 16:40:02,212: INFO/MainProcess] Task tasks.complex[b60c91a2-0116-4729-bec8-9d89a31b5346] received
```

</details>

<details><summary>Other C lib errors</summary>

```
E0000 00:00:1780499591.762198  164829 ssl_transport_security_utils.cc:114] Corruption detected.
E0000 00:00:1780499591.762252  164829 ssl_transport_security_utils.cc:71] error:100003fc:SSL routines:OPENSSL_internal:SSLV3_ALERT_BAD_RECORD_MAC
E0000 00:00:1780499591.762260  164829 secure_endpoint.cc:243] Decryption error: TSI_DATA_CORRUPTED
```

</details>


When sending a SIGUSR2, we get this stacktrace (worker is stuck in grpc code):

```
Current thread 0x00007fffe5cff6c0 (most recent call first):
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/grpc/_channel.py", line 2200 in _close_on_fork
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/billiard/popen_fork.py", line 70 in _launch
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/billiard/popen_fork.py", line 22 in __init__
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/billiard/context.py", line 331 in _Popen
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/billiard/process.py", line 120 in start
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/billiard/pool.py", line 1158 in _create_worker_process
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/billiard/pool.py", line 1328 in _repopulate_pool
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/billiard/pool.py", line 1343 in _maintain_pool
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/billiard/pool.py", line 563 in body
  File "/tmp/gcpubsub/.venv/lib/python3.10/site-packages/billiard/pool.py", line 504 in run
  File "/home/quentin/.local/share/uv/python/cpython-3.10-linux-x86_64-gnu/lib/python3.10/threading.py", line 1016 in _bootstrap_inner
  File "/home/quentin/.local/share/uv/python/cpython-3.10-linux-x86_64-gnu/lib/python3.10/threading.py", line 973 in _bootstrap
```


*It might be tempting to not set the recommended variables, but from our experience processing 60 celery tasks/second, it will take less than a day to hit a similar issue where the worker will hang again. It's just harder to write a reproducer.*

## Why `prefork` is no longer safe

#### `fork()` copies memory, but not the resources that memory points to.

When the prefork pool spawns a child, the child receives a copy-on-write snapshot of the parent's address space — every Python object, every module global, every data structure. What it does not receive is the operating-system state those objects refer to. 

POSIX is explicit that after fork() in a multithreaded process, only the calling thread survives in the child, and the child may safely call almost nothing until it execs. 

Consider a trivial example: the parent opens a file/socket and stores its descriptor in a global list. The child inherits the list, and the integer 7 is still sitting there — but in the child, descriptor 7 either does not refer to the same thing, or refers to a connection now shared with (and concurrently used by) the parent. Read from it and you get an error, a corrupted stream, or a hang. The Python object survived the fork; the resource behind it did not.
  
#### Stale resource leakage is not theoretical, it is the default for modern dependency stacks, starting with gRPC. 

gRPC runs background C threads and [explicitly does not support `fork()`](https://github.com/grpc/grpc/blob/master/doc/fork_support.md). The crucial point for Celery users: you do not have to use gRPC in your tasks to be affected — gRPC is pulled in by infrastructure you almost certainly run. The gcpubsub broker (via google-cloud-pubsub) is built on gRPC, and the OpenTelemetry OTLP exporter uses gRPC. 

The list of widely-used libraries that are unsafe across fork() — because they either hold native state or run background threads — is long and growing: psycopg/psycopg2 (libpq), SQLAlchemy connection pools, pymongo (which now even warns and calls os.register_at_fork), redis/hiredis, OpenSSL (via cryptography/ssl), confluent-kafka (librdkafka), the numeric stack (numpy/scipy/scikit-learn on OpenBLAS/MKL/OpenMP), CUDA-backed torch/tensorflow, and pure-Python-but-threaded SDKs like the OpenTelemetry SDK, Sentry, and Datadog tracers. 

*The probability that a real-world Celery worker imports none of these is essentially zero.*
  
#### Asyncio or gevent are not the way out.

The reason the prefork pool exists is not just parallelism; it is the only model in Python that can safely interrupt running code. You cannot safely inject an exception into a thread (the interpreter only delivers it at a bytecode boundary, never inside a blocking C call), and asyncio/gevent cancellation is strictly cooperative: it works only if the task yields, which blocking or CPU-bound or C-level code never does. 

The only mechanism that reliably reclaims a task stuck in a recv(), a C extension, or an infinite loop is killing the OS process running it — which is exactly what prefork's hard time_limit does. Interrupting code is a hard requirement for any real timeout guarantee, and process-kill is the only thing that delivers it. 

*So "just use a different pool" is not an answer for anyone who needs timeouts.*

#### The existing mitigation hooks cannot close the gap.

The usual advice is "(re)create your unsafe resources in worker_process_init." But this only works for resources you can fully reset, and for some libraries (gRPC chief among them) there is no supported way to reset the inherited native state from inside the forked child. 

The second piece of advice points the other way: "defer initializing the control process's own dangerous libraries until after it has forked its executors, so the children fork from a still-clean parent". This can protect the initial batch of executors, since the pool is forked early in startup. But it cannot protect replacements, and replacements are the whole point: the hard time_limit kills a stuck executor and forks a fresh one on demand, during steady-state operation. By then the control process has necessarily initialized exactly the libraries you tried to defer — the broker connection (gcpubsub → gRPC) and the telemetry exporter (OpenTelemetry → gRPC) must be live for the worker to receive and observe work at all. So the replacement executor is forked from a parent that is now irreversibly "dirty," and it inherits the corrupted, fork-unsafe state.
  
We (at consio.ai) have observed exactly this in our production workload: healthy operation right up to the first hard-timeout kill, then a poisoned child is started and hangs forever due to a deadlock in grpc. 

*The feature you adopt `prefork` for is the feature that breaks it.*


## Why this trade-off was fine before, and why it is not anymore

#### The fork-without-exec trade-off was a reasonable bet in its era.

Forking is fast and memory-cheap: the child inherits the already-imported application and configuration via copy-on-write, so workers start instantly and share read-only pages. For a single-threaded process linked against a conservative libc/malloc and a handful of simple Python libraries, forking "just worked," and the performance and simplicity wins were real.
  
#### That bet no longer pays off, because the platform and the ecosystem moved underneath it.

Modern application stacks are full of background threads (telemetry, tracing, async clients) and native extensions that hold locks and own kernel resources, precisely the conditions under which fork-without-exec is unsafe. 
  
Python maintainers have now reached the same verdict. After a four-year discussion in [bpo-40379](https://bugs.python.org/issue40379), CPython **changed the default `multiprocessing` start method on POSIX away from `fork` in Python 3.14**. The issue is titled *"multiprocessing's default start method of `fork()`-without-`exec()` is broken."* 

The reporter, Itamar Turner-Trauring, opened it by noting that:

> \[fork-without-exec] can lead to inconsistent state in subprocesses... quite often \[as] silent lockups [and that] in real world usage, this results in users getting mysterious hangs they do not have the knowledge to debug [...] I would not say that 'fork' works on Linux either. More like '99% of the time it works, 1% it randomly breaks in mysterious way.

PyPy's Michał Górny concurred from hard experience: 

> This is a very bad default and what's even worse is that it often causes deadlocks that are hard to reproduce or debug.


The thread contains the exact failure we are describing: ravwojdyla reported that:

> gRPC client (which was buried deep into one of our dependencies) can hang in some cases when forked... very tricky to debug
  
In other words, the rest of the ecosystem has already concluded that fork-without-exec is the wrong default. Celery's prefork pool, by hardcoding fork, is now swimming against the language itself: keeping a default that delivers diminishing speed gains in exchange for rising, hard-to-diagnose corruption.


## `prefork` can be safe again

#### The fix is to give each child a fresh address space instead of a copy of the parent's. 

If the child starts from a clean interpreter, there is no inherited gRPC channel, no frozen lock, no stale
descriptor to corrupt; resources are created fresh and correctly in the child. The way to achieve a clean
address space while still using the fork-based worker model is the spawn start method: fork(), then execv() a brand-new Python interpreter in the child. This preserves everything that makes prefork valuable (a separate, killable OS process per task) while shedding the inherited-state hazard.

This capability already exists in billiard, it is simply not exposed. billiard ships full spawn/forkserver contexts (SpawnContext → popen_spawn_posix), and `set_start_method('spawn', force=True)` switches the pool over to them. The prefork pool already threads a forking_enable boolean from BasePool through to on_start, and the worker bootstep hardcodes `forking_enable=True`, so the value was the only thing standing in the way.

#### AsynPool is not compatible with billiard spawn method
 
Celery's hub-integrated AsynPool (used with asynchronous transports such as amqp and redis) communicates with workers over file descriptors that are set up in the parent and inherited across fork(); a spawned child cannot reproduce that wiring without a substantial rework. 

However, the synchronous transports (including gcpubsub) already run on billiard's plain blocking Pool, which is much closer to the standard-library pool and works naturally with a spawn start method. 

So the initial, safe, low-risk scope is: expose the knob, and recommend it for the blocking-pool/synchronous-transport path (the gcpubsub broker docs should explicitly recommend it, since gcpubsub is gRPC-based and therefore one of the most fork-hostile setups in the ecosystem).

#### Longer term, the truly robust design might be a dedicated "IPC" pool and dropping billiard legacy

Rather than fork-then-exec, the control process and the executor processes would be fully independent from birth (no shared address space at all) communicating over an explicit IPC channel such as a Unix socket. This is the architecture chosen by software with a hard reputation for reliability: Postfix and PostgreSQL both run as cooperating, isolated processes that talk over well-defined channels rather than sharing inherited memory, which is precisely what lets them survive the death of any single worker without corruption.  Such a pool would give Celery clean isolation and the hard-kill-for-timeout guarantee by design. 

## How this PR partially fixes the issue

  - **Expose the prefork start method as a Celery setting.** billiard allows to configure the pool as either being `fork` or `spawn`, but it was hardcoded as `fork` in Celery. We expose that choice through the new worker_pool_start_method setting (fork/spawn), naming the mechanism rather than a boolean so it leaves room for future methods (e.g. forkserver). It defaults to fork to preserve current behavior (non-breaking, no migration), and is wired through both config and a CLI flag (--pool-start-method).
  - **Drive spawn through the API that actually works on Python 3.** The pool's `on_start` now calls
    `set_start_method('spawn', force=True)` for the spawn case instead of the legacy `forking_enable(False)`
    execv path. As described above, `forking_enable(False)` is a no-op on CPython 3 (it depends on a C
    extension billiard never builds there and merely warns), whereas `set_start_method('spawn')` is pure
    Python and takes effect. The fork case keeps calling `forking_enable(True)` for backward compatibility reasons.
 - **Reject start methods the active pool can't support (e.g. AsynPool + spawn)**. Spawn is fundamentally
    incompatible with the asynchronous prefork pool (AsynPool). Rather than letting that surface later as
    an obscure hang/crash, the worker validates as early as the pool type is known and refuses to start,
    turning an undiagnosable runtime failure into an upfront, actionable error.
 - **Document the setting, when to tune it, and the gcpubsub case it most affects.** Document the setting
    itself (default, trade-offs, the AsynPool caveat); add optimization guidance on when to switch
    (threads / fork-unsafe C-extensions like gRPC, psycopg, CUDA) and its costs; and call it out on the
    gcpubsub page, since its gRPC driver isn't fork-safe and is the concrete case that motivates spawn.

## Testing the PR on the reproducer

First patch the `pyproject.toml` as follow:

```diff
diff --git a/pyproject.toml b/pyproject.toml
index ba9ca95..b314917 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,5 @@ dependencies = [
     "google-cloud-monitoring>=2.30.0",
     "google-cloud-pubsub>=2.38.0",
 ]
+[tool.uv.sources]
+celery = { git = "https://github.com/ConsioAi/celery", branch = "worker-spawn-instead-of-fork" }
```

Then run `uv sync`. You may restart the worker and **confirm** the error is still there.

Now, we'll fix the error by configuring the `worker_pool_start_method` parameter:

```diff
diff --git a/tasks.py b/tasks.py
index b30cfe3..8d3813d 100644
--- a/tasks.py
+++ b/tasks.py
@@ -9,6 +9,7 @@ app = Celery('tasks', broker='gcpubsub://projects/consio-development/')
 app.conf.task_default_queue = 'a_qdu_reproducer'
 app.conf.task_default_exchange = 'a_qdu_reproducer'
 app.conf.task_default_routing_key = 'a_qdu_reproducer'
+app.conf.worker_pool_start_method = 'spawn'

 @app.task
 def dummy():
```

Restart the worker, schedule some workloads. Now the worker does not hang anymore.

---

*Note: this work  was done as part of my job at [Consio.ai](https://consio.ai).*