### PR TITLE
Modify default Python versions in workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ on:
         description: 'JSON array of Python versions to test'
         required: false
         type: string
-        default: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]'
+        default: '["3.11", "3.12", "3.13", "3.14"]'
       tox_environments:
         description: 'JSON array of tox environments to test'
         required: false


### PR DESCRIPTION
Updated default Python versions to exclude 3.10 and 3.14t.

