### PR TITLE
docs: README lists Python 3.9 but setup.py requires >=3.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ What do I need?
 
 Celery version 5.6.x runs on:
 
-- Python (3.9, 3.10, 3.11, 3.12, 3.13)
+- Python (3.10, 3.11, 3.12, 3.13)
 - PyPy3.9+ (v7.3.12+)
 
 This is the last version of Celery which will support Python 3.9.


### PR DESCRIPTION
Hi, and thank you for Celery.

`README.rst` (line 125, under 'Celery version 5.6.x runs on:') lists:
```
- Python (3.9, 3.10, 3.11, 3.12, 3.13)
```
but `setup.py` declares `python_requires=">=3.10"` (and the trove classifiers start at 3.10), so 3.9 isn't actually supported. This drops 3.9 from the README list to match.

For transparency: I used AI assistance to spot and draft this; I verified README.rst and setup.py against the current source myself.