### PR TITLE
Explain prefetching with late acknowledgments

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3456,7 +3456,9 @@ when one of its processes is available.
 You can also enable this via the :option:`--disable-prefetch <celery worker --disable-prefetch>`
 command line flag.
 
-For more on prefetching, read :ref:`optimizing-prefetch-limit`
+For more on prefetching, including how this setting interacts with late
+acknowledgment when reserving one task at a time, read
+:ref:`optimizing-prefetch-limit`.
 
 .. setting:: worker_eta_task_limit
 

--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -170,8 +170,8 @@ there are worker processes, with the condition that they are acknowledged
 late (10 unacknowledged tasks executing for :option:`-c 10 <celery worker -c>`)
 
 This condition is required because, with the default early acknowledgment,
-a task is acknowledged as soon as the worker starts executing it. Once that
-happens, the executing task no longer counts as an unacknowledged reserved
+a task is acknowledged just-in-time before being executed. Once that happens,
+the task no longer counts as an unacknowledged reserved
 message, so the broker is allowed to deliver another message up to the
 prefetch limit. With late acknowledgment enabled, executing tasks remain
 unacknowledged until they finish, which means they continue to occupy the

--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -169,6 +169,14 @@ possible with a catch. You can have a worker only reserve as many tasks as
 there are worker processes, with the condition that they are acknowledged
 late (10 unacknowledged tasks executing for :option:`-c 10 <celery worker -c>`)
 
+This condition is required because, with the default early acknowledgment,
+a task is acknowledged as soon as the worker starts executing it. Once that
+happens, the executing task no longer counts as an unacknowledged reserved
+message, so the broker is allowed to deliver another message up to the
+prefetch limit. With late acknowledgment enabled, executing tasks remain
+unacknowledged until they finish, which means they continue to occupy the
+worker's prefetch slots and prevent extra tasks from being reserved.
+
 For that, you need to enable  :term:`late acknowledgment`. Using this option over the
 default behavior means a task that's already started executing will be
 retried in the event of a power failure or the worker instance being killed


### PR DESCRIPTION
Fixes #9279.

## Summary
- explain why reserving one task at a time requires late acknowledgment with `worker_prefetch_multiplier = 1`
- clarify the `worker_prefetch_multiplier` setting link to the optimizing guide

## Tests
- Python assertion check for the new docs text and reference
- `git diff --check -- docs/userguide/optimizing.rst docs/userguide/configuration.rst`
