### PR TITLE
fix: handle invalid worker environment values

### DIFF
--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -15,7 +15,7 @@ from kombu.serialization import pickle, pickle_protocol
 from kombu.utils.objects import cached_property
 
 from celery import __version__
-from celery.exceptions import WorkerShutdown, WorkerTerminate
+from celery.exceptions import ImproperlyConfigured, WorkerShutdown, WorkerTerminate
 from celery.utils.collections import LimitedSet
 
 __all__ = (
@@ -23,6 +23,35 @@ __all__ = (
     'total_count', 'revoked', 'task_reserved', 'maybe_shutdown',
     'task_accepted', 'task_ready', 'Persistent',
 )
+
+
+def _int_env(name: str, default: int) -> int:
+    """Parse an integer environment variable with proper error handling."""
+    value = os.environ.get(name)
+    if value is None:
+        return default
+
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ImproperlyConfigured(
+            f"Invalid value for {name}: expected int, got {value!r}"
+        ) from exc
+
+
+def _float_env(name: str, default: float) -> float:
+    """Parse a float environment variable with proper error handling."""
+    value = os.environ.get(name)
+    if value is None:
+        return float(default)
+
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ImproperlyConfigured(
+            f"Invalid value for {name}: expected float, got {value!r}"
+        ) from exc
+
 
 #: Worker software/platform information.
 SOFTWARE_INFO = {
@@ -32,18 +61,18 @@ SOFTWARE_INFO = {
 }
 
 #: maximum number of revokes to keep in memory.
-REVOKES_MAX = int(os.environ.get('CELERY_WORKER_REVOKES_MAX', 50000))
+REVOKES_MAX = _int_env('CELERY_WORKER_REVOKES_MAX', 50000)
 
 #: maximum number of successful tasks to keep in memory.
-SUCCESSFUL_MAX = int(os.environ.get('CELERY_WORKER_SUCCESSFUL_MAX', 1000))
+SUCCESSFUL_MAX = _int_env('CELERY_WORKER_SUCCESSFUL_MAX', 1000)
 
 #: how many seconds a revoke will be active before
 #: being expired when the max limit has been exceeded.
-REVOKE_EXPIRES = float(os.environ.get('CELERY_WORKER_REVOKE_EXPIRES', 10800))
+REVOKE_EXPIRES = _float_env('CELERY_WORKER_REVOKE_EXPIRES', 10800)
 
 #: how many seconds a successful task will be cached in memory
 #: before being expired when the max limit has been exceeded.
-SUCCESSFUL_EXPIRES = float(os.environ.get('CELERY_WORKER_SUCCESSFUL_EXPIRES', 10800))
+SUCCESSFUL_EXPIRES = _float_env('CELERY_WORKER_SUCCESSFUL_EXPIRES', 10800)
 
 #: Mapping of reserved task_id->Request.
 requests = {}

--- a/t/unit/worker/test_state.py
+++ b/t/unit/worker/test_state.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from celery import uuid
-from celery.exceptions import WorkerShutdown, WorkerTerminate
+from celery.exceptions import ImproperlyConfigured, WorkerShutdown, WorkerTerminate
 from celery.platforms import EX_OK
 from celery.utils.collections import LimitedSet
 from celery.worker import state
@@ -220,3 +220,49 @@ class test_state_configuration():
         assert state.SUCCESSFUL_MAX == 1000
         assert state.REVOKE_EXPIRES == 10800
         assert state.SUCCESSFUL_EXPIRES == 10800
+
+    def test_default_float_type_preserved(self):
+        """Ensure float defaults remain float type, not int."""
+        state = self.import_state()
+        assert isinstance(state.REVOKE_EXPIRES, float)
+        assert isinstance(state.SUCCESSFUL_EXPIRES, float)
+
+    @patch.dict(os.environ, {
+        'CELERY_WORKER_REVOKES_MAX': 'abc',
+    })
+    def test_malformed_revokes_max_raises_improperly_configured(self):
+        with pytest.raises(ImproperlyConfigured) as exc_info:
+            self.import_state()
+        assert 'CELERY_WORKER_REVOKES_MAX' in str(exc_info.value)
+        assert 'expected int' in str(exc_info.value)
+        assert 'abc' in str(exc_info.value)
+
+    @patch.dict(os.environ, {
+        'CELERY_WORKER_SUCCESSFUL_MAX': 'not_a_number',
+    })
+    def test_malformed_successful_max_raises_improperly_configured(self):
+        with pytest.raises(ImproperlyConfigured) as exc_info:
+            self.import_state()
+        assert 'CELERY_WORKER_SUCCESSFUL_MAX' in str(exc_info.value)
+        assert 'expected int' in str(exc_info.value)
+        assert 'not_a_number' in str(exc_info.value)
+
+    @patch.dict(os.environ, {
+        'CELERY_WORKER_REVOKE_EXPIRES': 'invalid_float',
+    })
+    def test_malformed_revoke_expires_raises_improperly_configured(self):
+        with pytest.raises(ImproperlyConfigured) as exc_info:
+            self.import_state()
+        assert 'CELERY_WORKER_REVOKE_EXPIRES' in str(exc_info.value)
+        assert 'expected float' in str(exc_info.value)
+        assert 'invalid_float' in str(exc_info.value)
+
+    @patch.dict(os.environ, {
+        'CELERY_WORKER_SUCCESSFUL_EXPIRES': 'xyz',
+    })
+    def test_malformed_successful_expires_raises_improperly_configured(self):
+        with pytest.raises(ImproperlyConfigured) as exc_info:
+            self.import_state()
+        assert 'CELERY_WORKER_SUCCESSFUL_EXPIRES' in str(exc_info.value)
+        assert 'expected float' in str(exc_info.value)
+        assert 'xyz' in str(exc_info.value)


### PR DESCRIPTION
## Description

Fix malformed worker environment variables raising a raw `ValueError` during `celery.worker.state` import.

This replaces the direct `int()`/`float()` parsing for the worker state configuration values with dedicated helpers that raise `ImproperlyConfigured` with the environment variable name, expected type, and invalid value.

The fix also preserves the existing float default behavior and adds regression tests covering invalid integer/float values and default float types.

Fixes #10388.
