### PR TITLE
Fix certificate expiration during verification

### DIFF
--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -64,8 +64,10 @@ class Certificate:
 
     def verify(self, data: bytes, signature: bytes, digest: HashAlgorithm | Prehashed) -> None:
         """Verify signature for string containing data."""
-        with reraise_errors('Bad signature: {0!r}'):
+        if self.has_expired():
+            raise SecurityError(f'Expired certificate: {self.get_id()!r}')
 
+        with reraise_errors('Bad signature: {0!r}'):
             pad = padding.PSS(
                 mgf=padding.MGF1(digest),
                 salt_length=padding.PSS.MAX_LENGTH)

--- a/t/unit/security/test_certificate.py
+++ b/t/unit/security/test_certificate.py
@@ -3,9 +3,12 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
+from kombu.utils.encoding import ensure_bytes
 
 from celery.exceptions import SecurityError
 from celery.security.certificate import Certificate, CertStore, FSCertStore
+from celery.security.key import PrivateKey
+from celery.security.utils import get_digest_algorithm
 from t.unit import conftest
 
 from . import CERT1, CERT2, CERT_ECDSA, KEY1
@@ -53,6 +56,22 @@ class test_Certificate(SecurityCase):
         x._cert.not_valid_after_utc = time_after
 
         assert x.has_expired() is False
+
+    def test_verify_rejects_expired_certificate(self):
+        """Test that expired certificates cannot verify signatures."""
+        cert = Certificate(CERT1)
+        pkey = PrivateKey(KEY1)
+
+        data = ensure_bytes('test data')
+        digest = get_digest_algorithm()
+        signature = pkey.sign(data, digest)
+
+        with patch.object(cert, 'has_expired', return_value=False):
+            cert.verify(data, signature, digest)
+
+        with patch.object(cert, 'has_expired', return_value=True):
+            with pytest.raises(SecurityError, match='Expired certificate'):
+                cert.verify(data, signature, digest)
 
 
 class test_CertStore(SecurityCase):

--- a/t/unit/security/test_serialization.py
+++ b/t/unit/security/test_serialization.py
@@ -19,9 +19,17 @@ class test_secureserializer(SecurityCase):
     def _get_s(self, key, cert, certs, serializer="json"):
         store = CertStore()
         for c in certs:
-            store.add_cert(Certificate(c))
+            cert_obj = Certificate(c)
+            # Mock has_expired to return False since test certificates are expired
+            # These tests focus on serialization, not certificate expiration
+            cert_obj.has_expired = lambda: False
+            store.add_cert(cert_obj)
+        cert_obj = Certificate(cert)
+        # Mock has_expired to return False since test certificates are expired
+        # These tests focus on serialization, not certificate expiration
+        cert_obj.has_expired = lambda: False
         return SecureSerializer(
-            PrivateKey(key), Certificate(cert), store, serializer=serializer
+            PrivateKey(key), cert_obj, store, serializer=serializer
         )
 
     @pytest.mark.parametrize(

--- a/t/unit/security/test_serialization.py
+++ b/t/unit/security/test_serialization.py
@@ -1,5 +1,6 @@
 import base64
 import os
+from unittest.mock import patch
 
 import pytest
 from kombu.serialization import registry
@@ -16,19 +17,18 @@ from .case import SecurityCase
 
 class test_secureserializer(SecurityCase):
 
-    def _get_s(self, key, cert, certs, serializer="json"):
-        def _get_certificate(cert):
-            cert_obj = Certificate(cert)
-            # Test certificates are expired; serialization tests do not exercise
-            # certificate expiration.
-            cert_obj.has_expired = lambda: False
-            return cert_obj
+    @pytest.fixture(autouse=True)
+    def _patch_expired(self):
+        with patch.object(Certificate, 'has_expired', return_value=False):
+            yield
 
+    def _get_s(self, key, cert, certs, serializer="json"):
         store = CertStore()
         for c in certs:
-            store.add_cert(_get_certificate(c))
+            cert_obj = Certificate(c)
+            store.add_cert(cert_obj)
 
-        cert_obj = _get_certificate(cert)
+        cert_obj = Certificate(cert)
 
         return SecureSerializer(
             PrivateKey(key), cert_obj, store, serializer=serializer

--- a/t/unit/security/test_serialization.py
+++ b/t/unit/security/test_serialization.py
@@ -17,17 +17,19 @@ from .case import SecurityCase
 class test_secureserializer(SecurityCase):
 
     def _get_s(self, key, cert, certs, serializer="json"):
+        def _get_certificate(cert):
+            cert_obj = Certificate(cert)
+            # Test certificates are expired; serialization tests do not exercise
+            # certificate expiration.
+            cert_obj.has_expired = lambda: False
+            return cert_obj
+
         store = CertStore()
         for c in certs:
-            cert_obj = Certificate(c)
-            # Mock has_expired to return False since test certificates are expired
-            # These tests focus on serialization, not certificate expiration
-            cert_obj.has_expired = lambda: False
-            store.add_cert(cert_obj)
-        cert_obj = Certificate(cert)
-        # Mock has_expired to return False since test certificates are expired
-        # These tests focus on serialization, not certificate expiration
-        cert_obj.has_expired = lambda: False
+            store.add_cert(_get_certificate(c))
+
+        cert_obj = _get_certificate(cert)
+
         return SecureSerializer(
             PrivateKey(key), cert_obj, store, serializer=serializer
         )


### PR DESCRIPTION
## Summary

Fixes #10509 

A certificate could be valid when loaded into `FSCertStore`, later expire while the worker remained running, and still be used to successfully verify signed messages.

This PR enforces certificate expiration at verification time.

## Root Cause

`FSCertStore` already checks `has_expired()` when certificates are loaded. However, `Certificate.verify()` only performed cryptographic signature verification and did not re-check the certificate's validity.

This created a time-of-use gap:

1. Certificate is valid when the worker starts.
2. Certificate is loaded and stored.
3. Certificate later expires.
4. `Certificate.verify()` is called for a new message.
5. Signature verification succeeds even though the certificate is expired.

## Changes

- Added an expiration check at the beginning of `Certificate.verify()`.
- Expired certificates now raise `SecurityError` before cryptographic signature verification.
- Kept the existing `FSCertStore` load-time expiration check unchanged.
- Added a regression test covering verification before and after certificate expiration.
- Updated the existing serialization test setup because its historical test certificates are expired and those tests are intended to exercise serialization behavior rather than certificate validity.

## Testing

- All security tests pass: `37 passed, 1 skipped`
- Flake8 passes for the modified files.
- The regression test verifies that:
  - a valid certificate can successfully verify a valid signature;
  - the same certificate is rejected once it is considered expired.

## Scope

This change is intentionally limited to certificate expiration during verification. It does not change signature algorithms, certificate loading, certificate parsing, or unrelated exception handling.