### PR TITLE
docs(result): drop doubled 'in in' in the ResultSet class comment

### DIFF
--- a/celery/result.py
+++ b/celery/result.py
@@ -585,7 +585,7 @@ class ResultSet(ResultBase):
 
     _app = None
 
-    #: List of results in in the set.
+    #: List of results in the set.
     results = None
 
     def __init__(self, results, app=None, ready_barrier=None, **kwargs):


### PR DESCRIPTION
`celery/result.py`'s `#:` comment on `ResultSet.results` read "List of results **in in** the set." — the comment renders in the API docs via `automodule:: celery.result`.