### PR TITLE
Fix Signature.clone() kwargs aliasing

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -458,7 +458,7 @@ class Signature(dict):
         if args or kwargs or opts:
             args, kwargs, opts = self._merge(args, kwargs, opts)
         else:
-            args, kwargs, opts = self.args, self.kwargs, self.options
+            args, kwargs, opts = self.args, deepcopy(self.kwargs), self.options
         signature = Signature.from_dict({'task': self.task,
                                          'args': tuple(args),
                                          'kwargs': kwargs,

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -457,6 +457,7 @@ class Signature(dict):
         # need to deepcopy options so origins links etc. is not modified.
         if args or kwargs or opts:
             args, kwargs, opts = self._merge(args, kwargs, opts)
+            kwargs = deepcopy(kwargs)
         else:
             args, kwargs, opts = self.args, deepcopy(self.kwargs), self.options
         signature = Signature.from_dict({'task': self.task,

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -85,8 +85,8 @@ def _deepcopy_kwargs(kwargs):
         clone = type(value).__new__(type(value))
         memo[value_id] = clone
         dict.__init__(clone)
-        collect(value)
         for key, nested_value in value.items():
+            collect(nested_value)
             dict.__setitem__(clone, deepcopy(key, memo), deepcopy(nested_value, memo))
         clone._app = value._app
         if '_type' in value.__dict__:

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -75,6 +75,7 @@ def _stamp_regen_task(task, visitor, append_stamps, **headers):
 def _deepcopy_kwargs(kwargs):
     """Copy signature kwargs without exhausting lazy group inputs."""
     memo = {}
+    seen = set()
 
     def collect(value):
         if isinstance(value, _regen):
@@ -82,9 +83,17 @@ def _deepcopy_kwargs(kwargs):
         elif isinstance(value, Signature):
             memo[id(value)] = value.clone()
         elif isinstance(value, dict):
+            value_id = id(value)
+            if value_id in seen:
+                return
+            seen.add(value_id)
             for nested_value in value.values():
                 collect(nested_value)
         elif isinstance(value, (list, tuple, set, frozenset)):
+            value_id = id(value)
+            if value_id in seen:
+                return
+            seen.add(value_id)
             for nested_value in value:
                 collect(nested_value)
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -11,7 +11,7 @@ import types
 import warnings
 from abc import ABCMeta, abstractmethod
 from collections import deque
-from collections.abc import MutableSequence
+from collections.abc import Mapping, MutableSequence
 from copy import deepcopy
 from functools import partial as _partial
 from functools import reduce
@@ -77,25 +77,54 @@ def _deepcopy_kwargs(kwargs):
     memo = {}
     seen = set()
 
+    def clone_signature(value):
+        value_id = id(value)
+        if value_id in memo:
+            return memo[value_id]
+
+        clone = type(value).__new__(type(value))
+        memo[value_id] = clone
+        dict.__init__(clone)
+        collect(value)
+        for key, nested_value in value.items():
+            dict.__setitem__(clone, deepcopy(key, memo), deepcopy(nested_value, memo))
+        clone._app = value._app
+        if '_type' in value.__dict__:
+            clone._type = value._type
+        return clone
+
+    def clone_item(value):
+        collect(value)
+        return deepcopy(value, memo)
+
+    def clone_regen(value):
+        return _regen(clone_item(item) for item in value)
+
     def collect(value):
         if isinstance(value, _regen):
-            memo[id(value)] = value
-        elif isinstance(value, Signature):
-            memo[id(value)] = value.clone()
-        elif isinstance(value, dict):
-            value_id = id(value)
-            if value_id in seen:
-                return
-            seen.add(value_id)
+            memo.setdefault(id(value), clone_regen(value))
+            return
+
+        if isinstance(value, Signature):
+            clone_signature(value)
+            return
+
+        value_id = id(value)
+        if value_id in seen:
+            return
+        seen.add(value_id)
+        if isinstance(value, Mapping):
             for nested_value in value.values():
                 collect(nested_value)
-        elif isinstance(value, (list, tuple, set, frozenset)):
-            value_id = id(value)
-            if value_id in seen:
-                return
-            seen.add(value_id)
+        elif isinstance(value, (list, tuple, set, frozenset, deque)):
             for nested_value in value:
                 collect(nested_value)
+        elif hasattr(value, '__dict__'):
+            collect(vars(value))
+        elif hasattr(value, '__slots__'):
+            for slot in value.__slots__:
+                if hasattr(value, slot):
+                    collect(getattr(value, slot))
 
     for value in kwargs.values():
         collect(value)

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -72,6 +72,16 @@ def _stamp_regen_task(task, visitor, append_stamps, **headers):
     return task
 
 
+def _deepcopy_kwargs(kwargs):
+    """Copy signature kwargs without exhausting lazy group inputs."""
+    memo = {
+        id(value): value
+        for value in kwargs.values()
+        if isinstance(value, _regen)
+    }
+    return deepcopy(kwargs, memo)
+
+
 def _merge_dictionaries(d1, d2, aggregate_duplicates=True):
     """Merge two dictionaries recursively into the first one.
 
@@ -457,9 +467,9 @@ class Signature(dict):
         # need to deepcopy options so origins links etc. is not modified.
         if args or kwargs or opts:
             args, kwargs, opts = self._merge(args, kwargs, opts)
-            kwargs = deepcopy(kwargs)
+            kwargs = _deepcopy_kwargs(kwargs)
         else:
-            args, kwargs, opts = self.args, deepcopy(self.kwargs), self.options
+            args, kwargs, opts = self.args, _deepcopy_kwargs(self.kwargs), self.options
         signature = Signature.from_dict({'task': self.task,
                                          'args': tuple(args),
                                          'kwargs': kwargs,

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -74,11 +74,22 @@ def _stamp_regen_task(task, visitor, append_stamps, **headers):
 
 def _deepcopy_kwargs(kwargs):
     """Copy signature kwargs without exhausting lazy group inputs."""
-    memo = {
-        id(value): value
-        for value in kwargs.values()
-        if isinstance(value, _regen)
-    }
+    memo = {}
+
+    def collect(value):
+        if isinstance(value, _regen):
+            memo[id(value)] = value
+        elif isinstance(value, Signature):
+            memo[id(value)] = value.clone()
+        elif isinstance(value, dict):
+            for nested_value in value.values():
+                collect(nested_value)
+        elif isinstance(value, (list, tuple, set, frozenset)):
+            for nested_value in value:
+                collect(nested_value)
+
+    for value in kwargs.values():
+        collect(value)
     return deepcopy(kwargs, memo)
 
 

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -203,6 +203,16 @@ class test_Signature(CanvasCase):
             'task_id': '123',
         }
 
+    def test_clone_copies_kwargs(self):
+        original = self.add.s(1, 2, extra={'shared': True})
+        clone = original.clone()
+
+        assert clone.kwargs is not original.kwargs
+        assert clone.kwargs['extra'] is not original.kwargs['extra']
+
+        clone.kwargs['extra']['shared'] = False
+        assert original.kwargs['extra']['shared'] is True
+
     def test_set(self):
         assert Signature('TASK', x=1).set(task_id='2').options == {
             'x': 1, 'task_id': '2',

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -213,6 +213,14 @@ class test_Signature(CanvasCase):
         clone.kwargs['extra']['shared'] = False
         assert original.kwargs['extra']['shared'] is True
 
+    def test_clone_copies_kwargs_with_overrides(self):
+        original = self.add.s(1, 2, extra={'shared': True})
+
+        clone = original.clone(args=(3,))
+        clone.kwargs['extra']['shared'] = False
+
+        assert original.kwargs['extra']['shared'] is True
+
     def test_set(self):
         assert Signature('TASK', x=1).set(task_id='2').options == {
             'x': 1, 'task_id': '2',

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1,5 +1,6 @@
 import json
 import math
+from collections import deque
 from collections.abc import Iterable
 from unittest.mock import ANY, MagicMock, Mock, call, patch, sentinel
 
@@ -232,18 +233,40 @@ class test_Signature(CanvasCase):
         assert clone.kwargs['payload'] is not original.kwargs['payload']
         assert clone.kwargs['payload']['self'] is clone.kwargs['payload']
 
+    def test_clone_preserves_signatures_in_unsupported_containers(self):
+        child = self.add.s(1, 2)
+        original = self.add.s(payload=deque([child]))
+
+        clone = original.clone()
+
+        assert isinstance(clone.kwargs['payload'], deque)
+        assert clone.kwargs['payload'][0] is not child
+        assert isinstance(clone.kwargs['payload'][0], Signature)
+
+    def test_clone_preserves_signature_cycles(self):
+        original = self.add.s()
+        original.kwargs['self'] = original
+
+        clone = original.clone()
+
+        assert isinstance(clone.kwargs['self'], Signature)
+        assert clone.kwargs['self'] is not original
+
     def test_clone_preserves_lazy_group_generator(self):
         consumed = []
+        source = self.add.s(1, 2)
 
         def task_generator():
             consumed.append(True)
-            yield self.add.s(1, 2)
+            yield source
 
         original = group(task_generator())
         clone = original.clone()
 
         assert consumed == []
-        assert len(list(clone.tasks)) == 1
+        cloned_tasks = list(clone.tasks)
+        assert len(cloned_tasks) == 1
+        assert cloned_tasks[0] is not source
         assert consumed == [True]
 
     def test_set(self):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -221,6 +221,20 @@ class test_Signature(CanvasCase):
 
         assert original.kwargs['extra']['shared'] is True
 
+    def test_clone_preserves_lazy_group_generator(self):
+        consumed = []
+
+        def task_generator():
+            consumed.append(True)
+            yield self.add.s(1, 2)
+
+        original = group(task_generator())
+        clone = original.clone()
+
+        assert consumed == []
+        assert len(list(clone.tasks)) == 1
+        assert consumed == [True]
+
     def test_set(self):
         assert Signature('TASK', x=1).set(task_id='2').options == {
             'x': 1, 'task_id': '2',

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -221,6 +221,17 @@ class test_Signature(CanvasCase):
 
         assert original.kwargs['extra']['shared'] is True
 
+    def test_clone_handles_cyclic_kwargs(self):
+        payload = {}
+        payload['self'] = payload
+        original = self.add.s(payload=payload)
+
+        clone = original.clone()
+
+        assert clone.kwargs is not original.kwargs
+        assert clone.kwargs['payload'] is not original.kwargs['payload']
+        assert clone.kwargs['payload']['self'] is clone.kwargs['payload']
+
     def test_clone_preserves_lazy_group_generator(self):
         consumed = []
 

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -416,6 +416,15 @@ class test_Signature(CanvasCase):
 
 class test_xmap_xstarmap(CanvasCase):
 
+    @pytest.mark.parametrize("attr", ("map", "starmap"))
+    def test_clone_preserves_task_signature(self, attr):
+        original = getattr(self.add, attr)([1, 2])
+        clone = original.clone()
+
+        assert isinstance(clone.kwargs["task"], Signature)
+        assert clone.kwargs["task"] is not original.kwargs["task"]
+        assert repr(clone)
+
     def test_apply(self):
         for type, attr in [(xmap, 'map'), (xstarmap, 'starmap')]:
             args = [(i, i) for i in range(10)]
@@ -433,6 +442,13 @@ class test_xmap_xstarmap(CanvasCase):
 
 
 class test_chunks(CanvasCase):
+
+    def test_clone_preserves_task_signature(self):
+        original = self.add.chunks(range(4), 2)
+        clone = original.clone()
+
+        assert isinstance(clone.kwargs["task"], Signature)
+        assert clone.kwargs["task"] is not original.kwargs["task"]
 
     def test_chunks_preserves_state(self):
         x = self.add.chunks(range(100), 10)


### PR DESCRIPTION
`Signature.clone()` is expected to return an independent signature when called without overrides. The no-override branch currently reuses the original `kwargs` dictionary, so mutating a clone can mutate the source and sibling clones.

This change deep-copies `kwargs` in that branch, matching the existing defensive copy of `options`. The regression test covers both the mapping and a nested value.

Refs #10560

Tests:
- `./.venv/bin/python -m pytest -q t/unit/tasks/test_canvas.py -k test_clone_copies_kwargs`
- `./.venv/bin/python -m compileall -q celery/canvas.py t/unit/tasks/test_canvas.py`
