### PR TITLE
feat(task): support timedelta instances for time_limit and soft_time_limit

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -656,6 +656,12 @@ class Task:
             Also supports all keyword arguments supported by
             :meth:`kombu.Producer.publish`.
         """
+        from datetime import timedelta
+        if isinstance(self.time_limit, timedelta):
+            self.time_limit = self.time_limit.total_seconds()
+        if isinstance(self.soft_time_limit, timedelta):
+            self.soft_time_limit = self.soft_time_limit.total_seconds()
+
         if self.soft_time_limit and self.time_limit and self.soft_time_limit > self.time_limit:
             raise ValueError('soft_time_limit must be less than or equal to time_limit')
 


### PR DESCRIPTION
## Description
This PR resolves issue #10367 by supporting `timedelta` instances for `time_limit` and `soft_time_limit` in `celery/app/task.py`.

## Details
- Automatically converts `timedelta` duration arguments into seconds (`total_seconds()`) when evaluating task time limits.