### PR TITLE
Fix free worker stalling after broker reconnect (AsynPool.flush clearing _busy_workers)

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -1097,12 +1097,18 @@ class AsynPool(_pool.Pool):
             # worker) instead depends on still_busy including every accepted
             # job's executing fd, which is why we source it from
             # _write_to/_scheduled_for of the running job above.
+            #
+            # The proc._is_alive() guard keeps the set limited to workers that
+            # are actually still executing: a genuinely running accepted job
+            # always has a live worker, while a worker that died (whose fd may
+            # since have been reused by a fresh replacement) must not be
+            # re-counted as busy.
             still_busy = set()
             for job in self._cache.values():
                 if not job._accepted:
                     continue
                 proc = job._write_to or job._scheduled_for
-                if proc is not None:
+                if proc is not None and proc._is_alive():
                     still_busy.add(proc.inqW_fd)
             self._busy_workers.intersection_update(still_busy)
 

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -1081,7 +1081,7 @@ class AsynPool(_pool.Pool):
             self._active_writers.clear()
             self._active_writes.clear()
 
-            # Rebuild _busy_workers from the workers still executing an
+            # Trim _busy_workers down to the workers still executing an
             # accepted (running) job instead of clearing it outright, so the
             # fair scheduler keeps avoiding mid-task workers across a broker
             # reconnect. A worker is marked busy keyed on
@@ -1091,7 +1091,8 @@ class AsynPool(_pool.Pool):
             # _scheduled_for.
             #
             # intersection_update only ever removes fds from _busy_workers,
-            # never adds one, so the rebuild can't fabricate a phantom-busy
+            # never adds one (it filters the existing set rather than
+            # repopulating it), so this trim can't fabricate a phantom-busy
             # entry that would permanently sideline a healthy worker. Avoiding
             # double-booking (writing a second task onto a still-running
             # worker) instead depends on still_busy including every accepted

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -1080,7 +1080,13 @@ class AsynPool(_pool.Pool):
             self.outbound_buffer.clear()
             self._active_writers.clear()
             self._active_writes.clear()
-            self._busy_workers.clear()
+
+            still_busy = {
+                job._scheduled_for.inqW_fd
+                for job in self._cache.values()
+                if job._accepted and job._scheduled_for is not None
+            }
+            self._busy_workers.intersection_update(still_busy)
 
     def _flush_writer(self, proc, writer):
         fds = {proc.inq._writer}

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -1081,11 +1081,29 @@ class AsynPool(_pool.Pool):
             self._active_writers.clear()
             self._active_writes.clear()
 
-            still_busy = {
-                job._scheduled_for.inqW_fd
-                for job in self._cache.values()
-                if job._accepted and job._scheduled_for is not None
-            }
+            # Rebuild _busy_workers from the workers still executing an
+            # accepted (running) job instead of clearing it outright, so the
+            # fair scheduler keeps avoiding mid-task workers across a broker
+            # reconnect. A worker is marked busy keyed on
+            # job._scheduled_for.inqW_fd at write time; once the body has been
+            # written job._write_to points at the same process, so prefer it
+            # (the process actually executing the job) and fall back to
+            # _scheduled_for.
+            #
+            # intersection_update only ever removes fds from _busy_workers,
+            # never adds one, so the rebuild can't fabricate a phantom-busy
+            # entry that would permanently sideline a healthy worker. Avoiding
+            # double-booking (writing a second task onto a still-running
+            # worker) instead depends on still_busy including every accepted
+            # job's executing fd, which is why we source it from
+            # _write_to/_scheduled_for of the running job above.
+            still_busy = set()
+            for job in self._cache.values():
+                if not job._accepted:
+                    continue
+                proc = job._write_to or job._scheduled_for
+                if proc is not None:
+                    still_busy.add(proc.inqW_fd)
             self._busy_workers.intersection_update(still_busy)
 
     def _flush_writer(self, proc, writer):

--- a/t/smoke/tests/quorum_queues/test_qos.py
+++ b/t/smoke/tests/quorum_queues/test_qos.py
@@ -92,7 +92,7 @@ class test_quorum_qos_prefetch_reduction_skipped_on_reconnect:
         # Terminate in-flight acks_late tasks when the connection drops so
         # their pool slots are released before the reconnect. Without this
         # the original long-running tasks keep occupying their pool slots
