### PR TITLE
Fix KeyError in MongoDB backend for results stored without a request

### DIFF
--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -200,15 +200,20 @@ class MongoBackend(BaseBackend):
         obj = self.collection.find_one({'_id': task_id})
         if obj:
             if self.app.conf.find_value_for_key('extended', 'result'):
+                # The request-derived fields are only written by
+                # ``_get_result_meta`` when a request is available, so a
+                # document stored without one (for example by
+                # ``AbortableAsyncResult.abort``) does not carry them.
+                # Default them to None instead of raising KeyError.
                 return self.meta_from_decoded({
-                    'name': obj['name'],
-                    'args': obj['args'],
+                    'name': obj.get('name'),
+                    'args': obj.get('args'),
                     'task_id': obj['_id'],
-                    'queue': obj['queue'],
-                    'kwargs': obj['kwargs'],
+                    'queue': obj.get('queue'),
+                    'kwargs': obj.get('kwargs'),
                     'status': obj['status'],
-                    'worker': obj['worker'],
-                    'retries': obj['retries'],
+                    'worker': obj.get('worker'),
+                    'retries': obj.get('retries'),
                     'children': obj['children'],
                     'date_done': obj['date_done'],
                     'traceback': obj['traceback'],

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -22,6 +22,7 @@ else:
 
 from celery import states, uuid
 from celery.backends.mongodb import Binary, InvalidDocument, MongoBackend
+from celery.contrib.abortable import ABORTED
 from celery.exceptions import ImproperlyConfigured
 from t.unit import conftest
 
@@ -463,6 +464,101 @@ class test_MongoBackend:
             'traceback', 'result', 'children',
             'name', 'args', 'queue', 'kwargs', 'worker', 'retries',
         ])) == list(sorted(ret_val.keys()))
+
+    @patch('celery.backends.mongodb.MongoBackend._get_database')
+    def test_get_task_meta_for_result_extended_with_request(
+            self, mock_get_database):
+        self.backend.taskmeta_collection = MONGODB_COLLECTION
+
+        mock_database = MagicMock(spec=['__getitem__', '__setitem__'])
+        mock_collection = Mock()
+        mock_collection.find_one.return_value = {
+            '_id': sentinel.task_id,
+            'name': 'proj.tasks.add',
+            'args': sentinel.args,
+            'queue': 'celery',
+            'kwargs': sentinel.kwargs,
+            'status': states.SUCCESS,
+            'worker': 'worker1@example.com',
+            'retries': 2,
+            'children': [],
+            'date_done': sentinel.date_done,
+            'traceback': None,
+            'result': sentinel.result,
+        }
+
+        mock_get_database.return_value = mock_database
+        mock_database.__getitem__.return_value = mock_collection
+
+        self.app.conf.result_extended = True
+        ret_val = self.backend._get_task_meta_for(sentinel.task_id)
+
+        assert ret_val['task_id'] is sentinel.task_id
+        assert ret_val['name'] == 'proj.tasks.add'
+        assert ret_val['args'] is sentinel.args
+        assert ret_val['queue'] == 'celery'
+        assert ret_val['kwargs'] is sentinel.kwargs
+        assert ret_val['status'] == states.SUCCESS
+        assert ret_val['worker'] == 'worker1@example.com'
+        assert ret_val['retries'] == 2
+
+    @patch('celery.backends.mongodb.MongoBackend._get_database')
+    def test_get_task_meta_for_result_extended_without_request(
+            self, mock_get_database):
+        # A result stored without a request (as AbortableAsyncResult.abort
+        # does) has no request-derived fields, see
+        # https://github.com/celery/celery/issues/8877
+        self.backend.taskmeta_collection = MONGODB_COLLECTION
+
+        mock_database = MagicMock(spec=['__getitem__', '__setitem__'])
+        mock_collection = Mock()
+        mock_collection.find_one.return_value = {
+            '_id': sentinel.task_id,
+            'status': ABORTED,
+            'result': sentinel.result,
+            'traceback': None,
+            'children': None,
+            'date_done': None,
+        }
+
+        mock_get_database.return_value = mock_database
+        mock_database.__getitem__.return_value = mock_collection
+
+        self.app.conf.result_extended = True
+        ret_val = self.backend._get_task_meta_for(sentinel.task_id)
+
+        assert ret_val['task_id'] is sentinel.task_id
+        assert ret_val['status'] == ABORTED
+        for key in ('name', 'args', 'queue', 'kwargs', 'worker', 'retries'):
+            assert ret_val[key] is None
+
+    @patch('celery.backends.mongodb.MongoBackend._get_database')
+    def test_get_task_meta_for_result_extended_aborted_roundtrip(
+            self, mock_get_database):
+        # End to end: store an aborted result the way
+        # AbortableAsyncResult.abort does, then read the stored document
+        # back through _get_task_meta_for.
+        self.backend.taskmeta_collection = MONGODB_COLLECTION
+
+        mock_database = MagicMock(spec=['__getitem__', '__setitem__'])
+        mock_collection = Mock()
+        mock_get_database.return_value = mock_database
+        mock_database.__getitem__.return_value = mock_collection
+
+        self.app.conf.result_extended = True
+        self.backend.store_result(
+            sentinel.task_id, result=None, state=ABORTED, traceback=None,
+        )
+
+        stored = mock_collection.replace_one.call_args[0][1]
+        assert 'name' not in stored
+
+        mock_collection.find_one.return_value = stored
+        ret_val = self.backend._get_task_meta_for(sentinel.task_id)
+
+        assert ret_val['task_id'] is sentinel.task_id
+        assert ret_val['status'] == ABORTED
+        assert ret_val['name'] is None
 
     @patch('celery.backends.mongodb.MongoBackend._get_database')
     def test_get_task_meta_for_no_result(self, mock_get_database):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Fixes #8877.

