### PR TITLE
Detect spawned pool children in process_initializer

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -84,6 +84,13 @@ BUILTIN_FIXUPS = {
 }
 USING_EXECV = os.environ.get('FORKED_BY_MULTIPROCESSING')
 
+
+def _using_execv():
+    # Also checked at call time: a spawned pool child only sets the
+    # variable from process_initializer(), after this module was imported.
+    return USING_EXECV or os.environ.get('FORKED_BY_MULTIPROCESSING')
+
+
 ERR_ENVVAR_NOT_SET = """
 The environment variable {0!r} is not set,
 and as such the configuration could not be loaded.
@@ -547,7 +554,7 @@ class Celery:
             not access any attributes on the returned object until the
             application is fully set up (finalized).
         """
-        if USING_EXECV and opts.get('lazy', True):
+        if _using_execv() and opts.get('lazy', True):
             # When using execv the task in the original module will point to a
             # different app, so doing things like 'add.request' will point to
             # a different task instance.  This makes sure it will always use

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -6,7 +6,7 @@ import os
 import threading
 import time
 
-from billiard import forking_enable, set_start_method
+from billiard import forking_enable, get_start_method, set_start_method
 from billiard.common import REMAP_SIGTERM, TERM_SIGNAME
 from billiard.pool import CLOSE, RUN
 from billiard.pool import Pool as BlockingPool
@@ -50,6 +50,13 @@ def process_initializer(app, hostname):
     platforms.signals.reset(*WORKER_SIGRESET)
     platforms.signals.ignore(*WORKER_SIGIGNORE)
     platforms.set_mp_process_title('celeryd', hostname=hostname)
+    if get_start_method() != 'fork':
+        # billiard started this child as a fresh interpreter on its own
+        # (for example the macOS default since billiard 4.3), so announce
+        # it the same way the parent does for worker_pool_start_method
+        # 'spawn' -- before init_worker() imports the task modules, which
+        # must bind their tasks to the current app (see celery.app.base).
+        os.environ['FORKED_BY_MULTIPROCESSING'] = '1'
     # This is for Windows and other platforms not supporting
     # fork().  Note that init_worker makes sure it's only
     # run once per process.
@@ -65,7 +72,7 @@ def process_initializer(app, hostname):
                   str(os.environ.get('CELERY_LOG_REDIRECT_LEVEL')),
                   hostname=hostname)
     if os.environ.get('FORKED_BY_MULTIPROCESSING'):
-        # pool did execv after fork
+        # the child is a fresh interpreter (spawn, forkserver or execv)
         trace.setup_worker_optimizations(app, hostname)
     else:
         app.set_current()

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -206,6 +206,17 @@ class test_App:
             _appbase.USING_EXECV = prev
         assert not _appbase.USING_EXECV
 
+    @pytest.mark.usefixtures('depends_on_current_app')
+    def test_task_execv_env_set_after_import(self):
+        # a spawned pool child sets the variable from process_initializer()
+        with patch.dict(os.environ, {'FORKED_BY_MULTIPROCESSING': '1'}):
+            @self.app.task(shared=False)
+            def foo():
+                pass
+
+            assert foo._get_current_object()  # is proxy
+        assert not _appbase.USING_EXECV
+
     def test_task_takes_no_args(self):
         with pytest.raises(TypeError):
             @self.app.task(1)

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -66,7 +66,8 @@ class test_process_initializer:
         return loader
 
     @patch('celery.platforms.signals')
-    def test_process_initializer(self, _signals, set_mp_process_title, restore_logging):
+    @patch('celery.concurrency.prefork.get_start_method', return_value='fork')
+    def test_process_initializer(self, _get_start_method, _signals, set_mp_process_title, restore_logging):
         from celery import signals
         from celery._state import _tls
         from celery.concurrency.prefork import WORKER_SIGIGNORE, WORKER_SIGRESET, process_initializer
@@ -100,8 +101,38 @@ class test_process_initializer:
             finally:
                 os.environ.pop('CELERY_LOG_FILE', None)
 
