### PR TITLE
Accept timedelta for countdown, expires and time limits

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -14,7 +14,7 @@ from celery import signals
 from celery.utils.nodenames import anon_nodename
 from celery.utils.saferepr import saferepr
 from celery.utils.text import indent as textindent
-from celery.utils.time import maybe_make_aware
+from celery.utils.time import maybe_make_aware, maybe_seconds
 
 from . import routes as _routes
 
@@ -339,6 +339,10 @@ class AMQP:
             raise TypeError('task args must be a list or tuple')
         if not isinstance(kwargs, Mapping):
             raise TypeError('task keyword arguments must be a mapping')
+        countdown = maybe_seconds(countdown)
+        expires = maybe_seconds(expires)
+        time_limit = maybe_seconds(time_limit)
+        soft_time_limit = maybe_seconds(soft_time_limit)
         if countdown:  # convert countdown to ETA
             self._verify_seconds(countdown, 'countdown')
             now = now or self.app.now()
@@ -432,6 +436,10 @@ class AMQP:
             raise TypeError('task args must be a list or tuple')
         if not isinstance(kwargs, Mapping):
             raise TypeError('task keyword arguments must be a mapping')
+        countdown = maybe_seconds(countdown)
+        expires = maybe_seconds(expires)
+        time_limit = maybe_seconds(time_limit)
+        soft_time_limit = maybe_seconds(soft_time_limit)
         if countdown:  # convert countdown to ETA
             self._verify_seconds(countdown, 'countdown')
             now = now or self.app.now()

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -38,7 +38,7 @@ from celery.utils.functional import first, head_from_fun, maybe_list
 from celery.utils.imports import gen_task_name, instantiate, symbol_by_name
 from celery.utils.log import get_logger
 from celery.utils.objects import FallbackContext, mro_lookup
-from celery.utils.time import maybe_make_aware, timezone, to_utc
+from celery.utils.time import maybe_make_aware, maybe_seconds, timezone, to_utc
 
 from ..utils.annotations import annotation_is_class, annotation_issubclass, get_optional_arg
 from ..utils.quorum_queues import detect_quorum_queues
@@ -935,6 +935,14 @@ class Celery:
             expires = options.pop('expires', None)
         else:
             options.pop('expires', None)
