### PR TITLE
RPC result backend recirculates final results on every state poll

### DIFF
--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -143,6 +143,13 @@ class ResultConsumer(BaseResultConsumer):
         if self._consumer:
             self._consumer.cancel_by_queue(self._create_binding(task_id).name)
 
+    def on_state_change(self, meta, message):
+        super().on_state_change(meta, message)
+        if meta['status'] in states.READY_STATES:
+            # final state delivered by the consumer: any copy buffered
+            # by an earlier poll is stale now.
+            self.backend._out_of_band.pop(meta.get('task_id'), None)
+
 
 class RPCBackend(base.Backend, AsyncBackendMixin):
     """Base class for the RPC result backend."""
@@ -199,7 +206,9 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
 
     def _after_fork(self):
         # clear state for child processes.
-        self._pending_results.clear()
+        for mapping in self._pending_results:
+            mapping.clear()
+        self._out_of_band.clear()
         self.result_consumer._after_fork()
 
     def _create_exchange(self, name, type='direct', delivery_mode=2):
@@ -248,6 +257,15 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
         # but we don't have to cancel since we have one queue per process.
         pass
 
+    def forget(self, task_id):
+        self._out_of_band.pop(task_id, None)
+        super().forget(task_id)
+
+    def _forget(self, task_id):
+        # results are messages on the reply queue,
+        # there is nothing stored server-side to delete.
+        pass
+
     def as_uri(self, include_password=True):
         return 'rpc://'
 
@@ -283,7 +301,15 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
         # buffer: probably it will become pending later.
         if self.result_consumer:
             self.result_consumer.on_out_of_band_result(message)
-        self._out_of_band[task_id] = message
+        if message.payload.get('status') in states.READY_STATES:
+            # final meta is served from the cache,
+            # no need to buffer the message itself.
+            self._set_cache_by_message(task_id, message)
+        else:
+            self._out_of_band[task_id] = message
+        # the payload is buffered/cached in memory now, so complete the
+        # delivery instead of leaving it unacked on the channel.
+        message.ack()
 
     def get_task_meta(self, task_id, backlog_limit=1000):
         buffered = self._out_of_band.pop(task_id, None)
@@ -307,15 +333,29 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
             self.on_out_of_band_result(tid, msg)
 
         if latest:
-            latest.requeue()
-            return self._set_cache_by_message(task_id, latest)
+            meta = self._set_cache_by_message(task_id, latest)
+            if meta['status'] in states.READY_STATES:
+                # final state: resolve any pending waiter from the cache
+                # and ack, requeueing would keep the message circulating
+                # between the queue and _out_of_band forever.
+                self.result_consumer.on_out_of_band_result(latest)
+                latest.ack()
+            else:
+                latest.requeue()
+            return meta
         else:
             # no new state, use previous
             try:
                 return self._cache[task_id]
             except KeyError:
-                # result probably pending.
-                return {'status': states.PENDING, 'result': None}
+                pass
+            # a final state consumed by an earlier poll is kept in the
+            # pending buffer for late waiters, peek without consuming.
+            buf = self._pending_messages.get(task_id)
+            if buf:
+                return self.meta_from_decoded(dict(buf.data[-1]))
+            # result probably pending.
+            return {'status': states.PENDING, 'result': None}
     poll = get_task_meta  # XXX compat
 
     def _set_cache_by_message(self, task_id, message):

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -259,6 +259,12 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
 
     def forget(self, task_id):
         self._out_of_band.pop(task_id, None)
+        try:
+            buf = self._pending_messages.pop(task_id)
+        except KeyError:
+            pass
+        else:
+            self._pending_messages.total -= len(buf)
         super().forget(task_id)
 
     def _forget(self, task_id):

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -209,6 +209,11 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
         for mapping in self._pending_results:
             mapping.clear()
         self._out_of_band.clear()
+        # the child must not inherit the parent's buffered final
+        # states or cached metas.
+        self._pending_messages.clear()
+        self._pending_messages.total = 0
+        self._cache.clear()
         self.result_consumer._after_fork()
 
     def _create_exchange(self, name, type='direct', delivery_mode=2):
@@ -359,7 +364,7 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
             # pending buffer for late waiters, peek without consuming.
             buf = self._pending_messages.get(task_id)
             if buf:
-                return self.meta_from_decoded(dict(buf.data[-1]))
+                return self.meta_from_decoded(dict(buf[-1]))
             # result probably pending.
             return {'status': states.PENDING, 'result': None}
     poll = get_task_meta  # XXX compat

