### PR TITLE
Fix Redis result consumer redundant unsubscribe

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -195,10 +195,11 @@ class ResultConsumer(BaseResultConsumer):
 
     def cancel_for(self, task_id):
         key = self._get_key_for_task(task_id)
-        self.subscribed_to.discard(key)
-        if self._pubsub:
-            with self.reconnect_on_error():
-                self._pubsub.unsubscribe(key)
+        if key in self.subscribed_to:
+            self.subscribed_to.discard(key)
+            if self._pubsub:
+                with self.reconnect_on_error():
+                    self._pubsub.unsubscribe(key)
 
 
 class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -271,6 +271,25 @@ class test_RedisResultConsumer:
         consumer.cancel_for('some-task')
         assert consumer._pubsub._subscribed_to == {b'celery-task-meta-initial'}
 
+    def test_cancel_for_never_subscribed_is_noop(self):
+        consumer = self.get_consumer()
+        consumer.start('initial')
+        task_id = uuid()
+        consumer.cancel_for(task_id)
+        consumer._pubsub.unsubscribe.assert_not_called()
+
+    def test_cancel_for_second_call_after_already_cancelled_is_noop(self):
+        consumer = self.get_consumer()
+        consumer.start('initial')
+        task_id = uuid()
+        consumer.consume_from(task_id)
+        consumer.cancel_for(task_id)
+        consumer._pubsub.unsubscribe.reset_mock()
+        # simulates AsyncResult.__del__ firing again after get() already
+        # drove cleanup once — this is the literal deadlock trigger in #10477
+        consumer.cancel_for(task_id)
+        consumer._pubsub.unsubscribe.assert_not_called()
+
     @patch('celery.backends.redis.ResultConsumer.cancel_for')
     @patch('celery.backends.asynchronous.BaseResultConsumer.on_state_change')
     def test_drain_events_connection_error(self, parent_on_state_change, cancel_for):


### PR DESCRIPTION
## Description

Fixes #10477.

`ResultConsumer.cancel_for()` could call `unsubscribe()` even after the task had already been removed from `subscribed_to`. When cleanup was triggered again from `AsyncResult.__del__`, this redundant Redis operation could re-enter redis-py's non-reentrant `PubSub._lock` and cause a deadlock.

This change makes `cancel_for()` return early when the task is no longer subscribed, preventing the redundant `UNSUBSCRIBE`.

Added regression tests covering:
- cancelling a task that was never subscribed;
- cancelling the same task twice, ensuring the second call does not issue another `UNSUBSCRIBE`.

The fix is intentionally scoped to `cancel_for()` and does not change the existing result lifecycle or finalizer behavior.