### PR TITLE
fix(schedules): ensure hourly crontab executes during fall-back DST transition when 1 hour passes in UTC

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -588,7 +588,8 @@ class crontab(BaseSchedule):
             last_run_at.month == now.month and
             last_run_at.year == now.year and
             last_run_at.hour in self.hour and
-            last_run_at.minute < max(self.minute)
+            last_run_at.minute < max(self.minute) and
+            (now - last_run_at).total_seconds() < 3600
         )
 
         if execute_this_hour:


### PR DESCRIPTION
## Description
This PR resolves issue #10107 by checking `(now - last_run_at).total_seconds() < 3600` in `execute_this_hour` in `celery/schedules.py`.

## Details
- Prevents hourly crontab tasks from skipping execution during fall-back DST transitions when local times repeat but 1 full hour has elapsed in real time.