### PR TITLE
fix: handle spring-forward DST gap in make_aware()

### DIFF
--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -352,8 +352,16 @@ def make_aware(dt: datetime, tz: tzinfo) -> datetime:
     """Set timezone for a :class:`~datetime.datetime` object."""
 
     dt = dt.replace(tzinfo=tz)
-    if _is_ambiguous(dt, tz):
-        dt = min(dt.replace(fold=0), dt.replace(fold=1))
+    if _can_detect_ambiguous(tz):
+        if not dateutil_tz.datetime_exists(dt):
+            # Spring-forward DST gap: this local time does not exist.
+            # Advance to the post-transition time by using fold=1,
+            # which picks the later UTC instant for non-existent times.
+            dt = dt.replace(fold=1)
+        elif dateutil_tz.datetime_ambiguous(dt):
+            # Fall-back DST: two wall-clock instants map to the same
+            # local time. Pick the earlier UTC instant (fold=0).
+            dt = min(dt.replace(fold=0), dt.replace(fold=1))
     return dt
 
 

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -257,6 +257,59 @@ class test_make_aware:
         utcnow = datetime.now()
         assert maybe_make_aware(utcnow, 'UTC').tzinfo is ZoneInfo("UTC")
 
+    def test_spring_forward_dst_gap(self):
+        """Spring-forward DST: non-existent local times advance with fold=1."""
+        tz = ZoneInfo('US/Eastern')
+        # March 8, 2026: clocks spring forward 2:00 AM → 3:00 AM EST→EDT
+        # 2:30 AM does not exist in US/Eastern on this date
+        dt = datetime(2026, 3, 8, 2, 30)
+        result = make_aware(dt, tz)
+        assert result.fold == 1
+        # Post-transition offset is EDT (UTC-4)
+        assert result.utcoffset() == timedelta(hours=-4)
+        # The UTC instant must be usable for comparison
+        utc = result.astimezone(ZoneInfo('UTC'))
+        assert utc.hour == 6
+        assert utc.minute == 30
+
+    def test_fall_back_dst_ambiguous(self):
+        """Fall-back DST: ambiguous times pick the earlier occurrence."""
+        tz = ZoneInfo('US/Eastern')
+        # Nov 1, 2026: clocks fall back 2:00 AM → 1:00 AM EDT→EST
+        # 1:30 AM occurs twice; we should pick the earlier (EDT, fold=0)
+        dt = datetime(2026, 11, 1, 1, 30)
+        result = make_aware(dt, tz)
+        assert result.fold == 0
+        # Earlier occurrence is EDT (UTC-4)
+        assert result.utcoffset() == timedelta(hours=-4)
+
+    def test_dst_normal_time_unaffected(self):
+        """Normal times outside DST transitions are unaffected."""
+        tz = ZoneInfo('US/Eastern')
+        dt = datetime(2026, 6, 15, 12, 0)
+        result = make_aware(dt, tz)
+        assert result.fold == 0
+        assert result.utcoffset() == timedelta(hours=-4)  # EDT
+
+    def test_dst_utc_timezone_unaffected(self):
+        """UTC timezone has no DST and is unaffected."""
+        dt = datetime(2026, 3, 8, 2, 30)
+        result = make_aware(dt, ZoneInfo('UTC'))
+        assert result.utcoffset() == timedelta(hours=0)
+
+    def test_spring_forward_exact_transition_edge(self):
+        """Exact transition time (2:00 AM) and post-gap time (3:00 AM)."""
+        tz = ZoneInfo('US/Eastern')
+        # 3:00 AM after the gap — should be a valid EDT time
+        dt = datetime(2026, 3, 8, 3, 0)
+        result = make_aware(dt, tz)
+        assert result.utcoffset() == timedelta(hours=-4)
+        # 2:00 AM — exact transition start, may be ambiguous
+        dt2 = datetime(2026, 3, 8, 2, 0)
+        result2 = make_aware(dt2, tz)
+        # The result should be a valid aware datetime regardless
+        assert result2.tzinfo is not None
+
 
 class test_localize:
 


### PR DESCRIPTION
## Problem

`make_aware()` only handled ambiguous (fall-back) DST times via `_is_ambiguous()`. Non-existent times during spring-forward DST transitions (e.g., 2:30 AM on the day clocks jump from 2:00 to 3:00) were not detected, causing the resulting aware datetime to carry the pre-transition UTC offset.

This caused crontab tasks scheduled during the spring-forward gap to fire one hour late (UTC) or be skipped entirely, because the scheduler's datetime comparisons used the wrong UTC mapping.

Closes: #10322

## Root Cause

Two issues in `make_aware()`:

1. `dateutil.tz.datetime_ambiguous(dt)` returns True for **both** ambiguous and non-existent times during DST transitions. The existing `_is_ambiguous()` check was matching non-existent times and applying the wrong correction (`min(fold=0, fold=1)` which keeps fold=0 — the pre-transition offset).

2. There was no check at all for non-existent times (spring-forward gap).

## Fix

Restructure `make_aware()` to check `datetime_exists()` **before** `datetime_ambiguous()`:

```python
def make_aware(dt, tz):
    dt = dt.replace(tzinfo=tz)
    if _can_detect_ambiguous(tz):
        if not dateutil_tz.datetime_exists(dt):
            # Spring-forward DST gap → fold=1 (post-transition)
            dt = dt.replace(fold=1)
        elif dateutil_tz.datetime_ambiguous(dt):
            # Fall-back DST → fold=0 (earlier occurrence)
            dt = min(dt.replace(fold=0), dt.replace(fold=1))
    return dt
```

## Tests

Added 5 tests covering:
- Spring-forward gap (non-existent time) → fold=1, EDT offset
- Fall-back ambiguous time → fold=0, EDT offset (earlier occurrence)
- Normal time outside DST transitions → unaffected
- UTC timezone → unaffected (no DST)
- Exact transition edges (2:00 AM and 3:00 AM)

`dateutil` (`python-dateutil>=2.8.2`) is already a required dependency.