### PR TITLE
Honour `config_from_object(silent=True)` on the lazy config load

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -311,3 +311,4 @@ Brian Helba, 2026/01/12
 Hmn Falahi, 2026/07/08
 Oliver Haas, 2026/07/26
 Benjamin Chrobot, 2026/08/18
+Arockia Rajamanickam, 2026/08/29

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -1433,7 +1433,7 @@ class Celery:
         return (self.main, self._conf.changes if self.configured else {},
                 self.loader_cls, self.backend_cls, self.amqp_cls,
                 self.events_cls, self.log_cls, self.control_cls,
-                False, self._config_source)
+                False, self._config_source, self._config_source_silent)
 
     @cached_property
     def Worker(self):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -345,7 +345,7 @@ class Celery:
                  set_as_current=True, tasks=None, broker=None, include=None,
                  changes=None, config_source=None, fixups=None, task_cls=None,
                  autofinalize=True, namespace=None, strict_typing=True,
-                 **kwargs):
+                 config_source_silent=False, **kwargs):
 
         self._local = threading.local()
         self._backend_cache = None
@@ -375,8 +375,10 @@ class Celery:
         self.configured = False
         self._config_source = config_source
         # `silent` from config_from_object(), remembered so the lazy load in
-        # _load_config() honours it too and not only the eager path below
-        self._config_source_silent = False
+        # _load_config() honours it too and not only the eager path. Carried
+        # through __reduce_keys__ so an app pickled before its configuration
+        # was read does not lose it.
+        self._config_source_silent = config_source_silent
         self._pending_defaults = deque()
         self._pending_periodic_tasks = deque()
 
@@ -1421,6 +1423,7 @@ class Celery:
             'control': self.control_cls,
             'fixups': self.fixups,
             'config_source': self._config_source,
+            'config_source_silent': self._config_source_silent,
             'task_cls': self.task_cls,
             'namespace': self.namespace,
         }

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -374,6 +374,9 @@ class Celery:
 
         self.configured = False
         self._config_source = config_source
+        # `silent` from config_from_object(), remembered so the lazy load in
+        # _load_config() honours it too and not only the eager path below
+        self._config_source_silent = False
         self._pending_defaults = deque()
         self._pending_periodic_tasks = deque()
 
