### PR TITLE
Keep the execv flag from leaking between tests

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -82,14 +82,10 @@ else:
 BUILTIN_FIXUPS = {
     'celery.fixups.django:fixup',
 }
+# Set from prefork.process_initializer() as well: a pool child started with
+# spawn imports this module before it knows it is one, and @app.task has to
+# bind differently once it does.
 USING_EXECV = os.environ.get('FORKED_BY_MULTIPROCESSING')
-
-
-def _using_execv():
-    # Also checked at call time: a spawned pool child only sets the
-    # variable from process_initializer(), after this module was imported.
-    return USING_EXECV or os.environ.get('FORKED_BY_MULTIPROCESSING')
-
 
 ERR_ENVVAR_NOT_SET = """
 The environment variable {0!r} is not set,
@@ -554,7 +550,7 @@ class Celery:
             not access any attributes on the returned object until the
             application is fully set up (finalized).
         """
-        if _using_execv() and opts.get('lazy', True):
+        if USING_EXECV and opts.get('lazy', True):
             # When using execv the task in the original module will point to a
             # different app, so doing things like 'add.request' will point to
             # a different task instance.  This makes sure it will always use

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -14,6 +14,7 @@ from kombu.asynchronous import get_event_loop
 
 from celery import platforms, signals
 from celery._state import _set_task_join_will_block, set_default_app
+from celery.app import base as _app_base
 from celery.app import trace
 from celery.concurrency.base import BasePool
 from celery.utils.functional import noop
@@ -51,12 +52,15 @@ def process_initializer(app, hostname):
     platforms.signals.ignore(*WORKER_SIGIGNORE)
     platforms.set_mp_process_title('celeryd', hostname=hostname)
     if get_start_method() != 'fork':
-        # billiard started this child as a fresh interpreter on its own
-        # (for example the macOS default since billiard 4.3), so announce
-        # it the same way the parent does for worker_pool_start_method
-        # 'spawn' -- before init_worker() imports the task modules, which
-        # must bind their tasks to the current app (see celery.app.base).
+        # billiard started this child as a fresh interpreter on its own (for
+        # example the macOS default since billiard 4.3), so announce it the
+        # same way the parent does for worker_pool_start_method 'spawn'.
+        # Both have to be set before init_worker() imports the task modules:
+        # the environment variable for whatever this process starts later,
+        # and the flag in the already-imported module that decides how
+        # @app.task binds.
         os.environ['FORKED_BY_MULTIPROCESSING'] = '1'
+        _app_base.USING_EXECV = True
     # This is for Windows and other platforms not supporting
     # fork().  Note that init_worker makes sure it's only
     # run once per process.

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -10,11 +10,13 @@ from billiard.pool import ApplyResult
 from kombu.asynchronous import Hub
 
 import t.skip
+from celery.app import base as app_base
 from celery.app.defaults import DEFAULTS
 from celery.concurrency.asynpool import iterate_file_descriptors_safely
 from celery.utils.collections import AttributeDict
 from celery.utils.functional import noop
 from celery.utils.objects import Bunch
+from t.unit.conftest import restore_execv_state
 
 try:
     from celery.concurrency import asynpool
@@ -86,13 +88,11 @@ class test_process_initializer:
                 'celeryd', hostname='awesome.worker.com',
             )
 
-            with patch('celery.app.trace.setup_worker_optimizations') as S:
+            with restore_execv_state(), \
+                    patch('celery.app.trace.setup_worker_optimizations') as S:
                 os.environ['FORKED_BY_MULTIPROCESSING'] = '1'
-                try:
-                    process_initializer(app, 'luke.worker.com')
-                    S.assert_called_with(app, 'luke.worker.com')
-                finally:
-                    os.environ.pop('FORKED_BY_MULTIPROCESSING', None)
+                process_initializer(app, 'luke.worker.com')
+                S.assert_called_with(app, 'luke.worker.com')
 
             os.environ['CELERY_LOG_FILE'] = 'worker%I.log'
             app.log.setup = Mock(name='log_setup')
@@ -109,10 +109,15 @@ class test_process_initializer:
 
         with self.Celery(loader=self.Loader) as app:
             app.conf = AttributeDict(DEFAULTS)
-            with patch.dict(os.environ), patch('celery.app.trace.setup_worker_optimizations') as S:
+            with restore_execv_state(), \
+                    patch('celery.app.trace.setup_worker_optimizations') as S:
                 os.environ.pop('FORKED_BY_MULTIPROCESSING', None)
+                app_base.USING_EXECV = None
                 process_initializer(app, 'spawned.worker.com')
                 assert os.environ['FORKED_BY_MULTIPROCESSING'] == '1'
+                # base was imported before the child knew it was spawned, so
+                # the flag has to be set too, not just the variable.
+                assert app_base.USING_EXECV
                 S.assert_called_with(app, 'spawned.worker.com')
             assert app.loader.init_worker.call_count
 
@@ -124,10 +129,13 @@ class test_process_initializer:
 
         with self.Celery(loader=self.Loader) as app:
             app.conf = AttributeDict(DEFAULTS)
-            with patch.dict(os.environ), patch('celery.app.trace.setup_worker_optimizations') as S:
+            with restore_execv_state(), \
+                    patch('celery.app.trace.setup_worker_optimizations') as S:
                 os.environ.pop('FORKED_BY_MULTIPROCESSING', None)
