### PR TITLE
Respect result_extended in the RPC result backend

### DIFF
--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -271,13 +271,10 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
         return result
 
     def _to_result(self, task_id, state, result, traceback, request):
-        return {
-            'task_id': task_id,
-            'status': state,
-            'result': self.encode_result(result, state),
-            'traceback': traceback,
-            'children': self.current_task_children(request),
-        }
+        meta = self._get_result_meta(result=self.encode_result(result, state),
+                                     state=state, traceback=traceback, request=request)
+        meta['task_id'] = task_id
+        return meta
 
     def on_out_of_band_result(self, task_id, message):
         # Callback called when a reply for a task is received,

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -959,7 +959,7 @@ Supports the same options as the :setting:`task_compression` setting.
 Default: ``False``
 
 Enables extended task result attributes (name, args, kwargs, worker,
-retries, queue, delivery_info) to be written to backend.
+retries, queue) to be written to backend.
 
 .. setting:: result_expires
 

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -4,8 +4,9 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from celery import chord, group
+from celery import chord, group, states
 from celery._state import _task_stack
+from celery.app.task import Context
 from celery.backends.rpc import RPCBackend
 
 
@@ -286,3 +287,36 @@ class test_RPCBackend:
         ex = self.b._create_exchange('name')
         assert isinstance(ex, self.b.Exchange)
         assert ex.name == ''
+
+    def test_to_result_extended(self):
+        self.app.conf.result_extended = True
+        request = Context(
+            task='mytask', args=[1, 2], kwargs={'foo': 'bar'},
+            hostname='worker1@example.com', retries=2,
+            delivery_info={'routing_key': 'celery'},
+        )
+        meta = self.b._to_result('task-id', states.SUCCESS, 42, None, request)
+        assert meta['task_id'] == 'task-id'
+        assert meta['status'] == states.SUCCESS
+        assert meta['result'] == 42
+        assert meta['traceback'] is None
+        assert meta['name'] == 'mytask'
+        assert meta['args'] == [1, 2]
+        assert meta['kwargs'] == {'foo': 'bar'}
+        assert meta['worker'] == 'worker1@example.com'
+        assert meta['retries'] == 2
+        assert meta['queue'] == 'celery'
+
+    def test_to_result_not_extended(self):
+        self.app.conf.result_extended = False
+        request = Context(
+            task='mytask', args=[1, 2], kwargs={'foo': 'bar'},
+            delivery_info={'routing_key': 'celery'},
+        )
+        meta = self.b._to_result('task-id', states.SUCCESS, 42, None, request)
+        assert meta['task_id'] == 'task-id'
+        assert meta['status'] == states.SUCCESS
+        assert meta['result'] == 42
+        assert meta['traceback'] is None
+        for key in ('name', 'args', 'kwargs', 'worker', 'retries', 'queue'):
+            assert key not in meta


### PR DESCRIPTION
## Description
Closes: https://github.com/celery/celery/issues/5863

The `RPCBackend` result backend assembled its result payload by hand in `_to_result` and never went through `_get_result_meta`, so `result_extended` had no effect there.

This PR makes RPC results include extended metadata when `result_extended` is enabled.