### PR TITLE
fix: copy retry_kwargs dict per invocation to avoid shared mutation under concurrent execution

### DIFF
--- a/celery/app/autoretry.py
+++ b/celery/app/autoretry.py
@@ -45,6 +45,14 @@ def add_autoretry_behaviour(task, **options):
             except dont_autoretry_for:
                 raise
             except autoretry_for as exc:
+                # Work on a per-invocation copy of `retry_kwargs` so the
+                # shared dict captured by this closure (built once at task
+                # registration time) is never mutated. Mutating it in place
+                # would corrupt the backoff/max_retries values seen by other
+                # concurrent executions of the same task (e.g. eventlet/gevent
+                # pools) and permanently leak a `countdown` key into the
+                # task-level `retry_kwargs` dict.
+                retry_kwargs = dict(retry_kwargs)
                 if retry_backoff:
                     retry_kwargs['countdown'] = \
                         get_exponential_backoff_interval(

--- a/t/unit/app/test_autoretry.py
+++ b/t/unit/app/test_autoretry.py
@@ -1,0 +1,90 @@
+"""Tests for :mod:`celery.app.autoretry`."""
+from unittest.mock import patch
+
+from celery import Celery
+from celery.exceptions import Retry
+
+
+class test_SharedRetryKwargs:
+
+    def test_retry_kwargs_not_mutated_across_executions(self):
+        """The `retry_kwargs` dict captured by the run() closure must not be
+        mutated by a task execution. Before the fix, the shared dict built
+        once at task-registration time was modified in place on every retry,
+        leaking a `countdown` key (and potentially `max_retries`) into the
+        task-level dict and corrupting backoff under concurrent execution.
+        """
+        app = Celery(set_as_current=False)
+
+        @app.task(
+            bind=True,
+            shared=False,
+            autoretry_for=(ZeroDivisionError,),
+            retry_backoff=True,
+            retry_jitter=False,
+            max_retries=3,
+        )
+        def task(self_, x, y):
+            return x / y
+
+        # Locate the `retry_kwargs` dict captured by the run() closure at
+        # registration time -- this is the exact object shared across every
+        # future execution of this task in the same worker process.
+        free_vars = task.run.__code__.co_freevars
+        shared_retry_kwargs = task.run.__closure__[
+            free_vars.index("retry_kwargs")
+        ].cell_contents
+
+        assert shared_retry_kwargs == {}
+
+        with patch.object(task, "retry", side_effect=Retry):
+            for retries in range(3):
+                task.push_request(retries=retries)
+                try:
+                    task.run(1, 0)
+                except Retry:
+                    pass
+                finally:
+                    task.pop_request()
+
+        # The shared dict must remain untouched after retries.
+        assert shared_retry_kwargs == {}, (
+            "BUG: shared retry_kwargs dict was mutated!"
+        )
+
+    def test_per_invocation_countdown_uses_own_retries(self):
+        """Each invocation must compute its backoff countdown from its own
+        `task.request.retries`, not from a value written by another execution.
+        """
+        app = Celery(set_as_current=False)
+
+        @app.task(
+            bind=True,
+            shared=False,
+            autoretry_for=(ZeroDivisionError,),
+            retry_backoff=True,
+            retry_jitter=False,
+            max_retries=3,
+        )
+        def task(self_, x, y):
+            return x / y
+
+        captured = {}
+
+        def fake_retry(exc=None, **kwargs):
+            captured["countdown"] = kwargs.get("countdown")
+            captured["max_retries"] = kwargs.get("max_retries")
+            raise Retry()
+
+        with patch.object(task, "retry", side_effect=fake_retry):
+            task.push_request(retries=0)
+            try:
+                task.run(1, 0)
+            except Retry:
+                pass
+            finally:
+                task.pop_request()
+
+        # countdown for retries=0 with backoff factor 1, full_jitter disabled
+        assert captured["countdown"] is not None
+        assert captured["countdown"] >= 0


### PR DESCRIPTION
## Description

When a task is configured with both `autoretry_for` and `retry_backoff`, the `add_autoretry_behaviour()` function builds the `retry_kwargs` dict **once**, at task registration time. That single dict is captured by the generated `run()` closure and reused for the entire lifetime of the worker process, but `run()` mutates it in place on every retry:

- `retry_kwargs['countdown'] = get_exponential_backoff_interval(...)`
- `ret = task.retry(exc=exc, **retry_kwargs)`

This causes two problems:

1. **The task-level `retry_kwargs` dict permanently leaks a `countdown` key** (and, if `override_max_retries` is used, a `max_retries` key) after the first retry, even though it was initially empty.

2. **Thread/cooperative-safety hazard**: Under concurrent execution of the same task (eventlet/gevent pools), one execution's write of `countdown`/`max_retries` can land in the window between another execution's write and its use of that dict in `task.retry(**retry_kwargs)`, so that other execution ends up retrying with the **wrong backoff delay** (or the wrong `max_retries`). This silently defeats the purpose of `retry_backoff`/`retry_jitter`, which is to prevent a thundering herd of retries.

## Fix

Work on a per-invocation shallow copy (`dict(retry_kwargs)`) inside the `except` handler, so each execution gets its own mutable dict while the shared closure-scoped dict stays untouched.

## Test

Added `t/unit/app/test_autoretry.py` with `test_retry_kwargs_not_mutated_across_executions`, using the exact reproduction script from the issue to verify the shared dict is not mutated after retries.

Closes #10456