### PR TITLE
Allow crontab to correctly handle daylight switching time (correct fork...)

### DIFF
--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -500,7 +500,7 @@ class crontab(BaseSchedule):
         super().__init__(**state)
         self._orig_kwargs = dict(state)
 
-    def _next_occurence(self, current: datetime) -> datetime:
+    def _next_occurrence(self, current: datetime) -> datetime:
         """returns the date of next crontab execution after given current date.
 
         The returned date is timezone aware and uses the same timezone as the given
@@ -644,7 +644,7 @@ class crontab(BaseSchedule):
         last_run_at = self.maybe_make_aware(last_run_at).astimezone(schedule_tz)
         now = self.maybe_make_aware(self.now()).astimezone(schedule_tz)
 
-        _next = self._next_occurence(last_run_at)
+        _next = self._next_occurrence(last_run_at)
         delta = ffwd(
             year=_next.year if last_run_at.year != _next.year else None,
             month=_next.month if last_run_at.month != _next.month else None,
@@ -672,7 +672,7 @@ class crontab(BaseSchedule):
         last_run_at = self.maybe_make_aware(last_run_at).astimezone(schedule_tz)
         now = self.maybe_make_aware(self.now()).astimezone(schedule_tz)
 
-        next_run_at = self._next_occurence(last_run_at)
+        next_run_at = self._next_occurrence(last_run_at)
 
         if C_REMDEBUG:  # pragma: no cover
             print(

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -521,11 +521,10 @@ class crontab(BaseSchedule):
             """
             sorted_month_of_year = sorted(self.month_of_year)
             sorted_day_of_month = sorted(self.day_of_month)
