### PR TITLE
Propagate setup logging signal errors

### DIFF
--- a/celery/app/log.py
+++ b/celery/app/log.py
@@ -103,6 +103,10 @@ class Logging:
             sender=None, loglevel=loglevel, logfile=logfile,
             format=format, colorize=colorize,
         )
+        for _, response in receivers:
+            if isinstance(response, Exception):
+                Logging._setup = False
+                raise response
 
         if not receivers:
             root = logging.getLogger()

--- a/celery/app/log.py
+++ b/celery/app/log.py
@@ -106,7 +106,7 @@ class Logging:
         for _, response in receivers:
             if isinstance(response, Exception):
                 Logging._setup = False
-                raise response
+                raise response.with_traceback(response.__traceback__)
 
         if not receivers:
             root = logging.getLogger()

--- a/t/unit/app/test_log.py
+++ b/t/unit/app/test_log.py
@@ -201,6 +201,18 @@ class test_default_logger:
     def test_setup_logging_subsystem_misc(self, restore_logging):
         self.app.log.setup_logging_subsystem(loglevel=None)
 
+    def test_setup_logging_subsystem_propagates_receiver_error(self, restore_logging):
+        self.app.log.already_setup = False
+        signals.setup_logging.sender_receivers_cache.clear()
+
+        @signals.setup_logging.connect(weak=False)
+        def raise_error(**kwargs):
+            raise ValueError("logging setup failed")
+
+        with pytest.raises(ValueError, match="logging setup failed"):
+            self.app.log.setup_logging_subsystem()
+        assert not self.app.log.already_setup
+
     def test_setup_logging_subsystem_misc2(self, restore_logging):
         self.app.conf.worker_hijack_root_logger = True
         self.app.log.setup_logging_subsystem()

--- a/t/unit/app/test_log.py
+++ b/t/unit/app/test_log.py
@@ -213,6 +213,10 @@ class test_default_logger:
             self.app.log.setup_logging_subsystem()
         assert not self.app.log.already_setup
 
+        signals.setup_logging.disconnect(raise_error)
+        self.app.log.setup_logging_subsystem()
+        assert self.app.log.already_setup
+
     def test_setup_logging_subsystem_misc2(self, restore_logging):
         self.app.conf.worker_hijack_root_logger = True
         self.app.log.setup_logging_subsystem()

--- a/t/unit/app/test_log.py
+++ b/t/unit/app/test_log.py
@@ -202,20 +202,28 @@ class test_default_logger:
         self.app.log.setup_logging_subsystem(loglevel=None)
 
     def test_setup_logging_subsystem_propagates_receiver_error(self, restore_logging):
+        from celery.app.log import Logging
+
         self.app.log.already_setup = False
+        signals.setup_logging.receivers[:] = []
+        Logging._setup = False
         signals.setup_logging.sender_receivers_cache.clear()
 
         @signals.setup_logging.connect(weak=False)
         def raise_error(**kwargs):
             raise ValueError("logging setup failed")
 
-        with pytest.raises(ValueError, match="logging setup failed"):
-            self.app.log.setup_logging_subsystem()
-        assert not self.app.log.already_setup
+        try:
+            with pytest.raises(ValueError, match="logging setup failed"):
+                self.app.log.setup_logging_subsystem()
+            assert not self.app.log.already_setup
 
-        signals.setup_logging.disconnect(raise_error)
-        self.app.log.setup_logging_subsystem()
-        assert self.app.log.already_setup
+            signals.setup_logging.disconnect(raise_error)
+            self.app.log.setup_logging_subsystem()
+            assert Logging._setup
+        finally:
+            signals.setup_logging.disconnect(raise_error)
+            Logging._setup = False
 
     def test_setup_logging_subsystem_misc2(self, restore_logging):
         self.app.conf.worker_hijack_root_logger = True


### PR DESCRIPTION
## Summary

`setup_logging` signal handlers currently return exceptions as signal responses, so a failed custom logging configuration is treated as handled and the worker continues with the default logger. Propagate the first handler exception and reset the setup flag so logging can be retried after the failure.

Add regression coverage for the propagated error and retry state.

## Validation

- `python -m pytest -q t/unit/app/test_log.py`

Fixes #9506