### PR TITLE
Preserve group errback mutability

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1709,7 +1709,7 @@ class group(Signature):
         # each child task signature, of which there might be none!
         sig = maybe_signature(sig)
 
-        return tuple(child_task.link_error(sig.clone(immutable=True)) for child_task in self.tasks)
+        return tuple(child_task.link_error(sig.clone()) for child_task in self.tasks)
 
     def _prepared(self, tasks, partial_args, group_id, root_id, app,
                   CallableSignature=abstract.CallableSignature,

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1428,6 +1428,27 @@ class test_group:
             await_redis_echo({errback_msg, }, redis_key=redis_key)
         redis_connection.delete(redis_key)
 
+    @pytest.mark.parametrize("errback_task", [errback_old_style, errback_new_style])
+    def test_mutable_errback_called_by_group(self, errback_task, manager, subtests):
+        if not manager.app.conf.result_backend.startswith("redis"):
+            raise pytest.skip("Requires redis result backend.")
+        redis_connection = get_redis_connection()
+
+        fail_sig = fail.s()
+        fail_sig_id = fail_sig.freeze().id
+        errback = errback_task.s()
+
+        group_sig = group(fail_sig, identity.si(42))
+        group_sig.link_error(errback)
+        redis_connection.delete(fail_sig_id)
+        with subtests.test(msg="Error propagates from group"):
+            res = group_sig.delay()
+            with pytest.raises(ExpectedException):
+                res.get(timeout=TIMEOUT)
+        with subtests.test(msg="Mutable errback is called after group task fails"):
+            await_redis_count(1, redis_key=fail_sig_id)
+        redis_connection.delete(fail_sig_id)
+
     def test_errback_called_by_group_fail_multiple(self, manager, subtests):
         if not manager.app.conf.result_backend.startswith("redis"):
             raise pytest.skip("Requires redis result backend.")

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1085,7 +1085,7 @@ class test_group(CanvasCase):
         # We expect that all group children will be given the errback to ensure
         # it gets called
         for child_sig in g1.tasks:
-            child_sig.link_error.assert_called_with(sig.clone(immutable=True))
+            child_sig.link_error.assert_called_with(sig.clone())
 
     def test_link_error_with_dict_sig(self):
         g1 = group(Mock(name='t1'), Mock(name='t2'), app=self.app)
@@ -1095,7 +1095,17 @@ class test_group(CanvasCase):
         # We expect that all group children will be given the errback to ensure
         # it gets called
         for child_sig in g1.tasks:
-            child_sig.link_error.assert_called_with(errback.clone(immutable=True))
+            child_sig.link_error.assert_called_with(errback.clone())
+
+    def test_link_error_preserves_mutable_errback(self):
+        g1 = group(self.add.s(2, 2), self.add.s(4, 4), app=self.app)
+        errback = self.add.s()
+
+        linked = g1.link_error(errback)
+
+        assert len(linked) == 2
+        for child_sig in g1.tasks:
+            assert child_sig.options['link_error'][0].immutable is False
 
     def test_apply_empty(self):
         x = group(app=self.app)


### PR DESCRIPTION
Summary
- Keep group errback signatures mutable when linking them to child tasks.
- Update existing group link_error expectations to clone errbacks without forcing immutable=True.
- Add a regression test that checks mutable errbacks remain mutable after group.link_error().

Closes #6766

Tests
- `.venv\Scripts\python.exe -m pytest t/unit/tasks/test_canvas.py::test_group::test_link_error t/unit/tasks/test_canvas.py::test_group::test_link_error_with_dict_sig t/unit/tasks/test_canvas.py::test_group::test_link_error_preserves_mutable_errback -q`
- `.venv\Scripts\python.exe -m pytest t/unit/tasks/test_canvas.py::test_group -q`
- `.venv\Scripts\python.exe -m ruff check celery/canvas.py t/unit/tasks/test_canvas.py`
- `git diff --check`