### PR TITLE
Move task_sent and Result deprecations to the 6.0 timeline

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -493,8 +493,8 @@ class AMQP:
         send_after_publish = signals.after_task_publish.send
         after_receivers = signals.after_task_publish.receivers
 
-        send_task_sent = signals.task_sent.send   # XXX compat
-        sent_receivers = signals.task_sent.receivers
+        send_task_sent = signals.task_sent.send   # XXX compat (remove 6.0)
+        sent_receivers = signals.task_sent.receivers   # XXX compat (remove 6.0)
 
         default_evd = self._event_dispatcher
         default_exchange = self.default_exchange

--- a/celery/result.py
+++ b/celery/result.py
@@ -267,7 +267,7 @@ class AsyncResult(ResultBase):
             callback=callback,
             on_message=on_message,
         )
-    wait = get  # deprecated alias to :meth:`get`.
+    wait = get  # deprecated alias to :meth:`get` (remove 6.0).
 
     def _maybe_reraise_parent_error(self):
         for node in reversed(list(self._parents())):
@@ -531,15 +531,15 @@ class AsyncResult(ResultBase):
                 then contains the tasks return value.
         """
         return self._get_task_meta()['status']
-    status = state  # XXX compat
+    status = state  # XXX compat (remove 6.0)
 
     @property
-    def task_id(self):
+    def task_id(self):  # XXX compat (remove 6.0)
         """Compat. alias to :attr:`id`."""
         return self.id
 
     @task_id.setter
-    def task_id(self, id):
+    def task_id(self, id):  # XXX compat (remove 6.0)
         self.id = id
 
     @property
@@ -1068,7 +1068,7 @@ class EagerResult(AsyncResult):
                 raise self.result if isinstance(
                     self.result, Exception) else Exception(self.result)
             return self.result
-    wait = get  # XXX Compat (remove 5.0)
+    wait = get  # XXX Compat (remove 6.0)
 
     def forget(self):
         pass
@@ -1098,7 +1098,7 @@ class EagerResult(AsyncResult):
     def state(self):
         """The tasks state."""
         return self._state
-    status = state
+    status = state  # XXX compat (remove 6.0)
 
     @property
     def traceback(self):

--- a/celery/signals.py
+++ b/celery/signals.py
@@ -85,7 +85,7 @@ task_unknown = Signal(
     name='task_unknown',
     providing_args={'message', 'exc', 'name', 'id'},
 )
-#: Deprecated, use after_task_publish instead.
+#: Deprecated, use after_task_publish instead (remove 6.0).
 task_sent = Signal(
     name='task_sent',
     providing_args={

--- a/docs/internals/deprecation.rst
+++ b/docs/internals/deprecation.rst
@@ -26,6 +26,25 @@ The task attributes:
 
 are deprecated and must be set by :setting:`task_routes` instead.
 
+Task_sent signal
+----------------
+
+The :signal:`task_sent` signal is deprecated.
+Please use the :signal:`before_task_publish` and :signal:`after_task_publish`
+signals instead.
+
+Result
+------
+
+Apply to: :class:`~celery.result.AsyncResult`,
+:class:`~celery.result.EagerResult`:
+
+- ``Result.wait()`` -> ``Result.get()``
+
+- ``Result.task_id()`` -> ``Result.id``
+
+- ``Result.status`` -> ``Result.state``.
+
 .. _deprecations-v5.0:
 
 Removals for version 5.0
@@ -181,25 +200,6 @@ Settings
 ``REDIS_PASSWORD``                     :setting:`result_backend`
 =====================================  =====================================
 
-
-Task_sent signal
-----------------
-
-The :signal:`task_sent` signal will be removed in version 4.0.
-Please use the :signal:`before_task_publish` and :signal:`after_task_publish`
-signals instead.
-
-Result
-------
-
-Apply to: :class:`~celery.result.AsyncResult`,
-:class:`~celery.result.EagerResult`:
-
-- ``Result.wait()`` -> ``Result.get()``
-
-- ``Result.task_id()`` -> ``Result.id``
-
-- ``Result.status`` -> ``Result.state``.
 
 .. _deprecations-v3.1:
 

--- a/docs/internals/deprecation.rst
+++ b/docs/internals/deprecation.rst
@@ -41,7 +41,7 @@ Apply to: :class:`~celery.result.AsyncResult`,
 
 - ``Result.wait()`` -> ``Result.get()``
 
-- ``Result.task_id()`` -> ``Result.id``
+- ``Result.task_id`` -> ``Result.id``
 
 - ``Result.status`` -> ``Result.state``.
 


### PR DESCRIPTION
## Description

Follow-up to #10453

The deprecation timeline lists the `task_sent` signal and the `Result.wait()`/`.task_id`/`.status` aliases under [Removals for version 5.0](https://docs.celeryq.dev/en/latest/internals/deprecation.html#task-sent-signal), but they still work in 5.6.3.

This PR moves them to 6.0 and marks the code sites for later removal.