### PR TITLE
Include _keys in ConfigurationView.swap_with()

### DIFF
--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -434,6 +434,7 @@ class ConfigurationView(ChainMap, AttributeDictMixin):
             defaults=defaults,
             key_t=other.__dict__['key_t'],
             prefix=other.__dict__['prefix'],
+            _keys=other.__dict__['_keys'],
             maps=[changes] + defaults
         )
 

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -8,6 +8,7 @@ import pytest
 from billiard.einfo import ExceptionInfo
 
 import t.skip
+from celery.app.utils import _new_key_to_old, _old_key_to_new
 from celery.utils.collections import (AttributeDict, BufferMap, ChainMap, ConfigurationView, DictAttribute,
                                       LimitedSet, Messagebuffer)
 from celery.utils.objects import Bunch
@@ -84,6 +85,17 @@ class test_ConfigurationView:
         changes = dict(self.view.changes)
         self.view.update(a=1, b=2, c=3)
         assert self.view.changes == dict(changes, a=1, b=2, c=3)
+
+    def test_swap_with_keys(self):
+        view = ConfigurationView({})
+        other = ConfigurationView(
+            {'task_always_eager': 1},
+            keys=(_old_key_to_new, _new_key_to_old),
+        )
+        assert other['CELERY_ALWAYS_EAGER'] == 1
+
+        view.swap_with(other)
+        assert view['CELERY_ALWAYS_EAGER'] == 1
 
     def test_contains(self):
         assert 'changed_key' in self.view


### PR DESCRIPTION
## Description
`ConfigurationView.swap_with()` copies the mappings, prefix, and key_t, but leaves `_keys` unchanged. When the two views use different converters, a key that works on the source view can fail after the swap.

This PR copies `_keys` too.