--- a/t/smoke/tests/test_rpc_backend.py
+++ b/t/smoke/tests/test_rpc_backend.py
@@ -15,12 +15,17 @@ import json
 import urllib.request
 
 import pytest
-from pytest_celery import (RABBITMQ_PORTS, RESULT_TIMEOUT, CeleryBrokerCluster, CeleryTestSetup, RabbitMQContainer,
-                           RabbitMQTestBroker)
+from pytest_celery import (
+    RABBITMQ_PORTS,
+    RESULT_TIMEOUT,
+    CeleryBrokerCluster,
+    CeleryTestSetup,
+    RabbitMQContainer,
+    RabbitMQTestBroker,
+)
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from celery import Celery, states
-from t.integration.tasks import add, identity
 
 
 class RabbitMQManagementBroker(RabbitMQTestBroker):
@@ -93,13 +98,19 @@ def default_worker_app(default_worker_app: Celery) -> Celery:
     app = default_worker_app
     app.conf.worker_prefetch_multiplier = 1
     app.conf.worker_concurrency = 1
+    # direct attribute assignment lands in conf.changes, which is what
+    # pytest-celery serializes into the worker container config; the
+    # celery_setup_config dict alone only configures the client side.
+    app.conf.result_backend = "rpc://"
     return app
 
 
 class test_rpc_backend:
     def test_sanity(self, celery_setup: CeleryTestSetup):
         assert celery_setup.app.conf.result_backend == "rpc://"
