### PR TITLE
fix: preserve chord bookkeeping when revoking tasks

### DIFF
--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -217,9 +217,20 @@ def _revoke(state, task_ids, terminate=False, signal=None, **kwargs):
 
     worker_state.revoked.update(task_ids)
 
+    # Find locally-known Request objects for the task IDs
+    requests_by_id = {
+        request.id: request
+        for request in _find_requests_by_id(task_ids)
+    }
+
     for task_id in task_ids:
         try:
-            state.app.backend.mark_as_revoked(task_id, reason='revoked', store_result=True)
+            state.app.backend.mark_as_revoked(
+                task_id,
+                reason='revoked',
+                store_result=True,
+                request=requests_by_id.get(task_id),
+            )
         except Exception as exc:
             logger.warning('Failed to mark task %s as revoked in backend: %s', task_id, exc)
 

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -957,36 +957,55 @@ class test_ControlPanel:
         try:
             state = self.create_state()
 
-            # Spy on on_chord_part_return to verify it's called
-            original_on_chord_part_return = self.app.backend.on_chord_part_return
-            on_chord_part_return_calls = []
+            # Use patch.object to spy on on_chord_part_return
+            # We use the real backend, not a mock, so mark_as_revoked actually executes
+            with patch.object(
+                self.app.backend,
+                'on_chord_part_return',
+                wraps=self.app.backend.on_chord_part_return
+            ) as mock_on_chord_part_return:
+                # Call _revoke() - this should trigger chord bookkeeping
+                control._revoke(state, [task_id])
 
-            def spy_on_chord_part_return(*args, **kwargs):
-                on_chord_part_return_calls.append((args, kwargs))
-                return original_on_chord_part_return(*args, **kwargs)
-
-            self.app.backend.on_chord_part_return = spy_on_chord_part_return
-
-            # Call _revoke() - this should trigger chord bookkeeping
-            control._revoke(state, [task_id])
-
-            # Verify on_chord_part_return was called (chord bookkeeping triggered)
-            assert len(on_chord_part_return_calls) == 1, \
-                "on_chord_part_return should be called when a chord task is revoked"
-
-            call_args, call_kwargs = on_chord_part_return_calls[0]
-            assert call_args[0] == request, \
-                "on_chord_part_return should receive the request"
-            assert call_args[1] == 'REVOKED', \
-                "on_chord_part_return should receive the REVOKED state"
+                # Verify on_chord_part_return was called (chord bookkeeping triggered)
+                mock_on_chord_part_return.assert_called_once()
+                call_args = mock_on_chord_part_return.call_args
+                assert call_args.args[0] is request, \
+                    "on_chord_part_return should receive the request"
+                assert call_args.args[1] == 'REVOKED', \
+                    "on_chord_part_return should receive the REVOKED state"
 
         finally:
             # Cleanup
             if task_id in worker_state.requests:
                 del worker_state.requests[task_id]
-            # Restore original method
-            if hasattr(self.app.backend, 'on_chord_part_return'):
-                self.app.backend.on_chord_part_return = original_on_chord_part_return
+
+    @patch('celery.Celery.backend', new=PropertyMock(name='backend'))
+    def test_revoke_without_local_request_passes_none(self):
+        """
+        Test that when a task has no locally-known Request,
+        _revoke() passes None to mark_as_revoked() safely.
+
+        This ensures the fix doesn't break the case where a task
+        is revoked but has never been consumed by this worker.
+        """
+        task_id = 'unknown-task-123'
+
+        # Ensure task is NOT in worker_state.requests
+        assert task_id not in worker_state.requests
+
+        state = self.create_state()
+
+        # Call _revoke() - should pass request=None
+        control._revoke(state, [task_id])
+
+        # Verify mark_as_revoked was called with request=None
+        self.app.backend.mark_as_revoked.assert_called_once_with(
+            task_id,
+            reason='revoked',
+            store_result=True,
+            request=None
+        )
 
     def test_revoke_by_stamped_headers_terminates_matching_request(self):
         state = self.create_state()

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -929,17 +929,17 @@ class test_ControlPanel:
     def test_revoke_with_chord_request_triggers_chord_bookkeeping(self):
         """
         Regression test for chord bookkeeping bug.
-        
+
         When a task belongs to a chord and has a locally-known Request,
         _revoke() should pass the Request to mark_as_revoked() so that
         chord bookkeeping (on_chord_part_return) is actually triggered.
-        
+
         This test exercises the real mark_as_revoked implementation rather
         than mocking it entirely, ensuring the chord bookkeeping path works.
         """
         task_id = 'chord-task-123'
         chord_id = 'chord-456'
-        
+
         # Create a real Request with chord metadata
         message = self.TaskMessage(self.mytask.name, task_id)
         # chord is extracted from the embed dict in the payload
@@ -947,39 +947,39 @@ class test_ControlPanel:
         embed['chord'] = chord_id
         message.payload = (args, kwargs, embed)
         request = Request(message, app=self.app)
-        
+
         # Verify the request has chord metadata
         assert request.chord == chord_id, "Request should have chord metadata"
-        
+
         # Add request to worker_state.requests
         worker_state.requests[task_id] = request
-        
+
         try:
             state = self.create_state()
-            
+
             # Spy on on_chord_part_return to verify it's called
             original_on_chord_part_return = self.app.backend.on_chord_part_return
             on_chord_part_return_calls = []
-            
+
             def spy_on_chord_part_return(*args, **kwargs):
                 on_chord_part_return_calls.append((args, kwargs))
                 return original_on_chord_part_return(*args, **kwargs)
