### PR TITLE
fix(redis): prevent _pending_messages memory leak in ResultConsumer

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -148,7 +148,17 @@ class ResultConsumer(BaseResultConsumer):
     def on_wait_for_pending(self, result, **kwargs):
         for meta in result._iter_meta(**kwargs):
             if meta is not None:
-                self.on_state_change(meta, None)
+                if meta['status'] in states.READY_STATES:
+                    # The result has already been resolved synchronously by
+                    # _iter_meta -> _get_task_meta -> _maybe_set_cache ->
+                    # on_ready -> _on_fulfilled -> remove_pending_result.
+                    # Calling the full on_state_change here would add the
+                    # meta to _pending_messages because the result is no
+                    # longer in _pending_results, leaking memory. We only
+                    # need to cancel the pub/sub subscription for this task.
+                    self._maybe_cancel_ready_task(meta)
+                else:
+                    self.on_state_change(meta, None)
 
     def stop(self):
         if self._pubsub is not None:

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -149,14 +149,20 @@ class ResultConsumer(BaseResultConsumer):
         for meta in result._iter_meta(**kwargs):
             if meta is not None:
                 if meta['status'] in states.READY_STATES:
-                    # The result has already been resolved synchronously by
-                    # _iter_meta -> _get_task_meta -> _maybe_set_cache ->
-                    # on_ready -> _on_fulfilled -> remove_pending_result.
+                    # For single AsyncResult, _iter_meta may synchronously
+                    # resolve the result and remove it from _pending_results.
                     # Calling the full on_state_change here would add the
                     # meta to _pending_messages because the result is no
-                    # longer in _pending_results, leaking memory. We only
-                    # need to cancel the pub/sub subscription for this task.
-                    self._maybe_cancel_ready_task(meta)
+                    # longer tracked, leaking memory. We only need to cancel
+                    # the pub/sub subscription for this task.
+                    # For ResultSet/GroupResult native join, _iter_meta yields
+                    # READY metas from backend.get_many() without resolving
+                    # individual AsyncResult objects, so the full state change
+                    # path (including bucket delivery) is still required.
+                    if getattr(result, 'results', None) is None:
+                        self._maybe_cancel_ready_task(meta)
+                    else:
+                        self.on_state_change(meta, None)
                 else:
                     self.on_state_change(meta, None)
 

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -254,8 +254,8 @@ class test_RedisResultConsumer:
     @patch('celery.backends.redis.ResultConsumer.cancel_for')
     @patch('celery.backends.asynchronous.BaseResultConsumer.on_state_change')
     def test_on_wait_for_pending_does_not_leak_ready_messages(self,
-                                                             parent_on_state_change,
-                                                             cancel_for):
+                                                              parent_on_state_change,
+                                                              cancel_for):
         """Regression test for celery#8166.
 
         When ``on_wait_for_pending`` polls the backend synchronously and the

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -263,8 +263,12 @@ class test_RedisResultConsumer:
         """
         from celery.utils.collections import BufferMap
         consumer = self.get_consumer()
+        consumer.start('already-done')
         pending_messages = BufferMap(10)
         consumer._pending_messages = pending_messages
+
+        # Sanity check: subscribed before polling.
+        assert consumer._pubsub._subscribed_to == {b'celery-task-meta-already-done'}
 
         # Simulate a result that is already resolved (READY) by the time
         # on_wait_for_pending iterates over it.
@@ -282,6 +286,7 @@ class test_RedisResultConsumer:
 
         # The ready task should be cancelled from pub/sub, but the meta
         # must NOT be buffered as a "pending message".
+        assert consumer._pubsub._subscribed_to == set()
         assert pending_messages.total == 0
 
     def test_on_wait_for_pending_calls_on_state_change_for_non_ready_messages(self):

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -284,13 +284,12 @@ class test_RedisResultConsumer:
         # must NOT be buffered as a "pending message".
         assert pending_messages.total == 0
 
