### PR TITLE
Honour broker connection retry settings when purging at startup

### DIFF
--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -26,6 +26,7 @@ from celery.utils.debug import cry
 from celery.utils.imports import qualname
 from celery.utils.log import get_logger, in_sighandler, set_in_sighandler
 from celery.utils.text import pluralize
+from celery.utils.time import humanize_seconds
 from celery.worker import WorkController
 
 __all__ = ('Worker',)
@@ -189,8 +190,36 @@ class Worker(WorkController):
             redirect_stdouts=False, colorize=colorize, hostname=self.hostname,
         )
 
+    def _ensure_connected(self, connection):
+        """Connect to the broker, retrying if the app is configured to.
+
+        The connection is lazy, so without this the first thing to touch it
+        raises straight away. ``--purge`` runs from :meth:`on_start`, which
+        makes ``broker_connection_retry_on_startup`` the setting that decides
+        whether to retry, falling back to ``broker_connection_retry`` for apps
+        that predate it.
+        """
+        retry = self.app.conf.broker_connection_retry_on_startup
+        if retry is None:
+            retry = self.app.conf.broker_connection_retry
+
+        if not retry:
+            connection.connect()
+            return
+
+        def _error_handler(exc, interval):
+            logger.error(
+                'purge: Connection error: %s. Trying again %s...',
+                exc, humanize_seconds(interval, 'in', ' '),
+            )
+
+        connection.ensure_connection(
+            _error_handler, self.app.conf.broker_connection_max_retries,
+        )
+
     def purge_messages(self):
         with self.app.connection_for_write() as connection:
+            self._ensure_connected(connection)
             count = self.app.control.purge(connection=connection)
             if count:  # pragma: no cover
                 print(f"purge: Erased {count} {pluralize(count, 'message')} from the queue.\n", flush=True)

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -205,7 +205,7 @@ class Worker(WorkController):
 
         if not retry:
             connection.connect()
-            return
+            return connection
 
         def _error_handler(exc, interval):
             logger.error(
@@ -213,13 +213,13 @@ class Worker(WorkController):
                 exc, humanize_seconds(interval, 'in', ' '),
             )
 
