### PR TITLE
Fix Consumer.on_close() wiping in-flight reservations and breaking worker_disable_prefetch

### DIFF
--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -535,10 +535,11 @@ class Consumer:
         for bucket in self.task_buckets.values():
             if bucket:
                 bucket.clear_pending()
-        for request_id in reserved_requests:
-            if request_id in requests:
-                del requests[request_id]
+        for r in tuple(reserved_requests):
+            if r not in active_requests:
+                requests.pop(r.id, None)
         reserved_requests.clear()
+        reserved_requests.update(tuple(active_requests))
         if self.pool and self.pool.flush:
             self.pool.flush()
 

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -509,6 +509,49 @@ class test_Consumer(ConsumerTestCase):
             c.pool = None
             c.on_close()
 
+    def test_on_close_purges_orphan_reservations_from_requests_dict(self):
+        """Regression: ``on_close()`` must remove ``state.requests[id]``
+        entries for Requests that were reserved but never accepted (e.g.
+        ETA tasks queued in ``reserved_requests`` at the moment of a
+        connection loss). PR #7771 attempted this but iterated
+        ``reserved_requests`` (Request objects) and tested membership in
+        ``requests`` (a ``dict[str, Request]``), so ``Request in requests``
+        was always False and nothing was ever deleted.
+        """
+        from celery.worker import state
+        from celery.worker.consumer.consumer import Consumer
+
+        class FakeRequest:
+            def __init__(self, id):
+                self.id = id
+
+        consumer = Mock()
+        consumer.controller = Mock()
+        consumer.controller.semaphore = Mock()
+        consumer.task_buckets = {}
+        consumer.pool = Mock()
+        consumer.pool.flush = Mock()
+
+        state.reset_state()
+        try:
+            # Orphan reservation: present in ``requests`` and
+            # ``reserved_requests`` but never moved to ``active_requests``.
+            orphan = FakeRequest('orphan-1')
+            state.requests[orphan.id] = orphan
+            state.reserved_requests.add(orphan)
+
+            Consumer.on_close(consumer)
+
+            assert orphan.id not in state.requests, (
+                "on_close() did not purge an orphan reserved-but-not-"
+                "accepted Request from state.requests; this is the leak "
+                "PR #7771 tried to fix but its loop variable ('request_id') "
+                "actually held Request objects, so the membership check "
+                "never matched."
+            )
+        finally:
+            state.reset_state()
+
     def test_connect_error_handler(self):
         self.app._connection = _amqp_connection()
         conn = self.app._connection.return_value
@@ -821,6 +864,87 @@ class test_Consumer(ConsumerTestCase):
 
             # Should not be able to consume when at autoscale limit
             assert consumer.task_consumer.channel.qos.can_consume() is False
+
+    def test_disable_prefetch_after_connection_loss_keeps_gate_closed(self):
+        """Regression: ``can_consume`` must still refuse new messages while a
+        task from before a broker reconnect is still running in the pool.
+
+        With ``worker_disable_prefetch`` enabled and concurrency=1, after a
+        channel/connection interruption ``Consumer.on_close()`` clears
+        ``state.reserved_requests``. The disable-prefetch gate then sees an
+        empty set and lets a new message through, even though the pool is
+        still busy with the in-flight task. The gate must remain closed.
+        """
+        from celery.worker import state
+        from celery.worker.consumer.consumer import Consumer
+        from celery.worker.consumer.tasks import Tasks
+
+        self.app.conf.worker_disable_prefetch = True
+
+        # Plain class so it supports weakref (Mock() does not, and WeakSet
+        # would silently reject it).
+        class FakeRequest:
+            def __init__(self, id):
+                self.id = id
+
+        consumer = Mock()
+        consumer.app = self.app
+        consumer.pool = Mock()
+        consumer.pool.num_processes = 1
+        consumer.pool.flush = Mock()
+        consumer.controller = Mock()
+        consumer.controller.max_concurrency = None
+        consumer.controller.semaphore = Mock()
+        consumer.task_buckets = {}
+        consumer.initial_prefetch_count = 1
+        consumer.connection = Mock()
+        consumer.connection.connection_errors = ()
+        consumer.connection.channel_errors = ()
+        consumer.connection.default_channel = Mock()
+        consumer.connection.transport = Mock()
+        consumer.connection.transport.driver_type = 'redis'
+        consumer.update_strategies = Mock()
+        consumer.on_decode_error = Mock()
+
+        consumer.task_consumer = Mock()
+        consumer.task_consumer.channel = Mock()
+        consumer.task_consumer.channel.qos = Mock()
+        consumer.task_consumer.channel.qos.can_consume = Mock(return_value=True)
+        consumer.task_consumer.qos = Mock()
+        consumer.app.amqp = Mock()
+        consumer.app.amqp.TaskConsumer = Mock(return_value=consumer.task_consumer)
+
+        # Install the disable-prefetch gate on the (mocked) channel.
+        Tasks(consumer).start(consumer)
+        can_consume = consumer.task_consumer.channel.qos.can_consume
+
+        state.reset_state()
+        try:
+            # One task running in the pool: by the normal lifecycle
+            # (task_reserved + task_accepted) it lives in BOTH sets.
+            in_flight = FakeRequest('task-1')
+            state.reserved_requests.add(in_flight)
+            state.active_requests.add(in_flight)
+
+            # Pre-condition: gate refuses; concurrency is 1 and slot is taken.
+            assert can_consume() is False
+
+            # Simulate a broker channel/connection interruption.
+            Consumer.on_close(consumer)
+
+            # Pool still has the task running — active_requests is
+            # intentionally not cleared by on_close(). The gate must still
+            # refuse so we don't over-fetch a second message into a
+            # concurrency=1 pool.
+            assert in_flight in state.active_requests
+            assert can_consume() is False, (
+                "After a connection loss, can_consume() returned True while "
+                "a task is still running in the pool. Consumer.on_close() "
+                "cleared reserved_requests, hiding the in-flight task from "
+                "the worker_disable_prefetch gate."
+            )
+        finally:
+            state.reset_state()
 
     def test_disable_prefetch_ignored_for_non_redis_brokers(self):
         """Test that disable_prefetch is ignored for non-Redis brokers."""