@@ -718,6 +721,7 @@ class Celery:
                 By default the configuration will be read only when required.
         """
         self._config_source = obj
+        self._config_source_silent = silent
         self.namespace = namespace or self.namespace
         if force or self.configured:
             self._conf = None
@@ -1251,7 +1255,8 @@ class Celery:
             # used to be a method pre 4.0
             self.on_configure()
         if self._config_source:
-            self.loader.config_from_object(self._config_source)
+            self.loader.config_from_object(
+                self._config_source, silent=self._config_source_silent)
         self.configured = True
         settings = detect_settings(
             self.prepare_config(self.loader.conf), self._preconf,

--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -303,11 +303,12 @@ class AppPickler:
 
     def build_standard_kwargs(self, main, changes, loader, backend, amqp,
                               events, log, control, accept_magic_kwargs,
-                              config_source=None):
+                              config_source=None, config_source_silent=False):
         return {'main': main, 'loader': loader, 'backend': backend,
                 'amqp': amqp, 'changes': changes, 'events': events,
                 'log': log, 'control': control, 'set_as_current': False,
-                'config_source': config_source}
+                'config_source': config_source,
+                'config_source_silent': config_source_silent}
 
     def construct(self, cls, **kwargs):
         return cls(**kwargs)

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -63,6 +63,19 @@ class ObjectConfig2:
     UNDERSTAND_ME = True
 
 
+class CustomReduceApp(Celery):
+    """App that defines its own ``__reduce_args__()``.
+
+    Defining it is what makes ``Celery.__reduce__()`` route through the
+    deprecated ``__reduce_v1__()`` path, so this is how that path is reached.
+    Declared at module level because a class defined inside a test cannot be
+    pickled.
+    """
+
+    def __reduce_args__(self):
+        return super().__reduce_args__()
+
+
 class test_module:
 
     def test_default_app(self):
@@ -970,6 +983,44 @@ class test_App:
         """The eager path keeps working, and is not made silent by accident."""
         self.app.config_from_object('nonexistent.module', silent=True, force=True)
         assert self.app.conf.get('SOME_CONFIG') is None
+
+    def test_config_from_object__silent_survives_v1_pickle(self):
+        """The flag must survive the deprecated v1 reduction too.
+
+        `Celery.__reduce__()` still routes through `__reduce_v1__()` for any
+        subclass that defines its own `__reduce_args__()`, so carrying the flag
+        only in `__reduce_keys__()` would leave that path broken.
+        """
+        app = CustomReduceApp('silent-v1', set_as_current=False)
+        assert app._using_v1_reduce
+        app.config_from_object('nonexistent.module', silent=True)
+
+        unpickled = pickle.loads(pickle.dumps(app))
+        assert unpickled.conf.get('SOME_CONFIG') is None
+
+    def test_config_from_object__not_silent_survives_v1_pickle(self):
+        """Control: the v1 path must not silence anything by itself."""
+        app = CustomReduceApp('loud-v1', set_as_current=False)
+        app.config_from_object('nonexistent.module', silent=False)
+
+        unpickled = pickle.loads(pickle.dumps(app))
+        with pytest.raises(ImportError):
+            unpickled.conf.get('SOME_CONFIG')
+
+    def test_app_pickler_accepts_legacy_arg_count(self):
+        """An older v1 payload, without the trailing flag, must still load.
+
+        `config_source_silent` is appended after `config_source`, which is
+        itself optional, so a ten argument payload written by an older Celery
+        keeps working and simply defaults the flag off.
+        """
+        from celery.app.utils import AppPickler
+
+        kwargs = AppPickler().build_standard_kwargs(
+            'main', {}, None, None, None, None, None, None, False, 'src',
+        )
+        assert kwargs['config_source'] == 'src'
+        assert kwargs['config_source_silent'] is False
 
     def test_config_from_object__silent_survives_pickle(self):
         """`silent` must survive pickling of a not-yet-configured app.

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -949,6 +949,28 @@ class test_App:
 
         self.assert_config2()
 
+    def test_config_from_object__silent_lazy(self):
+        """`silent` must survive until the configuration is actually read.
+
+        Without `force`, `config_from_object()` only records the source; the
+        import happens later in `_load_config()`. The flag has to be carried
+        across that gap or the documented behaviour only holds for the eager
+        path.
+        """
+        self.app.config_from_object('nonexistent.module', silent=True)
+        assert self.app.conf.get('SOME_CONFIG') is None
+
+    def test_config_from_object__not_silent_lazy(self):
+        """Without `silent`, the import error must still surface."""
+        self.app.config_from_object('nonexistent.module', silent=False)
+        with pytest.raises(ImportError):
+            self.app.conf.get('SOME_CONFIG')
+
+    def test_config_from_object__silent_force(self):
+        """The eager path keeps working, and is not made silent by accident."""
+        self.app.config_from_object('nonexistent.module', silent=True, force=True)
+        assert self.app.conf.get('SOME_CONFIG') is None
+
     def test_config_from_object__compat(self):
 
         class Config:

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -971,6 +971,20 @@ class test_App:
         self.app.config_from_object('nonexistent.module', silent=True, force=True)
         assert self.app.conf.get('SOME_CONFIG') is None
 
