### PR TITLE
Fix pre-commit formatting error in test_time

### DIFF
--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -61,6 +61,7 @@ class test_LocalTimezone:
         assert result.utcoffset() == timedelta(hours=-4)
         assert result == datetime(2026, 6, 15, 8, 0, tzinfo=result.tzinfo)
 
+
 class test_iso8601:
 
     def test_parse_with_timezone(self):


### PR DESCRIPTION
After PR #10519 was merged, I noticed the pre-commit workflow was failing because of a small `flake8 E302` formatting issue in `t/unit/utils/test_time.py`.

Since this can keep affecting PRs that merge/rebase `main`, I fixed the missing blank line in this separate small PR.

`pre-commit run --all-files` now passes.

I could have included this fix in one of my other PRs, but I thought keeping it scoped would be cleaner. If you prefer, feel free to close this PR and I can include it elsewhere. Final call is yours.