+
+        # Durations may be given as a timedelta instead of a number of
+        # seconds; normalise them before anything downstream does
+        # arithmetic or comparisons with them.
+        countdown = maybe_seconds(countdown)
+        expires = maybe_seconds(expires)
+        time_limit = maybe_seconds(time_limit)
+        soft_time_limit = maybe_seconds(soft_time_limit)
 
         ignore_result = options.pop('ignore_result', False)
         options = router.route(

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -553,15 +553,18 @@ class Task:
 
             kwargs (Dict): The keyword arguments to pass on to the task.
 
-            countdown (float): Number of seconds into the future that the
-                task should execute.  Defaults to immediate execution.
+            countdown (float, ~datetime.timedelta): Number of seconds into
+                the future that the task should execute, or an equivalent
+                :class:`~datetime.timedelta`.  Defaults to immediate
+                execution.
 
             eta (~datetime.datetime): Absolute time and date of when the task
                 should be executed.  May not be specified if `countdown`
                 is also supplied.
 
-            expires (float, ~datetime.datetime): Datetime or
-                seconds in the future for the task should expire.
+            expires (float, ~datetime.timedelta, ~datetime.datetime):
+                Datetime, :class:`~datetime.timedelta`, or seconds in the
+                future for the task should expire.
                 The task won't be executed after the expiration time.
 
             shadow (str): Override task name used in logs/monitoring.
@@ -579,10 +582,11 @@ class Task:
             retry_policy (Mapping): Override the retry policy used.
                 See the :setting:`task_publish_retry_policy` setting.
 
-            time_limit (int): If set, overrides the default time limit.
+            time_limit (int, ~datetime.timedelta): If set, overrides the
+                default time limit.
 
-            soft_time_limit (int): If set, overrides the default soft
-                time limit.
+            soft_time_limit (int, ~datetime.timedelta): If set, overrides
+                the default soft time limit.
 
             queue (str, kombu.Queue): The queue to route the task to.
                 This must be a key present in :setting:`task_queues`, or
@@ -799,7 +803,9 @@ class Task:
 
                 If no exception was raised it will raise the ``exc``
                 argument provided.
-            countdown (float): Time in seconds to delay the retry for.
+            countdown (float, ~datetime.timedelta): Time in seconds, or an
+                equivalent :class:`~datetime.timedelta`, to delay the retry
+                for.
             eta (~datetime.datetime): Explicit time and date to run the
                 retry at.
             max_retries (int): If set, overrides the default retry limit for

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -31,7 +31,7 @@ else:
 logger = logging.getLogger(__name__)
 
 __all__ = (
-    'LocalTimezone', 'timezone', 'maybe_timedelta',
+    'LocalTimezone', 'timezone', 'maybe_timedelta', 'maybe_seconds',
     'delta_resolution', 'remaining', 'rate', 'weekday',
     'humanize_seconds', 'maybe_iso8601', 'is_naive',
     'make_aware', 'localize', 'to_utc', 'maybe_make_aware',
@@ -189,6 +189,19 @@ def maybe_timedelta(delta: int) -> timedelta:
     """Convert integer to timedelta, if argument is an integer."""
     if isinstance(delta, numbers.Real):
         return timedelta(seconds=delta)
+    return delta
+
+
+def maybe_seconds(delta: float | timedelta | None) -> float | None:
+    """Convert timedelta to seconds, if argument is a timedelta.
+
+    Any other value (including :const:`None`) is returned unchanged, so this
+    can be applied to duration arguments that are usually given as a number
+    of seconds but may also be expressed as a
+    :class:`~datetime.timedelta`.
+    """
+    if isinstance(delta, timedelta):
+        return delta.total_seconds()
     return delta
 
 

--- a/docs/userguide/calling.rst
+++ b/docs/userguide/calling.rst
@@ -279,7 +279,16 @@ If the task has a :attr:`~@Task.rate_limit` configured, the rate limit
 is enforced once the ETA has passed: the task starts no earlier than its
 ETA, and rate limiting may delay it further beyond that point.
 
-While `countdown` is an integer, `eta` must be a :class:`~datetime.datetime`
+`countdown` is a number of seconds, but may also be given as a
+:class:`~datetime.timedelta`, which can be clearer for longer delays:
+
+.. code-block:: pycon
+
+    >>> from datetime import timedelta
+
+    >>> add.apply_async((2, 2), countdown=timedelta(hours=2))
+
+`eta` must be a :class:`~datetime.datetime`
 object, specifying an exact date and time (including millisecond precision,
 and timezone information):
 
@@ -339,16 +348,19 @@ Expiration
 ==========
 
 The `expires` argument defines an optional expiry time,
-either as seconds after task publish, or a specific date and time using
-:class:`~datetime.datetime`:
+either as seconds after task publish, as a :class:`~datetime.timedelta`,
+or as a specific date and time using :class:`~datetime.datetime`:
 
 .. code-block:: pycon
 
     >>> # Task expires after one minute from now.
     >>> add.apply_async((10, 10), expires=60)
 
-    >>> # Also supports datetime
+    >>> # Also supports timedelta
     >>> from datetime import datetime, timedelta, timezone
+    >>> add.apply_async((10, 10), expires=timedelta(minutes=1))
+
+    >>> # Also supports datetime
     >>> add.apply_async((10, 10), kwargs,
     ...                 expires=datetime.now(timezone.utc) + timedelta(days=1))
 

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
@@ -250,6 +251,26 @@ class test_AMQP_proto1:
         self.app.amqp.utc = False
         self.app.amqp.as_task_v1(uuid(), 'foo', countdown=30, expires=40)
 
+    def test_timedelta_durations_match_seconds(self):
+        now = to_utc(datetime.now(timezone.utc)).astimezone(self.app.timezone)
+        task_id = uuid()
+        as_delta = self.app.amqp.as_task_v1(
+            task_id, 'foo', now=now,
+            countdown=timedelta(seconds=30),
+            expires=timedelta(seconds=40),
+            time_limit=timedelta(minutes=2),
+            soft_time_limit=timedelta(minutes=1),
+        )
+        as_seconds = self.app.amqp.as_task_v1(
+            task_id, 'foo', now=now,
+            countdown=30.0, expires=40.0,
+            time_limit=120.0, soft_time_limit=60.0,
+        )
+        assert as_delta.body == as_seconds.body
+        assert as_delta.properties == as_seconds.properties
+        assert as_delta.body['timelimit'] == (120.0, 60.0)
+        json.dumps(as_delta.body)
+
 
 class test_AMQP_Base:
     def setup_method(self):
@@ -496,6 +517,49 @@ class test_as_task_v2(test_AMQP_Base):
         )
         assert m.headers['expires'] == (
             now + timedelta(seconds=30)).isoformat()
+
+    def test_countdown_as_timedelta_to_eta(self):
+        now = to_utc(datetime.now(timezone.utc)).astimezone(self.app.timezone)
+        m = self.app.amqp.as_task_v2(
+            uuid(), 'foo', countdown=timedelta(minutes=10), now=now,
+        )
+        assert m.headers['eta'] == (now + timedelta(minutes=10)).isoformat()
+
+    def test_expires_as_timedelta_to_datetime(self):
+        now = to_utc(datetime.now(timezone.utc)).astimezone(self.app.timezone)
+        m = self.app.amqp.as_task_v2(
+            uuid(), 'foo', expires=timedelta(minutes=30), now=now,
+        )
+        assert m.headers['expires'] == (
+            now + timedelta(minutes=30)).isoformat()
+
+    def test_timedelta_durations_match_seconds(self):
+        now = to_utc(datetime.now(timezone.utc)).astimezone(self.app.timezone)
+        task_id = uuid()
+        as_delta = self.app.amqp.as_task_v2(
+            task_id, 'foo', now=now,
+            countdown=timedelta(hours=2),
+            expires=timedelta(hours=4),
+            time_limit=timedelta(minutes=61),
+            soft_time_limit=timedelta(minutes=60),
+        )
+        as_seconds = self.app.amqp.as_task_v2(
+            task_id, 'foo', now=now,
+            countdown=7200.0,
+            expires=14400.0,
+            time_limit=3660.0,
+            soft_time_limit=3600.0,
+        )
+        assert as_delta.headers == as_seconds.headers
+
+    def test_timelimit_as_timedelta_is_serializable(self):
+        m = self.app.amqp.as_task_v2(
+            uuid(), 'foo',
+            time_limit=timedelta(hours=2),
+            soft_time_limit=timedelta(hours=1),
+        )
+        assert m.headers['timelimit'] == [7200.0, 3600.0]
+        json.dumps(m.headers)
 
     def test_eta_to_datetime(self):
         eta = datetime.now(timezone.utc)

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1630,6 +1630,38 @@ class test_App:
             "expires should not appear in kwargs (passed positionally)"
 
     @patch('celery.app.base.detect_quorum_queues', return_value=[False, ""])
+    def test_send_task_accepts_timedelta_durations(self, detect_quorum_queues):
+        """Durations may be given as timedeltas instead of seconds."""
+
+        @self.app.task(name='test_task_timedelta_durations')
+        def test_task():
+            pass
+
+        self.app.finalize()
+
+        connection = Mock(name='connection')
+        router = Mock(name='router')
+        router.route.side_effect = lambda opts, *a, **kw: opts
+        self.app.amqp = Mock(name='amqp')
+        self.app.amqp.Producer.attach_mock(ContextMock(), 'return_value')
+
+        self.app.send_task(
+            'test_task_timedelta_durations', (1,),
+            connection=connection, router=router,
+            countdown=timedelta(minutes=5),
+            expires=timedelta(hours=1),
+            time_limit=timedelta(minutes=2),
+            soft_time_limit=timedelta(minutes=1),
+        )
+
+        args, kwargs = self.app.amqp.create_task_message.call_args
+        bound = inspect.signature(AMQP.as_task_v2).bind(None, *args, **kwargs)
+        assert bound.arguments['countdown'] == 300.0
+        assert bound.arguments['expires'] == 3600.0
+        assert bound.arguments['time_limit'] == 120.0
+        assert bound.arguments['soft_time_limit'] == 60.0
+
+    @patch('celery.app.base.detect_quorum_queues', return_value=[False, ""])
     def test_send_task_registry_without_get_method(self, detect_quorum_queues):
         """send_task should handle registries that lack a .get() method."""
 

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -14,8 +14,8 @@ else:
 from celery.utils.iso8601 import parse_iso8601
 from celery.utils.time import (LocalTimezone, _is_imaginary, delta_resolution, ffwd,
                                get_exponential_backoff_interval, humanize_seconds, localize, make_aware,
-                               maybe_iso8601, maybe_make_aware, maybe_timedelta, rate, remaining, timezone,
-                               utcoffset)
+                               maybe_iso8601, maybe_make_aware, maybe_seconds, maybe_timedelta, rate, remaining,
+                               timezone, utcoffset)
 
 
 class test_LocalTimezone:
