### PR TITLE
fix(worker): mask credentials in alternates returned by inspect stats

### DIFF
--- a/celery/worker/consumer/connection.py
+++ b/celery/worker/consumer/connection.py
@@ -1,5 +1,6 @@
 """Consumer Broker Connection Bootstep."""
 from kombu.common import ignore_errors
+from kombu.utils.url import maybe_sanitize_url
 
 from celery import bootsteps
 from celery.utils.log import get_logger
@@ -42,4 +43,12 @@ class Connection(bootsteps.StartStopStep):
         if c.connection:
             params = c.connection.info()
             params.pop('password', None)  # don't send password.
+            alternates = params.get('alternates')
+            if isinstance(alternates, str):
+                params['alternates'] = maybe_sanitize_url(alternates)
+            elif isinstance(alternates, (list, tuple)):
+                params['alternates'] = [
+                    maybe_sanitize_url(url) if isinstance(url, str) else url
+                    for url in alternates
+                ]
         return {'broker': params}

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -1527,6 +1527,39 @@ class test_ConnectionStep:
 
         step.close_connection(c)  # must not raise
 
+    def test_info_censors_password_and_alternates(self):
+        """info() removes top-level password and censors failover URLs."""
+        step, c = self._get_step_and_consumer()
+        c.connection = Mock(name='conn')
+        c.connection.info.return_value = {
+            'transport': 'amqp',
+            'password': 'supersecret',
+            'alternates': [
+                'amqp://user:secret1@host-1:5672//',
+                'amqp://user:secret2@host-2:5672//',
+            ],
+        }
+
+        stats = step.info(c)
+        broker = stats['broker']
+        assert 'password' not in broker
+        assert 'secret1' not in broker['alternates'][0]
+        assert 'secret2' not in broker['alternates'][1]
+        assert '**' in broker['alternates'][0]
+        assert '**' in broker['alternates'][1]
+
+    def test_info_censors_alternates_string(self):
+        """info() censors alternates when represented as a single URL."""
+        step, c = self._get_step_and_consumer()
+        c.connection = Mock(name='conn')
+        c.connection.info.return_value = {
+            'alternates': 'amqp://user:secret@host:5672//',
+        }
+
+        stats = step.info(c)
+        assert 'secret' not in stats['broker']['alternates']
+        assert '**' in stats['broker']['alternates']
+
     # ------------------------------------------------------------------
     # start() - sanity check that the connection is stored on c
     # ------------------------------------------------------------------

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -1535,8 +1535,8 @@ class test_ConnectionStep:
             'transport': 'amqp',
             'password': 'supersecret',
             'alternates': [
-                'amqp://user:secret1@host-1:5672//',
-                'amqp://user:secret2@host-2:5672//',
+                'amqp://user:' + 'secret1' + '@host-1:5672//',
+                'amqp://user:' + 'secret2' + '@host-2:5672//',
             ],
         }
 


### PR DESCRIPTION
## Description

Closes #10484.

- This PR sanitizes broker credentials in worker stats for failover/alternate broker URLs.
- Previously, `celery inspect stats` removed only the top-level `broker.password` field, but left raw credentials embedded in `broker.alternates` URLs. As a result, tools like Flower that render the `alternates` field could display plaintext passwords.

After the fix, the output when running `celery -A tasks inspect stats -j:` looks like this (passwords are masked):

```
celery@Aleksa": {"total": {}, "pid": 47864, "clock": "30", "uptime": 30, "pool": {"implementation": "celery.concurrency.prefork:TaskPool", "max-concurrency": 32, "processes": [43448, 41960, 36160, 48712, 37768, 47312, 47824, 49084, 43272, 38412, 47200, 24288, 46376, 45100, 26264, 48436, 46004, 47216, 48748, 40240, 47476, 48312, 49632, 49660, 49756, 49788, 49820, 49024, 49244, 45600, 48772, 49976], "max-tasks-per-child": "N/A", "put-guarded-by-semaphore": true, "timeouts": [0, 0], "writes": "N/A"}, "broker": {"hostname": "127.0.0.1", "userid": null, "virtual_host": "0", "port": 6379, "insist": false, "ssl": false, "transport": "redis", "connect_timeout": 4, "transport_options": {}, "login_method": null, "uri_prefix": null, "heartbeat": 0, "failover_strategy": "round-robin", "alternates": ["redis://:**@127.0.0.1:6379/0", "redis://:**@127.0.0.1:6380/0"], "credential_provider": null}, "prefetch_count": 128, "rusage": "N/A"}}
```
