### PR TITLE
Preserve group-buffered events when flush republish fails

### DIFF
--- a/celery/events/dispatcher.py
+++ b/celery/events/dispatcher.py
@@ -209,7 +209,14 @@ class EventDispatcher:
         if groups:
             with self.mutex:
                 for group, events in self._group_buffer.items():
-                    self._publish(events, self.producer, '%s.multi' % group)
+                    if not events:
+                        continue
+                    # Publish a detached copy, then clear: when buffering
+                    # offline _publish re-buffers the object it was handed, so
+                    # clearing the live list first would empty it; when it
+                    # raises instead, skipping the clear keeps the events.
+                    batch = list(events)
+                    self._publish(batch, self.producer, '%s.multi' % group)
                     events[:] = []  # list.clear
 
     def extend_buffer(self, other):

--- a/t/unit/events/test_events.py
+++ b/t/unit/events/test_events.py
@@ -119,7 +119,7 @@ class test_EventDispatcher:
         eventer.send('task-received', uuid=1)
         assert not eventer._group_buffer['task']
         eventer._publish.assert_has_calls([
-            call([], eventer.producer, 'task.multi'),
+            call(buf_received[0], eventer.producer, 'task.multi'),
         ])
         # clear in place
         assert eventer._group_buffer['task'] is prev_buffer
@@ -210,6 +210,60 @@ class test_EventDispatcher:
         eventer.flush()
         assert producer.has_event('Event 1')
         assert len(eventer._outbound_buffer) == 0
+
+    def test_flush_rebuffers_group_events_when_publish_fails(self):
+        producer = MockProducer()
+        producer.connection = self.app.connection_for_write()
+        producer.raise_on_publish = True
+        connection = Mock()
+        connection.transport.driver_type = 'amqp'
+        eventer = self.app.events.Dispatcher(connection, enabled=False,
+                                             buffer_while_offline=True,
+                                             buffer_group={'task'})
+        eventer.producer = producer
+        eventer.enabled = True
+        eventer.send('task-received', uuid=1)
+        assert len(eventer._group_buffer['task']) == 1
+
+        eventer.flush()
+        assert len(eventer._outbound_buffer) == 1
+        batch, routing_key = eventer._outbound_buffer[0]
+        assert routing_key == 'task.multi'
+        assert len(batch) == 1
+
+        producer.raise_on_publish = False
+        eventer.flush()
+        assert len(eventer._outbound_buffer) == 0
+        assert [event['uuid'] for batch in producer.sent for event in batch] == [1]
+
+    def test_flush_keeps_group_events_when_publish_raises(self):
+        # With buffer_while_offline off, _publish re-raises instead of
+        # re-buffering. The live group buffer must only be cleared after a
+        # successful publish, otherwise the events are lost when it raises.
+        producer = MockProducer()
+        producer.connection = self.app.connection_for_write()
+        producer.raise_on_publish = True
+        connection = Mock()
+        connection.transport.driver_type = 'amqp'
+        eventer = self.app.events.Dispatcher(connection, enabled=False,
+                                             buffer_while_offline=False,
+                                             buffer_group={'task'})
+        eventer.producer = producer
+        eventer.enabled = True
+        eventer.send('task-received', uuid=1)
+        eventer.send('task-received', uuid=2)
+        assert len(eventer._group_buffer['task']) == 2
+
+        with pytest.raises(KeyError):
+            eventer.flush()
+        # events stay buffered for the next flush instead of being dropped
+        assert len(eventer._group_buffer['task']) == 2
+        assert len(eventer._outbound_buffer) == 0
+
+        producer.raise_on_publish = False
+        eventer.flush()
+        assert [event['uuid'] for batch in producer.sent for event in batch] == [1, 2]
+        assert not eventer._group_buffer['task']
 
     def test_enter_exit(self):
         with self.app.connection_for_write() as conn:


### PR DESCRIPTION
## Description

`EventDispatcher.flush()` loses every group-buffered `task-*` event if the broker is down at flush time — the events are re-buffered for retry, but the batch they live in is emptied out from under them.