@@ -137,6 +137,20 @@ def test_iso8601_string_datetime(date_str, expected):
 ])
 def test_maybe_timedelta(arg, expected):
     assert maybe_timedelta(arg) == expected
+
+
+@pytest.mark.parametrize('arg,expected', [
+    (timedelta(seconds=30), 30.0),
+    (timedelta(hours=2), 7200.0),
+    (timedelta(milliseconds=1500), 1.5),
+    (timedelta(0), 0.0),
+    (timedelta(seconds=-30), -30.0),
+    (30, 30),
+    (30.6, 30.6),
+    (None, None),
+])
+def test_maybe_seconds(arg, expected):
+    assert maybe_seconds(arg) == expected
 
 
 def test_remaining():


### PR DESCRIPTION
## Description

Fixes #10367.

`countdown`, `expires`, `time_limit` and `soft_time_limit` are documented as a number of seconds, which makes longer durations awkward to write and easy to misread:

```python
@shared_task(
    soft_time_limit=60 * 60 * 2,       # 2 hours
    time_limit=60 * 60 * 2 + 60,       # 2 hours + 1 minute
    expires=60 * 60 * 4,               # 4 hours
)
def task(): ...
```

Passing a `timedelta` instead currently fails, in two different ways:

* **`countdown` / `expires`** raise `TypeError: '<' not supported between instances of 'datetime.timedelta' and 'int'`, from the seconds range check — far from the call site that caused it.
* **`time_limit` / `soft_time_limit`** are accepted silently and placed in the message headers as `timedelta` objects, then fail later when the message is serialized:

  ```
  timelimit header -> [datetime.timedelta(seconds=30), datetime.timedelta(seconds=10)]
  TypeError: Object of type timedelta is not JSON serializable
  ```

