### PR TITLE
Document interaction between rate_limit and countdown/eta

### DIFF
--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -275,6 +275,10 @@ are executed in a timely manner you should monitor the queue for congestion. Use
 Munin, or similar tools, to receive alerts, so appropriate action can be
 taken to ease the workload. See :ref:`monitoring-munin`.
 
+If the task has a :attr:`~@Task.rate_limit` configured, the rate limit
+is enforced once the ETA has passed: the task starts no earlier than its
+ETA, and rate limiting may delay it further beyond that point.
+
 While `countdown` is an integer, `eta` must be a :class:`~datetime.datetime`
 object, specifying an exact date and time (including millisecond precision,
 and timezone information):

--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -1034,6 +1034,12 @@ General
     maximum number of  requests per second), you must restrict to a given
     queue.
 
+    If a task is called with ``countdown`` or ``eta``, the ETA takes
+    precedence: the task will not start before its ETA, and the rate
+    limit is enforced afterwards, once the ETA has passed. In other
+    words, the task starts at the later of the two: its ETA, or the
+    next slot allowed by the rate limit.
+
 .. warning::
 
     A rate-limited task still counts against the worker's prefetch count


### PR DESCRIPTION
Fixes #5810

Turns out rate_limit isn't actually ignored for countdown/eta tasks - I went looking for the reported behavior and couldn't reproduce it on main. When a task has both an ETA and a rate limit, the strategy routes it through `limit_post_eta` (strategy.py): the timer waits for the ETA first, then the request goes into the task's token bucket, so the rate limit still applies. That path has been there since 2017 (#4251), two years before this issue.

Quick check I ran: 6 tasks with `rate_limit="2/s"` and `countdown=1` keep the same ~0.5s spacing as tasks without a countdown, just shifted by exactly the countdown. So the two options compose, one after the other.

What the issue got right is the docs. Nothing in the user guide explains how these two options interact, which is easy to trip over. So this adds two things:

- a note under `Task.rate_limit` saying the ETA comes first and the rate limit is applied after it
- a paragraph in the ETA and Countdown section of the calling guide pointing at the option

Docs build has the same warning count as main, the cross-reference resolves in the built HTML, and `test_strategy.py` + `test_consumer.py` pass (186 tests).
