### PR TITLE
refactor: remove pre-Python 3.10 leftovers

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -1024,13 +1024,11 @@ class AsynPool(_pool.Pool):
                 # flush outgoing buffers
                 intervals = fxrange(0.01, 0.1, 0.01, repeatlast=True)
 
-                # TODO: Rewrite this as a dictionary comprehension once we drop support for Python 3.7
-                #       This dict comprehension requires the walrus operator which is only available in 3.8.
-                owned_by = {}
-                for job in self._cache.values():
-                    writer = _get_job_writer(job)
-                    if writer is not None:
-                        owned_by[writer] = job
+                owned_by = {
+                    writer: job
+                    for job in self._cache.values()
+                    if (writer := _get_job_writer(job)) is not None
+                }
 
                 while self._active_writers:
                     writers = list(self._active_writers)

--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -142,13 +142,7 @@ def gen_task_name(app, name, module_name):
 
 
 def load_extension_class_names(namespace):
-    if sys.version_info >= (3, 10):
-        _entry_points = entry_points(group=namespace)
-    else:
-        try:
-            _entry_points = entry_points().get(namespace, [])
-        except AttributeError:
-            _entry_points = entry_points().select(group=namespace)
+    _entry_points = entry_points(group=namespace)
     for ep in _entry_points:
         yield ep.name, ep.value
 

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -12,6 +12,7 @@ from datetime import timezone as datetime_timezone
 from datetime import tzinfo
 from types import ModuleType
 from typing import Any, Callable
+from zoneinfo import ZoneInfo
 
 from dateutil import tz as dateutil_tz
 from dateutil.parser import isoparse
@@ -21,8 +22,6 @@ from tzlocal import get_localzone
 
 from .functional import dictfilter
 from .text import pluralize
-
-from zoneinfo import ZoneInfo
 
 logger = logging.getLogger(__name__)
 

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -5,7 +5,6 @@ import logging
 import numbers
 import os
 import random
-import sys
 import time as _time
 from calendar import monthrange
 from datetime import date, datetime, timedelta
@@ -23,10 +22,7 @@ from tzlocal import get_localzone
 from .functional import dictfilter
 from .text import pluralize
 
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-else:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 logger = logging.getLogger(__name__)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,8 +32,7 @@ per-file-ignores =
        D,
 
 [bdist_rpm]
-requires = backports.zoneinfo>=0.2.1;python_version<'3.9'
-           tzdata>=2022.7
+requires = tzdata>=2022.7
            tzlocal
            billiard >=4.1.0,<5.0
            kombu >= 5.3.4,<6.0.0


### PR DESCRIPTION
## Description

Celery's floor is `python_requires=">=3.10"` (setup.py). This PR removes leftovers from before that floor. Every item is provable from the project's own metadata, and there is no behavior change on any supported Python version.

`celery/utils/time.py`: `if sys.version_info >= (3, 9)` is always true on 3.10+, so the else-branch importing `backports.zoneinfo` is dead code. Unwrapped to a plain `from zoneinfo import ZoneInfo` and dropped the now-unused `import sys`.

`celery/utils/imports.py`: `if sys.version_info >= (3, 10)` is always true. Removed the dead fallback for older `importlib.metadata` APIs.

`celery/concurrency/asynpool.py`: performed the rewrite the TODO was waiting for ("once we drop support for Python 3.7"). The loop is now the dict comprehension with the walrus operator the comment described.

`setup.cfg`: removed `backports.zoneinfo>=0.2.1;python_version<'3.9'` from `[bdist_rpm] requires`. Under a 3.10 floor that environment marker can never be satisfied.

Found while auditing version-gated leftovers in popular open-source projects.