### PR TITLE
Honor zero timeouts in the result drainer

### DIFF
--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -254,7 +254,10 @@ class AsyncBackendMixin:
                     yield node.id, node._cache
         while bucket:
             node = bucket.popleft()
-            yield node.id, node._cache
+            if not hasattr(node, '_cache'):
+                yield node.id, node.children
+            else:
+                yield node.id, node._cache
 
     def add_pending_result(self, result, weak=False, start_drainer=True):
         if start_drainer:

--- a/celery/backends/asynchronous.py
+++ b/celery/backends/asynchronous.py
@@ -80,9 +80,10 @@ class Drainer:
         wait = wait or self.result_consumer.drain_events
         time_start = time.monotonic()
 
-        while 1:
+        # Ready results take precedence over an exhausted timeout.
+        while not p.ready:
             # Total time spent may exceed a single call to wait()
-            if timeout and time.monotonic() - time_start >= timeout:
+            if timeout is not None and time.monotonic() - time_start >= timeout:
                 raise socket.timeout()
             try:
                 yield self.wait_for(p, wait, timeout=interval)
@@ -102,8 +103,6 @@ class Drainer:
 
             if on_interval:
                 on_interval()
-            if p.ready:  # got event on the wanted channel.
-                break
 
     def wait_for(self, p, wait, timeout=None):
         wait(timeout=timeout)

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1184,6 +1184,32 @@ class test_result_set:
         assert rs.get(timeout=TIMEOUT) == [2, 4]
 
     @flaky
+    def test_join_exhausted_timeout(self, manager):
+        """A spent positive join budget must not become an unlimited wait."""
+        if not manager.app.conf.result_backend.startswith(('redis', 'rpc')):
+            raise pytest.skip('Requires redis or rpc result backend.')
+
+        assert_ping(manager)
+
+        # Simulate taking 0.3s to handle the first result, exhausting
+        # the 0.2s join timeout before waiting for the second task.
+        completed = add.delay(1, 1)
+        completed.get(timeout=TIMEOUT)
+        rs = ResultSet([completed, delayed_sum.delay([2, 2], pause_time=2)])
+        received = []
+
+        def collect(task_id, value):
+            received.append((task_id, value))
+            sleep(0.3)
+
+        try:
+            with pytest.raises(TimeoutError):
+                rs.join(timeout=0.2, callback=collect)
+            assert received == [(completed.id, 2)]
+        finally:
+            rs.get(timeout=TIMEOUT)
+
+    @flaky
     def test_join_native_timeout_zero_gives_up_on_pending_results(self, manager):
         """timeout=0 means poll once, not poll until the results show up."""
         if not isinstance(manager.app.backend, BaseKeyValueStoreBackend):

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -55,6 +55,24 @@ class test_Drainer_without_greenlets:
         assert p.ready
         assert calls[0] >= 3
 
+    def test_drain_times_out_immediately_when_timeout_is_zero(self, app):
+        drainer = _make_consumer(app).drainer
+        p = promise()
+        wait = Mock()
+
+        with pytest.raises(socket.timeout):
+            list(drainer.drain_events_until(p, timeout=0, wait=wait))
+        wait.assert_not_called()
+
+    def test_drain_returns_immediately_when_result_is_ready(self, app):
+        drainer = _make_consumer(app).drainer
+        p = promise()
+        p('done')
+        wait = Mock()
+
+        list(drainer.drain_events_until(p, timeout=0, wait=wait))
+        wait.assert_not_called()
+
     def test_drain_calls_on_interval(self, app):
         """on_interval callback is invoked every iteration."""
         consumer = _make_consumer(app)

--- a/t/unit/backends/test_asynchronous.py
+++ b/t/unit/backends/test_asynchronous.py
@@ -9,8 +9,10 @@ from unittest.mock import Mock, patch
 import pytest
 from vine import promise
 
+from celery import chain, group
 from celery.backends.asynchronous import E_CELERY_RESTART_REQUIRED, BaseResultConsumer, greenletDrainer
 from celery.backends.base import Backend
+from celery.backends.rpc import RPCBackend
 from celery.utils import cached_property
 
 # ---- helpers ---------------------------------------------------------------
@@ -729,3 +731,24 @@ class test_BaseResultConsumer_reconnect:
         consumer = self._make_consumer(app)
 
         assert consumer._reconnect() is None
+
+
+class test_AsyncBackendMixin:
+
+    @pytest.mark.parametrize('timeout', [0, 10])
+    def test_join_native_with_ready_nested_group(self, app, timeout):
+        # An already-ready group skips event draining; native joining must
+        # still return its nested results.
+        app._backend = RPCBackend(app)
+
+        header = group(
+            self.add.si(1, 100),
+            chain(
+                group(self.add.si(1, 1000), self.add.si(1, 2000)),
+                app=app,
+            ),
+        )
+        result = header.apply()
+
+        result.on_ready()
+        assert result.join_native(timeout=timeout) == [101, [1001, 2001]]


### PR DESCRIPTION
## Description

`Drainer.drain_events_until()` treats `timeout=0` as unlimited waiting. Since #10487, ResultSet.join() passes 0 after exhausting its timeout, which can cause it to wait indefinitely.
https://github.com/celery/celery/blob/918a740497a4ce883f37eb1a3e7c2a80dfcc8b7a/celery/result.py#L813-L815

This PR changes the timeout check to treat only `None` as unlimited. It also checks readiness first so already-ready results finish without waiting or raising a timeout.