-            # we cannot have more than 8 years between 2 leap years
-            # which should be the biggest possible gap between 2 runs
-            # (this is technically false if a day_of_week constraint is added to a
-            # crontab specifying month=2 day=29...)
-            for y in range(start.year, start.year + 8):
+
+            # 50 years search should above possible time between 2 leap days
+            # with day of week specified in the crontab
+            for y in range(start.year, start.year + 50):
                 for m in [
                     _m for _m in sorted_month_of_year
                     if y != start.year or _m >= start.month

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -550,9 +550,9 @@ class crontab(BaseSchedule):
             """
             original_day = d.day
             d = d.replace(minute=0)
-            # we should never try more than 25 hours for a complete day
-            # (24h + 1 potential duplicated hour during dst time shift)
-            for _ in range(25 - d.hour):
+            # we should never try more than 24 hours for a complete day
+            # (23h til last hour + 1 potential duplicated hour during dst time end)
+            for _ in range(24 - d.hour):
                 d = _move_forward(d, timedelta(hours=1))
                 # resolve time that do not exist in current timezone
                 # and move to next possible time

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -551,18 +551,16 @@ class crontab(BaseSchedule):
             We use a simple loop over the hours here to correctly handle DST changes.
             """
             original_day = d.day
-            d = d.replace(minute=0)
             # we should never try more than 24 hours for a complete day
             # (23h til last hour + 1 potential duplicated hour during dst time end)
             for _ in range(24 - d.hour):
-                d = _move_forward(d, timedelta(hours=1))
+                d = _move_forward(d, timedelta(minutes=60 - d.minute))
                 # resolve time that do not exist in current timezone
-                # and move to next possible time
-                d = resolve_imaginary(d)
+                # d = resolve_imaginary(d)
                 # check if this can make us change the day and get out if it does
                 if original_day != d.day:
                     return
-                if d.hour in self.hour:
+                if d.hour in self.hour and any(True for m in self.minute if m >= d.minute):
                     yield d
 
         def _has_run_hours_after(d: datetime) -> bool:
@@ -603,7 +601,10 @@ class crontab(BaseSchedule):
 
         # first we do a quick check on current day
         if _may_run_today:
-            _may_run_this_hour = candidate.hour in self.hour and any(m for m in self.minute if m > candidate.minute)
+            _may_run_this_hour = (
+                candidate.hour in self.hour
+                and any(True for m in self.minute if m > candidate.minute)
+            )
             if _may_run_this_hour:
                 # if there are slots later this hour, we can safely add one minute with worrying about hour change.
                 # the search for a correct minute will happen right after

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -541,7 +541,9 @@ class crontab(BaseSchedule):
                             continue
                         # check if we have constraint on day of week
                         if not _crontab_has_day_of_week or new_date.isoweekday() % 7 in self.day_of_week:
-                            yield new_date
+                            # at dst start for timezone that trigger the change at midnight,
+                            # we could be generating a non existent date
+                            yield resolve_imaginary(new_date)
 
         def _generate_run_hours_after(d: datetime) -> Generator[datetime]:
             """yields candidate hours for task execution.

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -2,20 +2,19 @@
 from __future__ import annotations
 
 import re
-from bisect import bisect, bisect_left
 from collections import namedtuple
 from datetime import datetime, timedelta, tzinfo
-from typing import Any, Callable, Iterable, Mapping, Sequence, Union
+from typing import Any, Callable, Generator, Iterable, Mapping, Sequence, Union
 
+from dateutil.tz import resolve_imaginary
 from kombu.utils.objects import cached_property
 
 from celery import Celery
 
 from . import current_app
 from .exceptions import ImproperlyConfigured
-from .utils.collections import AttributeDict
-from .utils.time import (ffwd, humanize_seconds, localize, maybe_make_aware, maybe_timedelta, remaining, timezone,
-                         weekday, yearmonth)
+from .utils.time import (C_REMDEBUG, ffwd, humanize_seconds, localize, maybe_make_aware, maybe_timedelta, remaining,
+                         timezone, weekday, yearmonth)
 
 __all__ = (
     'ParseException', 'schedule', 'crontab', 'crontab_parser',
@@ -485,83 +484,6 @@ class crontab(BaseSchedule):
                     min=min_, max=max_ - 1 + min_, value=number))
         return result
 
-    def _delta_to_next(self, last_run_at: datetime, next_hour: int,
-                       next_minute: int) -> ffwd:
-        """Find next delta.
-
-        Takes a :class:`~datetime.datetime` of last run, next minute and hour,
-        and returns a :class:`~celery.utils.time.ffwd` for the next
-        scheduled day and time.
-
-        Only called when ``day_of_month`` and/or ``month_of_year``
-        cronspec is specified to further limit scheduled task execution.
-        """
-        datedata = AttributeDict(year=last_run_at.year)
-        days_of_month = sorted(self.day_of_month)
-        months_of_year = sorted(self.month_of_year)
-
-        def day_out_of_range(year: int, month: int, day: int) -> bool:
-            try:
-                datetime(year=year, month=month, day=day)
-            except ValueError:
-                return True
-            return False
-
-        def is_before_last_run(year: int, month: int, day: int) -> bool:
-            return self.maybe_make_aware(
-                datetime(year, month, day, next_hour, next_minute),
-                naive_as_utc=False) < last_run_at
-
-        def roll_over() -> None:
-            for _ in range(2000):
-                flag = (datedata.dom == len(days_of_month) or
-                        day_out_of_range(datedata.year,
-                                         months_of_year[datedata.moy],
-                                         days_of_month[datedata.dom]) or
-                        (is_before_last_run(datedata.year,
-                                            months_of_year[datedata.moy],
-                                            days_of_month[datedata.dom])))
-
-                if flag:
-                    datedata.dom = 0
-                    datedata.moy += 1
-                    if datedata.moy == len(months_of_year):
-                        datedata.moy = 0
-                        datedata.year += 1
-                else:
-                    break
-            else:
-                # Tried 2000 times, we're most likely in an infinite loop
-                raise RuntimeError('unable to rollover, '
-                                   'time specification is probably invalid')
-
-        if last_run_at.month in self.month_of_year:
-            datedata.dom = bisect(days_of_month, last_run_at.day)
-            datedata.moy = bisect_left(months_of_year, last_run_at.month)
-        else:
-            datedata.dom = 0
-            datedata.moy = bisect(months_of_year, last_run_at.month)
-            if datedata.moy == len(months_of_year):
-                datedata.moy = 0
-        roll_over()
-
-        while 1:
-            th = datetime(year=datedata.year,
-                          month=months_of_year[datedata.moy],
-                          day=days_of_month[datedata.dom])
-            if th.isoweekday() % 7 in self.day_of_week:
-                break
-            datedata.dom += 1
-            roll_over()
-
-        return ffwd(year=datedata.year,
-                    month=months_of_year[datedata.moy],
-                    day=days_of_month[datedata.dom],
-                    hour=next_hour,
-                    minute=next_minute,
-                    second=0,
-                    microsecond=0)
-
     def __repr__(self) -> str:
         return CRON_REPR.format(self)
 
@@ -578,6 +500,135 @@ class crontab(BaseSchedule):
         super().__init__(**state)
         self._orig_kwargs = dict(state)
 
+    def _next_occurence(self, current: datetime) -> datetime:
+        """returns the date of next crontab execution after given current date.
+
+        The returned date is timezone aware and uses the same timezone as the given
+        `current` parameter.
+        """
+        # copy the date and stick seconds/microseconds to 0 to match crontab precision
+        candidate = current.replace(second=0, microsecond=0)
+        _crontab_has_day_of_week = len(self.day_of_week) < 7
+
+        def _generate_run_days_after(start: datetime) -> Generator[datetime]:
+            """yields candidate days for task execution after the current date.
+
+            We iterate on each possible days after the current one according to crontab resolution.
+            This is done by iterating only on months and days the crontab considers as valid.
+
+            The iteration runs on 8 years after current to deal with leap days but except
+            for a crontab(month_of_year=2, day_of_month=29) we should never need that much iteration.
+            """
+            sorted_month_of_year = sorted(self.month_of_year)
+            sorted_day_of_month = sorted(self.day_of_month)
+            # we cannot have more than 8 years between 2 leap years
+            # which should be the biggest possible gap between 2 runs
+            # (this is technically false if a day_of_week constraint is added to a
+            # crontab specifying month=2 day=29...)
+            for y in range(start.year, start.year + 8):
+                for m in [
+                    _m for _m in sorted_month_of_year
+                    if y != start.year or _m >= start.month
+                ]:
+                    for d in [
+                        _d for _d in sorted_day_of_month
+                        if y != start.year or m != start.month or _d > start.day
+                    ]:
+                        try:
+                            new_date = datetime(y, m, d, tzinfo=start.tzinfo)
+                        except ValueError:
+                            # feb 29th on non leap year and 31st on month with 30 days will raise an exception
+                            continue
+                        # check if we have constraint on day of week
+                        if not _crontab_has_day_of_week or new_date.isoweekday() % 7 in self.day_of_week:
+                            yield new_date
+
+        def _generate_run_hours_after(d: datetime) -> Generator[datetime]:
+            """yields candidate hours for task execution.
+
+            We use a simple loop over the hours here to correctly handle DST changes.
+            """
+            original_day = d.day
+            d = d.replace(minute=0)
+            # we should never try more than 25 hours for a complete day
+            # (24h + 1 potential duplicated hour during dst time shift)
+            for _ in range(25 - d.hour):
+                d = _move_forward(d, timedelta(hours=1))
+                # resolve time that do not exist in current timezone
+                # and move to next possible time
+                d = resolve_imaginary(d)
+                # check if this can make us change the day and get out if it does
+                if original_day != d.day:
+                    return
+                if d.hour in self.hour:
+                    yield d
+
+        def _has_run_hours_after(d: datetime) -> bool:
+            """Is there any possibility for the task to run on that day ?
+
+            This takes timezone time shifting in consideration because, on a given day,
+            a certain times may not exist (when clock moves forward).
+            """
+            try:
+                next(_generate_run_hours_after(d))
+            except StopIteration:
+                return False
+            return True
+
+        def _get_next_run_hour(d: datetime) -> datetime:
+            """
+            returns the date with hour set to next execution, with minute reset to 0.
+
+            We iterate on hours one by one here to handle DST shift in the middle
+            of the day that will make an hour appear twice or disappear.
+            """
+            return next(_generate_run_hours_after(d))
+
+        def _get_run_minute(d: datetime) -> datetime:
+            """returns the date with minute set to next execution."""
+            next_minute = min(m for m in self.minute if m >= d.minute)
+            return _move_forward(d, timedelta(minutes=next_minute - d.minute))
+
+        def _move_forward(d: datetime, delta: timedelta) -> datetime:
+            """apply delta to d using constant (UTC) time."""
+            return (d.astimezone(timezone.utc) + delta).astimezone(d.tzinfo)
+
+        _may_run_today = (
+            candidate.month in self.month_of_year
+            and candidate.day in self.day_of_month
+            and candidate.isoweekday() % 7 in self.day_of_week
+        )
+
+        # first we do a quick check on current day
+        if _may_run_today:
+            _may_run_this_hour = candidate.hour in self.hour and any(m for m in self.minute if m > candidate.minute)
+            if _may_run_this_hour:
+                # if there are slots later this hour, we can safely add one minute with worrying about hour change.
+                # the search for a correct minute will happen right after
+                candidate = _move_forward(candidate, timedelta(minutes=1))
+                return _get_run_minute(candidate)
+
+            if _has_run_hours_after(candidate):
+                # no more slots, go to the start of next hour
+                # candidate = _move_forward(candidate, timedelta(hours=1)).replace(minute=0)
+                candidate = _get_next_run_hour(candidate)
+                return _get_run_minute(candidate)
+
+            # in the end we did not find a slot that day (DST start day where an hour disappears, or just end of day)
+
+        # no possible run on current day, we look for another one
+        for _candidate in _generate_run_days_after(candidate):
+            _can_run_this_hour = _candidate.hour in self.hour
+            if _can_run_this_hour:
+                return _get_run_minute(_candidate)
+
+            if _has_run_hours_after(_candidate):
+                _candidate = _get_next_run_hour(_candidate)
+                _candidate = _get_run_minute(_candidate)
+                return _candidate
+
+        raise RuntimeError(f"unable to find a next occurrence for crontab {self}, start from {current}")
+
     def remaining_delta(self, last_run_at: datetime,
                         tz: str | tzinfo | None = None,
                         ffwd: type = ffwd) -> tuple[datetime, Any, datetime]:
@@ -589,69 +640,61 @@ class crontab(BaseSchedule):
         # in a different timezone (e.g. from django-celery-beat).
         last_run_at = self.maybe_make_aware(last_run_at).astimezone(schedule_tz)
         now = self.maybe_make_aware(self.now()).astimezone(schedule_tz)
-        dow_num = last_run_at.isoweekday() % 7  # Sunday is day 0, not day 7
 
-        execute_this_date = (
-            last_run_at.month in self.month_of_year and
-            last_run_at.day in self.day_of_month and
-            dow_num in self.day_of_week
+        _next = self._next_occurence(last_run_at)
+        delta = ffwd(
+            year=_next.year if last_run_at.year != _next.year else None,
+            month=_next.month if last_run_at.month != _next.month else None,
+            day=_next.day if last_run_at.day != _next.day else None,
+            hour=_next.hour,
+            minute=_next.minute,
+            second=0,
+            microsecond=0
         )
-
-        execute_this_hour = (
-            execute_this_date and
-            last_run_at.hour in self.hour and
-            last_run_at.minute < max(self.minute)
-        )
-
-        if execute_this_hour:
-            next_minute = min(minute for minute in self.minute
-                              if minute > last_run_at.minute)
-            delta = ffwd(minute=next_minute, second=0, microsecond=0)
-        else:
-            next_minute = min(self.minute)
-            execute_today = (execute_this_date and
-                             last_run_at.hour < max(self.hour))
-
-            if execute_today:
-                next_hour = min(hour for hour in self.hour
-                                if hour > last_run_at.hour)
-                delta = ffwd(hour=next_hour, minute=next_minute,
-                             second=0, microsecond=0)
-            else:
-                next_hour = min(self.hour)
-                all_dom_moy = (self._orig_day_of_month == '*' and
-                               self._orig_month_of_year == '*')
-                if all_dom_moy:
-                    next_day = min([day for day in self.day_of_week
-                                    if day > dow_num] or self.day_of_week)
-                    add_week = next_day == dow_num
-
-                    delta = ffwd(
-                        weeks=add_week and 1 or 0,
-                        weekday=(next_day - 1) % 7,
-                        hour=next_hour,
-                        minute=next_minute,
-                        second=0,
-                        microsecond=0,
-                    )
-                else:
-                    delta = self._delta_to_next(last_run_at,
-                                                next_hour, next_minute)
         return last_run_at, delta, now
 
     def remaining_estimate(
             self, last_run_at: datetime, ffwd: type = ffwd) -> timedelta:
-        """Estimate of next run time.
+        """Estimate of next run time as a timedelta.
+
+        Computed as the difference between next run date and now in UTC to ensure
+        we get the real time difference, not impacted by timezone with DST switch.
 
         Returns when the periodic task should run next as a
         :class:`~datetime.timedelta`.
         """
         # pylint: disable=redefined-outer-name
         # caching global ffwd
-        return remaining(*self.remaining_delta(last_run_at, ffwd=ffwd))
+        schedule_tz: tzinfo = timezone.get_timezone(self.tz)
+        last_run_at = self.maybe_make_aware(last_run_at).astimezone(schedule_tz)
+        now = self.maybe_make_aware(self.now()).astimezone(schedule_tz)
+
+        next_run_at = self._next_occurence(last_run_at)
+
+        if C_REMDEBUG:  # pragma: no cover
+            print(
+                'rem: LAST:{}\nLAST_UTC:{}\nNOW:{}\nNOW_UTC:{}\n'
+                'NEXT_DATE:{}\nNEXT_DATE_UTC:{}\nREM:{}'.format(
+                    last_run_at,
+                    last_run_at.astimezone(timezone.utc),
+                    now,
+                    now.astimezone(timezone.utc),
+                    next_run_at,
+                    next_run_at.astimezone(timezone.utc),
+                    next_run_at.astimezone(timezone.utc) - now.astimezone(timezone.utc)
+                )
+            )
+        return next_run_at.astimezone(timezone.utc) - now.astimezone(timezone.utc)
 
     def is_due(self, last_run_at: datetime) -> tuple[bool, datetime]:
-        """Return tuple of ``(is_due, next_time_to_run)``.
+        """Answers a double question: should a task run now (is_due) and what it is the
+        next time it should run ?
+
+        Returns tuple of ``(is_due, next_time_to_run)``.
+
+        This is done by first check if we exceeded the time between last_run and now.
+        If this is the case, a second computation is done to get the next_time_to_run
+        starting from now.
 
         If :setting:`beat_cron_starting_deadline`  has been specified, the
         scheduler will make sure that the `last_run_at` time is within the

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -616,6 +616,28 @@ class test_crontab_remaining_estimate:
 
         assert next == datetime(2022, 12, 5, 1, 30)
 
+    def test_minute_scheduling_remaining_estimate_during_dst_start(self):
+        tz = ZoneInfo("Europe/Paris")
+        self.app.timezone = tz
+        ct = crontab(app=self.app)
+        # Paris DST start 2024-03-31T03:00:00+02:00 + 1 minute
+        last_run_at = (datetime(2024, 3, 31, 1, 0, tzinfo=ZoneInfo("UTC")) + timedelta(minutes=1)).astimezone(tz)
+        now = last_run_at
+        ct.nowfun = lambda: now
+
+        assert ct.remaining_estimate(last_run_at).total_seconds() == 60
+
+    def test_minute_scheduling_remaining_estimate_during_dst_end(self):
+        tz = ZoneInfo("Europe/Paris")
+        self.app.timezone = tz
+        ct = crontab(app=self.app)
+        # # Paris DST end 2024-10-27T02:00:00+01:00 + 1 minute
+        last_run_at = (datetime(2024, 10, 27, 1, 0, tzinfo=ZoneInfo("UTC")) + timedelta(minutes=1)).astimezone(tz)
+        now = last_run_at
+        ct.nowfun = lambda: now
+
+        assert ct.remaining_estimate(last_run_at).total_seconds() == 60
+
 
 class test_crontab_is_due:
 
@@ -1155,3 +1177,24 @@ class test_crontab_is_due:
         with patch_crontab_nowfun(crontab, now):
             due, remaining = crontab.is_due(last_run_at)
             assert (due, remaining) == (True, 3600)
+
+    def test_minute_scheduling_is_due_during_dst_start(self):
+        tz = ZoneInfo("Europe/Paris")
+        self.app.timezone = tz
+        crontab = self.crontab()
+        # Paris DST start 2024-03-31T03:00:00+02:00 + 1 minute
+        last_run_at = (datetime(2024, 3, 31, 1, 0, tzinfo=ZoneInfo("UTC")) + timedelta(minutes=1)).astimezone(tz)
+        now = last_run_at
+        with patch_crontab_nowfun(crontab, now):
+            assert crontab.is_due(last_run_at) == (False, 60)
+
+    def test_minute_scheduling_is_due_during_dst_end(self):
+        tz = ZoneInfo("Europe/Paris")
+        self.app.timezone = tz
+        crontab = self.crontab()
+        # Paris DST end 2024-10-27T02:00:00+01:00 + 1 minute
+        last_run_at = (datetime(2024, 10, 27, 1, 0, tzinfo=ZoneInfo("UTC")) + timedelta(minutes=1)).astimezone(tz)
+        now = last_run_at
+
+        with patch_crontab_nowfun(crontab, now):
+            assert crontab.is_due(last_run_at) == (False, 60)

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -1198,3 +1198,29 @@ class test_crontab_is_due:
 
         with patch_crontab_nowfun(crontab, now):
             assert crontab.is_due(last_run_at) == (False, 60)
+
+    def test_hourly_scheduling_is_due_during_dst_start(self):
+        tz = ZoneInfo("Europe/Paris")
+        self.app.timezone = tz
+        crontab = self.crontab(minute=0)
+        # Paris DST start 2024-03-31T03:00:00+02:00 minus 1 hour
+        # -> 2024-03-31T01:00:00+01:00
+        last_run_at = (datetime(2024, 3, 31, 1, 0, tzinfo=ZoneInfo("UTC")) + timedelta(hours=-1)).astimezone(tz)
+        # Paris DST start 2024-03-31T03:00:00+02:00
+        now = datetime(2024, 3, 31, 1, 0, tzinfo=ZoneInfo("UTC")).astimezone(tz)
+        with patch_crontab_nowfun(crontab, now):
+            assert crontab.is_due(last_run_at) == (True, 3600)
+
+    def test_hourly_scheduling_is_due_during_dst_end(self):
+        # https://github.com/celery/celery/issues/10107 regression test
+        tz = ZoneInfo("Europe/Paris")
+        self.app.timezone = tz
+        crontab = self.crontab(minute=0)
+        # Paris DST end 2024-10-27T02:00:00+01:00 minus one hour
+        # -> 2024-10-27T02:00:00+01:00
+        last_run_at = (datetime(2024, 10, 27, 1, 0, tzinfo=ZoneInfo("UTC")) + timedelta(hours=-1)).astimezone(tz)
+        # Paris DST end 2024-10-27T02:00:00+01:00
+        now = datetime(2024, 10, 27, 1, 0, tzinfo=ZoneInfo("UTC")).astimezone(tz)
+
+        with patch_crontab_nowfun(crontab, now):
+            assert crontab.is_due(last_run_at) == (True, 3600)

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -698,6 +698,20 @@ class test_crontab_remaining_estimate_with_timezone:
 
         assert ct.remaining_estimate(last_run_at).total_seconds() == 60
 
+    def test_fixed_hour_scheduling_on_dst_start_new_hour(self):
+        """DST start makes midnight become 1h and the cron is scheduled at 01:00"""
+        tz = ZoneInfo("America/Santiago")
+        self.app.timezone = tz
+        ct = crontab(minute=0, hour=1, app=self.app)
+
+        now = (self.santiago_dst_start - timedelta(hours=1)).astimezone(tz)
+        ct.nowfun = lambda: now
+        assert ct.remaining_estimate(now).total_seconds() == 60 * 60
+
+        now = (self.santiago_dst_start).astimezone(tz)
+        ct.nowfun = lambda: now
+        assert ct.remaining_estimate(now).total_seconds() == 24 * 60 * 60
+
     @pytest.mark.parametrize(
         "tzname",
         [

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -507,6 +507,13 @@ class test_crontab_remaining_estimate:
         )
         assert next == datetime(2016, 2, 29, 14, 30)
 
+    def test_far_away_leapday(self):
+        next = self.next_occurrence(
+            self.crontab(day_of_month=29, month_of_year=2, day_of_week=2, minute=0, hour=0),
+            datetime(2084, 2, 29, 0, 1),
+        )
+        assert next == datetime(2124, 2, 29, 0, 0)
+
     def test_day_after_dst_end(self):
         # Test for #1604 issue with region configuration using DST
         tzname = "Europe/Paris"

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -642,37 +642,26 @@ class test_crontab_remaining_estimate:
 
 class test_crontab_remaining_estimate_with_timezone:
     # dst dates are setup in UTC so we can safely add timedelta for tests parametrization
-
-    # 2024-03-10T03:00:00-07:00 -> 2024-03-10T10:00:00+00:00
-    los_angeles_dst_start = datetime(2024, 3, 10, 10, 0, tzinfo=ZoneInfo("UTC"))
-
-    # 2024-11-03T01:00:00-08:00 -> 2024-11-03T09:00:00+00:00
-    los_angeles_dst_end = datetime(2024, 11, 3, 9, 0, tzinfo=ZoneInfo("UTC"))
-
-    # 2024-03-31T03:00:00+02:00 -> 2024-03-31T01:00:00+00:00
-    paris_dst_start = datetime(2024, 3, 31, 1, 0, tzinfo=ZoneInfo("UTC"))
-
-    # 2024-10-27T02:00:00+01:00 -> 2024-10-27T01:00:00+00:00
-    paris_dst_end = datetime(2024, 10, 27, 1, 0, tzinfo=ZoneInfo("UTC"))
-
-    # 2026-09-06T01:00:00-03:00 -> 2026-09-06T04:00:00+00:00
-    santiago_dst_start = datetime(2026, 9, 6, 4, 0, tzinfo=ZoneInfo("UTC"))
-
-    # 2026-04-04T23:00:00-04:00 -> 2026-09-05T03:00:00+00:00
-    santiago_dst_end = datetime(2026, 4, 5, 3, 0, tzinfo=ZoneInfo("UTC"))
-
     DST_CHANGE = {
         "America/Los_Angeles": {
-            "start": los_angeles_dst_start,
-            "end": los_angeles_dst_end,
+            "start": datetime(2024, 3, 10, 10, 0, tzinfo=ZoneInfo("UTC")),
+            "end": datetime(2024, 11, 3, 9, 0, tzinfo=ZoneInfo("UTC")),
         },
         "Europe/Paris": {
-            "start": paris_dst_start,
-            "end": paris_dst_end,
+            "start": datetime(2024, 3, 31, 1, 0, tzinfo=ZoneInfo("UTC")),
+            "end": datetime(2024, 10, 27, 1, 0, tzinfo=ZoneInfo("UTC")),
         },
         "America/Santiago": {
-            "start": santiago_dst_start,
-            "end": santiago_dst_end,
+            "start": datetime(2026, 9, 6, 4, 0, tzinfo=ZoneInfo("UTC")),
+            "end": datetime(2026, 4, 5, 3, 0, tzinfo=ZoneInfo("UTC")),
+        },
+        "Australia/Lord_Howe": {
+            "start": datetime(2026, 10, 3, 15, 30, tzinfo=ZoneInfo("UTC")),
+            "end": datetime(2026, 4, 4, 15, 00, tzinfo=ZoneInfo("UTC")),
+        },
+        "Pacific/Chatham": {
+            "start": datetime(2026, 9, 26, 14, 00, tzinfo=ZoneInfo("UTC")),
+            "end": datetime(2026, 4, 4, 14, 00, tzinfo=ZoneInfo("UTC")),
         }
     }
 
@@ -700,15 +689,16 @@ class test_crontab_remaining_estimate_with_timezone:
 
     def test_fixed_hour_scheduling_on_dst_start_new_hour(self):
         """DST start makes midnight become 1h and the cron is scheduled at 01:00"""
+        santiago_dst_start = self.DST_CHANGE["America/Santiago"]["start"]
         tz = ZoneInfo("America/Santiago")
         self.app.timezone = tz
         ct = crontab(minute=0, hour=1, app=self.app)
 
-        now = (self.santiago_dst_start - timedelta(hours=1)).astimezone(tz)
+        now = (santiago_dst_start - timedelta(hours=1)).astimezone(tz)
         ct.nowfun = lambda: now
         assert ct.remaining_estimate(now).total_seconds() == 60 * 60
 
-        now = (self.santiago_dst_start).astimezone(tz)
+        now = (santiago_dst_start).astimezone(tz)
         ct.nowfun = lambda: now
         assert ct.remaining_estimate(now).total_seconds() == 24 * 60 * 60
 
@@ -773,9 +763,9 @@ class test_crontab_remaining_estimate_with_timezone:
             ({"minute": "*/30"}, "start", timedelta(), timedelta(minutes=30), 0),
             ({"minute": "*/30"}, "end", timedelta(), timedelta(minutes=30), 0),
         ],
-        ids=lambda x: f"{crontab(**x)}" if isinstance(x, dict) else x
+        ids=lambda x: f"{x!r}" if isinstance(x, (dict, timedelta)) else x
     )
