### PR TITLE
fix: replace bare int()/float() env parsing with descriptive ValueError

### DIFF
--- a/celery/contrib/rdb.py
+++ b/celery/contrib/rdb.py
@@ -56,7 +56,19 @@ __all__ = (
 DEFAULT_PORT = 6899
 
 CELERY_RDB_HOST = os.environ.get('CELERY_RDB_HOST') or '127.0.0.1'
-CELERY_RDB_PORT = int(os.environ.get('CELERY_RDB_PORT') or DEFAULT_PORT)
+def _parse_rdb_port(default):
+    raw = os.environ.get('CELERY_RDB_PORT')
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        raise ValueError(
+            f"Invalid value for 'CELERY_RDB_PORT': expected integer, got {raw!r}"
+        ) from None
+
+
+CELERY_RDB_PORT = _parse_rdb_port(DEFAULT_PORT)
 
 #: Holds the currently active debugger.
 _current = [None]

--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -31,19 +31,43 @@ SOFTWARE_INFO = {
     'sw_sys': platform.system(),
 }
 
+def _get_int_env(name, default):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        raise ValueError(
+            f'Invalid value for {name!r}: expected integer, got {raw!r}'
+        ) from None
+
+
+def _get_float_env(name, default):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        raise ValueError(
+            f'Invalid value for {name!r}: expected float, got {raw!r}'
+        ) from None
+
+
 #: maximum number of revokes to keep in memory.
-REVOKES_MAX = int(os.environ.get('CELERY_WORKER_REVOKES_MAX', 50000))
+REVOKES_MAX = _get_int_env('CELERY_WORKER_REVOKES_MAX', 50000)
 
 #: maximum number of successful tasks to keep in memory.
-SUCCESSFUL_MAX = int(os.environ.get('CELERY_WORKER_SUCCESSFUL_MAX', 1000))
+SUCCESSFUL_MAX = _get_int_env('CELERY_WORKER_SUCCESSFUL_MAX', 1000)
 
 #: how many seconds a revoke will be active before
 #: being expired when the max limit has been exceeded.
-REVOKE_EXPIRES = float(os.environ.get('CELERY_WORKER_REVOKE_EXPIRES', 10800))
+REVOKE_EXPIRES = _get_float_env('CELERY_WORKER_REVOKE_EXPIRES', 10800)
 
 #: how many seconds a successful task will be cached in memory
 #: before being expired when the max limit has been exceeded.
-SUCCESSFUL_EXPIRES = float(os.environ.get('CELERY_WORKER_SUCCESSFUL_EXPIRES', 10800))
+SUCCESSFUL_EXPIRES = _get_float_env('CELERY_WORKER_SUCCESSFUL_EXPIRES', 10800)
 
 #: Mapping of reserved task_id->Request.
 requests = {}

--- a/t/unit/worker/test_state.py
+++ b/t/unit/worker/test_state.py
@@ -220,3 +220,13 @@ class test_state_configuration():
         assert state.SUCCESSFUL_MAX == 1000
         assert state.REVOKE_EXPIRES == 10800
         assert state.SUCCESSFUL_EXPIRES == 10800
+
+    @patch.dict(os.environ, {'CELERY_WORKER_REVOKES_MAX': 'not_an_int'})
+    def test_invalid_int_env_raises_clear_error(self):
+        with pytest.raises(ValueError, match=r"'CELERY_WORKER_REVOKES_MAX'.*expected integer"):
+            self.import_state()
+
+    @patch.dict(os.environ, {'CELERY_WORKER_REVOKE_EXPIRES': 'not_a_float'})
+    def test_invalid_float_env_raises_clear_error(self):
+        with pytest.raises(ValueError, match=r"'CELERY_WORKER_REVOKE_EXPIRES'.*expected float"):
+            self.import_state()


### PR DESCRIPTION
Fixes #10388

## Problem

Several numeric worker-related environment variables are parsed with bare `int()` / `float()` calls at module import time:

```python
# celery/worker/state.py
REVOKES_MAX = int(os.environ.get('CELERY_WORKER_REVOKES_MAX', 50000))
REVOKE_EXPIRES = float(os.environ.get('CELERY_WORKER_REVOKE_EXPIRES', 10800))
# ...

# celery/contrib/rdb.py
CELERY_RDB_PORT = int(os.environ.get('CELERY_RDB_PORT') or DEFAULT_PORT)
```

A malformed value fails with a raw Python traceback that does not mention the variable name:

```
ValueError: invalid literal for int() with base 10: 'abc'
```

## Solution

Introduce two small helpers `_get_int_env()` and `_get_float_env()` that include the variable name and expected type in the error message:

```
ValueError: Invalid value for 'CELERY_WORKER_REVOKES_MAX': expected integer, got 'abc'
```

## Changes

- `celery/worker/state.py` — replace `int(os.environ.get(...))` / `float(os.environ.get(...))` with `_get_int_env()` / `_get_float_env()` for all four numeric settings
- `celery/contrib/rdb.py` — replace `int(os.environ.get('CELERY_RDB_PORT') or DEFAULT_PORT)` with `_parse_rdb_port()`
- `t/unit/worker/test_state.py` — add two tests verifying that malformed values raise `ValueError` with the variable name in the message