### PR TITLE
Return Option objects consistently from find()

### DIFF
--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -430,7 +430,11 @@ def find_deprecated_settings(source):  # pragma: no cover
 
 @memoize(maxsize=None)
 def find(name, namespace='celery'):
-    """Find setting by name."""
+    """Find setting by name.
+
+    Returns:
+        Tuple: of ``(namespace, key, type)``.
+    """
     # - Try specified name-space first.
     namespace = namespace.lower()
     try:

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -403,8 +403,9 @@ def flatten(d, root='', keyfilter=_flatten_keys):
                 yield from keyfilter(ns, key, opt)
 
 
+_OPTIONS = dict(flatten(NAMESPACES))
 DEFAULTS = {
-    key: opt.default for key, opt in flatten(NAMESPACES)
+    key: opt.default for key, opt in _OPTIONS.items()
 }
 __compat = list(flatten(NAMESPACES, keyfilter=_to_compat))
 _OLD_DEFAULTS = {old_key: opt.default for old_key, _, opt in __compat}
@@ -447,4 +448,4 @@ def find(name, namespace='celery'):
                 except KeyError:
                     pass
     # - See if name is a qualname last.
-    return searchresult(None, name.lower(), DEFAULTS[name.lower()])
+    return searchresult(None, name.lower(), _OPTIONS[name.lower()])

--- a/docs/reference/celery.app.defaults.rst
+++ b/docs/reference/celery.app.defaults.rst
@@ -6,6 +6,11 @@
     :local:
 .. currentmodule:: celery.app.defaults
 
+.. versionchanged:: 5.7
+    :func:`find` now returns an :class:`Option` as the third item for
+    qualified-name lookups instead of returning the option's default value.
+    Use ``find(name).type.default`` to retrieve the default value.
+
 .. automodule:: celery.app.defaults
     :members:
     :undoc-members:

--- a/t/unit/app/test_defaults.py
+++ b/t/unit/app/test_defaults.py
@@ -40,7 +40,7 @@ class test_defaults:
         find = self.defaults.find
 
         assert find('default_queue')[2].default == 'celery'
-        assert find('task_default_exchange')[2] is None
+        assert find('task_default_exchange')[2].default is None
 
     @property
     def defaults(self):

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -158,6 +158,7 @@ class test_crontab_parser:
 
         assert isinstance(c.nowfun, functools.partial)
         assert c.nowfun.func is utcnow
+
     def test_range_steps_not_enough(self):
         with pytest.raises(crontab_parser.ParseException):
             crontab_parser(24)._range_steps([1])

--- a/t/unit/app/test_utils.py
+++ b/t/unit/app/test_utils.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping, MutableMapping
 from unittest.mock import Mock
 
+from celery.app.defaults import Option
 from celery.app.utils import Settings, bugreport, filter_hidden_settings
 
 
@@ -16,6 +17,11 @@ class test_Settings:
 
     def test_find(self):
         assert self.app.conf.find_option('always_eager')
+
+    def test_find_option_by_qualified_name(self):
+        result = self.app.conf.find_option('task_always_eager')
+        assert isinstance(result.type, Option)
+        assert result.type.default is False
 
     def test_get_by_parts(self):
         self.app.conf.task_do_this_and_that = 303


### PR DESCRIPTION
## Description

The third item returned by find() is inconsistent: it can be either an Option object or the option's default value, depending on how the setting is searched.

This is confusing because Settings.find_option() says it searches for an option, not its default value.
https://github.com/celery/celery/blob/1c7a471327bf70a58c9ff5f91ed8a70d6e8fe4c4/celery/app/utils.py#L141-L156

This change makes qualified-name lookups return the Option object as well, so the third item is consistent for both lookup forms.