### PR TITLE
Fix argument forwarding through nested chains in eager execution

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1306,8 +1306,9 @@ class _chain(Signature):
         kwargs = kwargs if kwargs else {}
         last, (fargs, fkwargs) = None, (args, kwargs)
         for task in self.tasks:
-            res = task.clone(fargs, fkwargs).apply(
-                last and (last.get(),), **dict(self.options, **options))
+            res = task.clone().apply(
+                (last.get(),) if last else fargs, fkwargs,
+                **dict(self.options, **options))
             res.parent, last, (fargs, fkwargs) = last, res, (None, None)
             if isinstance(res, EagerResult) and res.state in (IGNORED, REJECTED):
                 break

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -2220,7 +2220,6 @@ class test_chord:
         res1 = c1.apply(args=(1,))
         assert res1.get(timeout=TIMEOUT) == [1, 1]
 
-    @pytest.mark.xfail(reason="Issue #6200")
     def test_chain_in_chain_with_args(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -2201,7 +2201,6 @@ class test_chord:
         res = c.delay()
         assert res.get(timeout=TIMEOUT) == 7
 
-    @pytest.mark.xfail(reason="Issue #6176")
     def test_chord_in_chain_with_args(self, manager):
         try:
             manager.app.backend.ensure_chords_allowed()

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -862,6 +862,15 @@ class test_chain(CanvasCase):
         assert res.parent.parent.get() == 8
         assert res.parent.parent.parent is None
 
+    @pytest.mark.parametrize('args,kwargs', (((4,), {}), ((), {'x': 4})))
+    def test_apply_chord_in_chain_with_arguments(self, args, kwargs):
+        workflow = chain(
+            chord([self.add.s(y=2), self.add.s(y=3)], self.xsum.s()),
+            self.mul.s(10),
+        )
+
+        assert workflow.apply(args=args, kwargs=kwargs).get() == 130
+
     def test_apply_stops_chain_when_task_raises_ignore(self):
         executed = []
 

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -486,6 +486,37 @@ class test_chain(CanvasCase):
         assert x.clone().args == x.args
         assert isinstance(x.clone(), chain_type)
 
+    @pytest.mark.parametrize('depth', (1, 3))
+    @pytest.mark.parametrize('args,kwargs,expected', (
+        ((3,), {}, 50),
+        ((), {'x': 3}, 50),
+        ((3,), {'y': 4}, 70),
+    ))
+    def test_apply_nested_chain_with_arguments(
+        self, depth, args, kwargs, expected,
+    ):
+        workflow = chain(self.add.s(y=2), self.mul.s(10))
+        for _ in range(depth):
+            workflow = chain(workflow)
+        original = json.dumps(workflow)
+
+        assert workflow.apply(args=args, kwargs=kwargs).get() == expected
+        assert json.dumps(workflow) == original
+
+    def test_apply_nested_chain_with_immutable_first_task(self):
+        workflow = chain(chain(self.add.si(2, 3), self.mul.s(10)))
+
+        assert workflow.apply(args=(99,), kwargs={'y': 99}).get() == 50
+
+    def test_apply_nested_chain_with_tasks_keyword(self):
+        @self.app.task
+        def count_tasks(tasks):
+            return len(tasks)
+
+        workflow = chain(chain(count_tasks.s(), self.mul.s(10)))
+
+        assert workflow.apply(kwargs={'tasks': [1, 2, 3]}).get() == 30
+
     def test_repr(self):
         x = self.add.s(2, 2) | self.add.s(2)
         assert repr(x) == f'{self.add.name}(2, 2) | add(2)'


### PR DESCRIPTION
## Description

Fixes #6200.

`chain(chain(identity.s(), identity.s())).apply(args=(1,))` loses the argument when cloning the inner chain, so its first task raises `TypeError`. The same failure affects `task_always_eager`.

Forward invocation arguments through the cloned signature's `apply()` method. This preserves keyword overrides, immutable signatures and result-parent links, and keeps a task keyword named `tasks` separate from the chain's serialized task list. Add ten unit regressions and enable the existing #6200 and #6176 integration regressions. Both strict expected-failure markers are obsolete after the argument-forwarding fix.

Validation on Python 3.13.5:

- New cases: 9 fail on the base revision; all 10 pass with the fix.
- Related task/canvas suite: 1,018 passed, 1 skipped, 2 existing xfails.
- `pre-commit run --all-files`: passed.
- An isolated in-process worker using the memory transport/backend verifies worker execution, direct `apply`, and `task_always_eager`. A separate 27-case probe covers deeper nesting, groups/chords, immutable tasks and failure propagation.

API/configuration documentation checks have the same failures on the base revision in this lightweight environment. Bandit cannot parse the existing `bandit.json`; its 47 findings match the base revision. The external-broker integration suite and full Python-version matrix were not run locally.

Prepared and tested with OpenAI Codex.