This is the `groups` half of #10401. That PR fixed the identical re-buffer-then-clear loss in the `errors` branch a couple of weeks ago (Fixes #6487); the `groups` branch a few lines below has the same defect in a different shape, via aliasing rather than a `finally`.

### The bug

```python
if groups:
    with self.mutex:
        for group, events in self._group_buffer.items():
            self._publish(events, self.producer, '%s.multi' % group)
            events[:] = []  # list.clear
```

`_publish` re-buffers on failure with `self._outbound_buffer.append((event, routing_key))` — and `event` **is** `events`, the same list object. The next line clears it in place. The buffer entry survives; its payload does not.

### Reproducer

Three `task-succeeded` events buffered, broker fails during `flush()`, then recovers:

```
CONTROL: broker healthy throughout
  group buffer before flush : 3
  events delivered          : 3

BROKEN: broker down during flush, then recovers
  group buffer before flush : 3
  after failed flush, _outbound_buffer entries: 1
     re-buffered entry -> routing_key='task.multi' payload=[]
  events delivered after recovery: 0
  producer received payloads     : [[], []]
```

The control uses the same fixture and the same code path, so this isn't a broken reproducer — it's the failure path specifically. Note the two junk empty batches that go out as well.

### Reachability

Not a theoretical path — it's the default worker:

- `worker/consumer/events.py:45` sets `buffer_group=['task'] if c.hub else None`, so any worker with an event loop and events enabled (`-E`) group-buffers task events. That's the standard prefork worker, i.e. what Flower and every monitoring setup sees.
- `buffer_while_offline` defaults to `True` and the worker doesn't override it, so `_publish` does take the re-buffer path.
- `consumer.py:624-630` schedules `_flush_events` → `flush()` on the hub, and `worker/consumer/events.py:50` calls `dis.flush()` on reconnect — the comment there literally reads *"flush events sent while connection was down"*.

So this is `buffer_while_offline` failing at exactly the moment it exists for.

### Fix

Publish a detached copy, and skip groups with nothing buffered. The in-place clear is kept — `test_send_buffer_group` asserts the buffer keeps its identity (`is prev_buffer`), and `send()` holds a reference to it.

The empty-group skip is a small side benefit rather than a separate concern: `_group_buffer` is a `defaultdict`, so once the `task` key exists every later `flush()` published an empty `task.multi` to the broker.

### One thing worth flagging: I changed an assertion in an existing test

`test_send_buffer_group` asserted:

```python
eventer._publish.assert_has_calls([
    call([], eventer.producer, 'task.multi'),
])
```

That `[]` is an artifact of the bug, not a specification. `_publish` is a `Mock` there, and Mock stores a *reference* to the list it was called with — by assertion time, `events[:] = []` had emptied it. The same test already asserts, two lines later, that 2 events were really passed (`len(buf_received[0]) == 2`, snapshotted in the `side_effect`). So it currently asserts both "`[]` was passed" and "2 events were passed" about the same call, and only passes because of the aliasing this PR removes.

I changed it to `call(buf_received[0], ...)` so it asserts the real payload. Flagging it up front because "PR changes a test that was passing" deserves a look rather than a shrug.

### Verification

- New test `test_flush_rebuffers_group_events_when_publish_fails`, named and shaped after #10401's `test_flush_rebuffers_events_when_republish_fails`. Red before the fix (`assert len(batch) == 1` → `assert 0 == 1`), green after.
- No existing coverage for this: `test_send_buffer_group` mocks `_publish` outright, so the real failure path was never exercised, and #10401's test covers only the `errors` branch.
- `t/unit/events/ t/unit/worker/`: **713 passed, 2 skipped** with the fix vs. **712 passed, 2 skipped** on `main` — the one extra is the new test, and nothing regressed.
- `flake8` clean.

### AI disclosure

AI-assisted, and I'd rather say so plainly. The reproducer, the control, the reachability trace through `worker/consumer/`, the `buffer_while_offline` default check, and the `main`-vs-branch baseline comparison are all things I ran and read myself rather than assumed. Happy to adjust the scope or the framing.
