### PR TITLE
Censor broker_read_url and broker_write_url in filter_hidden_settings

### DIFF
--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -39,6 +39,9 @@ HIDDEN_SETTINGS = re.compile(
     re.IGNORECASE,
 )
 
+#: Settings holding a full broker URL, credentials included.
+BROKER_URL_SETTINGS = re.compile('BROKER(_READ|_WRITE)?_URL', re.IGNORECASE)
+
 E_MIX_OLD_INTO_NEW = """
 
 Cannot mix new and old setting keys, please rename the
@@ -332,7 +335,7 @@ def filter_hidden_settings(conf):
         if isinstance(key, str):
             if HIDDEN_SETTINGS.search(key):
                 return mask
-            elif 'broker_url' in key.lower():
+            elif BROKER_URL_SETTINGS.search(key):
                 from kombu import Connection
                 return Connection(value).as_uri(mask=mask)
             elif 'backend' in key.lower():

--- a/t/unit/app/test_utils.py
+++ b/t/unit/app/test_utils.py
@@ -48,6 +48,22 @@ class test_filter_hidden_settings:
         }
         filter_hidden_settings(conf)
 
+    def test_censors_every_broker_url_setting(self):
+        """broker_read_url and broker_write_url carry credentials as well"""
+        conf = {
+            'broker_url': 'amqp://user:pw@broker:5672//',
+            'broker_read_url': 'amqp://user:pw@replica:5672//',
+            'broker_write_url': 'amqp://user:pw@primary:5672//',
+        }
+
+        filtered = filter_hidden_settings(conf)
+
+        assert filtered['broker_url'] == 'amqp://user:********@broker:5672//'
+        assert filtered['broker_read_url'] == (
+            'amqp://user:********@replica:5672//')
+        assert filtered['broker_write_url'] == (
+            'amqp://user:********@primary:5672//')
+
 
 class test_bugreport:
 


### PR DESCRIPTION
## Description

`filter_hidden_settings` censors `broker_url`, but it recognises it with a substring test on the key name:

https://github.com/celery/celery/blob/2c42237d375718a84f01f3a7b4eb12a85e061e37/celery/app/utils.py#L335

`broker_read_url` and `broker_write_url` do not contain that substring, so neither matches, and both fall through to the final `return value`. Both are documented settings and both hold a full broker URL with the password in it.

```python
from celery import Celery
from celery.app.utils import filter_hidden_settings

app = Celery(set_as_current=False)
app.conf.update(
    broker_url='amqp://user:pw@broker:5672//',
    broker_read_url='amqp://user:pw@replica:5672//',
    broker_write_url='amqp://user:pw@primary:5672//',
)
filter_hidden_settings(dict(app.conf))
# broker_url        'amqp://user:********@broker:5672//'
# broker_read_url   'amqp://user:pw@replica:5672//'
# broker_write_url  'amqp://user:pw@primary:5672//'
```

Two paths carry that value out of the process:

* `celery -A proj report`, via `Settings.humanize()`. The bug report template in this repository asks the reporter to paste that output, so a split broker setup puts its password in a public issue.
* the `conf` remote control command, `celery inspect conf`, via `Settings.table()` in `celery/worker/control.py`. That one answers over the broker.

## Fix

One pattern covering the three settings that hold a broker URL. `BROKER(_READ|_WRITE)?_URL` matches everything the old substring test matched, so nothing that was censored before stops being censored, and the two missing keys now take the same `Connection(value).as_uri(mask=mask)` path as `broker_url`.

I checked the rest of the settings for the same shape. Everything else that can hold a credential is already covered: `result_backend` and `cache_backend` by the `backend` branch, `broker_password`, `security_key` and friends by `HIDDEN_SETTINGS`, and the transport option dicts by the `Mapping` recursion.

## Tests

New case in `t/unit/app/test_utils.py`. On `main` it fails on the `broker_read_url` assertion, with the change it passes.

Full unit suite on this branch: 3562 passed, 177 skipped, 30 xfailed, 28817 subtests passed, on Python 3.13.7.

## One question

`#10485` masked credentials in the alternates returned by `inspect stats` and went through as a normal pull request, so I took the same route here rather than the address in `SECURITY.md`. Tell me if you would rather have had this one privately and I will follow that next time.
