### PR TITLE
Add MemoryError regression for request callbacks

### DIFF
--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -1748,6 +1748,19 @@ class test_create_request_class(RequestCase):
         job.on_success((True, einfo, 1.0))
         job.on_failure.assert_called_with(einfo, return_ok=True)
 
+    def test_on_success__propagates_MemoryError(self):
+        self.task.acks_late = True
+        self.mytask.acks_late = True
+        einfo = None
+        try:
+            raise MemoryError('out of memory')
+        except MemoryError:
+            einfo = ExceptionInfo(internal=True)
+        assert einfo is not None
+
+        with pytest.raises(MemoryError, match='Process got: out of memory'):
+            self.zRequest(id=uuid()).on_success((True, einfo, 1.0))
+
     def test_on_success__acks_late_enabled(self):
         self.task.acks_late = True
         job = self.zRequest(id=uuid())


### PR DESCRIPTION
## Description

Add focused regression coverage for the Celery request callback path when an `acks_late` task fails with `MemoryError`.

The pool reports the traced task failure through `Request.on_success()`, which delegates to `Request.on_failure()`. Celery intentionally raises a new `MemoryError` from that path, but Billiard previously caught and swallowed it. celery/billiard#451 corrected the complementary pool callback behavior so `MemoryError` now propagates.

This test constructs the traced `MemoryError`, passes it through the optimized request class's `on_success()` callback, and verifies that the real `on_failure()` handler raises the transformed `Process got: out of memory` exception. It covers Celery's side of the callback contract without duplicating Billiard's `ApplyResult` regression.

Related to #10462.

## Validation

- `python -m pytest -q t/unit/worker/test_request.py`: 142 passed, 3 warnings.
- Focused `MemoryError` and callback-path tests: 3 passed.
- `python -m compileall -q t/unit/worker/test_request.py`: passed.
- Flake8, isort, codespell, pyupgrade, and yesqa checks passed for `t/unit/worker/test_request.py`.
- `git diff --check`: passed.

## Risk

Low. This is a test-only change and does not alter Celery runtime behavior or dependency constraints.

## AI disclosure

This PR includes AI-assisted code understanding to speed up the process; the test was updated and reviewed manually with AI assistance.
