### PR TITLE
Fix crontab state restoration across persistence cycles

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -576,6 +576,7 @@ class crontab(BaseSchedule):
         # Calling super's init because the kwargs aren't necessarily passed in
         # the same form as they are stored by the superclass
         super().__init__(**state)
+        self._orig_kwargs = dict(state)
 
     def remaining_delta(self, last_run_at: datetime,
                         tz: str | tzinfo | None = None,

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -148,6 +148,14 @@ class test_crontab_parser:
             nowfun=utcnow)
         assert c == loads(dumps(c))
 
+    def test_crontab_reduce_preserves_state_across_multiple_round_trips(self):
+        c = self.crontab(nowfun=utcnow)
+
+        for _ in range(5):
+            c = loads(dumps(c))
+
+        assert c.nowfun is utcnow
+
     def test_range_steps_not_enough(self):
         with pytest.raises(crontab_parser.ParseException):
             crontab_parser(24)._range_steps([1])

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -149,13 +149,15 @@ class test_crontab_parser:
         assert c == loads(dumps(c))
 
     def test_crontab_reduce_preserves_state_across_multiple_round_trips(self):
-        c = self.crontab(nowfun=utcnow)
+        import functools
+
+        c = self.crontab(nowfun=functools.partial(utcnow))
 
         for _ in range(5):
             c = loads(dumps(c))
 
-        assert c.nowfun is utcnow
-
+        assert isinstance(c.nowfun, functools.partial)
+        assert c.nowfun.func is utcnow
     def test_range_steps_not_enough(self):
         with pytest.raises(crontab_parser.ParseException):
             crontab_parser(24)._range_steps([1])


### PR DESCRIPTION
## Summary

- Preserve `_orig_kwargs` when restoring `crontab` state so custom `nowfun` values survive repeated `PersistentScheduler` sync and pickle cycles.
- Add a regression test covering five consecutive round trips.

Fixes #8790

## Testing

- `python -m pytest t/unit/app/test_schedules.py -q`
- 142 passed, 11 skipped