### PR TITLE
Preserve explicitly supplied empty timer schedules

### DIFF
--- a/celery/utils/timer2.py
+++ b/celery/utils/timer2.py
@@ -48,8 +48,8 @@ class Timer(threading.Thread):
                  on_tick: Optional[Callable[[float], None]] = None,
                  on_start: Optional[Callable[['Timer'], None]] = None,
                  max_interval: Optional[float] = None, **kwargs: Any) -> None:
-        self.schedule = schedule or self.Schedule(on_error=on_error,
-                                                  max_interval=max_interval)
+        self.schedule = schedule if schedule is not None else self.Schedule(
+            on_error=on_error, max_interval=max_interval)
         self.on_start = on_start
         self.on_tick = on_tick or self.on_tick
         super().__init__()

--- a/t/unit/utils/test_timer2.py
+++ b/t/unit/utils/test_timer2.py
@@ -2,10 +2,31 @@ import sys
 import time
 from unittest.mock import Mock, call, patch
 
+import pytest
+
 from celery.utils import timer2 as timer2
 
 
 class test_Timer:
+
+    @pytest.mark.parametrize('has_entries', [False, True])
+    def test_init_with_schedule(self, has_entries):
+        schedule = timer2.Schedule(max_interval=7)
+        if has_entries:
+            schedule.call_after(60, Mock())
+
+        t = timer2.Timer(schedule=schedule)
+
+        assert t.schedule is schedule
+
+    def test_init_without_schedule(self):
+        on_error = Mock()
+
+        t = timer2.Timer(on_error=on_error, max_interval=7)
+
+        assert isinstance(t.schedule, timer2.Schedule)
+        assert t.schedule.on_error is on_error
+        assert t.schedule.max_interval == 7
 
     def test_enter_after(self):
         t = timer2.Timer()


### PR DESCRIPTION
## Description

`Timer` silently discards an explicitly supplied empty `Schedule`: the constructor uses `schedule or self.Schedule(...)`, and a schedule with no queued entries evaluates to false. This loses the supplied instance's configuration and any custom schedule behavior.

For example, on main:

```python
from celery.utils.timer2 import Schedule, Timer

schedule = Schedule(max_interval=7)
timer = Timer(schedule=schedule)
assert timer.schedule is schedule  # fails
```

Use the default schedule only when `schedule is None`. Add regression coverage for empty and populated schedules, plus default construction with `on_error` and `max_interval`.

## Validation

- The empty-schedule regression fails against main at `5ea4a4919aec6be425bf7103a18d011ffea1c5f1`; all 12 timer tests pass with the fix.
- `pytest -p celery.contrib.pytest t/unit/utils t/unit/worker t/unit/concurrency -q --timeout=30`: 1,320 passed, 4 skipped, 1 xfailed (46 subtests passed).
- `pre-commit run --all-files`: passed, including mypy.
- Started a solo worker with an empty custom schedule, a memory broker/backend, and a countdown task. The task completes on both base and fixed source, but only the fixed source retains and invokes the custom schedule. Worker and timer shutdown completed in both runs.

Local validation used CPython 3.12.13 on macOS with Kombu 5.6.2. The full upstream test matrix was not run locally.
