### PR TITLE
Deny access to private attributes and dunders via registered()

### DIFF
--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -475,6 +475,8 @@ def registered(state, taskinfoitems=None, builtins=False, **kwargs):
     """
     reg = state.app.tasks
     taskinfoitems = taskinfoitems or DEFAULT_TASK_INFO_ITEMS
+    taskinfoitems = [item for item in taskinfoitems
+                     if isinstance(item, str) and not item.startswith('_')]
 
     tasks = reg if builtins else (
         task for task in reg if not task.startswith('celery.'))

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -375,6 +375,46 @@ class test_ControlPanel:
         finally:
             control.DEFAULT_TASK_INFO_ITEMS = prev
 
+    def test_dump_tasks_allows_public_attributes(self):
+        # public Task attributes (incl. non-defaults) remain available --
+        # this is the documented `registered('serializer', 'max_retries')`
+        # contract.
+        info = '\n'.join(self.panel.handle(
+            'dump_tasks',
+            arguments={'taskinfoitems': ['rate_limit', 'max_retries']}))
+        assert 'rate_limit=200' in info
+        assert 'max_retries=3' in info
+
+    def test_dump_tasks_rejects_dunder_attributes(self):
+        # a dunder such as __dict__ would otherwise bulk-dump every instance
+        # attribute; private/dunder names must be refused.
+        self.mytask.injected_secret = 'TOPSECRET'
+        info = '\n'.join(self.panel.handle(
+            'dump_tasks', arguments={'taskinfoitems': ['__dict__']}))
+        assert '__dict__' not in info
+        assert 'TOPSECRET' not in info
+
+    def test_dump_tasks_does_not_read_private_attributes(self):
+        # a private (underscore-prefixed) name must not reach getattr, so a
+        # side-effecting private property getter is never invoked.
+        from celery import Task
+        fired = []
+
+        class LeakyTask(Task):
+            @property
+            def _evil(self):
+                fired.append(True)
+                return 'leaked'
+
+        @self.app.task(base=LeakyTask, name='c.unittest.leaky', shared=False)
+        def leaky():
+            pass
+
+        info = '\n'.join(self.panel.handle(
+            'dump_tasks', arguments={'taskinfoitems': ['_evil']}))
+        assert fired == []
+        assert 'leaked' not in info
+
     def test_stats(self):
         prev_count, worker_state.total_count = worker_state.total_count, 100
         try:


### PR DESCRIPTION
## Description

The `Inspect.registered()` method ([docs](https://docs.celeryq.dev/en/latest/reference/celery.app.control.html#celery.app.control.Inspect.registered)) allows specifying, via `taskinfoitems`, the Task attributes to include in the response.

A possibly undesired side effect is that private attributes and dunders can also be accessed this way. For instance, requesting `__dict__` dumps all of a task's instance attributes, which — in the case of a custom `Task` subclass — could include sensitive values.

## Remediation

This PR filters out names beginning with `_` in the worker-side `registered` control handler (`celery/worker/control.py`). Public attributes remain accessible, so the documented `registered('serializer', 'max_retries')` usage is unaffected; this is the least invasive change that keeps the command out of object internals without breaking ergonomics. Unit tests included.
