### PR TITLE
fix: don't drop buffered events appended during publish

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -309,3 +309,4 @@ Diego Margoni, 2025/07/01
 Brian Helba, 2026/01/12
 송준호, 2026/04/22
 Hmn Falahi, 2026/07/08
+Oliver Haas, 2026/07/26

--- a/celery/events/dispatcher.py
+++ b/celery/events/dispatcher.py
@@ -211,13 +211,12 @@ class EventDispatcher:
                 for group, events in self._group_buffer.items():
                     if not events:
                         continue
-                    # Publish a detached copy, then clear: when buffering
-                    # offline _publish re-buffers the object it was handed, so
-                    # clearing the live list first would empty it; when it
-                    # raises instead, skipping the clear keeps the events.
+                    # Publish a detached copy, since _publish re-buffers the
+                    # object it was handed when offline. Clear only what was
+                    # published: other threads append during the socket write.
                     batch = list(events)
                     self._publish(batch, self.producer, '%s.multi' % group)
-                    events[:] = []  # list.clear
+                    del events[:len(batch)]
 
     def extend_buffer(self, other):
         """Copy the outbound buffer of another instance."""

--- a/t/unit/events/test_events.py
+++ b/t/unit/events/test_events.py
@@ -265,6 +265,39 @@ class test_EventDispatcher:
         assert [event['uuid'] for batch in producer.sent for event in batch] == [1, 2]
         assert not eventer._group_buffer['task']
 
+    def test_flush_keeps_group_events_appended_during_publish(self):
+        eventer = self.app.events.Dispatcher(Mock(), enabled=False,
+                                             buffer_group={'task'})
+        buffer = eventer._group_buffer['task']
+        buffer.extend(['first', 'second'])
+        published = []
+
+        def publish_then_append(batch, producer, routing_key):
+            published.extend(batch)
+            buffer.append('during-publish')
+
+        eventer._publish = publish_then_append
+        eventer.flush()
+
+        assert published == ['first', 'second']
+        assert buffer == ['during-publish']
+
+    def test_flush_keeps_events_appended_during_failed_publish(self):
+        eventer = self.app.events.Dispatcher(Mock(), enabled=False,
+                                             buffer_group={'task'})
+        buffer = eventer._group_buffer['task']
+        buffer.extend(['first', 'second'])
+
+        def append_then_raise(batch, producer, routing_key):
+            buffer.append('during-publish')
+            raise KeyError()
+
+        eventer._publish = append_then_raise
+        with pytest.raises(KeyError):
+            eventer.flush()
+
+        assert buffer == ['first', 'second', 'during-publish']
+
     def test_enter_exit(self):
         with self.app.connection_for_write() as conn:
             d = self.app.events.Dispatcher(conn)


### PR DESCRIPTION
See #10434

Note that it would have also been possible to put the append of events under the mutex, but the approach I've chosen seemed simpler given the constraints and a tiny bit more efficient as well.
