### PR TITLE
Show original and prefixed keys in configuration KeyError

### DIFF
--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -397,7 +397,7 @@ class ConfigurationView(ChainMap, AttributeDictMixin):
         except KeyError:
             if len(keys) > 1:
                 raise KeyError(
-                    'Key not found: {0!r} (with prefix: {0!r})'.format(*keys))
+                    'Key not found: {1!r} (with prefix: {0!r})'.format(*keys))
             raise
 
     def __setitem__(self, key, value):

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -72,6 +72,14 @@ class test_ConfigurationView:
         sp = object()
         assert self.view.get('nonexisting', sp) is sp
 
+    def test_missing_key_with_prefix(self):
+        view = ConfigurationView({}, prefix='celery')
+        with pytest.raises(KeyError) as exc_info:
+            view['nonexisting']
+        assert exc_info.value.args[0] == (
+            "Key not found: 'nonexisting' (with prefix: 'celery_nonexisting')"
+        )
+
     def test_update(self):
         changes = dict(self.view.changes)
         self.view.update(a=1, b=2, c=3)


### PR DESCRIPTION
## Description

I believe this error message uses the wrong placeholder:
https://github.com/celery/celery/blob/68a0eaa9f8a3409b54ba8b3429aeffa090fe21ac/celery/utils/collections.py#L399-L400
It currently prints the prefixed key twice:
>  Key not found: 'celery_nonexisting' (with prefix: 'celery_nonexisting')

Using `{1!r}` for the first value shows both the original key and its prefixed version:
> Key not found: 'nonexisting' (with prefix: 'celery_nonexisting')