-            
+
             self.app.backend.on_chord_part_return = spy_on_chord_part_return
-            
+
             # Call _revoke() - this should trigger chord bookkeeping
             control._revoke(state, [task_id])
-            
+
             # Verify on_chord_part_return was called (chord bookkeeping triggered)
             assert len(on_chord_part_return_calls) == 1, \
                 "on_chord_part_return should be called when a chord task is revoked"
-            
+
             call_args, call_kwargs = on_chord_part_return_calls[0]
             assert call_args[0] == request, \
                 "on_chord_part_return should receive the request"
             assert call_args[1] == 'REVOKED', \
                 "on_chord_part_return should receive the REVOKED state"
-            
+
         finally:
             # Cleanup
             if task_id in worker_state.requests:

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -902,8 +902,9 @@ class test_ControlPanel:
 
         assert self.app.backend.mark_as_revoked.call_count == 2
         calls = self.app.backend.mark_as_revoked.call_args_list
-        assert calls[0] == (('task-1',), {'reason': 'revoked', 'store_result': True})
-        assert calls[1] == (('task-2',), {'reason': 'revoked', 'store_result': True})
+        # Updated to expect request parameter (None when no local request exists)
+        assert calls[0] == (('task-1',), {'reason': 'revoked', 'store_result': True, 'request': None})
+        assert calls[1] == (('task-2',), {'reason': 'revoked', 'store_result': True, 'request': None})
 
     @patch('celery.Celery.backend', new=PropertyMock(name='backend'))
     def test_revoke_backend_failure_defensive(self):
@@ -922,8 +923,70 @@ class test_ControlPanel:
             control._revoke(state, ['task-1'], terminate=True)
 
         self.app.backend.mark_as_revoked.assert_called_once_with(
-            'task-1', reason='revoked', store_result=True
+            'task-1', reason='revoked', store_result=True, request=None
         )
+
+    def test_revoke_with_chord_request_triggers_chord_bookkeeping(self):
+        """
+        Regression test for chord bookkeeping bug.
+        
+        When a task belongs to a chord and has a locally-known Request,
+        _revoke() should pass the Request to mark_as_revoked() so that
+        chord bookkeeping (on_chord_part_return) is actually triggered.
+        
+        This test exercises the real mark_as_revoked implementation rather
+        than mocking it entirely, ensuring the chord bookkeeping path works.
+        """
+        task_id = 'chord-task-123'
+        chord_id = 'chord-456'
+        
+        # Create a real Request with chord metadata
+        message = self.TaskMessage(self.mytask.name, task_id)
+        # chord is extracted from the embed dict in the payload
+        args, kwargs, embed = message.payload
+        embed['chord'] = chord_id
+        message.payload = (args, kwargs, embed)
+        request = Request(message, app=self.app)
+        
+        # Verify the request has chord metadata
+        assert request.chord == chord_id, "Request should have chord metadata"
+        
+        # Add request to worker_state.requests
+        worker_state.requests[task_id] = request
+        
+        try:
+            state = self.create_state()
+            
+            # Spy on on_chord_part_return to verify it's called
+            original_on_chord_part_return = self.app.backend.on_chord_part_return
+            on_chord_part_return_calls = []
+            
+            def spy_on_chord_part_return(*args, **kwargs):
+                on_chord_part_return_calls.append((args, kwargs))
+                return original_on_chord_part_return(*args, **kwargs)
+            
+            self.app.backend.on_chord_part_return = spy_on_chord_part_return
+            
+            # Call _revoke() - this should trigger chord bookkeeping
+            control._revoke(state, [task_id])
+            
+            # Verify on_chord_part_return was called (chord bookkeeping triggered)
+            assert len(on_chord_part_return_calls) == 1, \
+                "on_chord_part_return should be called when a chord task is revoked"
+            
+            call_args, call_kwargs = on_chord_part_return_calls[0]
+            assert call_args[0] == request, \
+                "on_chord_part_return should receive the request"
+            assert call_args[1] == 'REVOKED', \
+                "on_chord_part_return should receive the REVOKED state"
+            
+        finally:
+            # Cleanup
+            if task_id in worker_state.requests:
+                del worker_state.requests[task_id]
+            # Restore original method
+            if hasattr(self.app.backend, 'on_chord_part_return'):
+                self.app.backend.on_chord_part_return = original_on_chord_part_return
 
     def test_revoke_by_stamped_headers_terminates_matching_request(self):
         state = self.create_state()


### PR DESCRIPTION
## Description

Fixes #10526

When a task belonging to a chord is revoked through the worker control command, `_revoke()` marks the task as `REVOKED` in the backend but does not pass the locally-known `Request` to `mark_as_revoked()`.

`BaseBackend.mark_as_revoked()` uses the `Request` to perform chord bookkeeping through `on_chord_part_return()`. Without the request, a locally-known revoked chord member can therefore be left out of the chord bookkeeping.

### Changes

* Reuse the existing `_find_requests_by_id()` helper to find locally-known `Request` objects.
* Pass the matching `Request` to `mark_as_revoked()`.
* Preserve `request=None` behavior when the task is not locally known.
* Add a regression test that exercises the real `mark_as_revoked()` path and verifies that `on_chord_part_return()` is triggered for a revoked chord member.
* Update existing revoke backend tests for the new `request` argument.

### Testing

* `pytest t/unit/worker/test_control.py`
* `pytest t/unit/worker/`

The change is limited to the worker revoke path and its regression tests.
