### PR TITLE
Fix DjangoTask selection for Celery subclasses without a custom task class

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -360,8 +360,8 @@ class Celery:
         self._custom_task_cls_used = (
             # Custom task class provided as argument
             bool(task_cls)
-            # subclass of Celery with a task_cls attribute
-            or self.__class__ is not Celery and hasattr(self.__class__, 'task_cls')
+            # Custom task class set as a class attribute
+            or bool(app_has_custom(self, 'task_cls'))
         )
         self.task_cls = task_cls or self.task_cls
         self.set_as_current = set_as_current

--- a/t/integration/test_worker.py
+++ b/t/integration/test_worker.py
@@ -71,6 +71,25 @@ def test_django_fixup_direct_worker(caplog, monkeypatch):
         f"AttributeError found in logs:\n{log_output}"
 
 
+def test_django_fixup_installs_django_task_for_celery_subclass(monkeypatch):
+    """A Celery subclass that leaves task_cls alone still gets DjangoTask."""
+    import django
+
+    from celery.contrib.django.task import DjangoTask
+
+    monkeypatch.setenv('DJANGO_SETTINGS_MODULE', 't.integration.django_settings')
+    django.setup()
+
+    class MyCustomCelery(Celery):
+        pass
+
+    app = MyCustomCelery('test_django_subclass')
+
+    assert issubclass(app.Task, DjangoTask)
+    assert hasattr(app.Task, 'delay_on_commit')
+    assert hasattr(app.Task, 'apply_async_on_commit')
+
+
 @flaky
 def test_pidbox_reset_after_repeated_control_errors(manager):
     def assert_ping():

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -144,6 +144,22 @@ class test_DjangoFixup(FixupCase):
             # The one from the user's class is
             assert app.task_cls == 'myapp.celery.tasks:Task'
 
+    def test_install_subclassed_app_without_custom_task_cls(self, patching):
+        patching('celery.fixups.django.signals')
+
+        from celery.app import Celery
+
+        class MyCeleryApp(Celery):
+            pass
+
+        app = MyCeleryApp('mytestapp')
+
+        with self.fixup_context(app) as (f, _, _):
+            f.install()
+            # Subclassing alone is not a custom task class,
+            # so the specialized DjangoTask is still used
+            assert app.task_cls == 'celery.contrib.django.task:DjangoTask'
+
     def test_now(self):
         with self.fixup_context(self.app) as (f, _, _):
             assert f.now(utc=True)

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -144,6 +144,11 @@ class test_DjangoFixup(FixupCase):
             # The one from the user's class is
             assert app.task_cls == 'myapp.celery.tasks:Task'
 
+    @pytest.mark.patched_module(
+        'django',
+        'django.db',
+        'django.db.transaction',
+    )
     def test_install_subclassed_app_without_custom_task_cls(self, patching):
         patching('celery.fixups.django.signals')
 
@@ -159,7 +164,10 @@ class test_DjangoFixup(FixupCase):
             # Subclassing alone is not a custom task class,
             # so the specialized DjangoTask is still used
             assert app.task_cls == 'celery.contrib.django.task:DjangoTask'
-
+            from celery.contrib.django.task import DjangoTask
+            assert issubclass(app.Task, DjangoTask)
+            assert hasattr(app.Task, 'delay_on_commit')
+            assert hasattr(app.Task, 'apply_async_on_commit')
     def test_now(self):
         with self.fixup_context(self.app) as (f, _, _):
             assert f.now(utc=True)

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -168,6 +168,26 @@ class test_DjangoFixup(FixupCase):
             assert issubclass(app.Task, DjangoTask)
             assert hasattr(app.Task, 'delay_on_commit')
             assert hasattr(app.Task, 'apply_async_on_commit')
+
+    def test_install_custom_user_task_inherited_from_base_app(self, patching):
+        patching('celery.fixups.django.signals')
+
+        from celery.app import Celery
+
+        class BaseCeleryApp(Celery):
+            task_cls = 'myapp.celery.tasks:Task'
+
+        class MyCeleryApp(BaseCeleryApp):
+            pass
+
+        app = MyCeleryApp('mytestapp')
+
+        with self.fixup_context(app) as (f, _, _):
+            f.install()
+            # Specialized DjangoTask class is NOT used,
+            # The one inherited from the user's base class is
+            assert app.task_cls == 'myapp.celery.tasks:Task'
+
     def test_now(self):
         with self.fixup_context(self.app) as (f, _, _):
             assert f.now(utc=True)

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -149,7 +149,7 @@ class test_DjangoFixup(FixupCase):
         'django.db',
         'django.db.transaction',
     )
-def test_install_subclassed_app_without_custom_task_cls(self, patching, module):
+    def test_install_subclassed_app_without_custom_task_cls(self, patching, module):
         patching('celery.fixups.django.signals')
 
         from celery.app import Celery

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -149,7 +149,7 @@ class test_DjangoFixup(FixupCase):
         'django.db',
         'django.db.transaction',
     )
-    def test_install_subclassed_app_without_custom_task_cls(self, patching):
+def test_install_subclassed_app_without_custom_task_cls(self, patching, module):
         patching('celery.fixups.django.signals')
 
         from celery.app import Celery


### PR DESCRIPTION
## Description

In a Django project, subclassing Celery causes `DjangoFixup` to skip installing the Django-specific task base class, even when the subclass does not override `task_cls`.

```python
# assume DJANGO_SETTINGS_MODULE is set
from celery import Celery
from celery.contrib.django.task import DjangoTask

class MyCustomCelery(Celery): pass
app = MyCustomCelery()

assert issubclass(app.Task, DjangoTask) # AssertionError
```
The problem lies in:
https://github.com/celery/celery/blob/cd07bcfd24e39bcaf46f0a1e41b22877ba9842ad/celery/app/base.py#L360-L365

`hasattr(self.__class__, 'task_cls')` follows the class MRO and eventually finds `Celery.task_cls`. Therefore, this condition is true for every subclass of Celery, whether or not that subclass overrides `task_cls`.

As a result, every Celery subclass is treated as having a custom task class, and DjangoFixup does not install DjangoTask.

Related issue: I looked around and didn't find any reported issue.