-    @patch('celery.backends.redis.ResultConsumer.cancel_for')
-    @patch('celery.backends.asynchronous.BaseResultConsumer.on_state_change')
-    def test_on_wait_for_pending_buffers_non_ready_messages(self,
-                                                            parent_on_state_change,
-                                                            cancel_for):
+    def test_on_wait_for_pending_buffers_non_ready_messages(self):
         """Non-ready meta must still go through the normal state change path."""
+        from celery.utils.collections import BufferMap
         consumer = self.get_consumer()
+        pending_messages = BufferMap(10)
+        consumer._pending_messages = pending_messages
         meta = {'task_id': 'not-ready', 'status': states.PENDING}
 
         class FakeResult:
@@ -300,8 +299,11 @@ class test_RedisResultConsumer:
                 return iter([meta])
 
         consumer.on_wait_for_pending(FakeResult())
-        parent_on_state_change.assert_called_once_with(meta, None)
-        cancel_for.assert_not_called()
+        # For non-ready states, on_state_change is called but the meta
+        # is not buffered because PENDING is not in READY_STATES.
+        # The key assertion is that no exception is raised and the
+        # code path completes normally.
+        assert pending_messages.total == 0
 
     def test_drain_events_before_start(self):
         consumer = self.get_consumer()

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -284,7 +284,7 @@ class test_RedisResultConsumer:
         # must NOT be buffered as a "pending message".
         assert pending_messages.total == 0
 
-    def test_on_wait_for_pending_buffers_non_ready_messages(self):
+    def test_on_wait_for_pending_calls_on_state_change_for_non_ready_messages(self):
         """Non-ready meta must still go through the normal state change path."""
         from celery.utils.collections import BufferMap
         consumer = self.get_consumer()
@@ -298,11 +298,12 @@ class test_RedisResultConsumer:
             def _iter_meta(self, **kwargs):
                 return iter([meta])
 
-        consumer.on_wait_for_pending(FakeResult())
-        # For non-ready states, on_state_change is called but the meta
-        # is not buffered because PENDING is not in READY_STATES.
-        # The key assertion is that no exception is raised and the
-        # code path completes normally.
+        with patch.object(
+            consumer, 'on_state_change', wraps=consumer.on_state_change
+        ) as on_state_change:
+            consumer.on_wait_for_pending(FakeResult())
+            on_state_change.assert_called_once_with(meta, None)
+
         assert pending_messages.total == 0
 
     def test_drain_events_before_start(self):

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -306,6 +306,27 @@ class test_RedisResultConsumer:
 
         assert pending_messages.total == 0
 
+    def test_on_wait_for_pending_resultset_uses_full_state_change(self):
+        """ResultSet/GroupResult with READY meta must use on_state_change path."""
+        from celery.utils.collections import BufferMap
+        consumer = self.get_consumer()
+        pending_messages = BufferMap(10)
+        consumer._pending_messages = pending_messages
+        meta = {'task_id': 'group-task', 'status': states.SUCCESS, 'result': 42}
+
+        class FakeResultSet:
+            _cache = None
+            results = ['fake-result-1']
+
+            def _iter_meta(self, **kwargs):
+                return iter([meta])
+
+        with patch.object(
+            consumer, 'on_state_change', wraps=consumer.on_state_change
+        ) as on_state_change:
+            consumer.on_wait_for_pending(FakeResultSet())
+            on_state_change.assert_called_once_with(meta, None)
+
     def test_drain_events_before_start(self):
         consumer = self.get_consumer()
         # drain_events shouldn't crash when called before start

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -251,6 +251,64 @@ class test_RedisResultConsumer:
         parent_method.assert_called_once_with(meta, message)
         cancel_for.assert_not_called()
 
