### PR TITLE
Utilizing Identity instead of Sequence for id column to avoid RDS Proxy from pinning the session connection

### DIFF
--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -56,7 +56,8 @@ class Task(ResultModelBase):
     @classmethod
     def configure(cls, schema=None, name=None):
         cls.__table__.schema = schema
-        cls.id.default.schema = schema
+        if isinstance(cls.id.default, sa.Sequence):
+            cls.id.default.schema = schema
         cls.__table__.name = name or cls.__tablename__
 
 
@@ -115,5 +116,6 @@ class TaskSet(ResultModelBase):
     @classmethod
     def configure(cls, schema=None, name=None):
         cls.__table__.schema = schema
-        cls.id.default.schema = schema
+        if isinstance(cls.id.default, sa.Sequence):
+            cls.id.default.schema = schema
         cls.__table__.name = name or cls.__tablename__

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -30,9 +30,7 @@ class Task(ResultModelBase):
     __tablename__ = 'celery_taskmeta'
     __table_args__ = {'sqlite_autoincrement': True}
 
-
-    id = sa.Column(DialectSpecificInteger, sa.Identity(cache=20),
-                primary_key=True)
+    id = sa.Column(DialectSpecificInteger, sa.Identity(cache=20), primary_key=True)
     task_id = sa.Column(sa.String(155), unique=True)
     status = sa.Column(sa.String(50), default=states.PENDING)
     result = sa.Column(PickleType, nullable=True)
@@ -94,8 +92,7 @@ class TaskSet(ResultModelBase):
     __tablename__ = 'celery_tasksetmeta'
     __table_args__ = {'sqlite_autoincrement': True}
 
-    id = sa.Column(DialectSpecificInteger, sa.Identity(cache=20),
-                primary_key=True)
+    id = sa.Column(DialectSpecificInteger, sa.Identity(cache=20), primary_key=True)
     taskset_id = sa.Column(sa.String(155), unique=True)
     result = sa.Column(PickleType, nullable=True)
     date_done = sa.Column(sa.DateTime, default=_get_utc_now,

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -30,8 +30,9 @@ class Task(ResultModelBase):
     __tablename__ = 'celery_taskmeta'
     __table_args__ = {'sqlite_autoincrement': True}
 
-    id = sa.Column(DialectSpecificInteger, sa.Sequence('task_id_sequence'),
-                   primary_key=True, autoincrement=True)
+
+    id = sa.Column(DialectSpecificInteger, sa.Identity(cache=20),
+                primary_key=True)
     task_id = sa.Column(sa.String(155), unique=True)
     status = sa.Column(sa.String(50), default=states.PENDING)
     result = sa.Column(PickleType, nullable=True)

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -94,8 +94,8 @@ class TaskSet(ResultModelBase):
     __tablename__ = 'celery_tasksetmeta'
     __table_args__ = {'sqlite_autoincrement': True}
 
-    id = sa.Column(DialectSpecificInteger, sa.Sequence('taskset_id_sequence'),
-                   autoincrement=True, primary_key=True)
+    id = sa.Column(DialectSpecificInteger, sa.Identity(cache=20),
+                primary_key=True)
     taskset_id = sa.Column(sa.String(155), unique=True)
     result = sa.Column(PickleType, nullable=True)
     date_done = sa.Column(sa.DateTime, default=_get_utc_now,

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -1,11 +1,10 @@
 import os
-import sqlalchemy as sa
-
 from datetime import datetime
 from pickle import dumps, loads
 from unittest.mock import Mock, patch
 
 import pytest
+import sqlalchemy as sa
 
 from celery import states, uuid
 from celery.app.task import Context

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -1,4 +1,6 @@
 import os
+import sqlalchemy as sa
+
 from datetime import datetime
 from pickle import dumps, loads
 from unittest.mock import Mock, patch

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -456,9 +456,11 @@ class test_DatabaseBackend:
         self.app.conf.database_create_tables_at_setup = False
         tb = DatabaseBackend(self.uri, app=self.app)
         assert tb.task_cls.__table__.schema == 'foo'
-        assert tb.task_cls.__table__.c.id.default.schema == 'foo'
+        task_id = tb.task_cls.__table__.c.id
+        assert task_id.identity is not None or isinstance(task_id.default, sa.Sequence)
         assert tb.taskset_cls.__table__.schema == 'bar'
-        assert tb.taskset_cls.__table__.c.id.default.schema == 'bar'
+        taskset_id = tb.taskset_cls.__table__.c.id
+        assert taskset_id.identity is not None or isinstance(taskset_id.default, sa.Sequence)
 
     def test_table_name_config(self):
         self.app.conf.database_table_names = {


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

backends/database/models.py uses the Sequence feature to generate incremental integer value for the ID column which serves as the primary key for the Task and TaskSet tables. Using the Sequence feature results in inserting `nextval` keyword into the SQL insert statement resulting in database session being pinned according to the AWS documentation (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-pinning.html#:~:text=functions%20such%20as-,nextval%20and%20setval,-)

To avoid RDS Proxy from pinning the session, we want to utilize the modern Postgres approach which is to utilize Identity feature (https://www.postgresql.org/docs/current/ddl-identity-columns.html)   

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

Fixes #10472
-->
