### PR TITLE
Keep preconfigured values out of configuration defaults

### DIFF
--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -277,7 +277,7 @@ def detect_settings(conf, preconf=None, ignore_keys=None, prefix=None,
         )))
 
     preconf = {info.convert.get(k, k): v for k, v in preconf.items()}
-    defaults = dict(deepcopy(info.defaults), **preconf)
+    defaults = deepcopy(info.defaults)
     return Settings(
         preconf, [conf, defaults],
         (_old_key_to_new, _new_key_to_old),

--- a/docs/reference/celery.app.utils.rst
+++ b/docs/reference/celery.app.utils.rst
@@ -9,3 +9,11 @@
 .. automodule:: celery.app.utils
     :members:
     :undoc-members:
+    :exclude-members: Settings
+
+    .. autoclass:: Settings
+        :members:
+        :undoc-members:
+
+        .. versionchanged:: 5.7
+            Preconfigured values are no longer copied into the built-in defaults mapping.

--- a/t/unit/app/test_utils.py
+++ b/t/unit/app/test_utils.py
@@ -32,6 +32,12 @@ class test_Settings:
         assert self.app.conf.find_value_for_key(
             'always_eager') is False
 
+    def test_clear_removes_preconfigured_override(self):
+        with self.Celery(task_always_eager=True) as app:
+            assert app.conf.task_always_eager is True
+            app.conf.clear()
+            assert app.conf.task_always_eager is False
+
     def test_table(self):
         assert self.app.conf.table(with_defaults=True)
         assert self.app.conf.table(with_defaults=False)


### PR DESCRIPTION
## Description

`detect_settings()` currently stores preconf values twice: once in the `changes` mapping and again in the `defaults` mapping. https://github.com/celery/celery/blob/de0806b701e51425186a5f49dd1827dc531722df/celery/app/utils.py#L280

Because of this, `app.conf.clear()` removes a preconfigured value from `changes`, but the same value is still returned from `defaults`. I believe the defaults mapping should contain only the built-in option `defaults`.

This PR removes the duplicate values so clearing the configuration correctly falls back to the built-in default.