+    @patch('celery.platforms.signals')
+    @patch('celery.concurrency.prefork.get_start_method', return_value='spawn')
+    def test_process_initializer_spawned_child(self, _get_start_method, _signals, set_mp_process_title,
+                                               restore_logging):
+        from celery.concurrency.prefork import process_initializer
+
+        with self.Celery(loader=self.Loader) as app:
+            app.conf = AttributeDict(DEFAULTS)
+            with patch.dict(os.environ), patch('celery.app.trace.setup_worker_optimizations') as S:
+                os.environ.pop('FORKED_BY_MULTIPROCESSING', None)
+                process_initializer(app, 'spawned.worker.com')
+                assert os.environ['FORKED_BY_MULTIPROCESSING'] == '1'
+                S.assert_called_with(app, 'spawned.worker.com')
+            assert app.loader.init_worker.call_count
+
+    @patch('celery.platforms.signals')
+    @patch('celery.concurrency.prefork.get_start_method', return_value='fork')
+    def test_process_initializer_forked_child(self, _get_start_method, _signals, set_mp_process_title,
+                                              restore_logging):
+        from celery.concurrency.prefork import process_initializer
+
+        with self.Celery(loader=self.Loader) as app:
+            app.conf = AttributeDict(DEFAULTS)
+            with patch.dict(os.environ), patch('celery.app.trace.setup_worker_optimizations') as S:
+                os.environ.pop('FORKED_BY_MULTIPROCESSING', None)
+                process_initializer(app, 'forked.worker.com')
+                assert 'FORKED_BY_MULTIPROCESSING' not in os.environ
+                S.assert_not_called()
+
     @patch('celery.platforms.set_pdeathsig')
-    def test_pdeath_sig(self, _set_pdeathsig, set_mp_process_title, restore_logging):
+    @patch('celery.concurrency.prefork.get_start_method', return_value='fork')
+    def test_pdeath_sig(self, _get_start_method, _set_pdeathsig, set_mp_process_title, restore_logging):
         from celery import signals
         on_worker_process_init = Mock()
         signals.worker_process_init.connect(on_worker_process_init)


### PR DESCRIPTION
## Summary

Since billiard 4.3.0rc1 (celery/billiard#443) the default start method on macOS is `spawn`. Celery's prefork pool only takes its "fresh interpreter" initialisation path when `FORKED_BY_MULTIPROCESSING` is set in the environment — which billiard's old execv path used to do, and which #10339 now does for `worker_pool_start_method='spawn'` — but nothing sets it when billiard itself chooses `spawn`. The spawned child then skips `setup_worker_optimizations()`, and every task fails in `fast_trace_task`:

- `main`: `RuntimeError: fast_trace_task: worker task registry is empty (_loc was not populated)`
- 5.6.2: `ValueError: not enough values to unpack (expected 3, got 0)`

The worker starts, `inspect ping` answers, `-P solo` / `-P threads` are fine — only prefork children are affected. Reproduced with a fresh `pip install 'celery==5.6.2' 'billiard==4.3.0rc1'` on macOS 15 with both the async pool (redis) and the blocking pool (`filesystem://`), and on Linux by forcing `set_start_method('spawn')`.

This makes `process_initializer()` detect the situation itself, using billiard's effective start method: when `get_start_method()` is not `fork`, the child sets `FORKED_BY_MULTIPROCESSING` before `init_worker()` imports the task modules, so the existing execv path is taken. `Celery.task()` now checks the variable at call time as well as at import time, so `@app.task` in those modules binds to the current app rather than to the module-level app instance the child creates on import (otherwise `task.request` on the module-level task object is empty).

The parent no longer has to know how the children were started: this covers billiard's platform default, `worker_pool_start_method='spawn'`, and Windows (where `get_start_method()` is always `spawn`; this is the case the error message in `fast_trace_task` describes).

## Testing

- Unit tests for the spawned and forked branches of `process_initializer()`, and for `app.task()` honouring the variable when it is set after import.
- macOS 15 + billiard 4.3.0rc1 (spawn default), fix vs `main`: async pool with hard time limit replacement and 50 tasks at `-c 2`, blocking pool with hard time limit replacement and 20 tasks, `-B` — all pass with the fix, all tasks fail on `main`.
- Linux (billiard 4.2.4, fork): behaviour unchanged (`FORKED_BY_MULTIPROCESSING` unset, module state inherited). `--pool-start-method spawn` from #10339 and an injected `set_start_method('spawn')` without the variable both work.

Related: #10339 (discussion in https://github.com/celery/celery/pull/10339#issuecomment-5592945298), celery/billiard#443.
