### PR TITLE
docs: repoint dead :ref: targets to the getting-help/bug-tracker labels

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -461,7 +461,7 @@ Can messages be encrypted?
 You can enable this using the :setting:`broker_use_ssl` setting.
 
 It's also possible to add additional encryption and security to messages,
-if you have a need for this then you should contact the :ref:`mailing-list`.
+if you have a need for this then you should contact the :ref:`getting-help`.
 
 Is it safe to run :program:`celery worker` as root?
 ---------------------------------------------------

--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -90,7 +90,7 @@ Celery is…
         Celery is easy to use and maintain, and it *doesn't need configuration files*.
 
         It has an active, friendly community you can talk to for support,
-        including a `mailing-list`_ and an :ref:`IRC channel <irc-channel>`.
+        including a `getting-help`_ and an :ref:`IRC channel <getting-help>`.
 
         Here's one of the simplest applications you can make:
 

--- a/docs/userguide/daemonizing.rst
+++ b/docs/userguide/daemonizing.rst
@@ -362,7 +362,7 @@ Commonly such errors are caused by insufficient permissions
 to read from, or write to a file, and also by syntax errors
 in configuration modules, user modules, third-party libraries,
 or even from Celery itself (if you've found a bug you
-should :ref:`report it <reporting-bugs>`).
+should :ref:`report it <bug-tracker>`).
 
 
 .. _daemon-systemd-generic:


### PR DESCRIPTION
Four `:ref:` targets were undefined anywhere in the docs tree:

- `docs/faq.rst`: `:ref:`mailing-list`` → `:ref:`getting-help``
- `docs/getting-started/introduction.rst`: `:ref:`IRC channel <irc-channel>`` → `<getting-help>` (and the dead implicit ``mailing-list`_`` reference on the same line repointed)
- `docs/userguide/daemonizing.rst`: `:ref:`report it <reporting-bugs>`` → `<bug-tracker>`

The intended targets (`getting-help`, `bug-tracker`) are the labels defined in `docs/includes/resources.txt`.