### PR TITLE
fix(canvas): propagate aggregate_duplicates through recursive stamp merges

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -100,7 +100,7 @@ def _merge_dictionaries(d1, d2, aggregate_duplicates=True):
     for key, value in d1.items():
         if key in d2:
             if isinstance(value, dict):
-                _merge_dictionaries(d1[key], d2[key])
+                _merge_dictionaries(d1[key], d2[key], aggregate_duplicates)
             else:
                 if isinstance(value, (int, float, str)):
                     d1[key] = [value] if aggregate_duplicates else value


### PR DESCRIPTION
`_merge_dictionaries`'s recursive call dropped the `aggregate_duplicates` parameter, resetting to the default `True`. Reached via `Signature.stamp(visitor, append_stamps=False, **headers)` (`_stamp_headers`) whenever the same header key holds a nested dict in both the signature headers and the visitor output: the worker received `{'a': [1, 2]}` instead of the visitor's override `{'a': 2}`, contradicting the documented contract ("duplicate keys will be taken from d2").

Repro:
```python
from celery import Celery
from celery.canvas import StampingVisitor
app = Celery('audit', set_as_current=True)
class V(StampingVisitor):
    def on_signature(self, sig, **headers): return {'task_header': {'a': 2}}
sig = app.signature('t', kwargs={'x': 1})
sig.stamp(V(), append_stamps=False, task_header={'a': 1, 'b': 1})
print(sig.options['task_header'])   # before: {'a': [1, 2], 'b': 1}  after: {'a': 2, 'b': 1}
```