### PR TITLE
Fix beat sleeping too long when is_due changes the heap

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -376,7 +376,7 @@ class Scheduler:
             return 0 if H and H[0][2] is not entry else min(adjust(reschedule_delay), max_interval)
         else:
             heappush(H, verify)
-            return min(verify[0] - now, max_interval)
+            return min(verify[0] - self._when(verify[2], 0), max_interval)
 
     def schedules_equal(self, old_schedules, new_schedules):
         if old_schedules is new_schedules is None:

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -502,6 +502,30 @@ class test_Scheduler:
         assert scheduler._heap[0] is intruder_event
         assert scheduler._heap[1] is stuck_event
 
+    @pytest.mark.parametrize('is_due', [True, False])
+    def test_tick_uses_fresh_time_when_heap_top_changes(self, is_due):
+        clock = [datetime(2026, 1, 1, tzinfo=timezone.utc)]
+
+        def nowfun():
+            return clock[0]
+
+        scheduler = mScheduler(app=self.app)
+        first = scheduler.add(name='first', task='c.first', schedule=schedule(1, nowfun=nowfun))
+        second = scheduler.add(name='second', task='c.second', schedule=schedule(1, nowfun=nowfun))
+        # so populate_heap() doesn't run and override our setup
+        scheduler.old_schedulers = scheduler.schedule
+        scheduler._heap = [event_t(scheduler._when(first, 0) - 1, 5, first)]
+
+        def replace_heap_top(_last_run_at):
+            # Make a delay calculated from the stale time exceed max_interval.
+            clock[0] += timedelta(seconds=scheduler.max_interval + 1)
+            scheduler._heap[0] = event_t(scheduler._when(second, 1), 5, second)
+            return is_due, 1
+
+        first.schedule.is_due = replace_heap_top
+        assert scheduler.tick() == pytest.approx(scheduler.adjust(1))
+        assert scheduler._heap[0].entry is second
+
     def test_tick_dispatches_missed_cron_within_deadline_non_uniform(self):
         # Non-uniform crontab (:00, :45). Most recent feasible run
         # (10:00) is 20 min before now=10:20, within the 30-min


### PR DESCRIPTION
## Description
This follows up on #10531. The Copilot review https://github.com/celery/celery/pull/10531#discussion_r3896913379 pointed out that the same fix was needed in two places:
> This issue also appears on line 379 of the same file.


but https://github.com/celery/celery/pull/10531/commits/4326919134de5484e0fbe2be204dbb493e254b0e only updated one of them.

This PR updates the other one.