### PR TITLE
Fix the delay beat returns when the heap top changes

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -362,7 +362,7 @@ class Scheduler:
                 return 0
             else:
                 heappush(H, verify)
-                return min(verify[0], max_interval)
+                return min(verify[0] - now, max_interval)
 
         # Heap says this entry should be ready by now, but the entry requests
         # to retry later.  Reheap it at that retry time, otherwise it just
@@ -376,7 +376,7 @@ class Scheduler:
             return 0 if H and H[0][2] is not entry else min(adjust(reschedule_delay), max_interval)
         else:
             heappush(H, verify)
-            return min(verify[0], max_interval)
+            return min(verify[0] - now, max_interval)
 
     def schedules_equal(self, old_schedules, new_schedules):
         if old_schedules is new_schedules is None:

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -362,7 +362,7 @@ class Scheduler:
                 return 0
             else:
                 heappush(H, verify)
-                return min(verify[0] - now, max_interval)
+                return min(verify[0] - self._when(verify[2], 0), max_interval)
 
         # Heap says this entry should be ready by now, but the entry requests
         # to retry later.  Reheap it at that retry time, otherwise it just

--- a/t/integration/test_beat.py
+++ b/t/integration/test_beat.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import uuid4
 
 import pytest
@@ -38,3 +38,94 @@ class test_beat_cron_starting_deadline:
         assert scheduler.tick() == 0
         # The worker received and executed the dispatched task.
         assert app.AsyncResult(task_id).get(timeout=30) == 3
+
+
+class test_beat_tick_heap_top_changed:
+    @flaky
+    @pytest.mark.usefixtures('celery_session_worker')
+    def test_dispatches_second_entry_after_heap_top_changed(self, app):
+        second_task_id = uuid4().hex
+        last_run = datetime(2022, 12, 5, 10, 20)
+        scheduler = beat.Scheduler(app=app, lazy=True)
+        first = scheduler.add(
+            name='first',
+            task=add.name,
+            args=(1, 2),
+            schedule=timedelta(seconds=1),
+            last_run_at=last_run,
+        )
+        # so populate_heap() doesn't run and override our setup
+        scheduler.old_schedulers = scheduler.schedule
+        scheduler._heap = [beat.event_t(scheduler._when(first, 0) - 1, 5, first)]
+
+        def mutating_first_entry_is_due(_last_run_at):
+            second = scheduler.add(
+                name='second',
+                task=add.name,
+                args=(3, 4),
+                schedule=timedelta(seconds=1),
+                last_run_at=last_run,
+                options={'task_id': second_task_id},
+            )
+            scheduler._heap.insert(0, beat.event_t(scheduler._when(second, 0) - 2, 5, second))
+            return True, 1
+
+        # simulates an entry inserted while first's is_due() is running
+        real_is_due = first.schedule.is_due
+        first.schedule.is_due = mutating_first_entry_is_due
+        # first is due, but second took the top of the heap while its is_due()
+        # ran, so tick() reschedules instead of dispatching it
+        assert scheduler.tick() < 0
+        assert scheduler.schedule['first'].total_run_count == 0
+
+        first.schedule.is_due = real_is_due
+        # tick() returns 0 only when it dispatches a due task, and second is
+        # now the top
+        assert scheduler.tick() == 0
+        assert app.AsyncResult(second_task_id).get(timeout=30) == 7
+        assert scheduler.schedule['first'].total_run_count == 0
+
+    @flaky
+    @pytest.mark.usefixtures('celery_session_worker')
+    def test_dispatches_second_entry_when_first_asks_to_retry_later(self, app):
+        second_task_id = uuid4().hex
+        last_run = datetime(2022, 12, 5, 10, 20)
+        scheduler = beat.Scheduler(app=app, lazy=True)
+        first = scheduler.add(
+            name='first',
+            task=add.name,
+            args=(1, 2),
+            schedule=timedelta(seconds=1),
+            last_run_at=last_run,
+        )
+        # so populate_heap() doesn't run and override our setup
+        scheduler.old_schedulers = scheduler.schedule
+        scheduler._heap = [beat.event_t(scheduler._when(first, 0) - 1, 5, first)]
+
+        def mutating_first_entry_is_due(_last_run_at):
+            second = scheduler.add(
+                name='second',
+                task=add.name,
+                args=(3, 4),
+                schedule=timedelta(seconds=1),
+                last_run_at=last_run,
+                options={'task_id': second_task_id},
+            )
+            scheduler._heap.insert(0, beat.event_t(scheduler._when(second, 0) - 2, 5, second))
+            # first is ready by heap time, but asks to run a second later
+            return False, 1
+
+        # simulates an entry inserted while first's is_due() is running
+        real_is_due = first.schedule.is_due
+        first.schedule.is_due = mutating_first_entry_is_due
+        # The heap says first is ready, but first asks to retry later, and
+        # second took the top of the heap while its is_due() ran, so tick()
+        # leaves the reheap to the next call
+        assert scheduler.tick() < 0
+
+        first.schedule.is_due = real_is_due
+        # tick() returns 0 only when it dispatches a due task, and second is
+        # now the top
+        assert scheduler.tick() == 0
+        assert app.AsyncResult(second_task_id).get(timeout=30) == 7
+        assert scheduler.schedule['first'].total_run_count == 0

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -376,6 +376,23 @@ class test_Scheduler:
                       kwargs={'foo': 'bar'})
         assert scheduler.tick() == 0
 
+    def test_due_tick_returns_delay_when_heap_top_changed(self):
+        scheduler = mScheduler(app=self.app)
+        first = scheduler.add(name='first', task='c.first', schedule=always_due)
+        second = scheduler.add(name='second', task='c.second', schedule=always_due)
+        # so populate_heap() doesn't run and override our setup
+        scheduler.old_schedulers = scheduler.schedule
+        scheduler._heap = [event_t(scheduler._when(first, 0) - 1, 5, first)]
+
+        def mutating_first_entry_is_due(_last_run_at):
+            scheduler._heap.insert(0, event_t(scheduler._when(second, 0) - 2, 5, second))
+            return True, 1
+
+        # simulates an entry inserted while first's is_due() is running
+        first.schedule.is_due = mutating_first_entry_is_due
+        assert scheduler.tick() < 0
+        assert not scheduler.sent
+
     @patch('celery.beat.error')
     def test_due_tick_SchedulingError(self, error):
         scheduler = mSchedulerSchedulingError(app=self.app)
@@ -480,7 +497,7 @@ class test_Scheduler:
 
         # simulates an entry inserted while stuck's is_due() is running
         stuck.schedule.is_due = mutating_stuck_entry_is_due
-        scheduler.tick()
+        assert scheduler.tick() < 0
         assert not scheduler.sent
         assert scheduler._heap[0] is intruder_event
         assert scheduler._heap[1] is stuck_event


### PR DESCRIPTION
## Description

When `Scheduler.tick` runs, if the entry is due but another entry took the top of the heap, then it's expected to sleep until that new top entry is due. But the current code is using `min(verify[0], max_interval)`, which compares a unix timestamp to max_interval (default to be 300), so max_interval always wins and beat sleeps 5 minutes.