-    def test_crontab_with_timezone_remaining_seconds_from_now(
+    def test_crontab_tz_with_1_hour_dstoffset_at_round_hour_remaining_seconds_from_now(
         self, cron, tzname, dst_start_or_end, last_run_delta, now_run_delta, expected_sec
     ):
         """now != last_run, this simulates the computation of the remaining_seconds from now until next_run."""
@@ -869,7 +859,191 @@ class test_crontab_remaining_estimate_with_timezone:
         ],
         ids=lambda x: f"{x}" if isinstance(x, dict) else x
     )
-    def test_crontab_with_timezone_remaining_seconds(
+    def test_crontab_tz_with_1_hour_dstoffset_remaining_seconds(
+        self, cron, tzname, dst_start_or_end, delta_to_dst_change, expected_sec
+    ):
+        """now == last_run, this simulates the computation of the remaining_seconds until next_run."""
+        tz = ZoneInfo(tzname)
+        self.app.timezone = tz
+        dst_change_for_tz_in_utc = self.DST_CHANGE[tzname][dst_start_or_end]
+
+        if isinstance(delta_to_dst_change, relativedelta):
+            # apply the relativedelta manually to the datetime in the final timezone to simplify setup
+            # should only be used if the delta is big enough to not finish in the dst change zone
+            if delta_to_dst_change.days is not None:
+                last_run = (dst_change_for_tz_in_utc + relativedelta(days=delta_to_dst_change.days)).astimezone(tz)
+            else:
+                last_run = dst_change_for_tz_in_utc.astimezone(tz)
+            if delta_to_dst_change.hour is not None:
+                last_run = last_run.replace(hour=delta_to_dst_change.hour)
+            if delta_to_dst_change.minute is not None:
+                last_run = last_run.replace(minute=delta_to_dst_change.minute)
+        else:
+            # apply timedelta to the utc version of date so we can move around the dst change time safely
+            last_run = (dst_change_for_tz_in_utc + delta_to_dst_change).astimezone(tz)
+        now = last_run
+
+        ct = crontab(**cron, app=self.app)
+        ct.nowfun = lambda: now
+
+        assert ct.remaining_estimate(last_run).total_seconds() == expected_sec
+
+    @pytest.mark.parametrize(
+        "tzname",
+        [
+            "Australia/Lord_Howe",  # Lord Howe Island has 30 minutes DST offset
+        ]
+    )
+    @pytest.mark.parametrize(
+        ("cron", "dst_start_or_end", "delta_to_dst_change", "expected_sec"),
+        [
+            # scheduled every minute, 1 minute before DST change
+            ({}, "start", timedelta(minutes=-1), 60),
+            ({}, "end", timedelta(minutes=-1), 60),
+
+            # scheduled every minute, at DST change
+            ({}, "start", timedelta(), 60),
+            ({}, "end", timedelta(), 60),
+
+            # scheduled every hour at minute 0, one hour before DST change
+            ({"minute": 0}, "start", timedelta(hours=-1), 3600 + 1800),
+            ({"minute": 0}, "end", timedelta(hours=-1), 3600 + 1800),
+
+            # scheduled every hour at minute 0, at DST change
+            ({"minute": 0}, "start", timedelta(), 1800),
+            ({"minute": 0}, "end", timedelta(), 1800),
+
+            # scheduled every hour at minute 30, 30 minutes before DST change
+            ({"minute": 30}, "start", timedelta(minutes=-30), 1800),
+            ({"minute": 30}, "end", timedelta(minutes=-30), 1800),
+
+            # scheduled every hour at minute 30, 1 minutes before DST change
+            ({"minute": 30}, "start", timedelta(minutes=-1), 60),
+            ({"minute": 30}, "end", timedelta(minutes=-1), 60),
+
+            # scheduled every hour at minute 30, at DST change
+            ({"minute": 30}, "start", timedelta(), 3600),
+            ({"minute": 30}, "end", timedelta(), 3600),
+
+            # scheduled every hour at minute 30, 30 minutes after DST change
+            ({"minute": 30}, "start", timedelta(minutes=30), 1800),
+            ({"minute": 30}, "end", timedelta(minutes=30), 1800),
+
+            # scheduled every 15 minutes, last run 15 minutes before DST change
+            ({"minute": "*/15"}, "start", timedelta(minutes=-15), 15 * 60),
+            ({"minute": "*/15"}, "end", timedelta(minutes=-15), 15 * 60),
+
+            # scheduled every 15 minutes, at DST change
+            ({"minute": "*/15"}, "start", timedelta(), 15 * 60),
+            ({"minute": "*/15"}, "end", timedelta(), 15 * 60),
+
+            # scheduled every day at noon, last run the day before DST change
+            # there is 30 minutes less until next_run
+            ({"hour": 12, "minute": 0}, "start", relativedelta(days=-1, hour=12, minute=0), 24 * 60 * 60 - 30 * 60),
+            # there is 30 minutes more until next_run
+            ({"hour": 12, "minute": 0}, "end", relativedelta(days=-1, hour=12, minute=0), 24 * 60 * 60 + 30 * 60),
+
+            # scheduled every day at midnight, last run the day before DST change
+            # there is 30 minutes less until next_run
+            ({"hour": 0, "minute": 0}, "start", relativedelta(hour=0, minute=0), 24 * 60 * 60 - 30 * 60),
+            # there is 30 minutes more until next_run
+            ({"hour": 0, "minute": 0}, "end", relativedelta(hour=0, minute=0), 24 * 60 * 60 + 30 * 60),
+        ],
+        ids=lambda x: f"{x!r}" if isinstance(x, (dict, timedelta, relativedelta)) else x
+    )
+    def test_crontab_tz_with_half_hour_dstoffset_remaining_seconds(
+        self, cron, tzname, dst_start_or_end, delta_to_dst_change, expected_sec
+    ):
+        """now == last_run, this simulates the computation of the remaining_seconds until next_run."""
+        tz = ZoneInfo(tzname)
+        self.app.timezone = tz
+        dst_change_for_tz_in_utc = self.DST_CHANGE[tzname][dst_start_or_end]
+
+        if isinstance(delta_to_dst_change, relativedelta):
+            # apply the relativedelta manually to the datetime in the final timezone to simplify setup
+            # should only be used if the delta is big enough to not finish in the dst change zone
+            if delta_to_dst_change.days is not None:
+                last_run = (dst_change_for_tz_in_utc + relativedelta(days=delta_to_dst_change.days)).astimezone(tz)
+            else:
+                last_run = dst_change_for_tz_in_utc.astimezone(tz)
+            if delta_to_dst_change.hour is not None:
+                last_run = last_run.replace(hour=delta_to_dst_change.hour)
+            if delta_to_dst_change.minute is not None:
+                last_run = last_run.replace(minute=delta_to_dst_change.minute)
+        else:
+            # apply timedelta to the utc version of date so we can move around the dst change time safely
+            last_run = (dst_change_for_tz_in_utc + delta_to_dst_change).astimezone(tz)
+        now = last_run
+
+        ct = crontab(**cron, app=self.app)
+        ct.nowfun = lambda: now
+
+        assert ct.remaining_estimate(last_run).total_seconds() == expected_sec
+
+    @pytest.mark.parametrize(
+        "tzname",
+        [
+            "Pacific/Chatham",  # Lord Howe Island has 30 minutes DST offset
+        ]
+    )
+    @pytest.mark.parametrize(
+        ("cron", "dst_start_or_end", "delta_to_dst_change", "expected_sec"),
+        [
+            # scheduled every minute, 1 minute before DST change
+            ({}, "start", timedelta(minutes=-1), 60),
+            ({}, "end", timedelta(minutes=-1), 60),
+
+            # scheduled every minute, at DST change
+            ({}, "start", timedelta(), 60),
+            ({}, "end", timedelta(), 60),
+
+            # scheduled every hour at minute 0, one hour before DST change
+            ({"minute": 0}, "start", timedelta(hours=-1), 900),
+            ({"minute": 0}, "end", timedelta(hours=-1), 900),
+
+            # scheduled every hour at minute 0, at DST change
+            ({"minute": 0}, "start", timedelta(), 900),
+            ({"minute": 0}, "end", timedelta(), 900),
+
+            # scheduled every hour at minute 30, 30 minutes before DST change
+            ({"minute": 30}, "start", timedelta(minutes=-30), 15 * 60),
+            ({"minute": 30}, "end", timedelta(minutes=-30), 15 * 60),
+
+            # scheduled every hour at minute 30, 1 minutes before DST change
+            ({"minute": 30}, "start", timedelta(minutes=-1), 45 * 60 + 60),
+            ({"minute": 30}, "end", timedelta(minutes=-1), 45 * 60 + 60),
+
+            # scheduled every hour at minute 30, at DST change
+            ({"minute": 30}, "start", timedelta(), 45 * 60),
+            ({"minute": 30}, "end", timedelta(), 45 * 60),
+
+            # scheduled every hour at minute 30, 30 minutes after DST change
+            ({"minute": 30}, "start", timedelta(minutes=30), 15 * 60),
+            ({"minute": 30}, "end", timedelta(minutes=30), 15 * 60),
+
+            # scheduled every 15 minutes, last run 15 minutes before DST change
+            ({"minute": "*/15"}, "start", timedelta(minutes=-15), 15 * 60),
+            ({"minute": "*/15"}, "end", timedelta(minutes=-15), 15 * 60),
+
+            # scheduled every 15 minutes, at DST change
+            ({"minute": "*/15"}, "start", timedelta(), 15 * 60),
+            ({"minute": "*/15"}, "end", timedelta(), 15 * 60),
+
+            # scheduled every day at noon, last run the day before DST change
+            # there is 30 minutes less until next_run
+            ({"hour": 12, "minute": 0}, "start", relativedelta(days=-1, hour=12, minute=0), 23 * 60 * 60),
+            # there is 30 minutes more until next_run
+            ({"hour": 12, "minute": 0}, "end", relativedelta(days=-1, hour=12, minute=0), 25 * 60 * 60),
+
+            # scheduled every day at midnight, last run the day before DST change
+            # there is 30 minutes less until next_run
+            ({"hour": 0, "minute": 0}, "start", relativedelta(hour=0, minute=0), 23 * 60 * 60),
+            # there is 30 minutes more until next_run
+            ({"hour": 0, "minute": 0}, "end", relativedelta(hour=0, minute=0), 25 * 60 * 60),
+        ],
+        ids=lambda x: f"{x!r}" if isinstance(x, (dict, timedelta, relativedelta)) else x
+    )
+    def test_crontab_tz_with_dst_applied_at_non_round_hour_remaining_seconds(
         self, cron, tzname, dst_start_or_end, delta_to_dst_change, expected_sec
     ):
         """now == last_run, this simulates the computation of the remaining_seconds until next_run."""
@@ -900,13 +1074,14 @@ class test_crontab_remaining_estimate_with_timezone:
 
     def test_imaginary_hour(self):
         """verify crontab is skipped when the hour does not exists due to DST end."""
+        paris_dst_start = self.DST_CHANGE["Europe/Paris"]["start"]
         tz = ZoneInfo("Europe/Paris")
         self.app.timezone = tz
         # last run the previous day
-        last_run = self.paris_dst_start.astimezone(tz) + relativedelta(days=-1, hour=2)
+        last_run = paris_dst_start.astimezone(tz) + relativedelta(days=-1, hour=2)
 
         # now just 1 minute before dst change
-        now = (self.paris_dst_start + timedelta(minutes=-1)).astimezone(tz)
+        now = (paris_dst_start + timedelta(minutes=-1)).astimezone(tz)
 
         # every day at 2
         ct = crontab(minute=0, hour=2, app=self.app)
@@ -920,7 +1095,7 @@ class test_crontab_remaining_estimate_with_timezone:
         )
 
         # now at dst change
