### PR TITLE
Pin socket_timeout in integration test Redis client

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -310,3 +310,4 @@ Brian Helba, 2026/01/12
 송준호, 2026/04/22
 Hmn Falahi, 2026/07/08
 Oliver Haas, 2026/07/26
+Benjamin Chrobot, 2026/08/18

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -23,7 +23,9 @@ def get_redis_connection():
 
     host = os.environ.get("REDIS_HOST", "localhost")
     port = os.environ.get("REDIS_PORT", 6379)
-    return StrictRedis(host=host, port=port)
+    # Callers issue blocking reads that wait far longer than redis-py's
+    # default socket timeout, which would otherwise abort them early.
+    return StrictRedis(host=host, port=port, socket_timeout=None)
 
 
 logger = get_task_logger(__name__)


### PR DESCRIPTION
## Description

The integration test helpers issue blocking reads that wait up to 60 seconds for a value to appear, and treat an expired wait as the read returning empty. That only holds while the client's socket timeout is longer than the wait itself.

Leaving `socket_timeout` unset inherits whatever default the installed `redis-py` ships. When that default is shorter than the blocking wait, the socket aborts the read first and raises an error the callers do not expect, so tests asserting on an expired wait fail. Recent `redis-py` versions ship a 5 second default, well under the 60 second wait.

Set `socket_timeout` explicitly so the helpers no longer depend on the installed `redis-py`'s default.

Refs: https://github.com/celery/kombu/pull/2579