### PR TITLE
Make ConfigurationView membership match key lookup

### DIFF
--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -422,8 +422,9 @@ class ConfigurationView(ChainMap, AttributeDictMixin):
 
     def __contains__(self, key):
         # type: (str) -> bool
-        keys = self._to_keys(key)
-        return any(any(k in m for k in keys) for m in self.maps)
+        contains = super().__contains__
+        all_keys = self._to_keys(key) + (tuple(f(key) for f in self._keys) if self._keys else ())
+        return any(contains(k) for k in all_keys)
 
     def swap_with(self, other):
         # type: (ConfigurationView) -> None

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -8,6 +8,7 @@ import pytest
 from billiard.einfo import ExceptionInfo
 
 import t.skip
+from celery.app.utils import _new_key_to_old, _old_key_to_new
 from celery.utils.collections import (AttributeDict, BufferMap, ChainMap, ConfigurationView, DictAttribute,
                                       LimitedSet, Messagebuffer)
 from celery.utils.objects import Bunch
@@ -89,6 +90,22 @@ class test_ConfigurationView:
         assert 'changed_key' in self.view
         assert 'default_key' in self.view
         assert 'new' not in self.view
+
+    def test_contains_with_keys(self):
+        view = ConfigurationView(
+            {'task_always_eager': 1},
+            keys=(_old_key_to_new, _new_key_to_old),
+        )
+
+        assert view['CELERY_ALWAYS_EAGER'] == 1
+        assert 'CELERY_ALWAYS_EAGER' in view
+
+    def test_contains_applies_key_t(self):
+        view = ConfigurationView({'FOO': 1})
+        view.__dict__['key_t'] = str.upper
+
+        assert view['foo'] == 1
+        assert 'foo' in view
 
     def test_repr(self):
         assert 'changed_key' in repr(self.view)


### PR DESCRIPTION
## Description

`ConfigurationView.__getitem__()` supports transformed keys through the `self._keys` and `ChainMap.key_t`, but `__contains__()` checks the mappings directly and skips those transformations.

This means a key can be readable while membership reports that it does not exist:

```python
view = ConfigurationView(
    {'task_always_eager': 1},
    keys=(_old_key_to_new, _new_key_to_old),
)

assert view['CELERY_ALWAYS_EAGER'] == 1
assert 'CELERY_ALWAYS_EAGER' in view
```
the second assertion gets 
`AssertionError: assert 'CELERY_ALWAYS_EAGER' in ConfigurationView({'task_always_eager': 1})`

This PR makes `__getitem__()` and `__contains__()` use the same lookup approach.