-        now = self.paris_dst_start.astimezone(tz)
+        now = paris_dst_start.astimezone(tz)
         ct.nowfun = lambda: now
 
         # it is now 3, expected next run is one day
@@ -928,13 +1103,14 @@ class test_crontab_remaining_estimate_with_timezone:
 
     def test_duplicated_hour(self):
         """verify crontab is due twice when the hour is duplicated due to DST end."""
+        paris_dst_end = self.DST_CHANGE["Europe/Paris"]["end"]
         tz = ZoneInfo("Europe/Paris")
         self.app.timezone = tz
         # last run the previous day
-        last_run = self.paris_dst_end.astimezone(tz) + relativedelta(days=-1, hour=2)
+        last_run = paris_dst_end.astimezone(tz) + relativedelta(days=-1, hour=2)
 
         # now just 1 hour before dst change
-        now = (self.paris_dst_end + timedelta(hours=-1)).astimezone(tz)
+        now = (paris_dst_end + timedelta(hours=-1)).astimezone(tz)
         # every day at 2
         ct = crontab(minute=0, hour=2, app=self.app)
         ct.nowfun = lambda: now
@@ -944,7 +1120,7 @@ class test_crontab_remaining_estimate_with_timezone:
 
         last_run = now
         # now at dst change, it is still 2 o'clock, due time should be 0
