### PR TITLE
docs: clarify RabbitMQ prefetch limits

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -3517,6 +3517,8 @@ when one of its processes is available.
 .. note::
 
     This feature is currently only supported when using Redis as the broker.
+    For RabbitMQ, use the late acknowledgment configuration described in
+    :ref:`optimizing-prefetch-limit`; it requires idempotent tasks.
 
 You can also enable this via the :option:`--disable-prefetch <celery worker --disable-prefetch>`
 command line flag.

--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -197,6 +197,10 @@ workers. This can also be set from the command line using
 :option:`--disable-prefetch <celery worker --disable-prefetch>`. This feature
 is currently only supported when using Redis as the broker.
 
+Celery does not support an early-acknowledgment equivalent of
+:setting:`worker_disable_prefetch` for RabbitMQ. The late acknowledgment
+configuration above is the alternative and requires idempotent tasks.
+
 Memory Usage
 ------------
 


### PR DESCRIPTION
## Summary
- clarify that `worker_disable_prefetch` has no early-acknowledgment equivalent for RabbitMQ
- direct RabbitMQ users to the existing late acknowledgment and prefetch multiplier guidance
- state the idempotency requirement for that alternative

## Validation
- `git diff --check`
- `pytest -q t/unit/worker/test_consumer.py t/unit/worker/test_components.py t/unit/worker/test_strategy.py t/unit/worker/test_request.py t/unit/bin/test_worker.py` (344 passed, 23 existing warnings)
- reviewed by Claude Code (Opus), Cursor Agent (GPT-5.6 Sol High), and OpenCode (GPT-5.6 Sol); all actionable findings were addressed

## Background
RabbitMQ releases delivery credit on early acknowledgment, so it cannot use the Redis-specific `worker_disable_prefetch` behavior safely. The existing late-acknowledgment configuration is the supported alternative.