### PR TITLE
Raise ImproperlyConfigured with install hint when ephem is missing for solar schedules

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -12,6 +12,7 @@ from kombu.utils.objects import cached_property
 from celery import Celery
 
 from . import current_app
+from .exceptions import ImproperlyConfigured
 from .utils.collections import AttributeDict
 from .utils.time import (ffwd, humanize_seconds, localize, maybe_make_aware, maybe_timedelta, remaining, timezone,
                          weekday, yearmonth)
@@ -48,6 +49,13 @@ Argument longitude {lon} is invalid, must be between -180 and 180.\
 
 SOLAR_INVALID_EVENT = """\
 Argument event "{event}" is invalid, must be one of {all_events}.\
+"""
+
+SOLAR_EPHEM_NOT_INSTALLED = """\
+You need to install the ephem library to use solar schedules.
+Please install by:
+
+    $ pip install celery[solar]
 """
 
 
@@ -791,7 +799,10 @@ class solar(BaseSchedule):
 
     def __init__(self, event: str, lat: int | float, lon: int | float, **
                  kwargs: Any) -> None:
-        self.ephem = __import__('ephem')
+        try:
+            self.ephem = __import__('ephem')
+        except ImportError as exc:
+            raise ImproperlyConfigured(SOLAR_EPHEM_NOT_INSTALLED) from exc
         self.event = event
         self.lat = lat
         self.lon = lon

--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -305,7 +305,16 @@ Solar schedules
 
 If you have a task that should be executed according to sunrise,
 sunset, dawn or dusk, you can use the
-:class:`~celery.schedules.solar` schedule type:
+:class:`~celery.schedules.solar` schedule type.
+
+Solar schedules require the :pypi:`ephem` library, so
+to use them you must install Celery with the ``solar`` extra:
+
+.. code-block:: console
+
+    $ pip install celery[solar]
+
+Example:
 
 .. code-block:: python
 

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from celery.exceptions import ImproperlyConfigured
 from celery.schedules import ParseException, crontab, crontab_parser, schedule, solar
 
 if sys.version_info >= (3, 9):
@@ -97,6 +98,15 @@ class test_solar:
                 pytest.fail(
                     f"{s.method} was called with 'use_center' which is not a "
                     "valid keyword for the function.")
+
+
+class test_solar_without_ephem:
+
+    def test_raises_improperly_configured_when_ephem_is_missing(
+            self, monkeypatch):
+        monkeypatch.setitem(sys.modules, 'ephem', None)
+        with pytest.raises(ImproperlyConfigured, match=r'celery\[solar\]'):
+            solar('sunrise', 60, 30, app=self.app)
 
 
 class test_schedule:


### PR DESCRIPTION
Fixes #7537

When a solar schedule is used without the `ephem` library installed, celery currently crashes with a bare `ModuleNotFoundError: No module named 'ephem'`, giving no hint that `pip install celery[solar]` is the fix.

This implements the direction settled on in the issue ("We should raise an error that instructs the user to install ephem... `pip install celery[solar]`, if this is not documented I suggest focusing your contributions there"), which @auvipy seconded.

Changes:
- `celery/schedules.py`: wrap the `__import__('ephem')` in `solar.__init__` and raise `ImproperlyConfigured` with an install hint (`pip install celery[solar]`), chaining the original `ImportError`. Message wording follows the existing `CRYPTOGRAPHY_NOT_INSTALLED` pattern in `celery/security/__init__.py`.
- `docs/userguide/periodic-tasks.rst`: the Solar schedules section never mentioned the `ephem` requirement — added a short install note in the same style as the serializer sections in `calling.rst`.
- `t/unit/app/test_schedules.py`: new test asserting `ImproperlyConfigured` (with `celery[solar]` in the message) is raised when `ephem` cannot be imported. It lives outside the `test_solar` class so it is not skipped by `pytest.importorskip('ephem')`, and forces the ImportError via `sys.modules`, so it runs with or without ephem installed.

Verified the new test fails on current main (bare `ModuleNotFoundError`) and passes with the fix; the full `t/unit/app/test_schedules.py` suite passes both with and without ephem installed.