+                app_base.USING_EXECV = None
                 process_initializer(app, 'forked.worker.com')
                 assert 'FORKED_BY_MULTIPROCESSING' not in os.environ
+                assert not app_base.USING_EXECV
                 S.assert_not_called()
 
     @patch('celery.platforms.set_pdeathsig')

--- a/t/unit/conftest.py
+++ b/t/unit/conftest.py
@@ -105,6 +105,27 @@ def reset_cache_backend_state(celery_app):
 
 
 @contextmanager
+def restore_execv_state():
+    """Undo the "this process is a spawned pool child" marks on exit.
+
+    Starting a prefork pool or running ``process_initializer()`` in-process
+    sets ``FORKED_BY_MULTIPROCESSING`` and ``celery.app.base.USING_EXECV``,
+    which change how ``@app.task`` binds for every test that follows.
+    """
+    from celery.app import base as app_base
+    previous_env = os.environ.get('FORKED_BY_MULTIPROCESSING')
+    previous_flag = app_base.USING_EXECV
+    try:
+        yield
+    finally:
+        app_base.USING_EXECV = previous_flag
+        if previous_env is None:
+            os.environ.pop('FORKED_BY_MULTIPROCESSING', None)
+        else:
+            os.environ['FORKED_BY_MULTIPROCESSING'] = previous_env
+
+
+@contextmanager
 def assert_signal_called(signal, **expected):
     """Context that verifies signal is called before exiting."""
     handler = Mock()

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -33,6 +33,7 @@ from celery.worker import worker as worker_module
 from celery.worker.consumer import Consumer
 from celery.worker.pidbox import gPidbox
 from celery.worker.request import Request
+from t.unit.conftest import restore_execv_state
 
 
 def MockStep(step=None):
@@ -1349,12 +1350,15 @@ class test_WorkController(ConsumerCase):
         w.use_eventloop = True
         w.consumer.restart_count = -1
         pool = components.Pool(w)
-        pool.create(w)
-        pool.register_with_event_loop(w, w.hub)
-        if sys.platform != 'win32':
-            assert isinstance(w.semaphore, LaxBoundedSemaphore)
-            P = w.pool
-            P.start()
+        # Starting the pool can mark this process as a spawned pool child,
+        # which changes how @app.task binds for every test that follows.
+        with restore_execv_state():
+            pool.create(w)
+            pool.register_with_event_loop(w, w.hub)
+            if sys.platform != 'win32':
+                assert isinstance(w.semaphore, LaxBoundedSemaphore)
+                P = w.pool
+                P.start()
 
     def test_wait_for_soft_shutdown(self):
         worker = self.worker


### PR DESCRIPTION
## Summary

Follow-up to #10583. Not a bug report: the full unit suite passes on `main` (3911 passed), and it passes with this change too. What this removes is an order dependency that #10583 introduced between two parts of the suite.

#10583 made `Celery.task()` read `FORKED_BY_MULTIPROCESSING` at call time rather than at import time. The reason was real: a pool child started with `spawn` imports `celery.app.base` while unpickling the app, before `process_initializer()` can announce that the child is a fresh interpreter, so the import-time constant is always empty there.

The side effect is that `@app.task` now depends on the variable's value at the moment it is called, and parts of the suite set it mid-process. `components.Pool.create()` reaches `prefork.TaskPool.on_start()`, which sets the variable and does not unset it, so from `t/unit/worker/test_worker.py::test_WorkController::test_Pool_create` onwards every `@app.task` returns a `current_app`-bound proxy:

```
$ pytest t/unit/worker t/unit/app/test_beat.py -q
7 failed, 726 passed          # RuntimeError: Test depends on current_app
$ pytest                      # the whole of t/unit
3911 passed
```

The full run is fine because later tests happen to clear the state again, so CI is unaffected. It shows up when running a subset, which is what I do while working on a change.

## Change

- `celery/app/base.py`: read the variable at import time again, so `@app.task` does not change behaviour part-way through a process.
- `celery/concurrency/prefork.py`: have `process_initializer()` set `celery.app.base.USING_EXECV` directly when the start method is not `fork`. That is what the spawned child actually needs, and it says so more directly than re-reading the environment. The variable is still set, for whatever the child starts later.
- `t/unit/conftest.py`: a `restore_execv_state()` context manager that puts both back.
- `t/unit/worker/test_worker.py`, `t/unit/concurrency/test_prefork.py`: use it in the three places that mark this process as a pool child.

## Testing

- `pytest` (the whole of `t/unit`): 3911 passed, 39 skipped, 3 xfailed, 27673 subtests — identical to `main`.
- `pytest t/unit/worker t/unit/app/test_beat.py`: 733 passed, where `main` gives 7 failed.
- `pytest t/unit/concurrency t/unit/app t/unit/fixups`: 818 passed, same as `main`.
- The behaviour #10583 fixed still works: macOS with billiard 4.3.0rc1 (spawn by default) and a redis broker runs 30/30 tasks, with the flag set in the children.
- The new assertion on `USING_EXECV` in `test_process_initializer_spawned_child` fails without the `prefork.py` change.
