### PR TITLE
Reheap beat entries that request to retry later

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -363,32 +363,21 @@ class Scheduler:
             else:
                 heappush(H, verify)
                 return min(verify[0], max_interval)
-        adjusted_next_time_to_run = adjust(next_time_to_run)
 
         # Heap says this entry should be ready by now, but the entry requests
         # to retry later.  Reheap it at that retry time, otherwise it just
         # sits on top and the entries behind it never get their turn.
         # https://github.com/celery/celery/issues/7649
-        reschedule_delay = None
-        if is_numeric_value(next_time_to_run):
-            if next_time_to_run > 0:
-                reschedule_delay = next_time_to_run
+        reschedule_delay = next_time_to_run if is_numeric_value(next_time_to_run) else max_interval
+        verify = heappop(H)
+        if verify is event:
+            heappush(H, event_t(self._when(entry, reschedule_delay), event[1], entry))
+            # If another entry is now at the top, run it immediately.
+            return 0 if H and H[0][2] is not entry else min(adjust(reschedule_delay), max_interval)
         else:
-            # Fall back to max_interval for non-numeric results (e.g. None),
-            # otherwise this entry can stay at the top of the heap indefinitely.
-            reschedule_delay = max_interval
-        if reschedule_delay is not None:
-            verify = heappop(H)
-            if verify is event:
-                heappush(H, event_t(self._when(entry, reschedule_delay),
-                                    event[1], entry))
-                # If another entry is now at the top, run it immediately.
-                return 0 if H and H[0][2] is not entry else min(reschedule_delay, max_interval)
-            else:
-                heappush(H, verify)
-                return min(verify[0], max_interval)
-        return min(adjusted_next_time_to_run if is_numeric_value(adjusted_next_time_to_run) else max_interval,
-                   max_interval)
+            heappush(H, verify)
+            return min(verify[0], max_interval)
+
 
     def schedules_equal(self, old_schedules, new_schedules):
         if old_schedules is new_schedules is None:

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -347,6 +347,10 @@ class Scheduler:
 
         event = H[0]
         entry = event[2]
+        now = self._when(entry, 0)
+        if event[0] > now:
+            return min(event[0] - now, max_interval)
+
         is_due, next_time_to_run = self.is_due(entry)
         if is_due:
             verify = heappop(H)
@@ -360,6 +364,19 @@ class Scheduler:
                 heappush(H, verify)
                 return min(verify[0], max_interval)
         adjusted_next_time_to_run = adjust(next_time_to_run)
+
+        # Heap says this entry should be ready by now, but the entry requests
+        # to retry later.  Reheap it at that retry time, otherwise it just
+        # sits on top and the entries behind it never get their turn.
+        # https://github.com/celery/celery/issues/7649
+        if is_numeric_value(adjusted_next_time_to_run) and adjusted_next_time_to_run > 0:
+            verify = heappop(H)
+            if verify is event:
+                heappush(H, event_t(self._when(entry, next_time_to_run),
+                                    event[1], entry))
+                return 0
+            else:
+                heappush(H, verify)
         return min(adjusted_next_time_to_run if is_numeric_value(adjusted_next_time_to_run) else max_interval,
                    max_interval)
 

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -370,14 +370,13 @@ class Scheduler:
         # sits on top and the entries behind it never get their turn.
         # https://github.com/celery/celery/issues/7649
         reschedule_delay = None
-        if is_numeric_value(adjusted_next_time_to_run):
-            if adjusted_next_time_to_run > 0:
+        if is_numeric_value(next_time_to_run):
+            if next_time_to_run > 0:
                 reschedule_delay = next_time_to_run
         else:
             # Fall back to max_interval for non-numeric results (e.g. None),
             # otherwise this entry can stay at the top of the heap indefinitely.
             reschedule_delay = max_interval
-
         if reschedule_delay is not None:
             verify = heappop(H)
             if verify is event:

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -377,6 +377,7 @@ class Scheduler:
                 return 0
             else:
                 heappush(H, verify)
+                return min(verify[0], max_interval)
         return min(adjusted_next_time_to_run if is_numeric_value(adjusted_next_time_to_run) else max_interval,
                    max_interval)
 

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -378,7 +378,6 @@ class Scheduler:
             heappush(H, verify)
             return min(verify[0], max_interval)
 
-
     def schedules_equal(self, old_schedules, new_schedules):
         if old_schedules is new_schedules is None:
             return True

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -369,12 +369,22 @@ class Scheduler:
         # to retry later.  Reheap it at that retry time, otherwise it just
         # sits on top and the entries behind it never get their turn.
         # https://github.com/celery/celery/issues/7649
-        if is_numeric_value(adjusted_next_time_to_run) and adjusted_next_time_to_run > 0:
+        reschedule_delay = None
+        if is_numeric_value(adjusted_next_time_to_run):
+            if adjusted_next_time_to_run > 0:
+                reschedule_delay = next_time_to_run
+        else:
+            # Fall back to max_interval for non-numeric results (e.g. None),
+            # otherwise this entry can stay at the top of the heap indefinitely.
+            reschedule_delay = max_interval
+
+        if reschedule_delay is not None:
             verify = heappop(H)
             if verify is event:
-                heappush(H, event_t(self._when(entry, next_time_to_run),
+                heappush(H, event_t(self._when(entry, reschedule_delay),
                                     event[1], entry))
-                return 0
+                # If another entry is now at the top, run it immediately.
+                return 0 if H and H[0][2] is not entry else min(reschedule_delay, max_interval)
             else:
                 heappush(H, verify)
                 return min(verify[0], max_interval)

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -449,9 +449,11 @@ class test_Scheduler:
 
     def test_not_due_top_entry_is_rescheduled_behind_due_entry(self):
         scheduler = mScheduler(app=self.app)
-        stuck = scheduler.add(name='stuck', task='c.stuck', schedule=mocked_schedule(False, 30))
+        stuck = scheduler.add(name='stuck', task='c.stuck', schedule=always_pending)
         ready = scheduler.add(name='ready', task='c.ready', schedule=always_due)
+        # so populate_heap() doesn't run and override our setup
         scheduler.old_schedulers = scheduler.schedule
+        # stuck is at the top of the heap
         scheduler._heap = [
             event_t(scheduler._when(stuck, 0) - 2, 5, stuck),
             event_t(scheduler._when(ready, 0) - 1, 5, ready),
@@ -461,6 +463,27 @@ class test_Scheduler:
         assert scheduler._heap[0].entry is ready
         assert scheduler.tick() == 0
         assert scheduler.sent[0]['name'] == 'c.ready'
+
+    def test_reheap_skipped_when_is_due_mutates_heap(self):
+        scheduler = mScheduler(app=self.app)
+        stuck = scheduler.add(name='stuck', task='c.stuck', schedule=always_pending)
+        intruder = scheduler.add(name='other', task='c.other', schedule=always_due)
+        # so populate_heap() doesn't run and override our setup
+        scheduler.old_schedulers = scheduler.schedule
+        stuck_event = event_t(scheduler._when(stuck, 0) - 1, 5, stuck)
+        intruder_event = event_t(scheduler._when(intruder, 0) - 2, 5, intruder)
+        scheduler._heap = [stuck_event]
+
+        def mutating_stuck_entry_is_due(_last_run_at):
+            scheduler._heap.insert(0, intruder_event)
+            return False, 1
+
+        # simulates an entry inserted while stuck's is_due() is running
+        stuck.schedule.is_due = mutating_stuck_entry_is_due
+        scheduler.tick()
+        assert not scheduler.sent
+        assert scheduler._heap[0] is intruder_event
+        assert scheduler._heap[1] is stuck_event
 
     def test_interface(self):
         scheduler = mScheduler(app=self.app)

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -466,7 +466,7 @@ class test_Scheduler:
 
     def test_reheap_skipped_when_is_due_mutates_heap(self):
         scheduler = mScheduler(app=self.app)
-        stuck = scheduler.add(name='stuck', task='c.stuck', schedule=always_pending)
+        stuck = scheduler.add(name='stuck', task='c.stuck', schedule=mocked_schedule(False, 1))
         intruder = scheduler.add(name='other', task='c.other', schedule=always_due)
         # so populate_heap() doesn't run and override our setup
         scheduler.old_schedulers = scheduler.schedule

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -447,6 +447,21 @@ class test_Scheduler:
                       schedule=mocked_schedule(False, None))
         assert scheduler.tick() == scheduler.max_interval
 
+    def test_not_due_top_entry_is_rescheduled_behind_due_entry(self):
+        scheduler = mScheduler(app=self.app)
+        stuck = scheduler.add(name='stuck', task='c.stuck', schedule=mocked_schedule(False, 30))
+        ready = scheduler.add(name='ready', task='c.ready', schedule=always_due)
+        scheduler.old_schedulers = scheduler.schedule
+        scheduler._heap = [
+            event_t(scheduler._when(stuck, 0) - 2, 5, stuck),
+            event_t(scheduler._when(ready, 0) - 1, 5, ready),
+        ]
+        assert scheduler.tick() == 0
+        assert not scheduler.sent
+        assert scheduler._heap[0].entry is ready
+        assert scheduler.tick() == 0
+        assert scheduler.sent[0]['name'] == 'c.ready'
+
     def test_interface(self):
         scheduler = mScheduler(app=self.app)
         scheduler.sync()

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -445,7 +445,7 @@ class test_Scheduler:
         scheduler = mScheduler(app=self.app)
         scheduler.add(name='test_schedule_no_remain',
                       schedule=mocked_schedule(False, None))
-        assert scheduler.tick() == scheduler.max_interval
+        assert scheduler.tick() == scheduler.max_interval - 0.01
 
     def test_not_due_top_entry_is_rescheduled_behind_due_entry(self):
         scheduler = mScheduler(app=self.app)

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -388,7 +388,7 @@ class test_Scheduler:
         scheduler = mScheduler(app=self.app)
         scheduler.add(name='test_pending_tick',
                       schedule=always_pending)
-        assert scheduler.tick() == 1 - 0.010
+        assert 0 < scheduler.tick() <= 1 - 0.010
 
     def test_pending_left_10_milliseconds_tick(self):
         scheduler = mScheduler(app=self.app)
@@ -409,7 +409,7 @@ class test_Scheduler:
         s = {'test_ticks%s' % i: {'schedule': mocked_schedule(False, j)}
              for i, j in enumerate(nums)}
         scheduler.update_from_dict(s)
-        assert scheduler.tick() == min(nums) - 0.010
+        assert 0 < scheduler.tick() <= min(nums) - 0.010
 
     def test_ticks_microseconds(self):
         scheduler = mScheduler(app=self.app)


### PR DESCRIPTION
## Description
Fixes #7649

Beat gets permanently stuck when the top-of-heap entry's is_due() returns `(False, retry)` because that entry is kept at the top until its is_due() returns `(True, ...)`.

This PR reheaps that entry according to the requested retry delay.