-        now = self.paris_dst_end.astimezone(tz)
+        now = paris_dst_end.astimezone(tz)
 
         ct.nowfun = lambda: now
 

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 import pytest
+from dateutil.relativedelta import relativedelta
 
 from celery.exceptions import ImproperlyConfigured
 from celery.schedules import ParseException, crontab, crontab_parser, schedule, solar
@@ -520,8 +521,8 @@ class test_crontab_remaining_estimate:
         crontab.nowfun = lambda: now
         next = now + crontab.remaining_estimate(last_run_at)
 
-        assert next.utcoffset().seconds == 3600
         assert next == datetime(2017, 10, 29, 9, 0, tzinfo=tz)
+        assert next.utcoffset().seconds == 3600
 
     def test_day_after_dst_start(self):
         # Test for #1604 issue with region configuration using DST
@@ -637,6 +638,303 @@ class test_crontab_remaining_estimate:
         ct.nowfun = lambda: now
 
         assert ct.remaining_estimate(last_run_at).total_seconds() == 60
+
+
+class test_crontab_remaining_estimate_with_timezone:
+    # dst dates are setup in UTC so we can safely add timedelta for tests parametrization
+
+    # 2024-03-10T03:00:00-07:00 -> 2024-03-10T10:00:00+00:00
+    los_angeles_dst_start = datetime(2024, 3, 10, 10, 0, tzinfo=ZoneInfo("UTC"))
+
+    # 2024-11-03T01:00:00-08:00 -> 2024-11-03T09:00:00+00:00
+    los_angeles_dst_end = datetime(2024, 11, 3, 9, 0, tzinfo=ZoneInfo("UTC"))
+
+    # 2024-03-31T03:00:00+02:00 -> 2024-03-31T01:00:00+00:00
+    paris_dst_start = datetime(2024, 3, 31, 1, 0, tzinfo=ZoneInfo("UTC"))
+
+    # 2024-10-27T02:00:00+01:00 -> 2024-10-27T01:00:00+00:00
+    paris_dst_end = datetime(2024, 10, 27, 1, 0, tzinfo=ZoneInfo("UTC"))
+
+    # 2026-09-06T01:00:00-03:00 -> 2026-09-06T04:00:00+00:00
+    santiago_dst_start = datetime(2026, 9, 6, 4, 0, tzinfo=ZoneInfo("UTC"))
+
+    # 2026-04-04T23:00:00-04:00 -> 2026-09-05T03:00:00+00:00
+    santiago_dst_end = datetime(2026, 4, 5, 3, 0, tzinfo=ZoneInfo("UTC"))
+
+    DST_CHANGE = {
+        "America/Los_Angeles": {
+            "start": los_angeles_dst_start,
+            "end": los_angeles_dst_end,
+        },
+        "Europe/Paris": {
+            "start": paris_dst_start,
+            "end": paris_dst_end,
+        },
+        "America/Santiago": {
+            "start": santiago_dst_start,
+            "end": santiago_dst_end,
+        }
+    }
+
+    def test_minute_scheduling_remaining_estimate_during_dst_start(self):
+        tz = ZoneInfo("Europe/Paris")
+        self.app.timezone = tz
+        ct = crontab(app=self.app)
+        # last_run_at = self.paris_dst_start + timedelta(minutes=1)
+        last_run_at = (datetime(2024, 3, 31, 1, 0, tzinfo=ZoneInfo("UTC")) + timedelta(minutes=1)).astimezone(tz)
+        now = last_run_at
+        ct.nowfun = lambda: now
+
+        assert ct.remaining_estimate(last_run_at).total_seconds() == 60
+
+    def test_minute_scheduling_remaining_estimate_during_dst_end(self):
+        tz = ZoneInfo("Europe/Paris")
+        self.app.timezone = tz
+        ct = crontab(app=self.app)
+        # last_run_at = self.paris_dst_end + timedelta(minutes=1)
+        last_run_at = (datetime(2024, 10, 27, 1, 0, tzinfo=ZoneInfo("UTC")) + timedelta(minutes=1)).astimezone(tz)
+        now = last_run_at
+        ct.nowfun = lambda: now
+
+        assert ct.remaining_estimate(last_run_at).total_seconds() == 60
+
+    @pytest.mark.parametrize(
+        "tzname",
+        [
+            "America/Los_Angeles",
+            "Europe/Paris",
+            "America/Santiago",  # Chile DST change happens at midnight local time
+        ]
+    )
+    @pytest.mark.parametrize(
+        ("cron", "dst_start_or_end", "last_run_delta", "now_run_delta", "expected_sec"),
+        [
+            # scheduled every minute
+            # last_run 1 minute before DST change, now at DST change
+            ({}, "start", timedelta(minutes=-1), timedelta(), 0),
+            ({}, "end", timedelta(minutes=-1), timedelta(), 0),
+
+            # scheduled every minute
+            # last_run at DST change, now at DST change + 1 minute
+            ({}, "start", timedelta(), timedelta(minutes=1), 0),
+            ({}, "end", timedelta(), timedelta(minutes=1), 0),
+
+            # scheduled every hour at minute 0
+            # last run one hour before DST change, now at DST change
+            ({"minute": 0}, "start", timedelta(hours=-1), timedelta(), 0),
+            ({"minute": 0}, "end", timedelta(hours=-1), timedelta(), 0),
+
+            # scheduled every hour at minute 0
+            # last run one hour before DST change, now 30 minutes before DST change
+            ({"minute": 0}, "start", timedelta(hours=-1), timedelta(minutes=-30), 30 * 60),
+            ({"minute": 0}, "end", timedelta(hours=-1), timedelta(minutes=-30), 30 * 60),
+
+            # scheduled every hour at minute 0
+            # last run one at DST change, now 30 minutes after DST change
+            ({"minute": 0}, "start", timedelta(), timedelta(minutes=30), 30 * 60),
+            ({"minute": 0}, "end", timedelta(), timedelta(minutes=30), 30 * 60),
+
+            # scheduled every hour at minute 0
+            # last run one at DST change, now 1 hour after DST change
+            ({"minute": 0}, "start", timedelta(), timedelta(hours=1), 0),
+            ({"minute": 0}, "end", timedelta(), timedelta(hours=1), 0),
+
+            # scheduled every hour at minute 30
+            # last run 30 minutes before at DST change, now at DST change
+            ({"minute": 30}, "start", timedelta(minutes=-30), timedelta(), 30 * 60),
+            ({"minute": 30}, "end", timedelta(minutes=-30), timedelta(), 30 * 60),
+
+            # scheduled every hour at minute 30
+            # last run 30 minutes before at DST change, now 30 minutes after DST change
+            ({"minute": 30}, "start", timedelta(minutes=-30), timedelta(minutes=30), 0),
+            ({"minute": 30}, "end", timedelta(minutes=-30), timedelta(minutes=30), 0),
+
+            # scheduled every hour at minute 30
+            # last run 30 minutes before at DST change, now at DST change
+            ({"minute": "*/30"}, "start", timedelta(minutes=-30), timedelta(), 0),
+            ({"minute": "*/30"}, "end", timedelta(minutes=-30), timedelta(), 0),
+
+            # scheduled every hour at minute 30
+            # last run at DST change, now 30 minutes after DST change
+            ({"minute": "*/30"}, "start", timedelta(), timedelta(minutes=30), 0),
+            ({"minute": "*/30"}, "end", timedelta(), timedelta(minutes=30), 0),
+        ],
+        ids=lambda x: f"{crontab(**x)}" if isinstance(x, dict) else x
+    )
+    def test_crontab_with_timezone_remaining_seconds_from_now(
+        self, cron, tzname, dst_start_or_end, last_run_delta, now_run_delta, expected_sec
+    ):
+        """now != last_run, this simulates the computation of the remaining_seconds from now until next_run."""
+        tz = ZoneInfo(tzname)
+        self.app.timezone = tz
+        dst_change_for_tz_in_utc = self.DST_CHANGE[tzname][dst_start_or_end]
+
+        if isinstance(last_run_delta, relativedelta):
+            # apply the relativedelta to the datetime in the final timezone to simplify setup
+            # should only be used if the delta is big enough to not finish in the dst change zone
+            last_run = dst_change_for_tz_in_utc.astimezone(tz) + last_run_delta
+        else:
+            # apply timedelta to the utc version of date so we can move around the dst change time safely
+            last_run = (dst_change_for_tz_in_utc + last_run_delta).astimezone(tz)
+
+        if isinstance(now_run_delta, relativedelta):
+            # apply the relativedelta to the datetime in the final timezone to simplify setup
+            # should only be used if the delta is big enough to not finish in the dst change zone
+            now = dst_change_for_tz_in_utc.astimezone(tz) + now_run_delta
+        else:
+            # apply timedelta to the utc version of date so we can move around the dst change time safely
+            now = (dst_change_for_tz_in_utc + now_run_delta).astimezone(tz)
+
+        ct = crontab(**cron, app=self.app)
+        ct.nowfun = lambda: now
+
+        assert ct.remaining_estimate(last_run).total_seconds() == expected_sec
+
+    @pytest.mark.parametrize(
+        "tzname",
+        [
+            "America/Los_Angeles",
+            "Europe/Paris",
+            "America/Santiago",  # Chile DST change happens at midnight local time
+        ]
+    )
+    @pytest.mark.parametrize(
+        ("cron", "dst_start_or_end", "delta_to_dst_change", "expected_sec"),
+        [
+            # scheduled every minute, 1 minute before DST change
+            ({}, "start", timedelta(minutes=-1), 60),
+            ({}, "end", timedelta(minutes=-1), 60),
+
+            # scheduled every minute, at DST change
+            ({}, "start", timedelta(), 60),
+            ({}, "end", timedelta(), 60),
+
+            # scheduled every hour at minute 0, one hour before DST change
+            ({"minute": 0}, "start", timedelta(hours=-1), 3600),
+            ({"minute": 0}, "end", timedelta(hours=-1), 3600),
+
+            # scheduled every hour at minute 0, at DST change
+            ({"minute": 0}, "start", timedelta(), 3600),
+            ({"minute": 0}, "end", timedelta(), 3600),
+
+            # scheduled every hour at minute 30, 30 minutes before DST change
+            ({"minute": 30}, "start", timedelta(minutes=-30), 3600),
+            ({"minute": 30}, "end", timedelta(minutes=-30), 3600),
+
+            # scheduled every hour at minute 30, 1 minutes before DST change
+            ({"minute": 30}, "start", timedelta(minutes=-1), 1860),
+            ({"minute": 30}, "end", timedelta(minutes=-1), 1860),
+
+            # scheduled every hour at minute 30, at DST change
+            ({"minute": 30}, "start", timedelta(), 1800),
+            ({"minute": 30}, "end", timedelta(), 1800),
+
+            # scheduled every hour at minute 30, 30 minutes after DST change
+            ({"minute": 30}, "start", timedelta(minutes=30), 3600),
+            ({"minute": 30}, "end", timedelta(minutes=30), 3600),
+
+            # scheduled every 15 minutes, last run 15 minutes before DST change
+            ({"minute": "*/15"}, "start", timedelta(minutes=-15), 15 * 60),
+            ({"minute": "*/15"}, "end", timedelta(minutes=-15), 15 * 60),
+
+            # scheduled every 15 minutes, at DST change
+            ({"minute": "*/15"}, "start", timedelta(), 15 * 60),
+            ({"minute": "*/15"}, "end", timedelta(), 15 * 60),
+
+            # scheduled every day at noon, last run the day before DST change
+            # there is one hour less until next_run
+            ({"hour": 12, "minute": 0}, "start", relativedelta(days=-1, hour=12), 23 * 60 * 60),
+            # there is one hour more until next_run
+            ({"hour": 12, "minute": 0}, "end", relativedelta(days=-1, hour=12), 25 * 60 * 60),
+
+            # scheduled every day at midnight, last run the day before DST change
+            # there is one hour less until next_run
+            ({"hour": 0, "minute": 0}, "start", relativedelta(hour=0), 23 * 60 * 60),
+            # there is one hour more until next_run
+            ({"hour": 0, "minute": 0}, "end", relativedelta(hour=0), 25 * 60 * 60),
+        ],
+        ids=lambda x: f"{x}" if isinstance(x, dict) else x
+    )
+    def test_crontab_with_timezone_remaining_seconds(
+        self, cron, tzname, dst_start_or_end, delta_to_dst_change, expected_sec
+    ):
+        """now == last_run, this simulates the computation of the remaining_seconds until next_run."""
+        tz = ZoneInfo(tzname)
+        self.app.timezone = tz
+        dst_change_for_tz_in_utc = self.DST_CHANGE[tzname][dst_start_or_end]
+
+        if isinstance(delta_to_dst_change, relativedelta):
+            # apply the relativedelta manually to the datetime in the final timezone to simplify setup
+            # should only be used if the delta is big enough to not finish in the dst change zone
+            if delta_to_dst_change.days is not None:
+                last_run = (dst_change_for_tz_in_utc + relativedelta(days=delta_to_dst_change.days)).astimezone(tz)
+            else:
+                last_run = dst_change_for_tz_in_utc.astimezone(tz)
+            if delta_to_dst_change.hour is not None:
+                last_run = last_run.replace(hour=delta_to_dst_change.hour)
+            if delta_to_dst_change.minute is not None:
+                last_run = last_run.replace(minute=delta_to_dst_change.minute)
+        else:
+            # apply timedelta to the utc version of date so we can move around the dst change time safely
+            last_run = (dst_change_for_tz_in_utc + delta_to_dst_change).astimezone(tz)
+        now = last_run
+
+        ct = crontab(**cron, app=self.app)
+        ct.nowfun = lambda: now
+
+        assert ct.remaining_estimate(last_run).total_seconds() == expected_sec
+
+    def test_imaginary_hour(self):
+        """verify crontab is skipped when the hour does not exists due to DST end."""
+        tz = ZoneInfo("Europe/Paris")
+        self.app.timezone = tz
+        # last run the previous day
+        last_run = self.paris_dst_start.astimezone(tz) + relativedelta(days=-1, hour=2)
+
+        # now just 1 minute before dst change
+        now = (self.paris_dst_start + timedelta(minutes=-1)).astimezone(tz)
+
+        # every day at 2
+        ct = crontab(minute=0, hour=2, app=self.app)
+        ct.nowfun = lambda: now
+
+        # expected next run is one day further, as the 2 o'clock hour does not exist on the day of dst start
+        # next day but one hour less because of time shift
+        assert (
+            ct.remaining_estimate(last_run).total_seconds()
+            == timedelta(days=1, hours=-1, minutes=1).total_seconds()
+        )
+
+        # now at dst change
+        now = self.paris_dst_start.astimezone(tz)
+        ct.nowfun = lambda: now
+
+        # it is now 3, expected next run is one day
+        assert ct.remaining_estimate(last_run).total_seconds() == timedelta(days=1, hours=-1).total_seconds()
+
+    def test_duplicated_hour(self):
+        """verify crontab is due twice when the hour is duplicated due to DST end."""
+        tz = ZoneInfo("Europe/Paris")
+        self.app.timezone = tz
+        # last run the previous day
+        last_run = self.paris_dst_end.astimezone(tz) + relativedelta(days=-1, hour=2)
+
+        # now just 1 hour before dst change
+        now = (self.paris_dst_end + timedelta(hours=-1)).astimezone(tz)
+        # every day at 2
+        ct = crontab(minute=0, hour=2, app=self.app)
+        ct.nowfun = lambda: now
+
+        # one hour before the dst end, it is 2 o'clock, due time is 0
+        assert ct.remaining_estimate(last_run).total_seconds() == 0
+
+        last_run = now
+        # now at dst change, it is still 2 o'clock, due time should be 0
+        now = self.paris_dst_end.astimezone(tz)
+
+        ct.nowfun = lambda: now
+
+        assert ct.remaining_estimate(last_run).total_seconds() == 0
 
 
 class test_crontab_is_due:
@@ -1224,3 +1522,405 @@ class test_crontab_is_due:
 
         with patch_crontab_nowfun(crontab, now):
             assert crontab.is_due(last_run_at) == (True, 3600)
+
+    def test_minute_crontab_with_negative_offset_tz_during_dst_end_is_due(self):
+        # Minute-level schedule during fall-back should still be due when the
+        # clock repeats the 1 AM hour.
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='*', hour='*')
+        last_run_at = datetime(2024, 11, 3, 1, 59, tzinfo=tz, fold=0)  # 2024-11-03T08:59:00+00:00
+        now = datetime(2024, 11, 3, 1, 0, tzinfo=tz, fold=1)  # 2024-11-03T09:00:00+00:00
+        print(last_run_at.isoformat(), last_run_at.astimezone(timezone.utc).isoformat())
+        print(now.isoformat(), now.astimezone(timezone.utc).isoformat())
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 60)
+
+    def test_minute_crontab_with_negative_offset_tz_during_dst_start_is_due(self):
+        # Minute-level schedule during the trigger after the switch to DST (1 hour disappears).
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='*', hour='*')
+        last_run_at = datetime(2024, 3, 10, 1, 59, tzinfo=tz, fold=1)  # 2024-03-10T01:59:00-08:00
+        now = datetime(2024, 3, 10, 3, 0, tzinfo=tz, fold=0)  # 2024-03-10T03:00:00-07:00
+        print(last_run_at.isoformat(), last_run_at.astimezone(timezone.utc).isoformat())
+        print(now.isoformat(), now.astimezone(timezone.utc).isoformat())
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 60)
+
+    def test_minute_crontab_with_positive_offset_tz_during_dst_end_is_due(self):
+        # Minute-level schedule during fall-back should still be due when the
+        # clock repeats the 1 AM hour.
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='*', hour='*')
+        last_run_at = datetime(2024, 10, 27, 2, 59, tzinfo=tz, fold=0)  # 2024-10-27T02:59:00+02:00
+        now = datetime(2024, 10, 27, 2, 0, tzinfo=tz, fold=1)  # 2024-10-27T02:00:00+01:00
+        print(last_run_at.isoformat(), last_run_at.astimezone(timezone.utc).isoformat())
+        print(now.isoformat(), now.astimezone(timezone.utc).isoformat())
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 60)
+
+    def test_minute_crontab_with_positive_offset_tz_during_dst_start_is_due(self):
+        # Minute-level schedule during the trigger after the switch to DST (1 hour disappears).
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='*', hour='*')
+        last_run_at = datetime(2024, 3, 31, 1, 59, tzinfo=tz, fold=1)  # 2024-03-31T01:59:00+01:00
+        now = datetime(2024, 3, 31, 3, 0, tzinfo=tz, fold=0)  # 2024-03-31T03:00:00+02:00
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 60)
+
+    def test_hour_crontab_with_negative_offset_tz_during_dst_end_is_due(self):
+        # local time goes 1h backward (at 2AM, it goes back to 1AM), an hourly crontab should run
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='0', hour='*')
+        # 2024-11-03T01:00:00-07:00 -> 2024-11-03T08:00:00Z
+        last_run_at = datetime(2024, 11, 3, 1, 0, tzinfo=tz, fold=0)
+        # 2024-11-03T01:00:00-08:00 -> 2024-11-03T09:00:00Z
+        now = datetime(2024, 11, 3, 1, 0, tzinfo=tz, fold=1)
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 3600)
+
+    def test_hour_crontab_with_negative_offset_tz_during_dst_start_is_due(self):
+        # local time goes 1h forward (at 2AM, it is now 3AM, the hour in between disappears),
+        # an hourly crontab should run
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='0', hour='*')
+        last_run_at = datetime(2024, 3, 10, 1, 0, tzinfo=tz)  # 2024-03-10T01:00:00-08:00 -> 2024-03-10T09:00:00Z
+        now = datetime(2024, 3, 10, 3, 0, tzinfo=tz)          # 2024-03-10T03:00:00-07:00 -> 2024-03-10T10:00:00Z
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 3600)
+
+    def test_hour_crontab_with_positive_offset_tz_during_dst_end_is_due(self):
+        # local time goes 1h backward (at 3AM, it goes back to 2AM), an hourly crontab should run
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='0', hour='*')
+        # 2024-10-27T02:00:00+02:00 -> 2024-10-27T00:00:00Z
+        last_run_at = datetime(2024, 10, 27, 2, 0, tzinfo=tz, fold=0)
+        # 2024-10-27T02:00:00+01:00 -> 2024-10-27T01:00:00Z
+        now = datetime(2024, 10, 27, 2, 0, tzinfo=tz, fold=1)
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 3600)
+
+    def test_hour_crontab_with_positive_offset_tz_during_dst_start_is_due(self):
+        # Hour-level schedule during the trigger after the switch to DST (1 hour disappears).
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='0', hour='*')
+        last_run_at = datetime(2024, 3, 31, 1, 0, tzinfo=tz)  # 2024-03-31T01:00:00+01:00 -> 2024-03-31T00:00:00Z
+        now = datetime(2024, 3, 31, 3, 0, tzinfo=tz)          # 2024-03-31T03:00:00+02:00 -> 2024-03-31T01:00:00Z
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 3600)
+
+    def test_daily_crontab_with_negative_offset_tz_during_dst_end_is_due(self):
+        # local time goes 1h backward (at 2AM, it goes back to 1AM)
+        # daily schedule should run at the correct time after transition
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='0', hour='0')
+        last_run_at = datetime(2024, 11, 3, 0, 0, tzinfo=tz)  # 2024-11-03T01:00:00-07:00 -> 2024-11-03T08:00:00Z
+        now = datetime(2024, 11, 4, 0, 0, tzinfo=tz)          # 2024-11-03T01:00:00-08:00 -> 2024-11-03T09:00:00Z
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 24 * 60 * 60)
+
+    def test_daily_crontab_with_negative_offset_tz_during_dst_start_is_due(self):
+        # after the switch to DST (where 1 hour disappears),
+        # daily schedule should run at the correct time after transition
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='0', hour='0')
+        last_run_at = datetime(2024, 3, 10, 0, 0, tzinfo=tz)  # 2024-03-10T01:00:00-08:00 -> 2024-03-10T09:00:00Z
+        now = datetime(2024, 3, 11, 0, 0, tzinfo=tz)          # 2024-03-10T03:00:00-07:00 -> 2024-03-10T10:00:00Z
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 24 * 60 * 60)
+
+    def test_daily_crontab_with_positive_offset_tz_during_dst_end_is_due(self):
+        # local time goes 1h backward (at 3AM, it goes back to 2AM),
+        # daily schedule should run at the correct time after transition
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='0', hour='0')
+        last_run_at = datetime(2024, 10, 27, 0, 0, tzinfo=tz)  # 2024-10-27T00:00:00+02:00 -> 2024-10-26T22:00:00Z
+        now = datetime(2024, 10, 28, 0, 0, tzinfo=tz)          # 2024-10-28T00:00:00+01:00 -> 2024-10-27T23:00:00Z
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 24 * 60 * 60)
+
+    def test_daily_crontab_with_positive_offset_tz_during_dst_start_is_due(self):
+        # after the switch to DST (where 1 hour disappears),
+        # daily schedule should run at the correct time after transition
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='0', hour='0')
+        last_run_at = datetime(2024, 3, 31, 0, 0, tzinfo=tz)  # 2024-03-31T00:00:00+01:00 -> 2024-03-30T23:00:00Z
+        now = datetime(2024, 4, 1, 0, 0, tzinfo=tz)           # 2024-04-01T00:00:00+02:00 -> 2024-03-31T22:00:00Z
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (True, 24 * 60 * 60)
+
+    def test_daily_crontab_with_negative_offset_tz_during_dst_start_is_not_due(self):
+        # after the switch to DST (where 1 hour disappears),
+        # daily schedule at the exact hour of the switch does not run after the switch
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='0', hour='2')
+        last_run_at = datetime(2024, 3, 9, 2, 0, tzinfo=tz)  # 2024-03-09T02:00:00-08:00 -> 2024-03-10T09:00:00Z
+        now = datetime(2024, 3, 10, 3, 0, tzinfo=tz)         # 2024-03-10T03:00:00-07:00 -> 2024-03-10T10:00:00Z
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (False, 23 * 60 * 60)
+
+    def test_daily_crontab_with_positive_offset_tz_during_dst_start_is_not_due(self):
+        # after the switch to DST (where 1 hour disappears),
+        # daily schedule at the exact hour of the switch does not run after the switch
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='0', hour='2')
+        last_run_at = datetime(2024, 3, 30, 2, 0, tzinfo=tz)  # 2024-03-30T02:00:00+01:00 -> 2024-03-30T01:00:00Z
+        now = datetime(2024, 3, 31, 3, 0, tzinfo=tz)          # 2024-03-31T03:00:00+02:00 -> 2024-03-31T01:00:00Z
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (False, 23 * 60 * 60)
+
+    def test_daily_crontab_with_negative_offset_tz_during_dst_start_is_really_not_due(self):
+        # after the switch to DST (where 1 hour disappears),
+        # daily schedule at the exact hour of the switch does not run after the switch
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='30', hour='2')
+        last_run_at = datetime(2024, 3, 9, 2, 30, tzinfo=tz)  # 2024-03-09T02:30:00-08:00 -> 2024-03-09T09:00:00Z
+        now = datetime(2024, 3, 10, 3, 30, tzinfo=tz)         # 2024-03-10T03:00:00-07:00 -> 2024-03-10T10:00:00Z
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (False, 23 * 60 * 60)
+
+    def test_daily_crontab_with_positive_offset_tz_during_dst_start_is_really_not_due(self):
+        # after the switch to DST (where 1 hour disappears),
+        # daily schedule at the exact hour of the switch does not run after the switch
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='30', hour='2')
+        last_run_at = datetime(2024, 3, 30, 2, 30, tzinfo=tz)  # 2024-03-30T02:30:00+01:00 -> 2024-03-30T01:30:00Z
+        now = datetime(2024, 3, 31, 3, 30, tzinfo=tz)          # 2024-03-31T03:30:00+02:00 -> 2024-03-31T01:30:00Z
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (False, 23 * 60 * 60)
+
+    def test_daily_crontab_with_positive_offset_tz_during_dst_start_is_due_next_day(self):
+        # after the switch to DST (where 1 hour disappears),
+        # daily schedule at the exact hour of the switch does not run after the switch
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute='30', hour='2')
+        last_run_at = datetime(2024, 3, 31, 1, 0, tzinfo=tz)  # 2024-03-30T01:00:00+01:00 -> 2024-03-31T00:00:00Z
+        now = datetime(2024, 3, 31, 1, 0, tzinfo=tz)          # 2024-03-31T01:00:00+01:00 -> 2024-03-31T00:00:00Z
+        ct.nowfun = lambda: now
+
+        is_due, rem = ct.is_due(last_run_at)
+        assert (is_due, rem) == (False, 24 * 60 * 60 + 30 * 60)
+
+    def test_hourly_crontab_during_dst_fall_back(self):
+        # Test for #10107: hourly crontab skips execution during fall-back
+        # DST transition when the same local hour occurs twice.
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute=0, hour='*')
+        # Fall-back Nov 3, 2024 America/Los_Angeles:
+        #   1:00 AM PDT (UTC-7, fold=0) = 08:00 UTC
+        #   1:00 AM PST (UTC-8, fold=1) = 09:00 UTC
+        last_run_at = datetime(2024, 11, 3, 1, 0, tzinfo=tz, fold=0)  # 1 AM PDT
+        now = datetime(2024, 11, 3, 1, 0, tzinfo=tz, fold=1)          # 1 AM PST
+        ct.nowfun = lambda: now
+
+        remaining = ct.remaining_estimate(last_run_at)
+        # One real hour has passed (8 UTC → 9 UTC), task should be due
+        assert remaining.total_seconds() <= 0
+
+    def test_hourly_crontab_during_dst_fall_back_is_due(self):
+        # Same as above but testing via is_due()
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute=0, hour='*')
+
+        last_run_at = datetime(2024, 11, 3, 1, 0, tzinfo=tz, fold=0)  # 1 AM PDT
+        now = datetime(2024, 11, 3, 1, 0, tzinfo=tz, fold=1)          # 1 AM PST
+        ct.nowfun = lambda: now
+
+        is_due, next_time = ct.is_due(last_run_at)
+        assert is_due
+
+    def test_daily_crontab_during_dst_fall_back_not_due(self):
+        # Daily at 1:00 AM should NOT fire twice on the same calendar day
+        # when the hour 1:00 occurs twice during fall-back.
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute=0, hour=1)
+
+        # Fall-back Nov 3, 2024:
+        #   1:00 AM PDT (UTC-7, fold=0) = 08:00 UTC
+        #   1:00 AM PST (UTC-8, fold=1) = 09:00 UTC
+        last_run_at = datetime(2024, 11, 3, 1, 0, tzinfo=tz, fold=0)  # 1 AM PDT
+        now = datetime(2024, 11, 3, 1, 0, tzinfo=tz, fold=1)          # 1 AM PST
+        ct.nowfun = lambda: now
+
+        remaining = ct.remaining_estimate(last_run_at)
+        # Task ran once at 1:00 AM PDT; it should next run the following day,
+        # so it must not be considered due again at 1:00 AM PST.
+        assert remaining.total_seconds() == 0
+
+    def test_hourly_crontab_during_dst_spring_forward_is_due(self):
+        # Hourly schedule across the spring-forward gap should still be due.
+        # In America/Los_Angeles on 2024-03-10, clocks jump from 2 AM to 3 AM.
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute=0, hour='*')
+
+        last_run_at = datetime(2024, 3, 10, 1, 0, tzinfo=tz)
+        now = datetime(2024, 3, 10, 3, 0, tzinfo=tz)
+        ct.nowfun = lambda: now
+
+        is_due, next_time = ct.is_due(last_run_at)
+        assert is_due
+
+    def test_hourly_crontab_during_dst_fall_back_europe_london_is_due(self):
+        # Hourly schedule should fire during Europe/London fall-back.
+        # Oct 27, 2024: clocks go back from 2 AM BST to 1 AM GMT.
+        tzname = "Europe/London"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute=0, hour='*')
+
+        last_run_at = datetime(2024, 10, 27, 1, 0, tzinfo=tz, fold=0)
+        now = datetime(2024, 10, 27, 1, 0, tzinfo=tz, fold=1)
+        ct.nowfun = lambda: now
+
+        is_due, next_time = ct.is_due(last_run_at)
+        assert is_due
+
+    def test_hourly_crontab_no_dst_transition_normal_behavior(self):
+        # Regression: hourly schedule in a DST-aware timezone should work
+        # normally when no DST transition is happening.
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute=0, hour='*')
+
+        last_run_at = datetime(2024, 7, 15, 14, 0, tzinfo=tz)
+        now = datetime(2024, 7, 15, 15, 0, tzinfo=tz)
+        ct.nowfun = lambda: now
+
+        is_due, next_time = ct.is_due(last_run_at)
+        assert is_due
+
+    def test_hourly_crontab_dst_fall_back_stale_last_run_not_triggered(self):
+        # Guard: UTC proximity check.  If last_run_at is from much earlier
+        # (> 2 hours in UTC), the DST fall-back shortcut should NOT apply.
+        # The task should still be due via the normal scheduling path.
+        tzname = "America/Los_Angeles"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute=0, hour='*')
+
+        # Last run at 10 PM on Nov 2 (well before fall-back).
+        last_run_at = datetime(2024, 11, 2, 22, 0, tzinfo=tz)
+        # Now is 1 AM PST on Nov 3 (post fall-back, fold=1).
+        now = datetime(2024, 11, 3, 1, 0, tzinfo=tz, fold=1)
+        ct.nowfun = lambda: now
+
+        is_due, next_time = ct.is_due(last_run_at)
+        # Should be due via normal path (many hours elapsed), not DST shortcut
+        assert is_due
+
+    def test_hourly_crontab_dst_fall_back_australia(self):
+        # Southern hemisphere: Australia/Sydney falls back on first Sunday
+        # of April.  2024-04-07: clocks go from 3 AM AEDT to 2 AM AEST.
+        # The 2 AM hour occurs twice.
+        tzname = "Australia/Sydney"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        ct = self.crontab(minute=0, hour='*')
+
+        # First 2 AM (AEDT, fold=0) and second 2 AM (AEST, fold=1).
+        last_run_at = datetime(2024, 4, 7, 2, 0, tzinfo=tz, fold=0)
+        now = datetime(2024, 4, 7, 2, 0, tzinfo=tz, fold=1)
+        ct.nowfun = lambda: now
+
+        is_due, next_time = ct.is_due(last_run_at)
+        assert is_due
+
+    def test_hour_after_dst_end(self):
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        crontab = self.crontab(minute=10)
+
+        # Set last_run_at just before DST end
+        last_run_at = datetime(2017, 10, 29, 0, 10, tzinfo=timezone.utc).astimezone(tz)
+        now = datetime(2017, 10, 29, 1, 0, tzinfo=timezone.utc).astimezone(tz)
+        crontab.nowfun = lambda: now
+
+        assert crontab.remaining_estimate(last_run_at) == timedelta(minutes=10)
+
+    def test_hour_after_dst_start(self):
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        crontab = self.crontab(minute=10)
+
+        # Set last_run_at Before DST start
+        last_run_at = datetime(2017, 3, 26, 0, 10, tzinfo=timezone.utc).astimezone(tz)
+        # Set now after DST start
+        now = datetime(2017, 3, 26, 1, 0, tzinfo=timezone.utc).astimezone(tz)
+        crontab.nowfun = lambda: now
+        assert crontab.remaining_estimate(last_run_at) == timedelta(minutes=10)

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -1924,3 +1924,31 @@ class test_crontab_is_due:
         now = datetime(2017, 3, 26, 1, 0, tzinfo=timezone.utc).astimezone(tz)
         crontab.nowfun = lambda: now
         assert crontab.remaining_estimate(last_run_at) == timedelta(minutes=10)
