### PR TITLE
Retain fallback context managers until exit

### DIFF
--- a/celery/utils/objects.py
+++ b/celery/utils/objects.py
@@ -82,10 +82,12 @@ class FallbackContext:
     def __enter__(self):
         if self.provided is not None:
             return self.provided
-        context = self._context = self.fallback(
+        context = self.fallback(
             *self.fb_args, **self.fb_kwargs
-        ).__enter__()
-        return context
+        )
+        value = context.__enter__()
+        self._context = context
+        return value
 
     def __exit__(self, *exc_info):
         if self._context is not None:

--- a/t/unit/utils/test_objects.py
+++ b/t/unit/utils/test_objects.py
@@ -1,4 +1,11 @@
-from celery.utils.objects import Bunch
+import gc
+import weakref
+from contextlib import contextmanager
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from celery.utils.objects import Bunch, FallbackContext
 
 
 class test_Bunch:
@@ -7,3 +14,95 @@ class test_Bunch:
         x = Bunch(foo='foo', bar=2)
         assert x.foo == 'foo'
         assert x.bar == 2
+
+
+class test_FallbackContext:
+
+    def test_exit_uses_manager_not_returned_resource(self):
+        manager = MagicMock()
+        resource = MagicMock()
+        manager.__enter__.return_value = resource
+
+        with FallbackContext(None, lambda: manager) as value:
+            assert value is resource
+
+        manager.__exit__.assert_called_once_with(None, None, None)
+        resource.__exit__.assert_not_called()
+
+    def test_failed_enter_does_not_retain_manager(self):
+        references = []
+
+        class Manager:
+            def __enter__(self):
+                raise ValueError('enter failed')
+
+            def __exit__(self, *exc_info):
+                pytest.fail('failed entry must not call exit')
+
+        def fallback():
+            manager = Manager()
+            references.append(weakref.ref(manager))
+            return manager
+
+        context = FallbackContext(None, fallback)
+        with pytest.raises(ValueError, match='enter failed'):
+            with context:
+                pytest.fail('failed entry must not enter body')
+
+        gc.collect()
+        assert references[0]() is None
+
+    @pytest.mark.parametrize('resource', [None, 'resource'])
+    def test_fallback_lifetime(self, resource):
+        events = []
+
+        @contextmanager
+        def fallback(value, *, name):
+            events.append(('enter', name))
+            try:
+                yield value
+            finally:
+                events.append(('exit', name))
+
+        with FallbackContext(None, fallback, resource, name='fallback') as value:
+            assert value is resource
+            assert events == [('enter', 'fallback')]
+
+        assert events == [('enter', 'fallback'), ('exit', 'fallback')]
+
+    @pytest.mark.parametrize('suppress', [False, True])
+    def test_fallback_receives_exception(self, suppress):
+        error = ValueError('body failed')
+        received = []
+
+        @contextmanager
+        def fallback():
+            try:
+                yield 'resource'
+            except ValueError as exc:
+                received.append(exc)
+                if not suppress:
+                    raise
+
+        def run():
+            with FallbackContext(None, fallback):
+                raise error
+
+        if suppress:
+            run()
+        else:
+            with pytest.raises(ValueError) as exc_info:
+                run()
+            assert exc_info.value is error
+
+        assert received == [error]
+
+    def test_provided_resource_is_not_managed(self):
+        resource = Mock()
+        fallback = Mock()
+
+        with FallbackContext(resource, fallback) as value:
+            assert value is resource
+
+        fallback.assert_not_called()
+        assert not resource.mock_calls


### PR DESCRIPTION
## Description

`FallbackContext` calls `__exit__()` on the value returned by `__enter__()`. That value may be a resource such as a path string, so it is not necessarily the object responsible for cleanup.

On CPython 3.12.13, this example deletes the temporary directory before the `with` body runs and raises `AttributeError` when exiting the block:

```python
from pathlib import Path
from tempfile import TemporaryDirectory

from celery.utils.objects import FallbackContext

with FallbackContext(None, TemporaryDirectory) as directory:
    assert Path(directory).is_dir()
```

This change keeps the context manager for cleanup and returns its `__enter__()` result to the caller. The manager is saved only after entry succeeds, so a failed entry does not keep it alive. Tests cover the manager and returned resource being different objects, failed entry, `None` return values, exception handling, and provided resources.

## Validation

- `test_objects.py`: 5 failed and 3 passed on main at `5ea4a4919aec6be425bf7103a18d011ffea1c5f1`; all 8 pass with the fix.
- `pytest -p celery.contrib.pytest t/unit/utils t/unit/app t/unit/test_generics.py -q --timeout=30`: 1,268 passed, 14 skipped, 1 xfailed, and 6 subtests passed.
- `pre-commit run --all-files`: passed, including mypy.
- Actual temporary-directory creation, file write/read and cleanup passed with the fix. Connection and producer acquisition with a memory broker also passed on both base and fixed source, including message round trips and cleanup after exceptions.

These checks used CPython 3.12.13 on macOS. The full upstream test matrix was not run locally.