-        # while the broker also redelivers them (acks_late); the original +
+        # while the broker also redelivers them (acks_late); the original and
         # redelivered copies then fill every pool process and the
         # post-restart probe task in
         # ``test_worker_resumes_consuming_after_broker_restart`` can never be

--- a/t/smoke/tests/quorum_queues/test_qos.py
+++ b/t/smoke/tests/quorum_queues/test_qos.py
@@ -89,17 +89,6 @@ class test_quorum_qos_prefetch_reduction_skipped_on_reconnect:
         # applies when reduction is enabled. We must NOT silently rely on
         # the user-discovered workaround of disabling it.
         app.conf.worker_enable_prefetch_count_reduction = True
-        # Terminate in-flight acks_late tasks when the connection drops so
-        # their pool slots are released before the reconnect. Without this
-        # the original long-running tasks keep occupying their pool slots
-        # while the broker also redelivers them (acks_late); the original and
-        # redelivered copies then fill every pool process and the
-        # post-restart probe task in
-        # ``test_worker_resumes_consuming_after_broker_restart`` can never be
-        # dispatched. The #9512 regression itself is asserted by
-        # ``test_skip_log_emitted_after_broker_restart`` through the skip log,
-        # which does not depend on this setting.
-        app.conf.worker_cancel_long_running_tasks_on_connection_loss = True
         return app
 
     # No RedisTestBroker xfail guard is needed: the ``quorum_queues/``
@@ -135,6 +124,39 @@ class test_quorum_qos_prefetch_reduction_skipped_on_reconnect:
         celery_setup.worker.assert_log_does_not_exist(
             "Temporarily reducing the prefetch count"
         )
