### PR TITLE
Handle EPERM from os.kill in multi stopwait node liveness check

### DIFF
--- a/celery/apps/multi.py
+++ b/celery/apps/multi.py
@@ -198,8 +198,11 @@ class Node:
             try:
                 os.kill(pid, sig)
             except OSError as exc:
-                if exc.errno != errno.ESRCH:
+                if exc.errno not in (errno.ESRCH, errno.EPERM):
                     raise
+                # ESRCH: pid is gone. EPERM: the pid was recycled by
+                # the OS and now belongs to another user's process.
+                # Either way, treat it as this node no longer being alive.
                 maybe_call(on_error, self)
                 return False
             return True

--- a/t/unit/apps/test_multi.py
+++ b/t/unit/apps/test_multi.py
@@ -215,6 +215,13 @@ class test_Node:
         kill.assert_called_with(self.node.pid, 9)
 
     @patch('os.kill')
+    def test_send__EPERM(self, kill):
+        kill.side_effect = OSError()
+        kill.side_effect.errno = errno.EPERM
+        assert not self.node.send(9)
+        kill.assert_called_with(self.node.pid, 9)
+
+    @patch('os.kill')
     def test_send__error(self, kill):
         kill.side_effect = OSError()
         kill.side_effect.errno = errno.ENOENT


### PR DESCRIPTION
## Summary
- `Node.send()` in `celery/apps/multi.py` (used by `celery multi stopwait` to poll whether a worker process is still alive) only ignored `ESRCH` from `os.kill()`.
- If the OS recycles a pid and reassigns it to a different user's process while polling, `kill()` raises `EPERM` instead, crashing `multi stopwait` with an unhandled `OSError`.
- This treats `EPERM` the same as `ESRCH`: either way, the node is no longer alive from our perspective.

Closes #2785