### PR TITLE
fix(worker): handle malformed numeric worker env vars safely (#10388)

### DIFF
--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -31,19 +31,39 @@ SOFTWARE_INFO = {
     'sw_sys': platform.system(),
 }
 
+def _env_int(name: str, default: int) -> int:
+    val = os.environ.get(name)
+    if val:
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            pass
+    return default
+
+
+def _env_float(name: str, default: float) -> float:
+    val = os.environ.get(name)
+    if val:
+        try:
+            return float(val)
+        except (ValueError, TypeError):
+            pass
+    return default
+
+
 #: maximum number of revokes to keep in memory.
-REVOKES_MAX = int(os.environ.get('CELERY_WORKER_REVOKES_MAX', 50000))
+REVOKES_MAX = _env_int('CELERY_WORKER_REVOKES_MAX', 50000)
 
 #: maximum number of successful tasks to keep in memory.
-SUCCESSFUL_MAX = int(os.environ.get('CELERY_WORKER_SUCCESSFUL_MAX', 1000))
+SUCCESSFUL_MAX = _env_int('CELERY_WORKER_SUCCESSFUL_MAX', 1000)
 
 #: how many seconds a revoke will be active before
 #: being expired when the max limit has been exceeded.
-REVOKE_EXPIRES = float(os.environ.get('CELERY_WORKER_REVOKE_EXPIRES', 10800))
+REVOKE_EXPIRES = _env_float('CELERY_WORKER_REVOKE_EXPIRES', 10800)
 
 #: how many seconds a successful task will be cached in memory
 #: before being expired when the max limit has been exceeded.
-SUCCESSFUL_EXPIRES = float(os.environ.get('CELERY_WORKER_SUCCESSFUL_EXPIRES', 10800))
+SUCCESSFUL_EXPIRES = _env_float('CELERY_WORKER_SUCCESSFUL_EXPIRES', 10800)
 
 #: Mapping of reserved task_id->Request.
 requests = {}

--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -31,6 +31,7 @@ SOFTWARE_INFO = {
     'sw_sys': platform.system(),
 }
 
+
 def _env_int(name: str, default: int) -> int:
     val = os.environ.get(name)
     if val:

--- a/t/unit/worker/test_state.py
+++ b/t/unit/worker/test_state.py
@@ -23,6 +23,14 @@ def reset_state():
     state.total_count.clear()
 
 
+def test_env_numeric_defaults(monkeypatch):
+    monkeypatch.setenv("CELERY_WORKER_REVOKES_MAX", "invalid")
+    monkeypatch.setenv("CELERY_WORKER_REVOKE_EXPIRES", "invalid")
+    assert state._env_int("CELERY_WORKER_REVOKES_MAX", 50000) == 50000
+    assert state._env_float("CELERY_WORKER_REVOKE_EXPIRES", 10800.0) == 10800.0
+
+
+
 class MockShelve(dict):
     filename = None
     in_sync = False

--- a/t/unit/worker/test_state.py
+++ b/t/unit/worker/test_state.py
@@ -30,7 +30,6 @@ def test_env_numeric_defaults(monkeypatch):
     assert state._env_float("CELERY_WORKER_REVOKE_EXPIRES", 10800.0) == 10800.0
 
 
-
 class MockShelve(dict):
     filename = None
     in_sync = False


### PR DESCRIPTION
### Summary of Changes

Fixes #10388 where malformed numeric environment variables (such as `CELERY_WORKER_REVOKES_MAX`, `CELERY_WORKER_REVOKE_EXPIRES`, etc.) cause unhandled `ValueError` crashes at module import time.

- Introduced safe numeric environment parsing helpers `_env_int` and `_env_float` in `celery/worker/state.py` that gracefully catch `(ValueError, TypeError)` and fall back to specified default values.
- Added unit test `test_env_numeric_defaults` in `t/unit/worker/test_state.py`.