After this change:

```python
@shared_task(
    soft_time_limit=timedelta(hours=2),
    time_limit=timedelta(hours=2, minutes=1),
    expires=timedelta(hours=4),
)
def task(): ...
```

## Implementation

Adds `celery.utils.time.maybe_seconds()`, the inverse of the existing `maybe_timedelta()`, and uses it to normalise these four arguments in:

* `Celery.send_task()`
* `AMQP.as_task_v1()` and `AMQP.as_task_v2()`

Normalising in `send_task()` matters as well as in `amqp.py`: the native delayed-delivery routing and the expiration check both do arithmetic and comparisons on these values before the message is built, so converting only at message-creation time would leave those paths broken.

A `timedelta` and the equivalent number of seconds now produce identical task messages. Numbers, `None` and `datetime` values are unaffected, so this is backwards compatible.

Docstrings for `apply_async()` and `retry()` and the *ETA and Countdown* / *Expiration* sections of the calling guide are updated to mention the accepted types.

## Verification

New tests, all passing:

* `t/unit/utils/test_time.py` — `maybe_seconds()` over timedeltas, numbers and `None`
* `t/unit/app/test_amqp.py` — timedelta `countdown`/`expires` for `as_task_v2`; an equivalence test asserting a timedelta and the equivalent seconds produce identical messages for both protocols; a JSON-serialisability test for `timelimit`
* `t/unit/app/test_app.py` — `send_task()` normalises all four arguments

Checklist from `CONTRIBUTING.rst`:

* `pytest t/unit` — same 3 pre-existing failures as `main`, +14 passing tests, no new errors (the remaining errors are a pre-existing teardown cascade from a leaked thread in `t/unit/contrib/test_rdb.py`; running the affected modules without it gives 789 passed, 0 errors)
* `pre-commit run --files <changed>` — passed, including mypy and isort
* `bandit -b bandit.json celery/` — 0 issues
* `sphinx-build -b apicheck` / `-b configcheck` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)