### PR TITLE
Warn when two callables collide under one task name (#10576)

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -28,14 +28,14 @@ from vine import starpromise
 from celery import platforms, signals
 from celery._state import (_announce_app_finalized, _deregister_app, _register_app, _set_current_app, _task_stack,
                            connect_on_app_finalize, get_current_app, get_current_worker_task, set_default_app)
-from celery.exceptions import AlwaysEagerIgnored, ImproperlyConfigured, OperationalError
+from celery.exceptions import AlwaysEagerIgnored, DuplicateTaskNameWarning, ImproperlyConfigured, OperationalError
 from celery.loaders import get_loader_cls
 from celery.local import PromiseProxy, maybe_evaluate
 from celery.utils import abstract
 from celery.utils.collections import AttributeDictMixin
 from celery.utils.dispatch import Signal
 from celery.utils.functional import first, head_from_fun, maybe_list
-from celery.utils.imports import gen_task_name, instantiate, symbol_by_name
+from celery.utils.imports import gen_task_name, instantiate, qualname, symbol_by_name
 from celery.utils.log import get_logger
 from celery.utils.objects import FallbackContext, mro_lookup
 from celery.utils.time import maybe_make_aware, timezone, to_utc
@@ -100,6 +100,19 @@ a valid configuration module.
 
 Example:
     {0}="proj.celeryconfig"
+"""
+
+
+W_DUPTASK = """\
+Task name {0!r} is already registered to a different callable.
+
+Existing: {1}
+New:      {2}
+
+{3}
+
+Every task must have a unique name. Pass an explicit name= to the task \
+decorator, or rename one of the callables.\
 """
 
 
@@ -392,6 +405,7 @@ class Celery:
         self.finalized = False
         self._finalize_mutex = threading.RLock()
         self._pending = deque()
+        self._duplicate_task_names_warned = set()
         self._tasks = tasks
         if not isinstance(self._tasks, TaskRegistry):
             self._tasks = self.registry_cls(self._tasks or {})
@@ -642,6 +656,7 @@ class Celery:
             add_autoretry_behaviour(task, **options)
         else:
             task = self._tasks[name]
+            self._warn_if_duplicate_task_name(task, fun, name)
         return task
 
     def register_task(self, task, **options):
@@ -657,11 +672,48 @@ class Celery:
             task_cls = type(task)
             task.name = self.gen_task_name(
                 task_cls.__name__, task_cls.__module__)
+        existing = self.tasks.get(task.name)
+        if existing is not None and existing is not task:
+            self._warn_duplicate_task_name(
+                task.name, qualname(type(existing)), qualname(type(task)),
+                'The new callable replaced the existing one; calls under this '
+                'name now reach the new callable.',
+            )
         add_autoretry_behaviour(task, **options)
         self.tasks[task.name] = task
         task._app = self
         task.bind(self)
         return task
+
+    def _warn_if_duplicate_task_name(self, task, fun, name):
+        """Warn when *name* is taken by a callable other than *fun*.
+
+        A module imported twice hands the same function object back, so
+        identity -- not the name -- is what tells a re-registration apart
+        from two distinct callables colliding under one generated name.
+        """
+        existing_fun = getattr(task, '__wrapped__', None)
+        if existing_fun is None or existing_fun is fun:
+            return
+        self._warn_duplicate_task_name(
+            name, qualname(existing_fun), qualname(fun),
+            'The new callable was not registered; calls under this name '
+            'reach the callable registered first.',
+        )
+
+    def _warn_duplicate_task_name(self, name, existing, new, consequence):
+        # one warning per name: a colliding name is a single mistake, and
+        # a test suite or module that trips it repeatedly should not bury
+        # everything else in output.
+        if name in self._duplicate_task_names_warned:
+            return
+        self._duplicate_task_names_warned.add(name)
+        warnings.warn(
+            DuplicateTaskNameWarning(
+                W_DUPTASK.format(name, existing, new, consequence),
+            ),
+            stacklevel=3,
+        )
 
     def gen_task_name(self, name, module):
         return gen_task_name(self, name, module)

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -112,6 +112,28 @@ decorator, or rename one of the callables.\
 """
 
 
+def caller_stacklevel():
+    """Depth of the first frame outside Celery, for :func:`warnings.warn`.
+
+    A task can be registered straight from the decorator or later, when a
+    :class:`~celery.local.PromiseProxy` is first evaluated, and those two
+    paths sit at different depths -- so the level is found rather than
+    assumed. Only reached when a warning is actually emitted.
+    """
+    frame, level = sys._getframe(1), 1
+    while frame is not None:
+        module = frame.f_globals.get('__name__', '')
+        if module != 'celery' and not module.startswith('celery.'):
+            return level
+        frame, level = frame.f_back, level + 1
+    return 2
+
+
+def task_callable_qualname(task):
+    """Name the callable behind *task*, decorated or class-based."""
+    return qualname(getattr(task, '_decorated_fun', None) or type(task))
+
+
 def app_has_custom(app, attr):
     """Return true if app has customized method `attr`.
 
@@ -623,6 +645,10 @@ class Celery:
     ):
         if not self.finalized and not self.autofinalize:
             raise RuntimeError('Contract breach: app not finalized')
+        # the callable as the caller passed it, kept before the pydantic
+        # rebind below and before ``run`` turns it into a descriptor, so
+        # that a re-registration can be recognised by identity.
+        decorated_fun = fun
         name = name or self.gen_task_name(fun.__name__, fun.__module__)
         base = base or self.Task
 
@@ -640,7 +666,8 @@ class Celery:
                 '__module__': fun.__module__,
                 '__annotations__': _get_annotations(fun),
                 '__header__': self.type_checker(fun, bound=bind),
-                '__wrapped__': run}, **options))()
+                '__wrapped__': run,
+                '_decorated_fun': staticmethod(decorated_fun)}, **options))()
             # for some reason __qualname__ cannot be set in type()
             # so we have to set it here.
             try:
@@ -652,7 +679,7 @@ class Celery:
             add_autoretry_behaviour(task, **options)
         else:
             task = self._tasks[name]
-            self._warn_if_duplicate_task_name(task, fun, name)
+            self._warn_if_duplicate_task_name(task, decorated_fun, name)
         return task
 
     def register_task(self, task, **options):
@@ -671,7 +698,8 @@ class Celery:
         existing = self.tasks.get(task.name)
         if existing is not None and existing is not task:
             self._warn_duplicate_task_name(
-                task.name, qualname(type(existing)), qualname(type(task)),
+                task.name, task_callable_qualname(existing),
+                task_callable_qualname(task),
                 'The new callable replaced the existing one; calls under this '
                 'name now reach the new callable.',
             )
@@ -687,8 +715,11 @@ class Celery:
         A module imported twice hands the same function object back, so
         identity -- not the name -- is what tells a re-registration apart
         from two distinct callables colliding under one generated name.
+        The comparison uses the callable as the caller passed it, since
+        ``__wrapped__`` holds ``run``, which is a bound method under
+        ``bind=True`` and the wrapper under ``pydantic=True``.
         """
-        existing_fun = getattr(task, '__wrapped__', None)
+        existing_fun = getattr(task, '_decorated_fun', None)
         if existing_fun is None or existing_fun is fun:
             return
         self._warn_duplicate_task_name(
@@ -698,9 +729,12 @@ class Celery:
         )
 
     def _warn_duplicate_task_name(self, name, existing, new, consequence):
-        # one warning per name: a colliding name is a single mistake, and
-        # a test suite or module that trips it repeatedly should not bury
-        # everything else in output.
+        # One warning per name. A colliding name is a single mistake, and
+        # a module or test suite that trips it repeatedly should not bury
+        # everything else in output. The set only grows, and a concurrent
+        # registration could race on this check and warn twice; both are
+        # accepted, as registration is an import-time, single-threaded
+        # activity and the cost of either is one extra line of output.
         if name in self._duplicate_task_names_warned:
             return
         self._duplicate_task_names_warned.add(name)
@@ -708,7 +742,7 @@ class Celery:
             DuplicateTaskNameWarning(
                 W_DUPTASK.format(name, existing, new, consequence),
             ),
-            stacklevel=3,
+            stacklevel=caller_stacklevel(),
         )
 
     def gen_task_name(self, name, module):

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -112,6 +112,12 @@ decorator, or rename one of the callables.\
 """
 
 
+def frame_is_celery(frame):
+    """Return true if *frame* is executing Celery's own code."""
+    module = frame.f_globals.get('__name__', '')
+    return module == 'celery' or module.startswith('celery.')
+
+
 def caller_stacklevel():
     """Depth of the first frame outside Celery, for :func:`warnings.warn`.
 
@@ -121,12 +127,9 @@ def caller_stacklevel():
     assumed. Only reached when a warning is actually emitted.
     """
     frame, level = sys._getframe(1), 1
