### PR TITLE
Honor a timeout of 0 in get_many instead of polling forever

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -1202,6 +1202,7 @@ class BaseKeyValueStoreBackend(Backend):
 
         ids.difference_update(cached_ids)
         iterations = 0
+        time_elapsed = 0.0
         while ids:
             keys = list(ids)
             r = self._mget_to_results(self.mget([self.get_key_for_task(k)
@@ -1212,11 +1213,17 @@ class BaseKeyValueStoreBackend(Backend):
                 if on_message is not None:
                     on_message(value)
                 yield bytes_to_str(key), value
-            if timeout and iterations * interval >= timeout:
+            if timeout is not None and time_elapsed >= timeout:
                 raise TimeoutError(f'Operation timed out ({timeout})')
             if on_interval:
                 on_interval()
-            time.sleep(interval)  # don't busy loop.
+            # don't busy loop, and never sleep past the deadline: with the
+            # deadline counted in whole intervals, timeout=0 waited forever
+            # and any timeout below interval overshot to interval.
+            nap = interval if timeout is None else min(interval,
+                                                       timeout - time_elapsed)
+            time.sleep(nap)
+            time_elapsed += nap
             iterations += 1
             if max_iterations and iterations >= max_iterations:
                 break

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -1213,6 +1213,8 @@ class BaseKeyValueStoreBackend(Backend):
                 if on_message is not None:
                     on_message(value)
                 yield bytes_to_str(key), value
+            if not ids:
+                break
             if timeout is not None and time_elapsed >= timeout:
                 raise TimeoutError(f'Operation timed out ({timeout})')
             if on_interval:

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -1214,6 +1214,9 @@ class BaseKeyValueStoreBackend(Backend):
                     on_message(value)
                 yield bytes_to_str(key), value
             if not ids:
+                # everything asked for has been handed back, so there is
+                # nothing left to time out on. wait_for checks the same way,
+                # returning a ready result before it looks at the deadline.
                 break
             if timeout is not None and time_elapsed >= timeout:
                 raise TimeoutError(f'Operation timed out ({timeout})')

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1183,6 +1183,39 @@ class test_result_set:
         rs.add(add.delay(2, 2))
         assert rs.get(timeout=TIMEOUT) == [2, 4]
 
+    @flaky
+    def test_join_native_timeout_zero_gives_up_on_pending_results(self, manager):
+        """timeout=0 means poll once, not poll until the results show up."""
+        if not isinstance(manager.app.backend, BaseKeyValueStoreBackend):
+            raise pytest.skip('get_many is the key/value backend poll loop')
+
+        # ids nothing will ever write a result for, so the only way out of
+        # the loop is the deadline. The interval is far longer than the
+        # bound below, so sleeping even one of them fails the test.
+        rs = ResultSet([AsyncResult(str(uuid.uuid4())) for _ in range(3)])
+
+        start = monotonic()
+        with pytest.raises(TimeoutError):
+            rs.join_native(timeout=0, interval=30)
+        assert monotonic() - start < 30
+
+    @flaky
+    def test_join_native_timeout_zero_returns_results_that_are_ready(self, manager):
+        """timeout=0 still collects results the backend can hand over."""
+        if not isinstance(manager.app.backend, BaseKeyValueStoreBackend):
+            raise pytest.skip('get_many is the key/value backend poll loop')
+
+        assert_ping(manager)
+
+        rs = ResultSet([add.delay(1, 1), add.delay(2, 2), add.delay(3, 3)])
+        assert rs.join_native(timeout=TIMEOUT) == [2, 4, 6]
+
+        # answered from the cache the poll loop is never entered, and the
+        # poll loop is what has to hand the results back before it looks at
+        # the deadline.
+        rs.backend._cache.clear()
+        assert rs.join_native(timeout=0, interval=30) == [2, 4, 6]
+
 
 class test_group:
     @flaky

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -1336,6 +1336,28 @@ class test_KeyValueStoreBackend:
         with pytest.raises(self.b.TimeoutError):
             list(self.b.get_many(tasks, timeout=0.01, interval=0.01))
 
+    def test_get_many__timeout_zero_does_not_wait_forever(self):
+        """A timeout of 0 must time out, not fall back to waiting forever."""
+        # max_iterations keeps this test terminating if the deadline is
+        # skipped again, so the regression shows up as a failure not a hang.
+        sleep = self.patching('time.sleep')
+        tasks = [uuid() for _ in range(4)]
+        self.b._cache[tasks[1]] = {'status': 'PENDING'}
+        with pytest.raises(self.b.TimeoutError):
+            list(self.b.get_many(
+                tasks, timeout=0, interval=0.01, max_iterations=3))
+        # timeout=0 means do not block, so it must not sleep either.
+        sleep.assert_not_called()
+
+    def test_get_many__does_not_sleep_past_the_timeout(self):
+        """A timeout below the poll interval must not be overshot."""
+        sleep = self.patching('time.sleep')
+        tasks = [uuid() for _ in range(4)]
+        self.b._cache[tasks[1]] = {'status': 'PENDING'}
+        with pytest.raises(self.b.TimeoutError):
+            list(self.b.get_many(tasks, timeout=0.1, interval=0.5))
+        assert sum(c.args[0] for c in sleep.call_args_list) == 0.1
+
     def test_get_many_passes_ready_states(self):
         tasks_length = 10
         ready_states = frozenset({states.SUCCESS})

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -1358,6 +1358,45 @@ class test_KeyValueStoreBackend:
             list(self.b.get_many(tasks, timeout=0.1, interval=0.5))
         assert sum(c.args[0] for c in sleep.call_args_list) == 0.1
 
+    def test_get_many__timeout_zero_returns_results_that_are_ready(self):
+        """A timeout of 0 still gets to return work that is already done."""
+        sleep = self.patching('time.sleep')
+        self.b._cache.clear()
+        ids = {uuid(): i for i in range(4)}
+        for id, i in ids.items():
+            self.b.mark_as_done(id, i)
+        # the ids are served by the first mget, not out of the cache, so the
+        # poll loop is entered and the deadline check is reached.
+        self.b._cache.clear()
+
+        got = dict(self.b.get_many(list(ids), timeout=0, interval=0.5))
+
+        assert {id: state['result'] for id, state in got.items()} == ids
+        sleep.assert_not_called()
+
+    def test_get_many__ids_completing_on_the_deadline_is_not_a_timeout(self):
+        """Satisfying the last id as the budget runs out is a success."""
+        sleep = self.patching('time.sleep')
+        self.b._cache.clear()
+        ids = {uuid(): i for i in range(4)}
+        polls = []
+
+        def mget(keys):
+            # nothing is stored until the second poll, which lands exactly
+            # when the one interval of budget has been spent.
+            polls.append(keys)
+            if len(polls) > 1:
+                for id, i in ids.items():
+                    self.b.mark_as_done(id, i)
+            return [self.b.get(k) for k in keys]
+
+        self.b.mget = mget
+
+        got = dict(self.b.get_many(list(ids), timeout=0.5, interval=0.5))
+
+        assert {id: state['result'] for id, state in got.items()} == ids
+        assert sleep.call_args_list == [call(0.5)]
+
     def test_get_many_passes_ready_states(self):
         tasks_length = 10
         ready_states = frozenset({states.SUCCESS})


### PR DESCRIPTION
## Description

On a key-value result backend, `GroupResult.join_native(timeout=0)` and `iter_native(timeout=0)` never return. `KeyValueStoreBackend.get_many` guards its deadline with `if timeout and iterations * interval >= timeout`, so a timeout of 0 is falsy and the check is skipped on every pass. Measured on `cache+memory://` against ids that stay pending:

```
timeout=0      still running after 2.5s
timeout=0.01   TimeoutError after 0.058s
timeout=0.2    TimeoutError after 0.225s
```

The middle line is the other half of it: the deadline is counted in whole intervals, so any timeout below `interval` is rounded up to one interval. After this change those three read 0.000s, 0.013s and 0.216s.

#10487 fixed both of these in `SyncBackendMixin.wait_for`. This applies the same two changes to `get_many` 170 lines below in the same file: compare against `None`, and clamp the nap to what is left of the budget. Semantics then match `wait_for`, where a budget of 0 polls once and raises rather than blocking.

`test_get_many_times_out` uses `timeout=0.01, interval=0.01`. A truthy timeout cannot separate `if timeout` from `if timeout is not None`, and with the interval equal to the timeout the overshoot is invisible.

Full unit suite and `pre-commit` are green. Reverting only `backends/base.py` fails both new tests, and `max_iterations` keeps them failing rather than hanging if the deadline is skipped again.

Not included: `Drainer.drain_events_until` has the same falsy guard, but its check sits above the `p.ready` break, so flipping it there would raise on an already-ready result. That needs the loop reordered.