`MongoBackend._get_task_meta_for` reads the extended fields with direct subscripts, but `BaseBackend._get_result_meta` only writes them when it is given a request. `AbortableAsyncResult.abort` calls `store_result` without one, so the document carries only the base fields and reading it back raises `KeyError: 'name'`. The abort path is the reported reproducer but not the only one: any document written while `result_extended` was off and read after it was turned on is missing the same fields, as is any other request-less `store_result`.

### The full set of affected keys

`name`, `args`, `kwargs`, `worker`, `retries`, `queue`. The issue names only `name` because it is the first subscript evaluated and the traceback stops there; fixing it alone moves the `KeyError` to `args`. `status`, `result`, `traceback`, `children`, `date_done` and `_id` are always written, so they keep their direct subscripts, since a document missing one of those is genuinely malformed.

### What a missing value should be

`None`, not dropped from the mapping. That matches the SQLAlchemy `database` backend, the other one with an explicit extended schema: `TaskExtended` declares all six as nullable and `to_dict` emits them unconditionally. Redis and Elasticsearch omit the keys instead, because they round-trip whatever mapping `_get_result_meta` produced; that difference is invisible through the public API, since `AsyncResult.name` and friends all read the meta with `.get()`. `None` keeps the returned mapping the same shape for a given `result_extended` setting regardless of which write path produced the document.

### Other backends

`mongodb` is the only one that indexes the extended fields directly. `database` goes through `to_dict` and guards its two `decode` calls with `.get(...) is not None`, the key/value backends decode the stored mapping as-is, and `cassandra` and `rpc` have no extended branch. This stays scoped to MongoDB.

### Testing

Three tests in `t/unit/backends/test_mongodb.py`. The existing `test_get_task_meta_for_result_extended` passes a bare `MagicMock` as the found document, so every subscript resolves and the missing-key case was never exercised. The new ones cover a request-less document (all six come back `None`), a fully populated one (values unchanged, so nothing is quietly blanked), and an aborted round trip that calls `store_result` the way `abort` does, confirms the stored document has no `name`, and reads the meta back. The two regression tests fail with `KeyError: 'name'` against the unpatched backend.

`t/unit/backends/`, `t/unit/contrib/test_abortable.py` and `t/unit/tasks/test_result.py`: 691 passed, 20 skipped. `flake8`, `isort` and `pyupgrade` clean on both changed files. The rest of the unit suite and the integration suite are left to CI.
