### PR TITLE
fix: pass locally-known Request to `mark_as_revoked` in worker control `_revoke`

### DIFF
--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -219,7 +219,13 @@ def _revoke(state, task_ids, terminate=False, signal=None, **kwargs):
 
     for task_id in task_ids:
         try:
-            state.app.backend.mark_as_revoked(task_id, reason='revoked', store_result=True)
+            # Pass the locally-known Request to the backend so that chord
+            # bookkeeping is updated for revoked chord members, mirroring the
+            # normal request-based revocation path.
+            request = next(_find_requests_by_id([task_id]), None)
+            state.app.backend.mark_as_revoked(
+                task_id, reason='revoked', store_result=True, request=request
+            )
         except Exception as exc:
             logger.warning('Failed to mark task %s as revoked in backend: %s', task_id, exc)
 


### PR DESCRIPTION
## Summary

Fixes #10526: when a chord member is revoked via the worker control command (`app.control.revoke(task_id)`), `_revoke()` in `celery/worker/control.py` calls `backend.mark_as_revoked(task_id, reason='revoked', store_result=True)` **without** the task's `Request`. `BaseBackend.mark_as_revoked` only performs chord bookkeeping (`on_chord_part_return`) when `request` is provided and `request.chord` is set — so the chord never accounts for the revoked member and may wait forever.

## Changes

- `celery/worker/control.py`: `_revoke()` now looks up the locally-known `Request` via the existing `_find_requests_by_id()` helper and passes it to `mark_as_revoked(..., request=request)`, mirroring the normal request-based revocation path. When the worker does not know the task (e.g. revoking a task_id never received), `request` is `None` and behavior is unchanged.

## Verification

- `ast.parse` passes
- Simulated assertions:
  - task known to worker with `request.chord` set → `request` passed through → chord bookkeeping can trigger (the fix)
  - task unknown to worker → `request=None` passed (identical to previous behavior)
- Full celery test suite not run locally (no celery install in this environment); change is 5 lines in one control-command