-    while frame is not None:
-        module = frame.f_globals.get('__name__', '')
-        if module != 'celery' and not module.startswith('celery.'):
-            return level
+    while frame is not None and frame_is_celery(frame):
         frame, level = frame.f_back, level + 1
-    return 2
+    return level
 
 
 def task_callable_qualname(task):

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -42,6 +42,7 @@ Error Hierarchy
     - :class:`~celery.exceptions.CeleryWarning`
         - :class:`~celery.exceptions.AlwaysEagerIgnored`
         - :class:`~celery.exceptions.DuplicateNodenameWarning`
+        - :class:`~celery.exceptions.DuplicateTaskNameWarning`
         - :class:`~celery.exceptions.FixupWarning`
         - :class:`~celery.exceptions.NotConfigured`
         - :class:`~celery.exceptions.SecurityWarning`
@@ -62,7 +63,8 @@ __all__ = (
     # Warnings
     'CeleryWarning',
     'AlwaysEagerIgnored', 'DuplicateNodenameWarning',
-    'FixupWarning', 'NotConfigured', 'SecurityWarning',
+    'DuplicateTaskNameWarning', 'FixupWarning', 'NotConfigured',
+    'SecurityWarning',
 
     # Core errors
     'CeleryError',
@@ -120,6 +122,10 @@ class AlwaysEagerIgnored(CeleryWarning):
 
 class DuplicateNodenameWarning(CeleryWarning):
     """Multiple workers are using the same nodename."""
+
+
+class DuplicateTaskNameWarning(CeleryWarning):
+    """Multiple callables are registered under the same task name."""
 
 
 class FixupWarning(CeleryWarning):

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -7,6 +7,7 @@ import ssl
 import sys
 import typing
 import uuid
+import warnings
 from copy import deepcopy
 from datetime import datetime, timedelta
 from datetime import timezone as datetime_timezone
@@ -29,7 +30,7 @@ from celery.app import defaults
 from celery.app.amqp import AMQP
 from celery.backends.base import Backend
 from celery.contrib.testing.mocks import ContextMock
-from celery.exceptions import ImproperlyConfigured, OperationalError
+from celery.exceptions import DuplicateTaskNameWarning, ImproperlyConfigured, OperationalError
 from celery.loaders.base import unconfigured
 from celery.platforms import pyimplementation
 from celery.utils.collections import DictAttribute
@@ -146,6 +147,101 @@ class test_App:
         setup_security.assert_called_with(
             {'json'}, 'key', None, 'cert', 'store', 'digest', 'serializer',
             app=self.app)
+
+    def test_duplicate_task_name_warns__closure(self):
+        """Two closures share __name__, __qualname__ and __code__."""
+        def make_scaler(factor):
+            @self.app.task(shared=False)
+            def scale(x):
+                return x * factor
+            return scale
+
+        with pytest.warns(DuplicateTaskNameWarning) as w:
+            double, triple = make_scaler(2), make_scaler(3)
+            assert double.name == triple.name
+
+        assert double.name in str(w[0].message)
+
+    def test_duplicate_task_name_warns__same_method_name(self):
+        with pytest.warns(DuplicateTaskNameWarning):
+            class Alpha:
+                @staticmethod
+                @self.app.task(shared=False)
+                def handler(x):
+                    return 'alpha'
+
+            class Beta:
+                @staticmethod
+                @self.app.task(shared=False)
+                def handler(x):
+                    return 'beta'
+
+            assert Alpha.handler.name == Beta.handler.name
+
+    def test_duplicate_task_name_warns__register_task(self):
+        from celery.app.task import Task
+
+        class T1(Task):
+            name = 'dup'
+
+            def run(self, x):
+                return 'first'
+
+        class T2(Task):
+            name = 'dup'
+
+            def run(self, x):
+                return 'second'
+
+        self.app.register_task(T1())
+        with pytest.warns(DuplicateTaskNameWarning) as w:
+            self.app.register_task(T2())
+        assert 'replaced' in str(w[0].message)
+
+    def test_duplicate_task_name_silent__explicit_names(self):
+        """Negative control: distinct explicit names must not warn."""
+        def make_scaler(factor):
+            @self.app.task(name=f'scale{factor}', shared=False)
+            def scale(x):
+                return x * factor
+            return scale
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            double, triple = make_scaler(2), make_scaler(3)
+            assert double.name != triple.name
+        assert not [x for x in w
+                    if isinstance(x.message, DuplicateTaskNameWarning)]
+
+    def test_duplicate_task_name_silent__distinct_names(self):
+        """Negative control (near miss): only __name__ differs."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
+            @self.app.task(shared=False)
+            def scale_a(x):
+                return x * 2
+
+            @self.app.task(shared=False)
+            def scale_b(x):
+                return x * 3
+
+            assert scale_a.name != scale_b.name
+        assert not [x for x in w
+                    if isinstance(x.message, DuplicateTaskNameWarning)]
+
+    def test_duplicate_task_name_silent__same_function_twice(self):
+        """Negative control: a re-imported module yields the same object."""
+        def plain(x):
+            return x
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            first = self.app._task_from_fun(plain)
+            second = self.app._task_from_fun(plain)
+            assert first is second
+        assert not [x for x in w
+                    if isinstance(x.message, DuplicateTaskNameWarning)]
 
     def test_task_autofinalize_disabled(self):
         with self.Celery('xyzibari', autofinalize=False) as app:

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -19,7 +19,9 @@ from unittest.mock import ANY, DEFAULT, MagicMock, Mock, patch
 import pytest
 from kombu import Exchange, Queue
 from kombu.exceptions import LimitExceeded
-from pydantic import BaseModel, ValidationInfo, model_validator
+from pydantic import BaseModel
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ValidationInfo, model_validator
 from vine import promise
 
 from celery import Celery, _state
@@ -229,6 +231,63 @@ class test_App:
             assert scale_a.name != scale_b.name
         assert not [x for x in w
                     if isinstance(x.message, DuplicateTaskNameWarning)]
+
+    def test_duplicate_task_name_silent__same_function_twice_bound(self):
+        """Negative control: ``run`` is a bound method under bind=True."""
+        def plain(x):
+            return x
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            first = self.app._task_from_fun(plain, bind=True)
+            second = self.app._task_from_fun(plain, bind=True)
+            assert first is second
+        assert not [x for x in w
+                    if isinstance(x.message, DuplicateTaskNameWarning)]
+
+    def test_duplicate_task_name_silent__same_function_twice_pydantic(self):
+        """Negative control: ``fun`` is rebound by the pydantic wrapper."""
+        class Args(PydanticBaseModel):
+            x: int
+
+        def pydantic_fun(args: Args):
+            return args.x
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            first = self.app._task_from_fun(pydantic_fun, pydantic=True)
+            second = self.app._task_from_fun(pydantic_fun, pydantic=True)
+            assert first is second
+        assert not [x for x in w
+                    if isinstance(x.message, DuplicateTaskNameWarning)]
+
+    def test_duplicate_task_name_warns__bound_closures(self):
+        """bind=True must still detect two distinct callables."""
+        def make_scaler(factor):
+            @self.app.task(shared=False, bind=True)
+            def scale(self, x):
+                return x * factor
+            return scale
+
+        with pytest.warns(DuplicateTaskNameWarning):
+            double, triple = make_scaler(2), make_scaler(3)
+            assert double.name == triple.name
+
+    def test_duplicate_task_name_warning_points_at_the_caller(self):
+        """The warning must name the caller's frame, not celery's."""
+        def make_scaler(factor):
+            @self.app.task(shared=False)
+            def scale(x):
+                return x * factor
+            return scale
+
+        with pytest.warns(DuplicateTaskNameWarning) as w:
+            double, triple = make_scaler(2), make_scaler(3)
+            assert double.name == triple.name
+
+        assert not w[0].filename.endswith(
+            os.path.join('celery', 'app', 'base.py'))
+        assert w[0].filename == __file__
 
     def test_duplicate_task_name_silent__same_function_twice(self):
         """Negative control: a re-imported module yields the same object."""

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -200,6 +200,68 @@ class test_App:
             self.app.register_task(T2())
         assert 'replaced' in str(w[0].message)
 
+    def test_duplicate_task_name_warns_once_per_name(self):
+        """A third callable under the same name must not warn again."""
+        def make_scaler(factor):
+            @self.app.task(shared=False)
+            def scale(x):
+                return x * factor
+            return scale
+
+        with pytest.warns(DuplicateTaskNameWarning) as w:
+            first, second = make_scaler(2), make_scaler(3)
+            assert first.name == second.name
+
+        with warnings.catch_warnings(record=True) as again:
+            warnings.simplefilter('always')
+            third = make_scaler(4)
+            assert third.name == first.name
+        assert len(w) == 1
+        assert not [x for x in again
+                    if isinstance(x.message, DuplicateTaskNameWarning)]
+
+    def test_duplicate_task_name_silent__no_recorded_callable(self):
+        """A task registered by class carries no callable to compare."""
+        from celery.app.task import Task
+
+        class T(Task):
+            name = 'shared.name'
+
+            def run(self, x):
+                return x
+
+        self.app.register_task(T())
+
+        def other(x):
+            return x
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            task = self.app._task_from_fun(other, name='shared.name')
+            assert task.name == 'shared.name'
+        assert not [x for x in w
+                    if isinstance(x.message, DuplicateTaskNameWarning)]
+
+    def test_duplicate_task_name_register_task_names_the_function(self):
+        """register_task reports a decorated task by its function."""
+        @self.app.task(name='taken.name', shared=False)
+        def decorated(x):
+            return x
+
+        assert decorated.name == 'taken.name'
+
+        from celery.app.task import Task
+
+        class T(Task):
+            name = 'taken.name'
+
+            def run(self, x):
+                return x
+
+        with pytest.warns(DuplicateTaskNameWarning) as w:
+            self.app.register_task(T())
+        assert 'decorated' in str(w[0].message)
+
     def test_duplicate_task_name_silent__explicit_names(self):
         """Negative control: distinct explicit names must not warn."""
         def make_scaler(factor):


### PR DESCRIPTION
Closes #10576.

## What this does

A task's registered name is `f"{fun.__module__}.{fun.__name__}"`, so two distinct callables that share `__name__` inside one module collapse into a single registered task. The caller of the second one gets `SUCCESS` and the **first** function's result, and neither registration path says anything.

Task names are the wire format — they appear in messages, `task_routes`, beat schedules and monitoring — so **this changes no names**. It only makes the collapse audible, next to the `DuplicateNodenameWarning` that already covers the same class of mistake for node names:

- `DuplicateTaskNameWarning`, in the `CeleryWarning` tree, mirroring `DuplicateNodenameWarning` and `W_DUPNODE`.
- **Both** registration paths report, and each states its own outcome: the decorator path keeps the **first** callable, `register_task` replaces with the **last**. (That disagreement is the second half of the issue; this makes it visible rather than choosing a winner — happy to unify if you would rather, but that is a behaviour change and seemed yours to make.)
- The colliding callables are named with `celery.utils.imports.qualname()` — the helper that lives 94 lines above `gen_task_name` in the same module, and already prefers `__qualname__`. `Backend.prepare_exception` makes the same choice for exception types on the wire.
- One warning per name per app.

## Why identity, not the name

Detection compares the **function object**, not the name. Two closures from one factory share `__name__`, `__qualname__` **and** `__code__`, so no name-based test separates them; a module imported twice hands back the same function object. Object identity is the only thing that tells a re-registration apart from a real collision — the same distinction `DBOS.register_class` makes with `is not cls`.

## Tests

Six tests in `t/unit/app/test_app.py`, in the shape of `test_control.py::test_flatten_reply`:

- closures sharing `__name__`/`__qualname__`/`__code__`
- two classes with same-named methods
- the `register_task` path
- **negative control**: distinct explicit `name=`
- **negative control** (the near miss): identical factory shape, only `__name__` differs
- **negative control**: the *same* function registered twice, i.e. the re-import shape

`t/unit/app` + `t/unit/tasks`: 1699 passed, 0 failed. `flake8` and `isort` clean with your `setup.cfg`.

## Two things you should know before reviewing

**1. Your suite trips this 113 times, and they are real collisions.** Inside `t/unit/tasks/test_trace.py`, `TraceCase.setup_method` registers `add`, and 100+ tests then define their own local `add` in the same module. Celery keeps the first, so the "fresh" task each test believes it created is the fixture's task. I verified the consequence rather than assuming it: mutations such as `add.acks_late = True` land on `self.add` (`mutation visible on self.add -> True`). The tests pass, but the isolation is not there. I have **not** touched your suite — the fix could be explicit `name=`, or nothing at all, and that call is yours. If the output volume is the blocker, say so and I will adjust.

**2. No CI breakage, and one number in the issue thread was mine.** I first ran the full unit suite with `-W error::celery.exceptions.DuplicateTaskNameWarning` and saw 30 failures. That flag was **mine**, not yours: there is no `filterwarnings` in `setup.cfg`/`pyproject.toml` and no `-W error` in the workflows, so the warning does not fail your build.

## Scope

Python only. I did not change which callable survives, add a setting, or touch name generation. Reachability is a `__name__` collision within one module — closures from a factory, same-named methods on two classes, or two same-named functions.

If any of this was raised before, point me at the existing PR and I will close this in favour of it.
