### PR TITLE
fix(utils/text): off-by-one in truncate() when len(s) == maxlen

### DIFF
--- a/celery/utils/text.py
+++ b/celery/utils/text.py
@@ -88,7 +88,7 @@ def indent(t: str, indent: int = 0, sep: str = '\n') -> str:
 
 def truncate(s: str, maxlen: int = 128, suffix: str = '...') -> str:
     """Truncate text to a maximum number of characters."""
-    if maxlen and len(s) >= maxlen:
+    if maxlen and len(s) > maxlen:
         return s[:maxlen].rsplit(' ', 1)[0] + suffix
     return s
 

--- a/t/unit/utils/test_text.py
+++ b/t/unit/utils/test_text.py
@@ -51,8 +51,9 @@ class test_Info:
 
 @pytest.mark.parametrize('s,maxsize,expected', [
     ('ABCDEFGHI', 3, 'ABC...'),
+    ('ABCDEFGHI', 9, 'ABCDEFGHI'),
     ('ABCDEFGHI', 10, 'ABCDEFGHI'),
-
+    ('hello world', 11, 'hello world'),
 ])
 def test_truncate_text(s, maxsize, expected):
     assert truncate(s, maxsize) == expected


### PR DESCRIPTION
## Bug

`truncate()` in `celery/utils/text.py` uses `>=` to compare `len(s)` with `maxlen`:

```python
if maxlen and len(s) >= maxlen:
    return s[:maxlen].rsplit(' ', 1)[0] + suffix
```

When the string is **exactly** `maxlen` characters long, it doesn't need to be truncated — it already fits within the limit. However, the current `>=` condition truncates it anyway and appends the suffix, producing a string **longer** than `maxlen`.

## Example

```python
>>> truncate('ABCDEFGHI', 9)  # len == maxlen == 9
'ABCDEFGHI...'  # 12 chars — exceeds the stated limit
```

## Fix

Change `>=` to `>` so only strings strictly longer than `maxlen` are truncated:

```python
>>> truncate('ABCDEFGHI', 9)
'ABCDEFGHI'   # 9 chars — correct, no truncation needed
```

## Verification

```
pytest t/unit/utils/test_text.py -v
# 15 passed
```

> Note: this fix was developed with AI assistance.