### PR TITLE
Fix shared retry_kwargs mutation in autoretry

### DIFF
--- a/celery/app/autoretry.py
+++ b/celery/app/autoretry.py
@@ -45,8 +45,9 @@ def add_autoretry_behaviour(task, **options):
             except dont_autoretry_for:
                 raise
             except autoretry_for as exc:
+                retry_kwargs_for_attempt = retry_kwargs.copy()
                 if retry_backoff:
-                    retry_kwargs['countdown'] = \
+                    retry_kwargs_for_attempt['countdown'] = \
                         get_exponential_backoff_interval(
                             factor=int(max(1.0, retry_backoff)),
                             retries=task.request.retries,
@@ -54,10 +55,9 @@ def add_autoretry_behaviour(task, **options):
                             full_jitter=retry_jitter)
                 # Override max_retries
                 if hasattr(task, 'override_max_retries'):
-                    retry_kwargs['max_retries'] = getattr(task,
-                                                          'override_max_retries',
-                                                          task.max_retries)
-                ret = task.retry(exc=exc, **retry_kwargs)
+                    retry_kwargs_for_attempt['max_retries'] = getattr(
+                        task, 'override_max_retries', task.max_retries)
+                ret = task.retry(exc=exc, **retry_kwargs_for_attempt)
                 # Stop propagation
                 if hasattr(task, 'override_max_retries'):
                     delattr(task, 'override_max_retries')

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1785,6 +1785,41 @@ class test_apply_task(TasksCase):
             assert data['parent_id'] == 'parent-id-123'
             assert data['root_id'] == data['task_id']
 
+    def test_autoretry_shared_retry_kwargs_not_mutated_by_max_retries_override(self):
+        """Verify that task.retry(max_retries=...) setting override_max_retries
+        does not mutate the shared retry_kwargs dict captured at task
+        registration time (regression test for celery#10456)."""
+        @self.app.task(bind=True, shared=False,
+                       autoretry_for=(ZeroDivisionError,),
+                       retry_kwargs={'max_retries': 5},
+                       retry_backoff=False, retry_jitter=False)
+        def task(self_, x, y):
+            self_.iterations += 1
+            return x / y
+        task.iterations = 0
+
+        free_vars = task.run.__code__.co_freevars
+        shared_retry_kwargs = task.run.__closure__[
+            free_vars.index("retry_kwargs")
+        ].cell_contents
+        assert shared_retry_kwargs == {'max_retries': 5}
+
+        task.override_max_retries = 2
+
+        with patch.object(task, "retry", side_effect=Retry):
+            task.push_request(retries=0)
+            try:
+                task.run(1, 0)
+            except Retry:
+                pass
+            finally:
+                task.pop_request()
+
+        assert shared_retry_kwargs == {'max_retries': 5}, (
+            "BUG: override_max_retries leaked into shared retry_kwargs! "
+            f"Got {shared_retry_kwargs}"
+        )
+
 
 class test_apply_async(TasksCase):
     def common_send_task_arguments(self):

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -833,6 +833,51 @@ class test_task_retries(TasksCase):
         ]
         assert retry_call_countdowns == expected_countdowns
 
+    def test_autoretry_does_not_mutate_shared_base_class_retry_kwargs(self):
+        """
+        Test that retry_kwargs defined as a class attribute on a shared base Task
+        is not mutated when a task retries. This covers the getattr(task, 'retry_kwargs', {})
+        branch in add_autoretry_behaviour, which is worse than the per-task case since
+        the same dict object is shared across all task classes using that base.
+        """
+        class BaseTaskWithRetry(Task):
+            autoretry_for = (ZeroDivisionError,)
+            retry_backoff = True
+            retry_jitter = False
+            retry_kwargs = {'max_retries': 5}
+            _app = self.app
+
+        @self.app.task(bind=True, base=BaseTaskWithRetry, shared=False)
+        def task_a(self_, x, y):
+            return x / y
+
+        @self.app.task(bind=True, base=BaseTaskWithRetry, shared=False)
+        def task_b(self_, x, y):
+            return x / y
+
+        # Verify that all three share the exact same dict object
+        assert task_a.retry_kwargs is task_b.retry_kwargs is BaseTaskWithRetry.retry_kwargs
+
+        # Run task_a to exhaustion, which would mutate the shared dict if bug exists
+        with patch.object(task_a, 'retry', wraps=task_a.retry) as fake_retry:
+            task_a.apply((1, 0))
+
+        # Base class retry_kwargs should remain unchanged (no 'countdown' key leaked in)
+        assert BaseTaskWithRetry.retry_kwargs == {'max_retries': 5}
+
+        # Verify task_a got correct countdown values
+        assert [call_[1]['countdown'] for call_ in fake_retry.call_args_list] == [
+            1, 2, 4, 8, 16, 32
+        ]
+
+        # Run task_b once and verify it uses its own first-attempt backoff,
+        # not something inherited from task_a's last retry
+        with patch.object(task_b, 'retry', wraps=task_b.retry) as fake_retry_b:
+            task_b.apply((1, 0))
+
+        # First retry should have countdown=1 (first attempt backoff)
+        assert fake_retry_b.call_args_list[0][1]['countdown'] == 1
+
 
 class test_canvas_utils(TasksCase):
 


### PR DESCRIPTION
## Description

Add a regression test covering the `getattr(task, "retry_kwargs", {})` code path in `add_autoretry_behaviour()`.

The existing regression test added in #10458 verifies that `retry_kwargs` passed explicitly via the task decorator is not mutated during autoretry. However, it does not cover the case where `retry_kwargs` is defined as a class attribute on a shared base `Task` class.

This test verifies that:

- `retry_kwargs` inherited from a shared base `Task` class is not mutated during autoretry.
- The shared base class dictionary remains unchanged after one task retries.
- Separate tasks inheriting from the same base class do not leak retry state (such as `countdown`) between each other.

This adds regression coverage for the `getattr(task, "retry_kwargs", {})` branch without modifying the implementation.

Fixes #10456 

Test:
<img width="1456" height="561" alt="Screenshot 2026-08-06 085329" src="https://github.com/user-attachments/assets/fbad78a9-90c1-4850-a430-cdde40e887bd" />