+
+
+class test_quorum_qos_worker_resumes_after_reconnect:
+    """Liveness regression test for the celery/celery#9512 reconnect path.
+
+    Split from ``test_quorum_qos_prefetch_reduction_skipped_on_reconnect``
+    because it requires
+    ``worker_cancel_long_running_tasks_on_connection_loss`` to free pool
+    slots after the restart. Enabling that setting drains
+    ``active_requests`` on disconnect, which would mask the #9512
+    regression in the skip-log test, so the two scenarios use separate
+    worker apps.
+    """
+
+    @pytest.fixture
+    def default_worker_app(self, default_worker_app: Celery) -> Celery:
+        app = default_worker_app
+        app.conf.worker_prefetch_multiplier = 1
+        app.conf.worker_concurrency = 4
+        app.conf.task_acks_late = True
+        app.conf.worker_enable_prefetch_count_reduction = True
+        # Terminate in-flight acks_late tasks when the connection drops so
+        # their pool slots are released before the reconnect. Without this
+        # the original long-running tasks keep occupying their pool slots
+        # while the broker also redelivers them (acks_late); the original
+        # and redelivered copies then fill every pool process and the
+        # post-restart probe task below can never be dispatched.
+        app.conf.worker_cancel_long_running_tasks_on_connection_loss = True
+        return app
+
+    # No RedisTestBroker xfail guard is needed: the ``quorum_queues/``
+    # conftest forces a RabbitMQ broker, so this test class only ever
+    # runs against amqp where the bug actually manifests.
 
     def test_worker_resumes_consuming_after_broker_restart(self, celery_setup: CeleryTestSetup):
         """A task submitted after a broker restart still gets processed.

--- a/t/smoke/tests/quorum_queues/test_qos.py
+++ b/t/smoke/tests/quorum_queues/test_qos.py
@@ -92,11 +92,13 @@ class test_quorum_qos_prefetch_reduction_skipped_on_reconnect:
         # Terminate in-flight acks_late tasks when the connection drops so
         # their pool slots are released before the reconnect. Without this
         # the original long-running tasks keep occupying their pool slots
-        # while the broker also redelivers them (acks_late), so the
-        # original + redelivered copies fill every slot and the
-        # post-restart probe task can never be dispatched. ``active_requests``
-        # is still read before these cancellations round-trip, so the
-        # legacy prefetch reduction on a pre-fix build is unaffected.
+        # while the broker also redelivers them (acks_late); the original +
+        # redelivered copies then fill every pool process and the
+        # post-restart probe task in
+        # ``test_worker_resumes_consuming_after_broker_restart`` can never be
+        # dispatched. The #9512 regression itself is asserted by
+        # ``test_skip_log_emitted_after_broker_restart`` through the skip log,
+        # which does not depend on this setting.
         app.conf.worker_cancel_long_running_tasks_on_connection_loss = True
         return app
 
@@ -135,30 +137,31 @@ class test_quorum_qos_prefetch_reduction_skipped_on_reconnect:
         )
 
     def test_worker_resumes_consuming_after_broker_restart(self, celery_setup: CeleryTestSetup):
-        """A task submitted after broker restart still gets processed.
+        """A task submitted after a broker restart still gets processed.
 
-        Two long-running tasks are placed in flight so the connection
-        error path actually enters the reduction code under test (without
-        active requests the bug branch is never reached and the test
-        would silently pass on a pre-fix build).
+        End-to-end liveness check for the reconnect path on quorum-queue
+        per-consumer QoS. Two acks_late long-running tasks are put in
+        flight so that, at the moment the broker dies, two pool processes
+        are genuinely busy and the broker still owns the (unacked)
+        messages.
 
         ``worker_cancel_long_running_tasks_on_connection_loss`` (set in
-        the fixture) terminates the two in-flight tasks when the
-        connection drops, releasing their pool slots before the
-        reconnect. ``active_requests`` is still read before those
-        cancellations round-trip, so the legacy reduction on a pre-fix
-        build still computes max(1, 4-2)=2. After the broker restarts and
-        ``task_acks_late`` causes the two long-running tasks to be
-        redelivered:
+        the fixture) terminates those two in-flight tasks on disconnect,
+        freeing their pool slots. After the restart the messages are
+        redelivered (acks_late); on a post-#9512 build the consumer keeps
+        its full prefetch of 4 (the reduction is skipped under
+        per-consumer QoS), so the redelivered tasks and the trailing noop
+        each find a free pool process and the noop completes within the
+        timeout.
 
-        - On a pre-fix build the consumer is stranded at the reduced
-          prefetch (max(1, 4-2)=2). Both prefetch slots are taken by the
-          redelivered long-running tasks, so the noop is never fetched
-          and the test times out.
-        - On a post-fix build the consumer keeps its full prefetch of 4,
-          so the noop is fetched. The cancelled originals freed their
-          pool slots, so the redelivered tasks and the noop all find a
-          free pool process and the noop completes.
+        Note: this test does not by itself distinguish the #9512 pre/post
+        fix behaviour. Enabling cancellation removes the tasks from
+        ``active_requests`` synchronously (``Request.cancel`` ->
+        ``_announce_cancelled`` -> ``task_ready``), so the legacy
+        reduction would read ``len(active_requests) == 0`` rather than 2.
+        The discriminating #9512 assertion lives in
+        ``test_skip_log_emitted_after_broker_restart``; here we only
+        assert that work resumes flowing after the reconnect.
         """
         queue = celery_setup.worker.worker_queue
         # Confirm the worker is healthy before perturbing it.
@@ -166,12 +169,10 @@ class test_quorum_qos_prefetch_reduction_skipped_on_reconnect:
 
         sig = group(long_running_task.s(420) for _ in range(2))
         sig.apply_async(queue=queue)
-        # Both tasks must be in flight before the broker restart so
-        # ``len(active_requests) == 2`` when the reduction is computed on
-        # a pre-fix build. A single ``wait_for_log`` returns as soon as
-        # the first task starts, which would compute max(1, 4-1)=3 instead
-        # of max(1, 4-2)=2 and leave enough prefetch slots free for the
-        # post-restart noop to succeed even on the buggy path.
+        # Both tasks must actually be running (occupying two pool
+        # processes) before the broker restart, otherwise there are no
+        # busy slots to free and the scenario is not exercised. A single
+        # ``wait_for_log`` would return as soon as the first task starts.
         _wait_for_log_count(celery_setup.worker, "Starting long running task", 2)
 
         celery_setup.broker.restart()

--- a/t/smoke/tests/quorum_queues/test_qos.py
+++ b/t/smoke/tests/quorum_queues/test_qos.py
@@ -89,6 +89,15 @@ class test_quorum_qos_prefetch_reduction_skipped_on_reconnect:
         # applies when reduction is enabled. We must NOT silently rely on
         # the user-discovered workaround of disabling it.
         app.conf.worker_enable_prefetch_count_reduction = True
