### PR TITLE
Allow worker_pool_start_method='spawn' with the asynchronous prefork pool

### DIFF
--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -243,9 +243,7 @@ def detach(path, argv, logfile=None, pidfile=None, uid=None,
               help="Start method used to create prefork pool child "
                    "processes. 'fork' (default) is faster and shares memory "
                    "copy-on-write but is unsafe with threads/C-extensions; "
-                   "'spawn' starts each child in a fresh interpreter. "
-                   "'spawn' is not supported with the asynchronous prefork "
-                   "pool.")
+                   "'spawn' starts each child in a fresh interpreter.")
 @click.option('--max-memory-per-child',
               type=int,
               cls=CeleryOption,

--- a/celery/worker/components.py
+++ b/celery/worker/components.py
@@ -141,14 +141,6 @@ class Pool(bootsteps.StartStopStep):
         if w.app.conf.worker_pool in GREEN_POOLS:  # pragma: no cover
             warnings.warn(UserWarning(W_POOL_SETTING), stacklevel=2)
         threaded = not w.use_eventloop or IS_WINDOWS
-        # The async pool (AsynPool) cannot start its children with the
-        # 'spawn' start method, so reject the combination as early as
-        # possible instead of failing later with an opaque error.
-        if not threaded and w.pool_start_method == 'spawn':
-            raise ImproperlyConfigured(
-                "worker_pool_start_method='spawn' is not supported when the "
-                "asynchronous prefork pool is used (broker transport with an "
-                "event loop). Use worker_pool_start_method='fork' instead.")
         procs = w.min_concurrency
         w.process_task = w._process_task
         if not threaded:

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -4299,14 +4299,9 @@ meaningful for the prefork pool; ignored by the eventlet/gevent/solo pools.
   safe in the presence of threads and fork-unsafe C-extensions, at the cost
   of slower start-up, higher memory usage, and the requirement that the app
   and task arguments are picklable and that your entry point is guarded by
-  ``if __name__ == '__main__':``.
-
-.. warning::
-
-    ``"spawn"`` is **not supported** when the asynchronous prefork pool is
-    used (i.e. when the broker transport drives the event loop, which is the
-    common case for AMQP/Redis). The worker raises
-    :exc:`~celery.exceptions.ImproperlyConfigured` at start-up in that case.
+  ``if __name__ == '__main__':``. A replacement child has to finish importing
+  your application within :setting:`worker_proc_alive_timeout`, so raise that
+  setting for applications that take longer to import.
 
 .. setting:: worker_autoscaler
 

--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -257,13 +257,6 @@ copy-on-write sharing), and the requirement that your app and task arguments
 are picklable and that your worker entry point is guarded by
 ``if __name__ == '__main__':``.
 
-.. note::
-
-    ``"spawn"`` only works with the synchronous prefork pool. When the broker
-    transport drives the event loop (the asynchronous prefork pool, used by
-    AMQP/Redis), the worker refuses to start with
-    :setting:`worker_pool_start_method` set to ``"spawn"``.
-
 
 .. rubric:: Footnotes
 

--- a/docs/userguide/optimizing.rst
+++ b/docs/userguide/optimizing.rst
@@ -233,6 +233,8 @@ instantly). A similar issue can occur when your tasks always exceed
 Pool start method (fork vs spawn)
 ---------------------------------
 
+.. versionadded:: 5.7
+
 By default the prefork pool creates its child processes with ``fork()``
 (:setting:`worker_pool_start_method` set to ``"fork"``). Forking is fast and
 lets children share the parent's already-imported modules and memory through

--- a/t/smoke/tests/test_worker.py
+++ b/t/smoke/tests/test_worker.py
@@ -8,9 +8,10 @@ from pytest_docker_tools.wrappers.container import wait_for_callable
 import celery
 from celery import Celery
 from celery.canvas import chain, group
+from celery.exceptions import TimeLimitExceeded
 from t.integration.tasks import add, identity
 from t.smoke.conftest import SuiteOperations, WorkerKill, WorkerRestart
-from t.smoke.tasks import long_running_task
+from t.smoke.tasks import long_running_task, soft_time_limit_must_exceed_time_limit
 from t.smoke.workers import alias as alias_worker_app
 from t.smoke.workers.dev import SmokeWorkerContainer
 
