### PR TITLE
fix: honor SIGTERM received during worker bootstep initialization

### DIFF
--- a/celery/bootsteps.py
+++ b/celery/bootsteps.py
@@ -81,6 +81,11 @@ class Blueprint:
         on_close (Callable): Optional callback applied before blueprint close.
         on_stopped (Callable): Optional callback applied after
             blueprint stopped.
+        shutdown_check (Callable): Optional callback invoked before each
+            bootstep starts.  Should raise :exc:`WorkerShutdown` or
+            :exc:`WorkerTerminate` when a shutdown signal was received,
+            so that initialization is aborted early instead of being
+            completed before the signal is honoured.
     """
 
     GraphFormatter = StepFormatter
@@ -97,12 +102,14 @@ class Blueprint:
     }
 
     def __init__(self, steps=None, name=None,
-                 on_start=None, on_close=None, on_stopped=None):
+                 on_start=None, on_close=None, on_stopped=None,
+                 shutdown_check=None):
         self.name = name or self.name or qualname(type(self))
         self.types = set(steps or []) | set(self.default_steps)
         self.on_start = on_start
         self.on_close = on_close
         self.on_stopped = on_stopped
+        self.shutdown_check = shutdown_check
         self.shutdown_complete = Event()
         self.steps = {}
 
@@ -111,6 +118,8 @@ class Blueprint:
         if self.on_start:
             self.on_start()
         for i, step in enumerate(s for s in parent.steps if s is not None):
+            if self.shutdown_check:
+                self.shutdown_check()
             self._debug('Starting %s', step.alias)
             self.started = i + 1
             step.start(parent)

--- a/celery/worker/worker.py
+++ b/celery/worker/worker.py
@@ -135,6 +135,7 @@ class WorkController:
             on_start=self.on_start,
             on_close=self.on_close,
             on_stopped=self.on_stopped,
+            shutdown_check=state.maybe_shutdown,
         )
         self.blueprint.apply(self, **kwargs)
 

--- a/t/unit/worker/test_bootsteps.py
+++ b/t/unit/worker/test_bootsteps.py
@@ -366,3 +366,47 @@ class test_Blueprint:
         x = MyBlueprint()
         x.apply(self)
         assert x._find_last() is None
+
+    def test_start_shutdown_check_fires_before_first_step(self):
+        """shutdown_check raising immediately prevents any step from starting."""
+        from celery.exceptions import WorkerShutdown
+
+        def always_abort():
+            raise WorkerShutdown(0)
+
+        parent = Mock()
+        step1 = Mock(name='step1')
+        parent.steps = [step1]
+
+        blueprint = self.Blueprint(shutdown_check=always_abort)
+
+        with pytest.raises(WorkerShutdown):
+            blueprint.start(parent)
+
+        step1.start.assert_not_called()
+
+    def test_start_shutdown_check_aborts_between_steps(self):
+        """shutdown_check fires after step 1, preventing step 2 from starting."""
+        from celery.exceptions import WorkerShutdown
+
+        step1_done = [False]
+
+        def on_step1_start(_parent):
+            step1_done[0] = True
+
+        def shutdown_check():
+            if step1_done[0]:
+                raise WorkerShutdown(0)
+
+        parent = Mock()
+        step1, step2 = Mock(name='step1'), Mock(name='step2')
+        step1.start.side_effect = on_step1_start
+        parent.steps = [step1, step2]
+
+        blueprint = self.Blueprint(shutdown_check=shutdown_check)
+
+        with pytest.raises(WorkerShutdown):
+            blueprint.start(parent)
+
+        step1.start.assert_called_once_with(parent)
+        step2.start.assert_not_called()


### PR DESCRIPTION
## Description

### Bug

After `on_start()` installs signal handlers, a SIGTERM sets `state.should_stop` — but `Blueprint.start()` continued iterating through all bootsteps calling `step.start(parent)` without ever consulting `maybe_shutdown()`. The flag is only checked once the event loop starts, so the worker fully initializes before honoring the signal.

Concretely: with a pool of N workers, the N child processes are forked, the broker connection is established, all consumer steps come up — and only then does the worker notice it was asked to stop.

### Fix

Add a `shutdown_check` callback to `Blueprint.__init__()` that is called **before each bootstep starts**. `WorkController` wires it to `state.maybe_shutdown`, so `WorkerShutdown`/`WorkerTerminate` propagates out of `Blueprint.start()` and is caught by the existing handlers in `WorkController.start()`:

- `WorkerShutdown` (warm/SIGTERM) → `except SystemExit as exc: self.stop(exitcode=exc.code)`
- `WorkerTerminate` (cold/SIGQUIT) → `except WorkerTerminate: self.terminate()`

`Blueprint.stop()` already has a fast path for the partial-init case (`started != len(steps)`) so no additional cleanup code is needed.

The `shutdown_check` parameter is `None` by default, so existing direct users of `Blueprint` (consumer blueprint, etc.) are unaffected.

### Changes

- `celery/bootsteps.py`: add `shutdown_check` to `Blueprint.__init__()` and call it before each step in `start()`
- `celery/worker/worker.py`: pass `shutdown_check=state.maybe_shutdown` when constructing the worker Blueprint
- `t/unit/worker/test_bootsteps.py`: two new tests — one verifying no steps start when the check fires immediately, one simulating SIGTERM mid-startup and asserting subsequent steps are skipped