+        # Terminate in-flight acks_late tasks when the connection drops so
+        # their pool slots are released before the reconnect. Without this
+        # the original long-running tasks keep occupying their pool slots
+        # while the broker also redelivers them (acks_late), so the
+        # original + redelivered copies fill every slot and the
+        # post-restart probe task can never be dispatched. ``active_requests``
+        # is still read before these cancellations round-trip, so the
+        # legacy prefetch reduction on a pre-fix build is unaffected.
+        app.conf.worker_cancel_long_running_tasks_on_connection_loss = True
         return app
 
     # No RedisTestBroker xfail guard is needed: the ``quorum_queues/``
@@ -133,19 +142,23 @@ class test_quorum_qos_prefetch_reduction_skipped_on_reconnect:
         active requests the bug branch is never reached and the test
         would silently pass on a pre-fix build).
 
-        Two in-flight is deliberately less than ``worker_concurrency=4``
-        so that two pool slots remain free for the post-restart noop.
-        After the broker restarts and ``task_acks_late`` causes the two
-        long-running tasks to be redelivered:
+        ``worker_cancel_long_running_tasks_on_connection_loss`` (set in
+        the fixture) terminates the two in-flight tasks when the
+        connection drops, releasing their pool slots before the
+        reconnect. ``active_requests`` is still read before those
+        cancellations round-trip, so the legacy reduction on a pre-fix
+        build still computes max(1, 4-2)=2. After the broker restarts and
+        ``task_acks_late`` causes the two long-running tasks to be
+        redelivered:
 
         - On a pre-fix build the consumer is stranded at the reduced
           prefetch (max(1, 4-2)=2). Both prefetch slots are taken by the
           redelivered long-running tasks, so the noop is never fetched
           and the test times out.
-        - On a post-fix build the consumer keeps its full prefetch of 4.
-          The two redelivered long-running tasks take two prefetch slots
-          and two pool slots; the noop is fetched into a free prefetch
-          slot, dispatched to a free pool process, and completes.
+        - On a post-fix build the consumer keeps its full prefetch of 4,
+          so the noop is fetched. The cancelled originals freed their
+          pool slots, so the redelivered tasks and the noop all find a
+          free pool process and the noop completes.
         """
         queue = celery_setup.worker.worker_queue
         # Confirm the worker is healthy before perturbing it.

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -736,7 +736,8 @@ class test_AsynPool:
         assert gen not in pool._active_writers
 
     @t.skip.if_pypy
-    def test_flush_preserves_busy_worker_for_accepted_job(self):
+    @patch('billiard.pool.Pool._create_worker_process')
+    def test_flush_preserves_busy_worker_for_accepted_job(self, _create_worker_process):
         """flush() must keep a worker marked busy while it runs an accepted job.
 
         On a broker reconnect Consumer.on_close calls pool.flush(). A worker
@@ -773,7 +774,8 @@ class test_AsynPool:
         assert 7 in pool._busy_workers
 
     @t.skip.if_pypy
-    def test_flush_preserves_busy_worker_via_scheduled_for_fallback(self):
+    @patch('billiard.pool.Pool._create_worker_process')
+    def test_flush_preserves_busy_worker_via_scheduled_for_fallback(self, _create_worker_process):
         """flush() falls back to _scheduled_for when _write_to is unset.
 
         A job can be accepted before its body finished writing, leaving
@@ -803,7 +805,8 @@ class test_AsynPool:
         assert 5 in pool._busy_workers
 
     @t.skip.if_pypy
-    def test_flush_releases_busy_worker_for_unaccepted_job(self):
+    @patch('billiard.pool.Pool._create_worker_process')
+    def test_flush_releases_busy_worker_for_unaccepted_job(self, _create_worker_process):
         """flush() must free a worker whose job was not accepted yet.
 
         Unaccepted jobs are discarded/redelivered by the broker, so the worker
@@ -832,7 +835,8 @@ class test_AsynPool:
         assert 9 not in pool._busy_workers
 
     @t.skip.if_pypy
