### PR TITLE
Fix Redis result compression with decode_responses enabled

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -1,5 +1,6 @@
 """Redis result store backend."""
 import time
+import warnings
 from functools import partial
 from ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
 from urllib.parse import unquote
@@ -45,6 +46,11 @@ the Redis result store backend.
 E_REDIS_SENTINEL_MISSING = """
 You need to install the redis library with support of \
 sentinel in order to use the Redis result store backend.
+"""
+
+W_REDIS_COMPRESSION_DISABLED = """\
+The Redis result backend is configured with decode_responses enabled.
+The result_compression setting is ignored and results are stored uncompressed.
 """
 
 W_REDIS_SSL_CERT_OPTIONAL = """
@@ -220,7 +226,7 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
 
     supports_autoexpire = True
     supports_native_join = True
-    # Results are stored as opaque strings, which Redis keeps byte for byte.
+    # Redis preserves binary payloads; response decoding disables compression.
     supports_result_compression = True
 
     #: Maximal length of string value in Redis.
@@ -309,6 +315,10 @@ class RedisBackend(BaseKeyValueStoreBackend, AsyncBackendMixin):
 
         if url:
             self.connparams = self._params_from_url(url, self.connparams)
+
+        if self.compression and self.connparams.get('decode_responses'):
+            warnings.warn(W_REDIS_COMPRESSION_DISABLED, UserWarning)
+            self.compression = None
 
         # If we've received SSL parameters via query string or the
         # redis_backend_use_ssl dict, check ssl_cert_reqs is valid. If set

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -985,6 +985,9 @@ Google Cloud Storage and file-system backends. On any other backend the
 setting is ignored, a warning is emitted when the backend is created, and
 results are stored uncompressed.
 
+For Redis configured with ``decode_responses=True``, this setting is also
+ignored, a warning is emitted, and results are stored uncompressed.
+
 Each compressed result records which method compressed it, so a worker or
 client reads a compressed result correctly whether or not it has this
 setting turned on itself, and results written before the setting was turned

--- a/t/integration/test_redis_backend.py
+++ b/t/integration/test_redis_backend.py
@@ -1,0 +1,32 @@
+import pytest
+
+from celery import states, uuid
+
+
+@pytest.mark.celery(
+    result_serializer='json',
+    accept_content=['json'],
+    result_compression='gzip',
+)
+def test_decode_responses_disables_compression(app):
+    url = app.conf.result_backend
+    if not url.startswith('redis'):
+        pytest.skip('Requires redis result backend.')
+
+    separator = '&' if '?' in url else '?'
+    app.conf.result_backend = f'{url}{separator}decode_responses=true'
+    backend = app.backend
+    task_id = uuid()
+    result = {'answer': 42, 'text': 'hello world'}
+
+    try:
+        backend.store_result(task_id, result, states.SUCCESS)
+
+        assert app.AsyncResult(task_id).get(timeout=5) == result
+        assert isinstance(backend.client.get(backend.get_key_for_task(task_id)), str)
+        # With decode_responses enabled, the backend ignores the configured
+        # compression without changing the app configuration.
+        assert backend.compression is None
+        assert app.conf.result_compression == 'gzip'
+    finally:
+        backend.forget(task_id)

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -678,6 +678,17 @@ class test_RedisBackend(basetest_RedisBackend):
         assert x.connparams['socket_timeout'] == 30.0
         assert x.connparams['socket_connect_timeout'] == 100.0
 
+    def test_url_with_decode_responses_disables_compression(self):
+        self.app.conf.result_compression = 'gzip'
+        backend = self.Backend(
+            app=self.app, url='redis://localhost/0?decode_responses=true',
+        )
+
+        assert backend.compression is None
+        assert backend.connparams['decode_responses']
+        assert self.app.conf.result_compression == 'gzip'
+        assert self.Backend(app=self.app).compression == 'gzip'
+
     def test_url_with_credential_provider(self):
         self.app.conf.redis_socket_timeout = 30.0
         self.app.conf.redis_socket_connect_timeout = 100.0


### PR DESCRIPTION
## Description

A regression of #10504.

When `result_compression` is enabled and `decode_responses=True`, Redis stores results successfully, but `AsyncResult.get()` fails with UnicodeDecodeError because the Redis library tries to decode the compressed bytes as UTF-8 before Celery can decompress them.

  This PR disables compression for Redis backends with response decoding enabled