### PR TITLE
Warn when routing options are set as task attributes

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -13,7 +13,7 @@ from celery.canvas import _chain, group, signature
 from celery.exceptions import Ignore, ImproperlyConfigured, MaxRetriesExceededError, Reject, Retry
 from celery.local import class_property
 from celery.result import EagerResult, denied_join_result
-from celery.utils import abstract
+from celery.utils import abstract, deprecated
 from celery.utils.functional import mattrgetter, maybe_list
 from celery.utils.imports import instantiate
 from celery.utils.nodenames import gethostname
@@ -421,6 +421,17 @@ class Task:
         cls._app = app
         conf = app.conf
         cls._exec_options = None  # clear option cache
+
+        if not was_bound:
+            for attr in ('queue', 'exchange', 'exchange_type',
+                         'routing_key', 'delivery_mode', 'priority'):
+                if attr in cls.__dict__:
+                    # In Celery 6.0, make these task attributes have no effect
+                    deprecated.warn(
+                        description=f'The {attr!r} task attribute',
+                        removal='6.0',
+                        alternative='Use the task_routes setting instead.',
+                    )
 
         if cls.typing is None:
             cls.typing = app.strict_typing

--- a/docs/internals/deprecation.rst
+++ b/docs/internals/deprecation.rst
@@ -7,6 +7,25 @@
 .. contents::
     :local:
 
+.. _deprecations-v6.0:
+
+Removals for version 6.0
+========================
+
+Task attributes
+---------------
+
+The task attributes:
+
+- ``queue``
+- ``exchange``
+- ``exchange_type``
+- ``routing_key``
+- ``delivery_mode``
+- ``priority``
+
+are deprecated and must be set by :setting:`task_routes` instead.
+
 .. _deprecations-v5.0:
 
 Removals for version 5.0
@@ -92,21 +111,6 @@ on the class, but have to instantiate the task first:
 
 
     >>> MyTask().delay()        # WORKS!
-
-
-Task attributes
----------------
-
-The task attributes:
-
-- ``queue``
-- ``exchange``
-- ``exchange_type``
-- ``routing_key``
-- ``delivery_mode``
-- ``priority``
-
-is deprecated and must be set by :setting:`task_routes` instead.
 
 
 Modules to Remove

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -11,7 +11,7 @@ from celery import Task, chain, group, uuid
 from celery.app.task import _reprtask
 from celery.canvas import StampingVisitor, signature
 from celery.contrib.testing.mocks import ContextMock
-from celery.exceptions import Ignore, ImproperlyConfigured, Retry
+from celery.exceptions import CDeprecationWarning, Ignore, ImproperlyConfigured, Retry
 from celery.result import AsyncResult, EagerResult
 from celery.utils.serialization import UnpickleableExceptionWrapper
 
@@ -1508,6 +1508,19 @@ class test_tasks(TasksCase):
             assert yyy_result.state == 'FAILURE'
         except ValueError as e:
             assert str(e) == 'soft_time_limit must be less than or equal to time_limit'
+
+
+class test_task_routing_attribute_deprecation(TasksCase):
+
+    @pytest.mark.parametrize('attr', [
+        'queue', 'exchange', 'exchange_type',
+        'routing_key', 'delivery_mode', 'priority',
+    ])
+    def test_warns_when_routing_attribute_declared(self, attr):
+        with pytest.warns(CDeprecationWarning, match=f"The {attr!r} task attribute is deprecated"):
+            @self.app.task(shared=False, lazy=False, **{attr: 'foo'})
+            def task_with_routing_attr():
+                pass
 
 
 class test_apply_task(TasksCase):


### PR DESCRIPTION
## Description

Fixes #8396

The deprecation timeline lists these attributes under [Removals for version 5.0](https://docs.celeryq.dev/en/latest/internals/deprecation.html#task-attributes), but they still work in 5.x and emit no warning. Per [the comment](https://github.com/celery/celery/issues/8396#issuecomment-1653414178) the actual removal target is 6.0.

This PR adds the deprecation warning and fixes the doc.