### PR TITLE
Sanitize failover broker URLs in worker inspect stats

### DIFF
--- a/celery/worker/consumer/connection.py
+++ b/celery/worker/consumer/connection.py
@@ -1,5 +1,6 @@
 """Consumer Broker Connection Bootstep."""
 from kombu.common import ignore_errors
+from kombu.utils.url import maybe_sanitize_url
 
 from celery import bootsteps
 from celery.utils.log import get_logger
@@ -42,4 +43,8 @@ class Connection(bootsteps.StartStopStep):
         if c.connection:
             params = c.connection.info()
             params.pop('password', None)  # don't send password.
+            # don't leak credentials in failover (alternate) broker URLs.
+            params['alternates'] = [
+                maybe_sanitize_url(url) for url in params.get('alternates', [])
+            ]
         return {'broker': params}

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -1545,6 +1545,26 @@ class test_ConnectionStep:
 
         assert c.connection is fake_conn
 
+    def test_info_sanitizes_alternate_broker_credentials(self):
+        """info() masks credentials in failover (alternate) broker URLs."""
+        from kombu import Connection as KombuConnection
+
+        from celery.worker.consumer.connection import Connection
+        step = Connection.__new__(Connection)
+        c = Mock(name='consumer')
+        c.connection = KombuConnection(
+            'redis://:mainpass@127.0.0.1:6379/0;'
+            'redis://:altpass@127.0.0.1:6380/0'
+        )
+
+        broker = step.info(c)['broker']
+
+        assert 'password' not in broker
+        assert len(broker['alternates']) == 2
+        assert all('**' in url for url in broker['alternates'])
+        assert 'mainpass' not in str(broker)
+        assert 'altpass' not in str(broker)
+
 
 class test_Gossip:
 


### PR DESCRIPTION
closes #10484

### Problem

`inspect stats` returned the worker's broker connection info verbatim from kombu's `Connection.info()`. While the top-level `password` key was already stripped, the `alternates` list — the failover broker URLs configured with a `;`-separated broker URL — was returned unchanged. Any password embedded in those URLs (e.g. `redis://:altpass@127.0.0.1:6380/0`) was therefore exposed through the control interface, and through tooling built on it such as Flower's Broker tab (mher/flower#1512).

### Fix

In the consumer's `Connection` bootstep `info()` method, run every alternate URL through kombu's `maybe_sanitize_url`, which masks the password portion, in addition to the existing removal of the `password` key:

```python
params['alternates'] = [
    maybe_sanitize_url(url) for url in params.get('alternates', [])
]
```

Example before/after:

```python
Connection('redis://:mainpass@127.0.0.1:6379/0;redis://:altpass@127.0.0.1:6380/0')
# before: alternates = ['redis://:mainpass@127.0.0.1:6379/0', 'redis://:altpass@127.0.0.1:6380/0']
# after:  alternates = ['redis://:**@127.0.0.1:6379/0', 'redis://:**@127.0.0.1:6380/0']
```

### Tests

- Added `test_info_sanitizes_alternate_broker_credentials` to `test_ConnectionStep` covering the multi-broker failover case, asserting both passwords are masked and no `password` key is present.
- `t/unit/worker/test_consumer.py`: 113 passed; `t/unit/worker/test_control.py`: 60 passed.
