### PR TITLE
Update reserved requests to use new event dispatcher on reconnect

### DIFF
--- a/celery/worker/consumer/events.py
+++ b/celery/worker/consumer/events.py
@@ -5,6 +5,7 @@
 from kombu.common import ignore_errors
 
 from celery import bootsteps
+from celery.worker.state import reserved_requests
 
 from .connection import Connection
 
@@ -47,6 +48,8 @@ class Events(bootsteps.StartStopStep):
         if prev:
             dis.extend_buffer(prev)
             dis.flush()
+            for request in tuple(reserved_requests):
+                request.eventer = dis
 
     def stop(self, c):
         pass

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -186,6 +186,17 @@ class test_Consumer(ConsumerCase):
         event_dispatcher.disable.assert_called()
         heart.stop.assert_called_with()
 
+    def test_events_start_updates_request_eventers_on_reconnect(self):
+        c = self.NoopConsumer()
+        events = find_step(c, consumer.Events)
+        prev = c.event_dispatcher
+        req = Mock(name='request')
+        req.eventer = prev
+        with patch('celery.worker.consumer.events.reserved_requests', {req}):
+            events.start(c)
+        assert c.event_dispatcher is not prev
+        assert req.eventer is c.event_dispatcher
+
     @patch('celery.worker.consumer.consumer.warn')
     def test_receive_message_unknown(self, warn):
         c = self.LoopConsumer()


### PR DESCRIPTION
## Description
This PR fixes the `The worker main process is not emitting the task-succeeded event` reported in #8541.

The cause is that on broker reconnect, the Events bootstep creates a new Dispatcher, but already reserved task requests still reference the previous disabled dispatcher. If those tasks complete after reconnect, their success events will be lost, leaving Flower showing them as `STARTED` forever.

I don't experience the other symptoms in #8541, so I think the missing task-succeeded event is the only one left.