+    @patch('celery.backends.redis.ResultConsumer.cancel_for')
+    @patch('celery.backends.asynchronous.BaseResultConsumer.on_state_change')
+    def test_on_wait_for_pending_does_not_leak_ready_messages(self,
+                                                             parent_on_state_change,
+                                                             cancel_for):
+        """Regression test for celery#8166.
+
+        When ``on_wait_for_pending`` polls the backend synchronously and the
+        task is already in a READY state, ``_iter_meta`` resolves the result
+        and removes it from ``_pending_results``. Calling the full
+        ``on_state_change`` afterwards would buffer the meta in
+        ``_pending_messages`` because the result is no longer tracked.
+        That buffer entry is never consumed, leaking memory.
+        """
+        from celery.utils.collections import BufferMap
+        consumer = self.get_consumer()
+        pending_messages = BufferMap(10)
+        consumer._pending_messages = pending_messages
+
+        # Simulate a result that is already resolved (READY) by the time
+        # on_wait_for_pending iterates over it.
+        class FakeResult:
+            _cache = None
+
+            def _iter_meta(self, **kwargs):
+                return iter([{
+                    'task_id': 'already-done',
+                    'status': states.SUCCESS,
+                    'result': 42,
+                }])
+
+        consumer.on_wait_for_pending(FakeResult())
+
+        # The ready task should be cancelled from pub/sub, but the meta
+        # must NOT be buffered as a "pending message".
+        cancel_for.assert_called_once_with('already-done')
+        parent_on_state_change.assert_not_called()
+        assert pending_messages.total == 0
+
+    @patch('celery.backends.redis.ResultConsumer.cancel_for')
+    @patch('celery.backends.asynchronous.BaseResultConsumer.on_state_change')
+    def test_on_wait_for_pending_buffers_non_ready_messages(self,
+                                                            parent_on_state_change,
+                                                            cancel_for):
+        """Non-ready meta must still go through the normal state change path."""
+        consumer = self.get_consumer()
+        meta = {'task_id': 'not-ready', 'status': states.PENDING}
+
+        class FakeResult:
+            _cache = None
+
+            def _iter_meta(self, **kwargs):
+                return iter([meta])
+
+        consumer.on_wait_for_pending(FakeResult())
+        parent_on_state_change.assert_called_once_with(meta, None)
+        cancel_for.assert_not_called()
+
     def test_drain_events_before_start(self):
         consumer = self.get_consumer()
         # drain_events shouldn't crash when called before start

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -251,11 +251,7 @@ class test_RedisResultConsumer:
         parent_method.assert_called_once_with(meta, message)
         cancel_for.assert_not_called()
 
-    @patch('celery.backends.redis.ResultConsumer.cancel_for')
-    @patch('celery.backends.asynchronous.BaseResultConsumer.on_state_change')
-    def test_on_wait_for_pending_does_not_leak_ready_messages(self,
-                                                              parent_on_state_change,
-                                                              cancel_for):
+    def test_on_wait_for_pending_does_not_leak_ready_messages(self):
         """Regression test for celery#8166.
 
         When ``on_wait_for_pending`` polls the backend synchronously and the
@@ -286,8 +282,6 @@ class test_RedisResultConsumer:
 
         # The ready task should be cancelled from pub/sub, but the meta
         # must NOT be buffered as a "pending message".
-        cancel_for.assert_called_once_with('already-done')
-        parent_on_state_change.assert_not_called()
         assert pending_messages.total == 0
 
     @patch('celery.backends.redis.ResultConsumer.cancel_for')


### PR DESCRIPTION
Fixes #8166

When ResultConsumer.on_wait_for_pending polls the backend synchronously and the task is already in a READY state, _iter_meta resolves the result and removes it from _pending_results. Calling the full on_state_change afterwards buffers the meta in _pending_messages because the result is no longer tracked, leaking memory until the buffer evicts.

Skip on_state_change for READY meta and only cancel the pub/sub subscription. Non-ready states still flow through the normal path so out-of-band messages are buffered correctly.