@@ -28,6 +29,27 @@ def assert_container_exited(worker: CeleryTestWorker, attempts: int = RESULT_TIM
 
     worker.container.reload()
     assert worker.container.status == "exited"
+
+
+class test_pool_start_method_spawn:
+    @pytest.fixture
+    def default_worker_app(self, default_worker_app: Celery) -> Celery:
+        app = default_worker_app
+        app.conf.worker_pool_start_method = "spawn"
+        return app
+
+    def test_tasks_run_in_spawned_children(self, celery_setup: CeleryTestSetup):
+        queue = celery_setup.worker.worker_queue
+        sig = long_running_task.si(1, verbose=True).set(queue=queue)
+        assert sig.delay().get(RESULT_TIMEOUT) is True
+        celery_setup.worker.assert_log_exists("SpawnPoolWorker-")
+
+    def test_child_is_replaced_after_hard_time_limit(self, celery_setup: CeleryTestSetup):
+        queue = celery_setup.worker.worker_queue
+        with pytest.raises(TimeLimitExceeded):
+            soft_time_limit_must_exceed_time_limit.si().set(queue=queue).delay().get(RESULT_TIMEOUT)
+        sig = long_running_task.si(1, verbose=True).set(queue=queue)
+        assert sig.delay().get(RESULT_TIMEOUT) is True
 
 
 @pytest.mark.parametrize("method", list(WorkerRestart.Method))

--- a/t/smoke/tests/test_worker.py
+++ b/t/smoke/tests/test_worker.py
@@ -11,7 +11,7 @@ from celery.canvas import chain, group
 from celery.exceptions import TimeLimitExceeded
 from t.integration.tasks import add, identity
 from t.smoke.conftest import SuiteOperations, WorkerKill, WorkerRestart
-from t.smoke.tasks import long_running_task, soft_time_limit_must_exceed_time_limit
+from t.smoke.tasks import long_running_task
 from t.smoke.workers import alias as alias_worker_app
 from t.smoke.workers.dev import SmokeWorkerContainer
 
@@ -46,8 +46,9 @@ class test_pool_start_method_spawn:
 
     def test_child_is_replaced_after_hard_time_limit(self, celery_setup: CeleryTestSetup):
         queue = celery_setup.worker.worker_queue
+        sig = long_running_task.si(30, verbose=True).set(queue=queue, time_limit=3)
         with pytest.raises(TimeLimitExceeded):
-            soft_time_limit_must_exceed_time_limit.si().set(queue=queue).delay().get(RESULT_TIMEOUT)
+            sig.delay().get(RESULT_TIMEOUT)
         sig = long_running_task.si(1, verbose=True).set(queue=queue)
         assert sig.delay().get(RESULT_TIMEOUT) is True
 

--- a/t/unit/worker/test_components.py
+++ b/t/unit/worker/test_components.py
@@ -106,15 +106,16 @@ class test_Pool:
         assert comp.instantiate.call_args[1]['forking_enable'] is False
 
     @t.skip.if_win32
-    def test_create_spawn_with_async_pool_raises(self):
+    def test_create_spawn_with_async_pool(self):
         w = Mock()
         w.use_eventloop = w.pool_putlocks = w.pool_cls.uses_semaphore = True
         w.pool_start_method = 'spawn'
         comp = Pool(w)
         comp.instantiate = Mock()
 
-        with pytest.raises(ImproperlyConfigured):
-            comp.create(w)
+        comp.create(w)
+
+        assert comp.instantiate.call_args[1]['forking_enable'] is False
 
 
 class test_Beat:


### PR DESCRIPTION
## Summary

Follow-up to #10339, as discussed there. Related: #6036 (spawn support has been requested there since 2020; with this change it is available for both prefork pool implementations).

#10339 rejects `worker_pool_start_method='spawn'` whenever the worker uses an event loop, on the assumption that the asynchronous prefork pool cannot work with spawned children. In practice it does: I ran AsynPool with spawned children on Linux and macOS with hard and soft time limits, worker replacement after a hard time limit, `--autoscale`, `--max-tasks-per-child`, `acks_late` + `task_reject_on_worker_lost`, `revoke(terminate=True)`, `pool_restart`, grow/shrink, chains/groups/chords, ETA/retry, large payloads and warm/cold shutdown, without a difference to fork (details in https://github.com/celery/celery/pull/10339#issuecomment-5592945298). The wiring the PR description worried about — the child reporting `inqW_fd` back to the parent — holds up because `spawnv_passfds` preserves fd numbers.

The check also had a side effect: it keyed off `w.use_eventloop` rather than the pool class, so `-P solo` and `-P threads` with an async transport were rejected too.

This PR:

- removes the rejection in `Pool.create()`, so `spawn` works with both prefork pool implementations (and no longer blocks solo/threads);
- updates the CLI help and the docs accordingly, and notes in the setting docs that replacement children have to import the application within `worker_proc_alive_timeout`;
- adds smoke tests that run the worker with `worker_pool_start_method = "spawn"` against the smoke brokers (AsynPool): tasks run in `SpawnPoolWorker-*` children, and the pool keeps working after a hard time limit kill.

## Testing

- Unit tests updated (`test_create_spawn_with_async_pool` now asserts the pool is created with `forking_enable=False`).
- New smoke tests pass locally.
- Manual: redis broker with `--pool-start-method spawn` at `-c 2`, hard time limit replacement and 50 tasks; `-P solo --pool-start-method spawn` now starts.
