### PR TITLE
Preserve re-buffered events during dispatcher flush

### DIFF
--- a/celery/events/dispatcher.py
+++ b/celery/events/dispatcher.py
@@ -202,12 +202,10 @@ class EventDispatcher:
         """Flush the outbound buffer."""
         if errors:
             buf = list(self._outbound_buffer)
-            try:
-                with self.mutex:
-                    for event, routing_key in buf:
-                        self._publish(event, self.producer, routing_key)
-            finally:
-                self._outbound_buffer.clear()
+            self._outbound_buffer.clear()
+            with self.mutex:
+                for event, routing_key in buf:
+                    self._publish(event, self.producer, routing_key)
         if groups:
             with self.mutex:
                 for group, events in self._group_buffer.items():

--- a/t/unit/events/test_events.py
+++ b/t/unit/events/test_events.py
@@ -205,7 +205,7 @@ class test_EventDispatcher:
 
         eventer.flush()
         assert len(eventer._outbound_buffer) == 1
-        
+
         producer.raise_on_publish = False
         eventer.flush()
         assert producer.has_event('Event 1')

--- a/t/unit/events/test_events.py
+++ b/t/unit/events/test_events.py
@@ -190,6 +190,27 @@ class test_EventDispatcher:
             assert producer.has_event(name)
         assert len(eventer._outbound_buffer) == 0
 
+    def test_flush_rebuffers_events_when_republish_fails(self):
+        producer = MockProducer()
+        producer.connection = self.app.connection_for_write()
+        producer.raise_on_publish = True
+        connection = Mock()
+        connection.transport.driver_type = 'amqp'
+        eventer = self.app.events.Dispatcher(connection, enabled=False,
+                                             buffer_while_offline=True)
+        eventer.producer = producer
+        eventer.enabled = True
+        eventer.send('Event 1')
+        assert len(eventer._outbound_buffer) == 1
+
+        eventer.flush()
+        assert len(eventer._outbound_buffer) == 1
+        
+        producer.raise_on_publish = False
+        eventer.flush()
+        assert producer.has_event('Event 1')
+        assert len(eventer._outbound_buffer) == 0
+
     def test_enter_exit(self):
         with self.app.connection_for_write() as conn:
             d = self.app.events.Dispatcher(conn)


### PR DESCRIPTION
## Description
Fixes: https://github.com/celery/celery/issues/6487.

`EventDispatcher.flush` cleared the `_outbound_buffer` in a finally block after replaying buffered events. If publishing one of those events failed again, `_publish` re-buffered it, but the final clear immediately removed it, causing worker events to be lost.
https://github.com/celery/celery/blob/1a4768959ef1b41f2c3e2b447233e90455697239/celery/events/dispatcher.py#L201-L210

This PR clears the outbound buffer before republishing buffered events, so events re-buffered after a failed publish remain queued for the next flush.