+
+    def test_end_of_day_after_dst_start(self):
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        crontab = self.crontab(hour=23, minute=59)
+
+        # start of the day
+        last_run_at = datetime(2017, 3, 26, 0, 0, tzinfo=tz)
+        now = datetime(2017, 3, 26, 0, 0, tzinfo=tz)
+        crontab.nowfun = lambda: now
+
+        # 23h minus 1 minute
+        assert crontab.remaining_estimate(last_run_at).total_seconds() == 23 * 60 * 60 - 60
+
+    def test_end_of_day_after_dst_end(self):
+        tzname = "Europe/Paris"
+        self.app.timezone = tzname
+        tz = ZoneInfo(tzname)
+        crontab = self.crontab(hour=23, minute=59)
+
+        # start of the day
+        last_run_at = datetime(2017, 10, 29, 0, 0, tzinfo=tz)
+        now = datetime(2017, 10, 29, 0, 0, tzinfo=tz)
+        crontab.nowfun = lambda: now
+
+        # 25h minus 1 minute
+        assert crontab.remaining_estimate(last_run_at).total_seconds() == 25 * 60 * 60 - 60


### PR DESCRIPTION
(same as https://github.com/celery/celery/pull/10585 from a more open fork, see original PR for a first batch of review and comments)

## Description
This pull request is an attempt to get the crontab handle daylight saving correctly:
- do not produce a datetime that does not exists (at DST start, when an hour disappears)
- do not produce a date an hour late (this currently happens at DST end, when an hour appears twice the same day)
- do not produce a next date in the past (remaining_estimate does that on dst end)

After [trying to hack](https://github.com/opendatasoft/celery/commit/c8c73a3a2e643ac80360dba16b85d094e6ec57ac) the current code, I ended up with a complete rewrite of the main function that computes the next run date for a crontab because the existing code was entirely ignoring timezone and makes it very difficult to just hack around it to get a correct result in all cases.


## Disclaimer
That's a relatively big change on the crontab code (even more for a first time contribution), I hesitated quite some time before opening this and I would understand if was too risky but, given the number of issues involving timezones and DST, I think it could be a good thing to have a code that handles timezone at its heart.
It is also highly possible I overlooked some cases (not aware datetime do not seem to be possible in this part of the code but I wonder), so I would be happy to get more insight.
I'm obviously available to discuss all this and ready to change the approach if needed.


## Changes
The new `crontab._next_occurence()` function produces a correct timezone aware date for the next expected crontab run.
It replaces the uses of `remaining()` and `remaining_delta()` (and the internal `_delta_to_next()`).

It does not work with delta at all, the delta is simply computed in `remaining_estimate()` as a simple difference between now and next_run_at (in utc).

The logic inside `_next_occurence()` is a mix of the existing `remaining_delta()`, for the part where we check the current day first to be as fast as possible and `_delta_to_next()` where we look for candidate days.

The code tries to be as fast as possible while only producing correct datetimes, so it is possibly a bit slower, but as far as I can tell not significantly slower.

The existing `remaining_delta()` was kept and modified to use the new code but still produce an `ffwd` instance.
AFAIK it is not used in the codebase except in an assert in the tests but I don't know if it considered to be a visible method or not.

The changes here do not try to modify the cron behaviour, if a crontab is scheduled at `2` on a day that skips that hour in this timezone, I will just not run, and the opposite if the `2` hour happens 2 times, it will run twice that day.


## Tests
I added a whole bunch of tests for cases around DST in multiple timezone to ensure my implementation was correct.
Some tests come from https://github.com/celery/celery/pull/10131 and in the end, there are probably too many tests and duplicated cases...

Fixes #10107

First time contribution, do not hesitate to tell me if things should be done differently.