### PR TITLE
Move custom-worker integration tests to the smoke suite

### DIFF
--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from celery.contrib.pytest import celery_app, celery_session_worker, celery_worker
+from celery.contrib.pytest import celery_app, celery_session_worker
 from celery.contrib.testing.manager import Manager
 from celery.exceptions import TimeoutError
 from t.integration.tasks import get_redis_connection
@@ -39,7 +39,6 @@ def flaky(fn):
 __all__ = (
     'celery_app',
     'celery_session_worker',
-    'celery_worker',
     'flaky',
     'get_active_redis_channels',
 )

--- a/t/integration/test_worker.py
+++ b/t/integration/test_worker.py
@@ -1,12 +1,8 @@
 import subprocess
-from time import monotonic, sleep
 
 import pytest
-from kombu import Queue
 
 from celery import Celery
-from celery.exceptions import TimeoutError
-from t.integration.tasks import identity
 
 from .conftest import flaky
 from .tasks import add
@@ -73,49 +69,6 @@ def test_django_fixup_direct_worker(caplog, monkeypatch):
 
     assert "AttributeError: 'str' object has no attribute '__module__'." not in log_output, \
         f"AttributeError found in logs:\n{log_output}"
-
-
-class test_worker_queue_alias_reconnect:
-    @pytest.fixture
-    def celery_worker_parameters(self):
-        return {'queues': ('alias', 'celery')}
-
-    @pytest.mark.celery(task_queues=[Queue('real_name', alias='alias')])
-    def test_queue_selected_by_alias_is_not_reconsumed_after_cancel_by_real_name_and_reconnect(
-        self, celery_app, celery_worker
-    ):
-        consumer = celery_worker.consumer
-        celery_app.control.cancel_consumer('real_name', reply=True, timeout=10)
-
-        def _force_reconnect():
-            raise consumer.connection_errors[0]('forced reconnect')
-
-        # Force a reconnect so the worker rebuilds its consumers from _consume_from.
-        restarts = consumer.restart_count
-        consumer.hub.call_soon(_force_reconnect)
-        deadline = monotonic() + 10
-        while consumer.restart_count <= restarts and monotonic() < deadline:
-            sleep(0.5)
-        assert consumer.restart_count > restarts, 'worker did not reconnect'
-
-        with pytest.raises(TimeoutError):
-            identity.s('Hello').apply_async(queue='real_name').get(timeout=10)
-
-
-class test_explicit_routing_without_default_queue:
-    @pytest.fixture
-    def celery_worker_parameters(self):
-        return {'queues': ('non_default_queue',)}
-
-    @flaky
-    @pytest.mark.celery(
-        task_create_missing_queues=False,
-        task_queues=[Queue('non_default_queue')],
-        task_routes={'celery.ping': {'queue': 'non_default_queue'}},
-    )
-    def test_apply_async_succeeds_with_missing_queue_creation_disabled(self, celery_worker):
-        result = add.apply_async((1, 2), queue='non_default_queue')
-        assert result.get(timeout=10) == 3
 
 
 @flaky

--- a/t/smoke/tests/test_worker.py
+++ b/t/smoke/tests/test_worker.py
@@ -1,13 +1,18 @@
 from time import sleep
+from types import ModuleType
 
 import pytest
-from pytest_celery import CeleryTestSetup, CeleryTestWorker, RabbitMQTestBroker
+from pytest_celery import CeleryTestSetup, CeleryTestWorker, RabbitMQTestBroker, RedisTestBroker
+from pytest_docker_tools.wrappers.container import wait_for_callable
 
 import celery
 from celery import Celery
 from celery.canvas import chain, group
+from t.integration.tasks import add, identity
 from t.smoke.conftest import SuiteOperations, WorkerKill, WorkerRestart
 from t.smoke.tasks import long_running_task
+from t.smoke.workers import alias as alias_worker_app
+from t.smoke.workers.dev import SmokeWorkerContainer
 
 RESULT_TIMEOUT = 30
 
@@ -535,3 +540,91 @@ class test_worker_shutdown(SuiteOperations):
                     assert_container_exited(worker)
                     worker.restart()
                     assert res.get(RESULT_TIMEOUT)
