### PR TITLE
Fix Queues.deselect leaking routing-only queues into consumers

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -190,11 +190,12 @@ class Queues(dict):
         if exclude:
             exclude = maybe_list(exclude)
             if self._consume_from is None:
-                # using all queues
-                return self.select(k for k in self if k not in exclude)
-            # using selection
+                consume_from = self._default_consume_from
+            else:
+                consume_from = self._consume_from
+
             for queue in exclude:
-                self._consume_from.pop(queue, None)
+                consume_from.pop(queue, None)
 
     def new_missing(self, name):
         queue_arguments = None

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -107,6 +107,19 @@ class test_Queues:
         q.deselect('bar')
         assert sorted(q._consume_from.keys()) == ['foo']
 
+    def test_deselect_without_explicit_consume_selection_removes_excluded_queue(self):
+        q = Queues([Queue('foo'), Queue('bar')])
+        q.deselect('bar')
+        assert q._consume_from is None
+        assert sorted(q.consume_from.keys()) == ['foo']
+
+    def test_deselect_without_explicit_consume_selection_keeps_routing_only_queue_unconsumed(self):
+        q = Queues([Queue('foo'), Queue('bar')])
+        q.add('routing_only')
+        q.deselect('bar')
+        assert q._consume_from is None
+        assert sorted(q.consume_from.keys()) == ['foo']
+
     def test_add_default_exchange(self):
         ex = Exchange('fff', 'fanout')
         q = Queues(default_exchange=ex)


### PR DESCRIPTION
## Description
Related to https://github.com/celery/celery/issues/9462

When the worker runs with no explicit `-Q`, `Queues._consume_from` is `None`. If we triggrer the the cancel consumer control for example `app.control.cancel_consumer("any_queue")`, this will trigger each worker to call `Queues.deselect()`:

```python
def deselect(self, exclude):
    if exclude:
        exclude = maybe_list(exclude)
        if self._consume_from is None:
            # using all queues
            return self.select(k for k in self if k not in exclude)
        # using selection
        for queue in exclude:
            self._consume_from.pop(queue, None)
```
And since self._consume_from is None, it will be populated by all existing queues, which could include the routing ones.

Steps to reproduce:

1. Run celery worker with thread-pool
```
celery -A root worker --pool=threads
```
2. Run this in another terminal:
```python
from celery import Celery
app = Celery("root")

@app.task()
def task1():
    print("i am task 1")


@app.task(queue="second")
def task2(*args):
    print("i am task 2")

task1.apply_async(link=task2.s())
app.control.cancel_consumer("any_queue")
```
3. Restart Redis to force a reconnection from worker
4. After reconnect, the worker starts consuming queue second.
```
[2026-06-08 16:53:57,926: WARNING/MainProcess] i am task 2
```
