### PR TITLE
Update CI matrix to exclude Python 3.10 and 3.14t

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,18 +37,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.11']
+        python-version: ['3.11', '3.12', '3.13', '3.14', 'pypy3.11']
         os: ["blacksmith-4vcpu-ubuntu-2404", "windows-latest"]
         exclude:
-            - python-version: '3.10'
-              os: "windows-latest"
             - python-version: '3.11'
               os: "windows-latest"
             - python-version: '3.12'
               os: "windows-latest"
             - python-version: '3.13'
-              os: "windows-latest"
-            - python-version: '3.14t'
               os: "windows-latest"
             - python-version: 'pypy3.11'
               os: "windows-latest"


### PR DESCRIPTION
Removed Python 3.10 and 3.14t from the CI matrix for Windows for the upcoming v5.7 release


