### PR TITLE
Fix autoretry retry kwargs mutation

### DIFF
--- a/celery/app/autoretry.py
+++ b/celery/app/autoretry.py
@@ -45,8 +45,9 @@ def add_autoretry_behaviour(task, **options):
             except dont_autoretry_for:
                 raise
             except autoretry_for as exc:
+                retry_kwargs_for_attempt = retry_kwargs.copy()
                 if retry_backoff:
-                    retry_kwargs['countdown'] = \
+                    retry_kwargs_for_attempt['countdown'] = \
                         get_exponential_backoff_interval(
                             factor=int(max(1.0, retry_backoff)),
                             retries=task.request.retries,
@@ -54,10 +55,9 @@ def add_autoretry_behaviour(task, **options):
                             full_jitter=retry_jitter)
                 # Override max_retries
                 if hasattr(task, 'override_max_retries'):
-                    retry_kwargs['max_retries'] = getattr(task,
-                                                          'override_max_retries',
-                                                          task.max_retries)
-                ret = task.retry(exc=exc, **retry_kwargs)
+                    retry_kwargs_for_attempt['max_retries'] = getattr(
+                        task, 'override_max_retries', task.max_retries)
+                ret = task.retry(exc=exc, **retry_kwargs_for_attempt)
                 # Stop propagation
                 if hasattr(task, 'override_max_retries'):
                     delattr(task, 'override_max_retries')

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -658,6 +658,23 @@ class test_task_retries(TasksCase):
         ]
         assert retry_call_countdowns == expected_countdowns
 
+    def test_autoretry_does_not_mutate_retry_kwargs(self):
+        retry_kwargs = {}
+
+        @self.app.task(bind=True, shared=False, autoretry_for=(ZeroDivisionError,),
+                       retry_backoff=True, retry_jitter=False, max_retries=3,
+                       retry_kwargs=retry_kwargs)
+        def task(self_, x, y):
+            return x / y
+
+        with patch.object(task, 'retry', wraps=task.retry) as fake_retry:
+            task.apply((1, 0))
+
+        assert retry_kwargs == {}
+        assert [call_[1]['countdown'] for call_ in fake_retry.call_args_list] == [
+            1, 2, 4, 8
+        ]
+
     @pytest.mark.parametrize(
         'retry_backoff, expected_countdowns',
         [


### PR DESCRIPTION
## Description

Fixes #10456.

The autoretry wrapper now copies retry_kwargs for each retry attempt before adding calculated countdown or max_retries values. This prevents the task-level dictionary captured by the wrapper from being mutated and shared between executions.

Added a regression test covering retry backoff values and verifying that the caller-provided dictionary remains unchanged.

## Verification

- python -m pytest t/unit/tasks/test_tasks.py -k autoretry -q (35 passed)
- git diff --check