### PR TITLE
fix: skip stale heap entries in LimitedSet to prevent premature eviction of refreshed items

### DIFF
--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -590,21 +590,39 @@ class LimitedSet:
         # time based expiring:
         if self.expires:
             while len(self._data) > self.minlen >= 0:
-                inserted_time, _ = self._heap[0]
+                if not self._heap:
+                    break
+                entry = self._heap[0]
+                inserted_time, item = entry
                 if inserted_time + self.expires > now:
                     break  # oldest item hasn't expired yet
-                self.pop()
+                heappop(self._heap)
+                current = self._data.get(item)
+                if current is entry:
+                    # The heap entry matches the current entry in _data:
+                    # the item genuinely expired, so remove it.
+                    del self._data[item]
+                # Otherwise the item was already removed, or the heap entry
+                # is stale (the item was refreshed since it was pushed), in
+                # which case only the stale heap entry is discarded.
 
     def pop(self, default: Any = None) -> Any:
         """Remove and return the oldest item, or :const:`None` when empty."""
         while self._heap:
-            _, item = heappop(self._heap)
+            entry = heappop(self._heap)
+            _, item = entry
             try:
-                self._data.pop(item)
+                current = self._data[item]
             except KeyError:
-                pass
-            else:
-                return item
+                # item was already removed, skip the stale heap entry
+                continue
+            if current is not entry:
+                # The item was refreshed since this heap entry was pushed,
+                # so the heap entry is stale.  Keep the current entry and
+                # let the refreshed entry expire on its own schedule.
+                continue
+            del self._data[item]
+            return item
         return default
 
     def as_dict(self):

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -324,6 +324,29 @@ class test_LimitedSet:
         [s.add('foo') for i in range(1000)]
         assert len(s._heap) < 1150
 
+    def test_refresh_does_not_evict_item_until_new_expiry(self):
+        # Refreshing an item leaves a stale heap entry behind (until the
+        # heap is rebuilt).  That stale entry must not cause the current,
+        # refreshed entry to be removed when it later expires on its own.
+        s = LimitedSet(expires=10)
+
+        # Add an item at t=1.
+        s.add('task-id', now=1)
+
+        # Refresh the same item at t=6: the new entry should expire at t=16,
+        # while the old heap entry expires at t=11.
+        s.add('task-id', now=6)
+        assert 'task-id' in s
+
+        # The stale heap entry expires at t=11, but the refreshed entry is
+        # still valid, so the item must survive.
+        s.purge(now=11)
+        assert 'task-id' in s
+
+        # The refreshed entry finally expires at t=16.
+        s.purge(now=16)
+        assert 'task-id' not in s
+
 
 class test_AttributeDict:
 


### PR DESCRIPTION
## Description

Fixes #10506

When an item is refreshed (added again) to a `LimitedSet`, the old heap entry remains in `_heap` while `_data[item]` is replaced with the newer entry.  The stale entry could cause the current entry to be removed prematurely during `purge()`.

### Root cause

`purge()`'s expiry branch called `self.pop()`, which blindly removes the oldest item from `_data` — even when the heap entry it popped was stale (the item had been refreshed since that entry was pushed).

### Fix

1. **`purge()` expiry branch**: directly inspect `self._heap[0]` with identity comparison to distinguish stale heap entries from current ones.  Only delete from `_data` when the entry is both expired and current.

2. **`pop()`**: use the same identity check to skip stale heap entries instead of blindly removing the item from `_data`.

### Testing

Added `test_refresh_does_not_evict_item_until_new_expiry` — a regression test that reproduces the exact scenario from the issue.

All 52 tests in `test_collections.py` pass.