-        connection.ensure_connection(
+        return connection.ensure_connection(
             _error_handler, self.app.conf.broker_connection_max_retries,
         )
 
     def purge_messages(self):
         with self.app.connection_for_write() as connection:
-            self._ensure_connected(connection)
+            connection = self._ensure_connected(connection)
             count = self.app.control.purge(connection=connection)
             if count:  # pragma: no cover
                 print(f"purge: Erased {count} {pluralize(count, 'message')} from the queue.\n", flush=True)

--- a/t/unit/apps/test_worker.py
+++ b/t/unit/apps/test_worker.py
@@ -58,7 +58,7 @@ class test_Worker_purge:
         # Apps that never set the newer setting keep the old one's behaviour.
         worker = self._worker(
             broker_connection_retry_on_startup=None,
-            broker_connection_retry=False,
+            broker_connection_retry=True,
         )
         connection = Mock(name='connection')
 
@@ -68,5 +68,5 @@ class test_Worker_purge:
             with patch.object(self.app.control, 'purge', return_value=0):
                 worker.purge_messages()
 
-        connection.connect.assert_called_once_with()
-        connection.ensure_connection.assert_not_called()
+        connection.ensure_connection.assert_called_once()
+        connection.connect.assert_not_called()

--- a/t/unit/apps/test_worker.py
+++ b/t/unit/apps/test_worker.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from celery.apps.worker import Worker
 
 
@@ -10,6 +12,10 @@ class test_Worker_purge:
     exists, so the retry handling in :mod:`celery.worker.consumer` never sees
     it.  See https://github.com/celery/celery/issues/10102.
     """
+
+    @pytest.fixture(autouse=True)
+    def _setup_app(self, app):
+        self.app = app
 
     def _worker(self, **conf):
         self.app.conf.update(conf)

--- a/t/unit/apps/test_worker.py
+++ b/t/unit/apps/test_worker.py
@@ -1,0 +1,66 @@
+from unittest.mock import Mock, patch
+
+from celery.apps.worker import Worker
+
+
+class test_Worker_purge:
+    """Purging at startup must honour the broker connection retry settings.
+
+    ``purge_messages`` runs from ``on_start``, before the consumer blueprint
+    exists, so the retry handling in :mod:`celery.worker.consumer` never sees
+    it.  See https://github.com/celery/celery/issues/10102.
+    """
+
+    def _worker(self, **conf):
+        self.app.conf.update(conf)
+        worker = Worker(app=self.app, hostname='test@example.com')
+        return worker
+
+    def test_purge_retries_connection_on_startup(self):
+        worker = self._worker(
+            broker_connection_retry_on_startup=True,
+            broker_connection_max_retries=7,
+        )
+        connection = Mock(name='connection')
+
+        with patch.object(self.app, 'connection_for_write') as conn_for_write:
+            conn_for_write.return_value.__enter__ = Mock(return_value=connection)
+            conn_for_write.return_value.__exit__ = Mock(return_value=None)
+            with patch.object(self.app.control, 'purge', return_value=0):
+                worker.purge_messages()
+
+        connection.ensure_connection.assert_called_once()
+        assert connection.ensure_connection.call_args[0][1] == 7
+        connection.connect.assert_not_called()
+
+    def test_purge_does_not_retry_when_disabled(self):
+        worker = self._worker(
+            broker_connection_retry_on_startup=False,
+        )
+        connection = Mock(name='connection')
+
+        with patch.object(self.app, 'connection_for_write') as conn_for_write:
+            conn_for_write.return_value.__enter__ = Mock(return_value=connection)
+            conn_for_write.return_value.__exit__ = Mock(return_value=None)
+            with patch.object(self.app.control, 'purge', return_value=0):
+                worker.purge_messages()
+
+        connection.connect.assert_called_once_with()
+        connection.ensure_connection.assert_not_called()
+
+    def test_purge_falls_back_to_broker_connection_retry(self):
+        # Apps that never set the newer setting keep the old one's behaviour.
+        worker = self._worker(
+            broker_connection_retry_on_startup=None,
+            broker_connection_retry=False,
+        )
+        connection = Mock(name='connection')
+
+        with patch.object(self.app, 'connection_for_write') as conn_for_write:
+            conn_for_write.return_value.__enter__ = Mock(return_value=connection)
+            conn_for_write.return_value.__exit__ = Mock(return_value=None)
+            with patch.object(self.app.control, 'purge', return_value=0):
+                worker.purge_messages()
+
+        connection.connect.assert_called_once_with()
+        connection.ensure_connection.assert_not_called()


### PR DESCRIPTION
Fixes #10102.

`broker_connection_retry_on_startup` doesn't apply when the worker is started with `--purge`. `purge_messages()` runs from `on_start`, well before the consumer blueprint exists, so none of the retry handling in `celery/worker/consumer/consumer.py` is in play:

```python
def purge_messages(self):
    with self.app.connection_for_write() as connection:
        count = self.app.control.purge(connection=connection)
```

Kombu connections are lazy, so nothing has actually connected at that point. `control.purge()` is the first thing to touch the socket and it raises immediately if the broker isn't up yet — no retry, no matter how the app is configured. A worker started with `--purge` against a broker that's still coming up dies on the spot, while the same worker without `--purge` would have sat there retrying.

This connects explicitly before purging, and honours the same settings the consumer does: `broker_connection_retry_on_startup` decides, falling back to `broker_connection_retry` when it's unset so apps that predate the newer setting keep their old behaviour. The error handler mirrors the one in `celery/beat.py`, including passing `broker_connection_max_retries` through.

Three tests, one per branch — retry on, retry off, and the fallback. Reverting just `celery/apps/worker.py` fails all three; with the fix they pass, and `t/unit/apps/` plus `t/unit/worker/` are 675 passed / 1 skipped. flake8 clean on both files.
