### PR TITLE
Respect map order in ConfigurationView lookups

### DIFF
--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -384,13 +384,13 @@ class ConfigurationView(ChainMap, AttributeDictMixin):
     def __getitem__(self, key):
         # type: (str) -> Any
         keys = self._to_keys(key)
-        getitem = super().__getitem__
-        for k in keys + (
-                tuple(f(key) for f in self._keys) if self._keys else ()):
-            try:
-                return getitem(k)
-            except KeyError:
-                pass
+        all_keys = keys + (tuple(f(key) for f in self._keys) if self._keys else ())
+        for mapping in self.maps:
+            for k in all_keys:
+                try:
+                    return mapping[self._key(k)]
+                except KeyError:
+                    pass
         try:
             # support subclasses implementing __missing__
             return self.__missing__(key)

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1091,6 +1091,15 @@ class test_App:
         self.app.config_from_object(Config(), namespace='celery')
         assert self.app.conf.task_always_eager == 44
 
+    def test_config_from_object__runtime_changes_take_precedence(self):
+        self.app.config_from_object(
+            {'CELERY_WORKER_PREFETCH_MULTIPLIER': 10},
+            namespace='CELERY',
+        )
+        assert self.app.conf.worker_prefetch_multiplier == 10
+        self.app.conf.worker_prefetch_multiplier = 20
+        assert self.app.conf.worker_prefetch_multiplier == 20
+
     def test_config_from_object__mixing_new_and_old(self):
 
         class Config:

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -511,6 +511,7 @@ class test_ChainMap:
         cm = ChainMap(key_t=lambda key: key + '!')
         cm['foo'] = 1
         assert cm.get('foo') == 1
+        assert cm.get('missing', 'fallback') == 'fallback'
 
     def test_setdefault_applies_key_t_once(self):
         cm = ChainMap(key_t=lambda key: key + '!')
@@ -518,3 +519,8 @@ class test_ChainMap:
         assert cm.changes == {'foo!': 1}
         cm.setdefault('foo', 2)
         assert cm.changes == {'foo!': 1}
+
+    def test_getitem_respects_map_order(self):
+        cm = ChainMap({'foo': 1}, {'foo': 2, 'bar': 3})
+        assert cm['foo'] == 1
+        assert cm['bar'] == 3

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -8,6 +8,7 @@ import pytest
 from billiard.einfo import ExceptionInfo
 
 import t.skip
+from celery.app.utils import _new_key_to_old, _old_key_to_new
 from celery.utils.collections import (AttributeDict, BufferMap, ChainMap, ConfigurationView, DictAttribute,
                                       LimitedSet, Messagebuffer)
 from celery.utils.objects import Bunch
@@ -71,6 +72,39 @@ class test_ConfigurationView:
         assert self.view.get('both') == 2
         sp = object()
         assert self.view.get('nonexisting', sp) is sp
+
+    def test_getitem_respects_map_order(self):
+        # Changes are searched before defaults.
+        view = ConfigurationView(
+            {'foo': 1},
+            [{'CELERY_FOO': 2}],
+            prefix='CELERY',
+        )
+        assert view['foo'] == 1
+
+        # Default mappings are also searched in order.
+        view = ConfigurationView(
+            {},
+            [{'foo': 1}, {'CELERY_FOO': 2}],
+            prefix='CELERY',
+        )
+        assert view['foo'] == 1
+
+        # An old key in an earlier map wins over a new key in a later map.
+        view = ConfigurationView(
+            {'CELERY_ALWAYS_EAGER': 1},
+            [{'task_always_eager': 2}],
+            keys=(_old_key_to_new, _new_key_to_old),
+        )
+        assert view['task_always_eager'] == 1
+
+        # The same applies when the earlier map uses the new key.
+        view = ConfigurationView(
+            {'task_always_eager': 1},
+            [{'CELERY_ALWAYS_EAGER': 2}],
+            keys=(_old_key_to_new, _new_key_to_old),
+        )
+        assert view['CELERY_ALWAYS_EAGER'] == 1
 
     def test_missing_key_with_prefix(self):
         view = ConfigurationView({}, prefix='celery')


### PR DESCRIPTION
## Description

`ConfigurationView.__getitem__()` currently searches all maps for each key before trying the next key form. This means a prefixed key or alias in a later map can win over a value in an earlier map.

This changes the lookup to try all key forms within each map before moving to the next one, so earlier maps take precedence.