+
+
+class test_worker_queue_alias_reconnect:
+    @pytest.fixture
+    def default_worker_container_cls(self) -> type[SmokeWorkerContainer]:
+        class AliasQueueWorkerContainer(SmokeWorkerContainer):
+            @classmethod
+            def worker_queue(cls) -> str:
+                return "alias,celery"
+
+            @classmethod
+            def app_module(cls) -> ModuleType:
+                return alias_worker_app
+
+        return AliasQueueWorkerContainer
+
+    def test_queue_selected_by_alias_is_not_reconsumed_after_cancel_by_real_name_and_reconnect(
+        self,
+        celery_setup: CeleryTestSetup,
+    ):
+        worker = celery_setup.worker
+        assert identity.si("consumed").apply_async(queue="real_name").get(timeout=RESULT_TIMEOUT) == "consumed"
+
+        replies = celery_setup.app.control.cancel_consumer(
+            "real_name",
+            destination=[worker.hostname()],
+            reply=True,
+            timeout=RESULT_TIMEOUT,
+        )
+        assert replies == [{worker.hostname(): {"ok": "no longer consuming from real_name"}}]
+
+        # Sever all broker connections so the worker reconnects and rebuilds
+        # its consumers from _consume_from
+        connections = worker.logs().count("Connected to")
+        broker = celery_setup.broker
+        if isinstance(broker, RabbitMQTestBroker):
+            disconnect_cmd = ["rabbitmqctl", "close_all_connections", "forced reconnect"]
+        elif isinstance(broker, RedisTestBroker):
+            disconnect_cmd = ["redis-cli", "CLIENT", "KILL", "TYPE", "normal"]
+        else:
+            pytest.fail(f"Unsupported broker: {type(broker).__name__}")
+        exit_code, output = broker.container.exec_run(disconnect_cmd)
+        assert exit_code == 0, f"Failed to close broker-side connections: {output!r}"
+        worker.assert_log_exists("consumer: Connection to broker lost")
+        wait_for_callable(
+            message="Waiting for the worker to reconnect to the broker",
+            func=lambda: worker.logs().count("Connected to") > connections,
+            timeout=RESULT_TIMEOUT,
+        )
+
+        retry_policy = {"max_retries": 20, "interval_start": 1, "interval_step": 1, "interval_max": 2}
+        sanity = identity.si("sanity").apply_async(queue="celery", retry=True, retry_policy=retry_policy)
+        assert sanity.get(timeout=RESULT_TIMEOUT) == "sanity"
+
+        with pytest.raises(celery.exceptions.TimeoutError):
+            identity.si("ignored").apply_async(
+                queue="real_name",
+                retry=True,
+                retry_policy=retry_policy,
+            ).get(timeout=10)
+
+
+class test_explicit_routing_without_default_queue:
+    @pytest.fixture
+    def default_worker_container_cls(self) -> type[SmokeWorkerContainer]:
+        class NonDefaultQueueWorkerContainer(SmokeWorkerContainer):
+            @classmethod
+            def worker_queue(cls) -> str:
+                return "non_default_queue"
+
+        return NonDefaultQueueWorkerContainer
+
+    @pytest.fixture
+    def default_worker_app(self, default_worker_app: Celery) -> Celery:
+        app = default_worker_app
+        app.conf.task_create_missing_queues = False
+        app.conf.task_queues = {"non_default_queue": {}}
+        return app
+
+    def test_apply_async_succeeds_with_missing_queue_creation_disabled(
+        self,
+        celery_setup: CeleryTestSetup,
+    ):
+        app = celery_setup.app
+        app.conf.task_create_missing_queues = False
+        app.conf.task_queues = {"non_default_queue": {}}
+        result = add.apply_async((1, 2), queue="non_default_queue")
+        assert result.get(timeout=RESULT_TIMEOUT) == 3

--- a/t/smoke/workers/alias.py
+++ b/t/smoke/workers/alias.py
@@ -1,0 +1,28 @@
+"""Celery worker app module declaring a queue selected by its alias.
+
+Used as the app module of a worker container to declare a queue topology
+with :class:`kombu.Queue` objects, which cannot be serialized through the
+worker configuration changes.
+"""
+
+from __future__ import annotations
+
+import json
+
+from kombu import Queue
+
+from celery import Celery
+
+imports = None
+
+app = Celery("celery_test_app")
+config = None
+
+if config:
+    app.config_from_object(config)
+    print(f"Changed worker configuration: {json.dumps(config, indent=4)}")
+
+app.conf.task_queues = [Queue("real_name", alias="alias")]
+
+if __name__ == "__main__":
+    app.start()


### PR DESCRIPTION
The integration suite runs against a single shared session worker. test_worker_queue_alias_reconnect and
test_explicit_routing_without_default_queue each spawned a custom function-scoped worker via the celery_worker fixture, which breaks that contract. Relocate them to t/smoke/tests/test_worker.py using dedicated worker containers, and remove the celery_worker fixture from the integration conftest so integration tests can no longer spawn per-test workers.
