### PR TITLE
Docs: add missing @app.task decorator to chain example

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -2019,16 +2019,17 @@ Make your design asynchronous instead, for example by using *callbacks*.
 
 .. code-block:: python
 
+    @app.task
     def update_page_info(url):
         # fetch_page -> parse_page -> store_page
         chain = fetch_page.s(url) | parse_page.s() | store_page_info.s(url)
         chain()
 
-    @app.task()
+    @app.task
     def fetch_page(url):
         return myhttplib.get(url)
 
-    @app.task()
+    @app.task
     def parse_page(page):
         return myparser.parse_document(page)
 


### PR DESCRIPTION
## Description

Fixes #4750.

In the *Avoid launching synchronous subtasks* section of the task guide, the **Good** example is missing the `@app.task` decorator on `update_page_info`, even though the **Bad** example directly above it declares the task. As written, the recommended version isn't a task at all.

The same block also mixed `@app.task()` and `@app.task`, which reads as if the parentheses were meaningful. Normalised them to `@app.task` to match the surrounding examples; `store_page_info` keeps its arguments.

Both points were raised by the reporter in #4750.

## Verification

Documentation-only change to a `code-block` — no code paths affected.

- `pre-commit run --files docs/userguide/tasks.rst` — passed
- `sphinx-build -b apicheck` / `-b configcheck` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)