### PR TITLE
docs(gevent): document monkey-patching entrypoint requirement (#10067)

### DIFF
--- a/docs/userguide/concurrency/gevent.rst
+++ b/docs/userguide/concurrency/gevent.rst
@@ -47,8 +47,10 @@ worker option.
 
 .. note::
 
-    When using the gevent pool, ensure that gevent monkey-patching is performed
-    at the very entrypoint of your application (before importing Celery, task modules, or standard library I/O modules):
+    When using the gevent pool via the Celery CLI (``-P gevent``/``--pool=gevent``),
+    Celery applies gevent monkey-patching early during startup.
+    If you need to monkey-patch manually (e.g., when embedding a worker), do it at the very start of the process
+    (before importing task modules or standard library I/O modules):
 
     .. code-block:: python
 

--- a/docs/userguide/concurrency/gevent.rst
+++ b/docs/userguide/concurrency/gevent.rst
@@ -45,6 +45,17 @@ worker option.
 
     $ celery -A proj worker -P gevent -c 1000
 
+.. note::
+
+    When using the gevent pool, ensure that gevent monkey-patching is performed
+    at the very entrypoint of your application (before importing Celery, task modules, or standard library I/O modules):
+
+    .. code-block:: python
+
+        from gevent import monkey
+        monkey.patch_all()
+
+
 .. _eventlet-examples:
 
 Examples


### PR DESCRIPTION
### Summary of Changes

Documentation fix for #10067 clarifying gevent monkey-patching requirements.

- Added an explicit note and code snippet to `docs/userguide/concurrency/gevent.rst` emphasizing that `gevent.monkey.patch_all()` must be executed at the application entrypoint before importing Celery or standard library I/O modules to prevent blocking I/O deadlocks.