-        res = identity.s("test_sanity").apply_async(
+        res = celery_setup.app.send_task(
+            "t.integration.tasks.identity",
+            args=("test_sanity",),
             queue=celery_setup.worker.worker_queue,
         )
         assert res.get(RESULT_TIMEOUT) == "test_sanity"
@@ -110,20 +121,37 @@ class test_rpc_backend:
         app = celery_setup.app
         queue = celery_setup.worker.worker_queue
 
+        # publish through the setup app itself so the result reply queue
+        # is the same queue app.backend polls below.
         results = [
-            add.s(i, i).apply_async(queue=queue)
+            app.send_task("t.integration.tasks.add", args=(i, i), queue=queue)
             for i in range(3)
         ]
-        for i, res in enumerate(results):
-            assert res.get(RESULT_TIMEOUT) == i + i
 
-        # state polls after completion are served without putting the
+        @retry(
+            stop=stop_after_attempt(int(RESULT_TIMEOUT)),
+            wait=wait_fixed(1),
+            reraise=True,
+        )
+        def poll_until_ready(task_id):
+            meta = app.backend.get_task_meta(task_id)
+            assert meta["status"] in states.READY_STATES, meta
+            return meta
+
+        # poll each task through the backend until it completes: this is
+        # the exact poll path that used to requeue the final result
+        # message on every call.
+        for i, res in enumerate(results):
+            meta = poll_until_ready(res.id)
+            assert meta["status"] == states.SUCCESS
+            assert meta["result"] == i + i
+
+        # further polls are served from the cache without putting the
         # final result message back on the reply queue.
         for res in results:
             for _ in range(5):
                 meta = app.backend.get_task_meta(res.id)
-                assert meta["status"] == states.SUCCESS
-                assert meta["result"] is not None
+                assert meta["status"] == states.SUCCESS, meta
 
         broker = celery_setup.broker
 

--- a/t/smoke/tests/test_rpc_backend.py
+++ b/t/smoke/tests/test_rpc_backend.py
@@ -1,0 +1,140 @@
+"""Smoke tests for the RPC result backend.
+
+Regression coverage for https://github.com/celery/celery/issues/4830:
+polling the RPC backend for a completed task used to requeue the final
+result message instead of acking it, so final results recirculated on
+the reply queue on every state poll. These tests run against a real
+RabbitMQ broker and verify both the result round-trip and that repeated
+polling leaves no messages behind on the broker.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import urllib.request
+
+import pytest
+from pytest_celery import (RABBITMQ_PORTS, RESULT_TIMEOUT, CeleryBrokerCluster,
+                           CeleryTestSetup, RabbitMQContainer, RabbitMQTestBroker)
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+from celery import Celery, states
+from t.integration.tasks import add, identity
+
+
+class RabbitMQManagementBroker(RabbitMQTestBroker):
+    """RabbitMQ broker with the management API exposed.
+
+    Used to inspect queue depths directly, which is how recirculating
+    result messages are detected.
+    """
+
+    def get_management_url(self) -> str:
+        ports = self.container.attrs["NetworkSettings"]["Ports"]
+        ip = ports["15672/tcp"][0]["HostIp"]
+        port = ports["15672/tcp"][0]["HostPort"]
+        return f"http://{ip}:{port}"
+
+    def get_total_ready_messages(self) -> int:
+        """Total messages sitting ready on all queues of the default vhost."""
+        url = f"{self.get_management_url()}/api/queues/%2F"
+        request = urllib.request.Request(url)
+        credentials = base64.b64encode(b"guest:guest").decode()
+        request.add_header("Authorization", f"Basic {credentials}")
+        with urllib.request.urlopen(request, timeout=10) as response:
+            queues = json.loads(response.read())
+        return sum(queue.get("messages_ready", 0) for queue in queues)
+
+
+@pytest.fixture
+def default_rabbitmq_broker_image() -> str:
+    return "rabbitmq:management"
+
+
+@pytest.fixture
+def default_rabbitmq_broker_ports() -> dict:
+    # expose the management UI/API port as well
+    ports = RABBITMQ_PORTS.copy()
+    ports.update({"15672/tcp": None})
+    return ports
+
+
+@pytest.fixture
+def celery_rabbitmq_broker(default_rabbitmq_broker: RabbitMQContainer) -> RabbitMQManagementBroker:
+    broker = RabbitMQManagementBroker(default_rabbitmq_broker)
+    yield broker
+    broker.teardown()
+
+
+@pytest.fixture
+def celery_broker_cluster(celery_rabbitmq_broker: RabbitMQTestBroker) -> CeleryBrokerCluster:
+    # the RPC result backend only works on top of the AMQP broker
+    cluster = CeleryBrokerCluster(celery_rabbitmq_broker)
+    yield cluster
+    cluster.teardown()
+
+
+@pytest.fixture
+def celery_backend_cluster() -> None:
+    # the RPC backend stores results in the AMQP broker itself,
+    # so no dedicated backend container is needed.
+    return None
+
+
+@pytest.fixture
+def celery_setup_config(celery_setup_config: dict) -> dict:
+    celery_setup_config["result_backend"] = "rpc://"
+    return celery_setup_config
+
+
+@pytest.fixture
+def default_worker_app(default_worker_app: Celery) -> Celery:
+    app = default_worker_app
+    app.conf.worker_prefetch_multiplier = 1
+    app.conf.worker_concurrency = 1
+    return app
+
+
+class test_rpc_backend:
+    def test_sanity(self, celery_setup: CeleryTestSetup):
+        assert celery_setup.app.conf.result_backend == "rpc://"
+        res = identity.s("test_sanity").apply_async(
+            queue=celery_setup.worker.worker_queue,
+        )
+        assert res.get(RESULT_TIMEOUT) == "test_sanity"
+
+    def test_repeated_final_polls_do_not_recirculate(self, celery_setup: CeleryTestSetup):
+        # regression test for #4830: polling many completed tasks must
+        # leave no result messages behind on the broker.
+        app = celery_setup.app
+        queue = celery_setup.worker.worker_queue
+
+        results = [
+            add.s(i, i).apply_async(queue=queue)
+            for i in range(3)
+        ]
+        for i, res in enumerate(results):
+            assert res.get(RESULT_TIMEOUT) == i + i
+
+        # state polls after completion are served without putting the
+        # final result message back on the reply queue.
+        for res in results:
+            for _ in range(5):
+                meta = app.backend.get_task_meta(res.id)
+                assert meta["status"] == states.SUCCESS
+                assert meta["result"] is not None
+
+        broker = celery_setup.broker
+
+        @retry(
+            stop=stop_after_attempt(30),
+            wait=wait_fixed(0.2),
+            reraise=True,
+        )
+        def assert_broker_drained():
+            # before the fix every poll requeued the final message, so
+            # the reply queue never stayed empty here.
+            assert broker.get_total_ready_messages() == 0
+
+        assert_broker_drained()

--- a/t/smoke/tests/test_rpc_backend.py
+++ b/t/smoke/tests/test_rpc_backend.py
@@ -15,14 +15,8 @@ import json
 import urllib.request
 
 import pytest
-from pytest_celery import (
-    RABBITMQ_PORTS,
-    RESULT_TIMEOUT,
-    CeleryBrokerCluster,
-    CeleryTestSetup,
-    RabbitMQContainer,
-    RabbitMQTestBroker,
-)
+from pytest_celery import (RABBITMQ_PORTS, RESULT_TIMEOUT, CeleryBrokerCluster, CeleryTestSetup, RabbitMQContainer,
+                           RabbitMQTestBroker)
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from celery import Celery, states

--- a/t/smoke/tests/test_rpc_backend.py
+++ b/t/smoke/tests/test_rpc_backend.py
@@ -15,8 +15,8 @@ import json
 import urllib.request
 
 import pytest
-from pytest_celery import (RABBITMQ_PORTS, RESULT_TIMEOUT, CeleryBrokerCluster,
-                           CeleryTestSetup, RabbitMQContainer, RabbitMQTestBroker)
+from pytest_celery import (RABBITMQ_PORTS, RESULT_TIMEOUT, CeleryBrokerCluster, CeleryTestSetup, RabbitMQContainer,
+                           RabbitMQTestBroker)
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from celery import Celery, states

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -320,3 +320,147 @@ class test_RPCBackend:
         assert meta['traceback'] is None
         for key in ('name', 'args', 'kwargs', 'worker', 'retries', 'queue'):
             assert key not in meta
+
+
+class test_RPCBackend_result_lifecycle:
+    """Result message lifecycle: polling must not leak or recirculate."""
+
+    def setup_method(self):
+        self.b = RPCBackend(app=self.app)
+
+    def make_message(self, task_id, status, result=None):
+        message = Mock(name=f'message-{task_id}')
+        message.payload = {
+            'task_id': task_id,
+            'status': status,
+            'result': result,
+            'traceback': None,
+        }
+        message.properties = {'correlation_id': task_id}
+        return message
+
+    def slurp(self, messages):
+        return patch.object(
+            self.b, '_slurp_from_queue', return_value=iter(messages))
+
+    def test_final_state_is_acked_not_requeued(self):
+        message = self.make_message('tid1', states.SUCCESS, 42)
+        with self.slurp([message]):
+            meta = self.b.get_task_meta('tid1')
+        assert meta['status'] == states.SUCCESS
+        assert meta['result'] == 42
+        message.ack.assert_called_once_with()
+        message.requeue.assert_not_called()
+
+    def test_final_state_cached_when_cache_enabled(self):
+        # the test app sets result_cache_max=-1 (cache disabled),
+        # with caching on the final meta is served from the cache.
+        self.app.conf.result_cache_max = 100
+        b = RPCBackend(app=self.app)
+        message = self.make_message('tid1', states.SUCCESS, 42)
+        with patch.object(b, '_slurp_from_queue',
+                          return_value=iter([message])):
+            b.get_task_meta('tid1')
+        assert b._cache['tid1']['status'] == states.SUCCESS
+        with patch.object(b, '_slurp_from_queue',
+                          return_value=iter([])):
+            assert b.get_task_meta('tid1')['result'] == 42
+
+    def test_non_final_state_is_requeued(self):
+        message = self.make_message('tid1', states.RETRY)
+        with self.slurp([message]):
+            meta = self.b.get_task_meta('tid1')
+        assert meta['status'] == states.RETRY
+        message.requeue.assert_called_once_with()
+        message.ack.assert_not_called()
+
+    def test_final_state_resolves_pending_waiter(self):
+        # a waiter blocked in get() must still resolve when a poll
+        # consumes the final message first.
+        result = self.app.AsyncResult('tid1')
+        self.b._add_pending_result('tid1', result)
+        message = self.make_message('tid1', states.SUCCESS, 42)
+        with self.slurp([message]):
+            self.b.get_task_meta('tid1')
+        message.ack.assert_called_once_with()
+        assert result._cache['status'] == states.SUCCESS
+        assert result._cache['result'] == 42
+
+    def test_final_state_buffered_for_later_waiter(self):
+        # a get() started after the poll resolves from the buffer
+        # instead of hanging on a message that will never arrive.
+        message = self.make_message('tid1', states.SUCCESS, 42)
+        with self.slurp([message]):
+            self.b.get_task_meta('tid1')
+        buffered = self.b._pending_messages.take('tid1')
+        assert buffered['status'] == states.SUCCESS
+
+    def test_repeated_final_polls_do_not_recirculate(self):
+        # regression test for #4830: polling many completed tasks must
+        # leave no messages on the queue and nothing in _out_of_band.
+        messages = [
+            self.make_message(f'tid{i}', states.SUCCESS, i)
+            for i in range(10)
+        ]
+        for i, message in enumerate(messages):
+            with self.slurp([message]):
+                meta = self.b.get_task_meta(f'tid{i}')
+            assert meta['status'] == states.SUCCESS
+            message.ack.assert_called_once_with()
+        assert self.b._out_of_band == {}
+        # later polls are served from the cache, no queue traffic needed.
+        with self.slurp([]):
+            assert self.b.get_task_meta('tid3')['result'] == 3
+
+    def test_out_of_band_final_state_is_cached_and_acked(self):
+        message = self.make_message('other', states.SUCCESS, 7)
+        with self.slurp([message]):
+            meta = self.b.get_task_meta('tid1')
+        assert meta['status'] == states.PENDING
+        message.ack.assert_called_once_with()
+        assert 'other' not in self.b._out_of_band
+        # a later poll for that task still sees the final state,
+        # served from the pending buffer without queue traffic.
+        with self.slurp([]):
+            assert self.b.get_task_meta('other')['result'] == 7
+
+    def test_out_of_band_non_final_state_is_buffered_and_acked(self):
+        message = self.make_message('other', states.STARTED)
+        with self.slurp([message]):
+            self.b.get_task_meta('tid1')
+        message.ack.assert_called_once_with()
+        assert self.b._out_of_band['other'] is message
+        # a later poll for that task uses the buffered copy.
+        with self.slurp([]):
+            meta = self.b.get_task_meta('other')
+        assert meta['status'] == states.STARTED
+        assert 'other' not in self.b._out_of_band
+
+    def test_stale_buffered_state_dropped_on_consumer_final(self):
+        # a stale non-final entry buffered by an earlier poll must not
+        # regress the state once the consumer delivers the final meta.
+        stale = self.make_message('tid1', states.STARTED)
+        self.b._out_of_band['tid1'] = stale
+        final = self.make_message('tid1', states.SUCCESS, 42)
+        self.b.result_consumer.on_state_change(final.payload, final)
+        assert 'tid1' not in self.b._out_of_band
+        assert self.b._pending_messages.take('tid1')['status'] == (
+            states.SUCCESS)
+
+    def test_forget_clears_out_of_band_and_cache(self):
+        message = self.make_message('tid1', states.STARTED)
+        self.b._out_of_band['tid1'] = message
+        self.b._cache['tid1'] = {'status': states.STARTED}
+        self.b.forget('tid1')
+        assert 'tid1' not in self.b._out_of_band
+        assert 'tid1' not in self.b._cache
+
+    def test_forget_does_not_raise(self):
+        # RPCBackend inherited the base _forget which just raises.
+        self.b.forget('tid1')
+
+    def test_after_fork_clears_out_of_band(self):
+        self.b._out_of_band['tid1'] = self.make_message(
+            'tid1', states.STARTED)
+        self.b._after_fork()
+        assert self.b._out_of_band == {}

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -355,16 +355,20 @@ class test_RPCBackend_result_lifecycle:
     def test_final_state_cached_when_cache_enabled(self):
         # the test app sets result_cache_max=-1 (cache disabled),
         # with caching on the final meta is served from the cache.
+        old_cache_max = self.app.conf.result_cache_max
         self.app.conf.result_cache_max = 100
-        b = RPCBackend(app=self.app)
-        message = self.make_message('tid1', states.SUCCESS, 42)
-        with patch.object(b, '_slurp_from_queue',
-                          return_value=iter([message])):
-            b.get_task_meta('tid1')
-        assert b._cache['tid1']['status'] == states.SUCCESS
-        with patch.object(b, '_slurp_from_queue',
-                          return_value=iter([])):
-            assert b.get_task_meta('tid1')['result'] == 42
+        try:
+            b = RPCBackend(app=self.app)
+            message = self.make_message('tid1', states.SUCCESS, 42)
+            with patch.object(b, '_slurp_from_queue',
+                              return_value=iter([message])):
+                b.get_task_meta('tid1')
+            assert b._cache['tid1']['status'] == states.SUCCESS
+            with patch.object(b, '_slurp_from_queue',
+                              return_value=iter([])):
+                assert b.get_task_meta('tid1')['result'] == 42
+        finally:
+            self.app.conf.result_cache_max = old_cache_max
 
     def test_non_final_state_is_requeued(self):
         message = self.make_message('tid1', states.RETRY)
@@ -464,3 +468,28 @@ class test_RPCBackend_result_lifecycle:
             'tid1', states.STARTED)
         self.b._after_fork()
         assert self.b._out_of_band == {}
+
+    def test_forget_clears_pending_messages(self):
+        # forget() must drop the buffered final state too, otherwise a
+        # later poll would still resolve the task as completed.
+        message = self.make_message('tid1', states.SUCCESS, 42)
+        with self.slurp([message]):
+            self.b.get_task_meta('tid1')
+        assert self.b._pending_messages.get('tid1')
+        self.b.forget('tid1')
+        assert self.b._pending_messages.get('tid1') is None
+        assert self.b._pending_messages.total == 0
+        with self.slurp([]):
+            assert self.b.get_task_meta('tid1')['status'] == states.PENDING
+
+    def test_after_fork_clears_pending_messages_and_cache(self):
+        # the forked child must not inherit the parent's buffered
+        # final states or cached metas.
+        message = self.make_message('tid1', states.SUCCESS, 42)
+        with self.slurp([message]):
+            self.b.get_task_meta('tid1')
+        self.b._cache = {'tid1': {'status': states.SUCCESS, 'result': 42}}
+        self.b._after_fork()
+        assert self.b._pending_messages.get('tid1') is None
+        assert self.b._pending_messages.total == 0
+        assert self.b._cache == {}


### PR DESCRIPTION
## Description

Was digging into why the reply queue on one of our RabbitMQ vhosts kept growing on a client that mostly polls `result.state` for a bunch of tasks, and ended up at #4830 — reported back in 2018, still reproduces on main.

What's happening: `get_task_meta()` slurps the reply queue with `basic_get` and then unconditionally calls `requeue()` on the latest message, even when it carries a final state (SUCCESS/FAILURE/REVOKED). So every state poll of a finished task puts the result message back on the queue. The next poll — for any task — slurps it again and it lands in `_out_of_band`, where nothing ever removes it. The message basically ping-pongs between the broker queue and `_out_of_band` until it expires, and `_out_of_band` is a plain unbounded dict, so long-running pollers grow memory on the client *and* hold messages on the broker. That matches exactly what the #4830 reporter saw with `_out_of_band` never emptying.

There's a stale-data variant too: if a poll buffers a non-final state (say STARTED) in `_out_of_band` and the consumer then delivers the final state for that task, the stale entry survives. A later poll pops it and regresses the cached state back to STARTED.

And while poking at this I noticed `AsyncResult.forget()` just raises `NotImplementedError` on this backend — it inherits the base `_forget` which only raises. `_after_fork` is broken as well (`self._pending_results.clear()` on a namedtuple). Both look like they've been that way for a long time.

What I changed, all in `celery/backends/rpc.py`:

- a final state picked up by `get_task_meta()` is acked instead of requeued. The meta is handed to the result consumer first, so a waiter already blocked in `get()` still resolves, and a `get()` that starts *after* the poll resolves from the pending-message buffer instead of hanging on a message that will never come
- non-final states keep the old requeue behavior, so polling progress states works exactly like before
- out-of-band messages are acked once their payload is buffered/cached (before, they were left unacked on the channel indefinitely)
- a final state arriving on the consumer drops any stale `_out_of_band` entry for that task
- `forget()` also clears `_out_of_band`, and `_forget` is a no-op now (results are queue messages, there's nothing stored server-side to delete)
- `_after_fork` clears both pending-result mappings plus `_out_of_band` instead of crashing

One behavior change worth calling out: with the default `result_cache_max=-1` (client-side cache disabled), re-polling a finished task from a *new* `AsyncResult` used to re-read the requeued message off the queue. Now it's served from the pending-message buffer (bounded, LRU-evicted) or the cache when enabled. I think that's the right trade since the old behavior is precisely what leaks, but if you'd rather keep requeueing when the cache is disabled I can gate it — kinda feels like it'd just reintroduce the bug though.

Added a `test_RPCBackend_result_lifecycle` class in `t/unit/backends/test_rpc.py` covering ack-vs-requeue, pending-waiter resolution, late `get()` resolution, the recirculation regression itself, stale buffer invalidation, `forget()`, and fork cleanup.

`python -m pytest t/unit/backends/test_rpc.py t/unit/backends/test_base.py t/unit/backends/test_asynchronous.py t/unit/tasks/test_result.py` — 302 passed. The 2 yaml/msgpack failures in test_base.py also fail on a clean main checkout here, so unrelated. flake8 clean on both files.

Fixes #4830
