### PR TITLE
Docs: clarify which tasks the celery_worker pytest fixture can run

### DIFF
--- a/docs/userguide/testing.rst
+++ b/docs/userguide/testing.rst
@@ -214,6 +214,18 @@ Example:
     def test_other(celery_worker):
         ...
 
+.. note::
+
+    The embedded ``celery_worker`` only runs tasks that are registered on the
+    ``celery_app`` fixture.  In practice this means tasks declared with
+    ``@shared_task`` (which are registered on every app), or tasks defined on
+    ``celery_app`` within the test (as shown in the ``celery_app`` example
+    above).  A task bound to a separately instantiated ``Celery()`` app is
+    registered only on that app and will **not** be found by the fixture
+    worker.  To make such a task available, declare it with ``@shared_task``,
+    define it on ``celery_app``, or register it on the fixture app before
+    calling ``celery_worker.reload()``.
+
 Heartbeats are disabled by default which means that the test worker doesn't
 send events for ``worker-online``, ``worker-offline`` and ``worker-heartbeat``.
 To enable heartbeats modify the :func:`celery_worker_parameters` fixture:


### PR DESCRIPTION
Closes #9372

## Summary
Documents a behaviour of the `celery.contrib.pytest` fixtures that has surprised
users: the embedded `celery_worker` only runs tasks that are registered on the
`celery_app` fixture. The fixtures work as designed — this change just makes the
requirement explicit in the testing guide.

## Root cause
Not a code defect. The `celery_worker` fixture starts an embedded worker bound to
the `celery_app` fixture (`celery/contrib/pytest.py` → `worker.start_worker(celery_app, …)`),
and a worker can only execute tasks present in that app's registry
(`celery/contrib/testing/worker.py` → `setup_app_for_worker`). `@shared_task` tasks
register on every app (so they resolve), and tasks defined on `celery_app` at test
time resolve too — but a task bound to a separately instantiated `Celery()` app is
registered only on that app and is never seen by the fixture worker. The testing
guide demonstrated the working patterns by example but never stated this rule.

## Solution
Add a `.. note::` to `docs/userguide/testing.rst`, in the `celery_worker` fixture
section, explaining that the worker only runs tasks registered on `celery_app`, and
listing the three ways to make a task available: declare it with `@shared_task`,
define it on `celery_app`, or register it on the fixture app before
`celery_worker.reload()`. Documentation-only; no code change.

## Changes
```
8703b57a7 Document task registration requirement for the celery_worker fixture

 docs/userguide/testing.rst | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```

## Testing performed
- Change is a standard reStructuredText `.. note::` directive (12 added lines, no
  code touched).
- **A local Sphinx docs build could not be run in this environment** — `sphinx-build`
  is not installed in the working clone (`make -C docs html` → `sphinx-build: No such
  file or directory`). The HTML build should be verified in CI or after
  `pip install -r requirements/docs.txt`.

## Checklist
- [x] Change is focused and minimal
- [x] Follows the project's documentation style (matches surrounding `.. note::` usage)
- [ ] Tests added or updated where appropriate — N/A (documentation only)
- [x] Documentation updated where appropriate
- [ ] `docs` build verified (`make -C docs html`) — **blocked locally; needs CI / docs env**