### PR TITLE
Tolerate task cancellation errors after connection loss

### DIFF
--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -442,7 +442,10 @@ class Consumer:
                 if request.task.acks_late and not request.acknowledged:
                     warn(TERMINATING_TASK_ON_RESTART_AFTER_A_CONNECTION_LOSS,
                          request)
-                    request.cancel(self.pool)
+                    try:
+                        request.cancel(self.pool)
+                    except Exception:  # pylint: disable=broad-except
+                        pass
         else:
             warnings.warn(CANCEL_TASKS_BY_DEFAULT, CPendingDeprecationWarning, stacklevel=2)
 

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -445,7 +445,7 @@ class Consumer:
                     try:
                         request.cancel(self.pool)
                     except Exception:  # pylint: disable=broad-except
-                        pass
+                        warn("Failed to cancel active request %r after connection loss", request, exc_info=True)
         else:
             warnings.warn(CANCEL_TASKS_BY_DEFAULT, CPendingDeprecationWarning, stacklevel=2)
 

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -629,12 +629,13 @@ class test_Consumer(ConsumerTestCase):
         active_requests.add(mock_request_cancel_raises)
         active_requests.add(mock_request_cancel_succeeds)
 
-        c.on_connection_error_after_connected(Mock())
+        try:
+            c.on_connection_error_after_connected(Mock())
 
-        mock_request_cancel_raises.cancel.assert_called_once_with(c.pool)
-        mock_request_cancel_succeeds.cancel.assert_called_once_with(c.pool)
-
-        active_requests.clear()
+            mock_request_cancel_raises.cancel.assert_called_once_with(c.pool)
+            mock_request_cancel_succeeds.cancel.assert_called_once_with(c.pool)
+        finally:
+            active_requests.clear()
 
     @pytest.mark.usefixtures('depends_on_current_app')
     def test_cancel_active_requests(self):

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -614,6 +614,28 @@ class test_Consumer(ConsumerTestCase):
         with pytest.deprecated_call(match=CANCEL_TASKS_BY_DEFAULT):
             c.on_connection_error_after_connected(Mock())
 
+    def test_cancel_long_running_tasks_on_connection_loss__cancel_error_is_swallowed(self):
+        c = self.get_consumer()
+        c.app.conf.worker_cancel_long_running_tasks_on_connection_loss = True
+
+        mock_request_cancel_raises = Mock()
+        mock_request_cancel_raises.task.acks_late = True
+        mock_request_cancel_raises.acknowledged = False
+        mock_request_cancel_raises.cancel.side_effect = ConnectionResetError('Connection reset by peer')
+        mock_request_cancel_succeeds = Mock()
+        mock_request_cancel_succeeds.task.acks_late = True
+        mock_request_cancel_succeeds.acknowledged = False
+
+        active_requests.add(mock_request_cancel_raises)
+        active_requests.add(mock_request_cancel_succeeds)
+
+        c.on_connection_error_after_connected(Mock())
+
+        mock_request_cancel_raises.cancel.assert_called_once_with(c.pool)
+        mock_request_cancel_succeeds.cancel.assert_called_once_with(c.pool)
+
+        active_requests.clear()
+
     @pytest.mark.usefixtures('depends_on_current_app')
     def test_cancel_active_requests(self):
         c = self.get_consumer()


### PR DESCRIPTION
## Description
Fixes: #7185.

The cause is that during task cancellation when `worker_cancel_long_running_tasks_on_connection_loss` is set, it marks the task as retry in the result backend.
https://github.com/celery/celery/blob/41b88388b9dce51e887d3aa6dc20fa8d4538e81a/celery/worker/request.py#L428-L432
If the result backend happens to be disconnected as well (probably if the worker node is isolated), no one catches this connection error to the result backend, causing the main process to be killed.

Steps to reproduce:

1. Set `worker_cancel_long_running_tasks_on_connection_loss = True`, configure result backend and trigger a long running task.
2. Disconnect both broker and result backend.