### PR DESCRIPTION
## Summary

`Consumer.on_close()` ran `reserved_requests.clear()` on every broker reconnect. Four call sites read that set — most visibly the `worker_disable_prefetch` gate (Redis), where it is the **only** concurrency limiter. Clearing it while a pool slot is still busy makes the gate report "free" and the worker pulls a second message off the queue into a concurrency=1 pool.

Additionally, the loop added in #7771 to also clean up `state.requests` was dead code: it iterated `Request` objects but checked membership against `requests` (a `dict[str, Request]`), so `Request in requests` was always `False` and nothing was ever deleted.

## Reproducer (Redis)

```python
app.conf.worker_disable_prefetch = True
# concurrency=1, one long-running task in flight
# kill broker connection -> Consumer.on_close() runs
# Before: can_consume() == True, second message fetched while pool busy
# After:  can_consume() == False until task_ready() fires
```

## Fix

Replace the unconditional `reserved_requests.clear()` with a rebuild from `active_requests`, so the set continues to reflect tasks that still occupy pool slots. Also iterate `reserved_requests` correctly to actually purge orphan entries (reserved-but-never-accepted, e.g. ETA tasks pending at disconnect) from `state.requests`:

```python
def on_close(self):
    if self.controller and self.controller.semaphore:
        self.controller.semaphore.clear()
    for bucket in self.task_buckets.values():
        if bucket:
            bucket.clear_pending()
    for r in tuple(reserved_requests):
        if r not in active_requests:
            requests.pop(r.id, None)
    reserved_requests.clear()
    reserved_requests.update(tuple(active_requests))
    if self.pool and self.pool.flush:
        self.pool.flush()
```

### Why rebuild from the live `active_requests`

`active_requests` is the authoritative set of tasks still holding a pool slot. A request is added to it (and gets `time_start`) in `Request.on_accepted`, and removed only by `task_ready`. Rebuilding `reserved_requests` from it keeps exactly the reservations that back running work, and drops the orphans the broker will redeliver.

### Interaction with `worker_cancel_long_running_tasks_on_connection_loss`

`on_connection_error_after_connected` runs **before** `on_close` and may call `request.cancel(self.pool)`. For any task that has started, `cancel()` synchronously calls `_announce_cancelled()` → `task_ready()`, which removes the request from **both** `active_requests` and `reserved_requests` and pops it from `state.requests`. So cancelled tasks are already gone by the time `on_close` runs, and the rebuild from `active_requests` correctly excludes them — no special-casing needed.

## Affected readers (impact summary)

| Reader | Symptom of the old `clear()` |
|---|---|
| `worker_disable_prefetch` gate (Redis) | **Hard correctness bug:** over-fetches into busy pool. |
| `Autoscaler.qty` | Spurious scale-down during reconnect window (`--autoscale` users). |
| `inspect reserved` / `is_reserved` revoke | Brief observability/control-plane lie during reconnect. |
| AMQP broker prefetch | Unaffected — broker enforces `basic.qos` server-side. |

## Tests

Two regression tests in `t/unit/worker/test_consumer.py`:

1. `test_on_close_purges_orphan_reservations_from_requests_dict` — locks in the leak that #7771 intended to fix.
2. `test_disable_prefetch_after_connection_loss_keeps_gate_closed` — the over-fetch scenario: `worker_disable_prefetch=True`, concurrency=1, in-flight task; `can_consume()` must remain `False` after `on_close()`.

Existing `test_on_close_clears_semaphore_and_reqs` continues to pass (we still call `reserved_requests.clear()` before re-populating).

## Backward compatibility

No public API change. `reserved_requests`, `active_requests`, and `state.requests` semantics are unchanged for the success path. Behavior change is strictly during the broker-reconnect window, where the new behavior matches the pre-existing intent of the four readers (a worker that has accepted a task into its pipeline still holds it as reserved).

Refs: #7771

Drafted-by: Claude Code (Opus 4.8)