### PR TITLE
Bound State._tasks_to_resolve to fix unbounded memory growth

### DIFF
--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -422,7 +422,7 @@ class State:
         self._mutex = threading.Lock()
         self.handlers = {}
         self._seen_types = set()
-        self._tasks_to_resolve = {}
+        self._tasks_to_resolve = LRUCache(max_tasks_in_memory)
         self.rebuild_taskheap()
 
         self.tasks_by_type = CallableDefaultdict(

--- a/t/integration/test_events_state_memory_leak.py
+++ b/t/integration/test_events_state_memory_leak.py
@@ -1,0 +1,63 @@
+"""
+Integration test for memory leak issue #4832.
+
+Reproduces the scenario of a long-running monitor (e.g. ``celery events``
+or Flower) consuming real events off the broker: child tasks whose
+parent is never observed (because it was scheduled with an ETA/countdown
+and its own event hasn't arrived yet, or because it was already evicted
+from ``State.tasks``) used to accumulate forever in
+``State._tasks_to_resolve``, since that mapping was a plain, unbounded
+``dict``.
+
+Unlike the unit test in ``t/unit/events/test_state.py`` (which calls
+``State.event()`` directly with synthetic dicts), this test exercises the
+real event pipeline: an ``EventDispatcher`` publishes events onto an
+actual (in-memory) broker connection, and an ``EventReceiver`` consumes
+and decodes them before handing them to ``State``.
+"""
+
+from celery import Celery, uuid
+
+
+def test_tasks_to_resolve_is_bounded_over_real_event_pipeline():
+    app = Celery('test_events_state_memory_leak')
+    app.conf.update(broker_url='memory://', result_backend='cache+memory://')
+
+    max_tasks_in_memory = 10
+    state = app.events.State(max_tasks_in_memory=max_tasks_in_memory)
+
+    orphan_count = 100
+
+    with app.connection_for_write() as connection:
+        receiver = app.events.Receiver(
+            connection, handlers={'*': state.event},
+        )
+        # Declare (and bind) the receiver's queue up front, since the
+        # in-memory transport drops messages published before a matching
+        # queue exists.
+        receiver.queue(connection.default_channel).declare()
+
+        with app.events.Dispatcher(connection) as dispatcher:
+            for _ in range(orphan_count):
+                # Simulate a child task event arriving before (or without
+                # ever seeing) its parent -- e.g. a task scheduled with a
+                # countdown/ETA whose parent id is never registered in
+                # State.tasks. Each one registers a pending entry in
+                # State._tasks_to_resolve keyed by a parent_id that will
+                # never show up.
+                dispatcher.send(
+                    'task-received',
+                    uuid=uuid(),
+                    parent_id=uuid(),
+                    root_id=uuid(),
+                    name='task1',
+                    args='()',
+                    kwargs='{}',
+                    retries=0,
+                    eta=None,
+                )
+
+        receiver.capture(limit=orphan_count, timeout=10)
+
+    assert state.event_count == orphan_count
+    assert len(state._tasks_to_resolve) <= max_tasks_in_memory

--- a/t/unit/events/test_state.py
+++ b/t/unit/events/test_state.py
@@ -665,6 +665,33 @@ class test_State:
         s._taskheap.append(s._taskheap[0])
         assert list(s.tasks_by_time())
 
+    def test_tasks_to_resolve_is_bounded(self):
+        # Children whose parent hasn't been seen yet register themselves in
+        # ``_tasks_to_resolve``. If the parent never shows up (e.g. it was
+        # already processed, or evicted from ``tasks``), that entry is never
+        # popped, so the mapping must be bounded like every other one on
+        # ``State`` -- otherwise a long-running monitor leaks memory
+        # (see issue #4832).
+        s = State(max_tasks_in_memory=10)
+        for _ in range(100):
+            parent_id = uuid()
+            s.event({
+                'type': 'task-received',
+                'uuid': uuid(),
+                'parent_id': parent_id,
+                'root_id': parent_id,
+                'name': 'task1',
+                'args': '()',
+                'kwargs': '{}',
+                'retries': 0,
+                'eta': None,
+                'hostname': 'utest1',
+                'clock': 0,
+                'timestamp': time(),
+                'local_received': time(),
+            })
+        assert len(s._tasks_to_resolve) <= s.max_tasks_in_memory
+
     def test_callback(self):
         scratch = {}
 


### PR DESCRIPTION
## Summary
- A task event carrying a `parent_id` whose parent isn't yet in `State.tasks` registers the child in `_tasks_to_resolve[parent_id]`. That entry is only popped when a later event for the parent itself arrives.
- If the parent never arrives again (its events were already processed, or a monitor evicted it from `tasks` on a `READY_STATE`, as the docs' real-time monitoring example used to encourage), the entry stays forever. The child `Task`s are held in a `WeakSet` and do get collected, but the `_tasks_to_resolve` dict key does not, so a long-running monitor leaks memory without bound.
- This bounds `_tasks_to_resolve` the same way every other mapping on `State` is bounded, using an `LRUCache(max_tasks_in_memory)` instead of a plain `dict`.

Fixes #4832

## Test plan
- [x] Added `test_tasks_to_resolve_is_bounded` in `t/unit/events/test_state.py`, asserting `len(state._tasks_to_resolve) <= state.max_tasks_in_memory` after feeding it more orphaned child events than the limit.
- [x] Full `t/unit/events/test_state.py` suite passes locally.
- [x] Manually reproduced the leak against the pre-fix code (unbounded growth of `_tasks_to_resolve`) and confirmed it's bounded after the fix.