-    def test_flush_preserves_accepted_and_releases_unaccepted_together(self):
+    @patch('billiard.pool.Pool._create_worker_process')
+    def test_flush_preserves_accepted_and_releases_unaccepted_together(self, _create_worker_process):
         """flush() must resolve a mixed _busy_workers set in a single call.
 
         When one worker runs an accepted job and another only had an
@@ -872,7 +876,8 @@ class test_AsynPool:
         assert 9 not in pool._busy_workers
 
     @t.skip.if_pypy
-    def test_flush_releases_busy_worker_for_dead_process(self):
+    @patch('billiard.pool.Pool._create_worker_process')
+    def test_flush_releases_busy_worker_for_dead_process(self, _create_worker_process):
         """flush() must not keep an accepted job's fd if its worker died.
 
         If the worker executing an accepted job has exited, its inqueue

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -735,6 +735,67 @@ class test_AsynPool:
         job.discard.assert_called_once()
         assert gen not in pool._active_writers
 
+    @t.skip.if_pypy
+    def test_flush_preserves_busy_worker_for_accepted_job(self):
+        """flush() must keep a worker marked busy while it runs an accepted job.
+
+        On a broker reconnect Consumer.on_close calls pool.flush(). A worker
+        still executing an accepted (running) task is genuinely busy, so its
+        inqueue write-fd must remain in _busy_workers. Clearing it would
+        desynchronize the fair scheduler from reality and let a new task be
+        written onto the busy worker, blocking it behind the long-running task
+        even while another worker is idle.
+        """
+        pool = asynpool.AsynPool(processes=2, synack=False, threads=False)
+        pool._state = asynpool.RUN
+        pool.maintain_pool = Mock(name='maintain_pool')
+
+        # Worker still running an accepted job, dispatched to fd 7.
+        proc = Mock(name='proc')
+        proc.inqW_fd = 7
+        job = Mock(name='job')
+        job._accepted = True
+        job._scheduled_for = proc
+        job._writer.return_value = None
+
+        pool._cache = {1: job}
+        pool._busy_workers = {7}
+        pool._active_writers.clear()
+        pool.outbound_buffer.clear()
+
+        pool.flush()
+
+        # The busy worker must still be marked busy after the flush.
+        assert 7 in pool._busy_workers
+
+    @t.skip.if_pypy
+    def test_flush_releases_busy_worker_for_unaccepted_job(self):
+        """flush() must free a worker whose job was not accepted yet.
+
+        Unaccepted jobs are discarded/redelivered by the broker, so the worker
+        they were tentatively scheduled to is no longer busy and its fd must be
+        dropped from _busy_workers.
+        """
+        pool = asynpool.AsynPool(processes=2, synack=False, threads=False)
+        pool._state = asynpool.RUN
+        pool.maintain_pool = Mock(name='maintain_pool')
+
+        proc = Mock(name='proc')
+        proc.inqW_fd = 9
+        job = Mock(name='job')
+        job._accepted = False
+        job._scheduled_for = proc
+        job._writer.return_value = None
+
+        pool._cache = {1: job}
+        pool._busy_workers = {9}
+        pool._active_writers.clear()
+        pool.outbound_buffer.clear()
+
+        pool.flush()
+
+        assert 9 not in pool._busy_workers
+
     def test_process_result(self):
         x = asynpool.ResultHandler(
             Mock(), Mock(), {}, Mock(),

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -755,6 +755,7 @@ class test_AsynPool:
         # is the preferred source of truth for the busy fd.
         proc = Mock(name='proc')
         proc.inqW_fd = 7
+        proc._is_alive.return_value = True
         job = Mock(name='job')
         job._accepted = True
         job._write_to = proc
@@ -785,6 +786,7 @@ class test_AsynPool:
 
         proc = Mock(name='proc')
         proc.inqW_fd = 5
+        proc._is_alive.return_value = True
         job = Mock(name='job')
         job._accepted = True
         job._write_to = None
@@ -844,6 +846,7 @@ class test_AsynPool:
 
         accepted_proc = Mock(name='accepted_proc')
         accepted_proc.inqW_fd = 7
+        accepted_proc._is_alive.return_value = True
         accepted_job = Mock(name='accepted_job')
         accepted_job._accepted = True
         accepted_job._write_to = accepted_proc
@@ -868,6 +871,36 @@ class test_AsynPool:
         assert 7 in pool._busy_workers
         assert 9 not in pool._busy_workers
 
+    @t.skip.if_pypy
+    def test_flush_releases_busy_worker_for_dead_process(self):
+        """flush() must not keep an accepted job's fd if its worker died.
+
+        If the worker executing an accepted job has exited, its inqueue
+        write-fd may be reused by a replacement process. Keeping the fd marked
+        busy would sideline that healthy replacement, so a dead worker's fd is
+        dropped from _busy_workers.
+        """
+        pool = asynpool.AsynPool(processes=2, synack=False, threads=False)
+        pool._state = asynpool.RUN
+        pool.maintain_pool = Mock(name='maintain_pool')
+
+        proc = Mock(name='proc')
+        proc.inqW_fd = 3
+        proc._is_alive.return_value = False
+        job = Mock(name='job')
+        job._accepted = True
+        job._write_to = proc
+        job._scheduled_for = proc
+        job._writer.return_value = None
+
+        pool._cache = {1: job}
+        pool._busy_workers = {3}
+        pool._active_writers.clear()
+        pool.outbound_buffer.clear()
+
+        pool.flush()
+
+        assert 3 not in pool._busy_workers
 
     def test_process_result(self):
         x = asynpool.ResultHandler(

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -750,11 +750,14 @@ class test_AsynPool:
         pool._state = asynpool.RUN
         pool.maintain_pool = Mock(name='maintain_pool')
 
-        # Worker still running an accepted job, dispatched to fd 7.
+        # Worker still running an accepted job, dispatched to fd 7. Once the
+        # body is written job._write_to points at the executing process, so it
+        # is the preferred source of truth for the busy fd.
         proc = Mock(name='proc')
         proc.inqW_fd = 7
         job = Mock(name='job')
         job._accepted = True
+        job._write_to = proc
         job._scheduled_for = proc
         job._writer.return_value = None
 
@@ -767,6 +770,35 @@ class test_AsynPool:
 
         # The busy worker must still be marked busy after the flush.
         assert 7 in pool._busy_workers
+
+    @t.skip.if_pypy
+    def test_flush_preserves_busy_worker_via_scheduled_for_fallback(self):
+        """flush() falls back to _scheduled_for when _write_to is unset.
+
+        A job can be accepted before its body finished writing, leaving
+        _write_to unset while _scheduled_for already identifies the worker the
+        task was dispatched to. The busy fd must still be preserved.
+        """
+        pool = asynpool.AsynPool(processes=2, synack=False, threads=False)
+        pool._state = asynpool.RUN
+        pool.maintain_pool = Mock(name='maintain_pool')
+
+        proc = Mock(name='proc')
+        proc.inqW_fd = 5
+        job = Mock(name='job')
+        job._accepted = True
+        job._write_to = None
+        job._scheduled_for = proc
+        job._writer.return_value = None
+
+        pool._cache = {1: job}
+        pool._busy_workers = {5}
+        pool._active_writers.clear()
+        pool.outbound_buffer.clear()
+
+        pool.flush()
+
+        assert 5 in pool._busy_workers
 
     @t.skip.if_pypy
     def test_flush_releases_busy_worker_for_unaccepted_job(self):
@@ -784,6 +816,7 @@ class test_AsynPool:
         proc.inqW_fd = 9
         job = Mock(name='job')
         job._accepted = False
+        job._write_to = proc
         job._scheduled_for = proc
         job._writer.return_value = None
 
@@ -795,6 +828,46 @@ class test_AsynPool:
         pool.flush()
 
         assert 9 not in pool._busy_workers
+
+    @t.skip.if_pypy
+    def test_flush_preserves_accepted_and_releases_unaccepted_together(self):
+        """flush() must resolve a mixed _busy_workers set in a single call.
+
+        When one worker runs an accepted job and another only had an
+        unaccepted job tentatively scheduled to it, the same flush() must keep
+        the accepted worker busy while releasing the unaccepted one, rather
+        than treating the set all-or-nothing.
+        """
+        pool = asynpool.AsynPool(processes=2, synack=False, threads=False)
+        pool._state = asynpool.RUN
+        pool.maintain_pool = Mock(name='maintain_pool')
+
+        accepted_proc = Mock(name='accepted_proc')
+        accepted_proc.inqW_fd = 7
+        accepted_job = Mock(name='accepted_job')
+        accepted_job._accepted = True
+        accepted_job._write_to = accepted_proc
+        accepted_job._scheduled_for = accepted_proc
+        accepted_job._writer.return_value = None
+
+        unaccepted_proc = Mock(name='unaccepted_proc')
+        unaccepted_proc.inqW_fd = 9
+        unaccepted_job = Mock(name='unaccepted_job')
+        unaccepted_job._accepted = False
+        unaccepted_job._write_to = unaccepted_proc
+        unaccepted_job._scheduled_for = unaccepted_proc
+        unaccepted_job._writer.return_value = None
+
+        pool._cache = {1: accepted_job, 2: unaccepted_job}
+        pool._busy_workers = {7, 9}
+        pool._active_writers.clear()
+        pool.outbound_buffer.clear()
+
+        pool.flush()
+
+        assert 7 in pool._busy_workers
+        assert 9 not in pool._busy_workers
+
 
     def test_process_result(self):
         x = asynpool.ResultHandler(


### PR DESCRIPTION
## Summary

A free prefork worker slot stalls after a broker reconnect: with `concurrency>=2`
and the default fair scheduler, a task queued after a reconnect waits for an
already-running long task instead of running on the idle worker. `AsynPool.flush()`
clears `_busy_workers` even for workers still executing an accepted task, which
desynchronizes the fair scheduler from reality.

## Reproduction

- Prefork pool, `--concurrency=2`, fair scheduling (default), Redis broker.
- `worker_disable_prefetch=true`, `worker_cancel_long_running_tasks_on_connection_loss=false`.

1. Start a long task (e.g. 5 min) — runs on worker P1.
2. Interrupt the broker connection; wait for reconnect.
3. Queue a second task.

**Expected:** the second task runs immediately on the idle worker P2.
**Actual:** it waits until the long task finishes. Queuing a third task (no further
interruption) also stalls, and normal concurrency only resumes once the backlog drains.

## Root cause

`Consumer.on_close()` calls `AsynPool.flush()` on every reconnect. Its `finally`
block ran `self._busy_workers.clear()`. But a worker running an **accepted** task is
genuinely busy, and `_busy_workers` is the *only* state the fair scheduler uses to
avoid double-assigning a worker:

- `on_poll_start`: `add_cond = outbound and len(busy_workers) < len(all_inqueues)`
- `schedule_writes`: `if is_fair_strategy and ready_fd in busy_workers: continue`

A worker is marked busy only at **write time** (`mark_worker_as_busy(ready_fd)` in
`schedule_writes`) and unmarked when the **completing** job's result returns
(`on_job_ready` → `_busy_workers.discard(inqW_fd)`). Nothing re-marks a worker when it
dequeues the next already-written job from its pipe. So after `flush()` wipes the set:

1. The pool forgets P1 is busy and writes the new task into P1's pipe, behind the long task.
2. When the long task completes, its fd is discarded — but the now-running task was
   already written and is never re-marked busy, so the set stays empty.
3. The next task is misrouted the same way. The desync persists and cascades until the
   pipe backlog drains, only then restoring concurrency.

## Relationship to #7515

This is the same bug reported in #7515 ("concurrency utilization breaks on
broker connection reset"). That report's diagnosis — *"Celery is avoiding to
schedule new tasks until the old tasks are done, by incorrectly keeping track of
which workers are busy"* — is exactly the `_busy_workers` desync fixed here.

- The issue's repro (prefork pool, default fair scheduling, submit a long task,
  reset the broker connection, then submit a short task → they run serially
  instead of in parallel) is the same path: `Consumer.on_close()` → `flush()` →
  `self._busy_workers.clear()`.
- The reporter notes the regression began with commit `123f002`, which introduced
  the `_busy_workers` fair-scheduling tracking; clearing it on every reconnect is
  what breaks the invariant.

The related reports #7277 (*"concurrency does not use all workers while multiple
tasks reserved"*) and #3765 (*"tasks intermittently get stuck as reserved even
with -Ofair"*) describe the same symptom and may also be addressed or mitigated
by this fix.

## Fix

Rebuild `_busy_workers` from the fds still backed by an accepted job instead of clearing
it, so the fair-scheduling invariant is preserved across the flush:

```python
still_busy = {
    job._scheduled_for.inqW_fd
    for job in self._cache.values()
    if job._accepted and job._scheduled_for is not None
}
self._busy_workers.intersection_update(still_busy)
```

Drafted-by: Claude Code (Opus 4.8)