+    def test_config_from_object__silent_survives_pickle(self):
+        """`silent` must survive pickling of a not-yet-configured app.
+
+        An app pickled after `config_from_object(silent=True)` but before its
+        configuration is first read reaches the child process unconfigured, so
+        the child performs the import itself. If the flag were not carried in
+        `__reduce_keys__()` the child would import without it and raise.
+        """
+        self.app.config_from_object('nonexistent.module', silent=True)
+        assert not self.app.configured
+
+        unpickled = pickle.loads(pickle.dumps(self.app))
+        assert unpickled.conf.get('SOME_CONFIG') is None
+
     def test_config_from_object__compat(self):
 
         class Config:


### PR DESCRIPTION
## Description

Fixes #4603.

`config_from_object()` records the source and defers the import until the configuration is first read. `silent` was only applied on the eager path, so by the time `_load_config()` did the import the flag was gone:

```python
# celery/app/base.py
def config_from_object(self, obj, silent=False, force=False, namespace=None):
    self._config_source = obj              # silent is not kept
    ...
    if force or self.configured:
        if self.loader.config_from_object(obj, silent=silent):   # honoured here
            return self.conf

def _load_config(self):
    ...
    if self._config_source:
        self.loader.config_from_object(self._config_source)      # and lost here
```

The reporter's case, on `main` at `a0fa027`:

```console
>>> app = Celery(__name__)
>>> app.config_from_object('nonexistent.module', silent=True)   # returns fine
>>> app.conf.get('SOME_CONFIG')
ModuleNotFoundError: No module named 'nonexistent'
```

The docstring says `silent (bool): If true then import errors will be ignored`, with no carve-out for the deferred path.

The flag is now remembered next to the source and passed through. `Loader.config_from_object()` already handles `silent` correctly (`celery/loaders/base.py:119-126`), it simply was not being told.

### One thing beyond the issue

The report is about the lazy path, but `force=True` was affected too, for a slightly different reason: the loader returns `False` on a silenced import, so `if self.loader.config_from_object(...)` falls through without returning, and the unsilenced `_load_config()` runs later anyway. `test_config_from_object__silent_force` covers that, and it also fails without the change.

## Tests

Six tests in `t/unit/app/test_app.py`:

- `test_config_from_object__silent_lazy` — the reported case
- `test_config_from_object__silent_force` — the eager path above
- `test_config_from_object__not_silent_lazy` — control: without `silent`, the `ImportError` must still surface, so this is a narrowing rather than a blanket suppression
- `test_config_from_object__silent_survives_pickle` — v2 reduction, app pickled while still unconfigured
- `test_config_from_object__silent_survives_v1_pickle` and `..._not_silent_survives_v1_pickle` — the deprecated v1 reduction and its control
- `test_app_pickler_accepts_legacy_arg_count` — a ten argument v1 payload, without the trailing flag, still loads

Reverting only `celery/app/base.py` and keeping the tests fails the first two; the control passes either way, which is the point of it.

`t/unit/app/` goes from 665 passed to 668 passed on the same machine, with an identical set of 4 pre-existing failures on both sides (`test_setup_security`, `test_backend_by_url`, and two `test_preload_cli` errors), none related to this change. I compared the failing sets rather than the counts, since the counts move by the three added tests.

## Pickling

`silent` is carried through both reduction paths.

`__reduce_keys__()` includes `config_source_silent`, and `__init__()` accepts it. That matters because an app pickled after `config_from_object(silent=True)` but before its configuration is first read reaches the child process unconfigured, so the child performs the import itself. My first version of this PR left that out on the reasoning that an app is "normally already configured by the time it is pickled", which is wrong: `configured` is `False` immediately after `config_from_object()`, which is the entire point of the lazy path.

`__reduce_args__()` and `AppPickler.build_standard_kwargs()` carry it too, because `Celery.__reduce__()` still routes through the deprecated `__reduce_v1__()` for any subclass defining its own `__reduce_args__()`. It is appended after `config_source`, which is itself optional, so a shorter payload written by an older Celery still loads and defaults the flag off.

I used an AI assistant while working on this. The reproduction, the discovery that `force=True` is affected as well, and the baseline comparison are mine, and I ran every result quoted here.
