### PR TITLE
 fix(canvas): propagate aggregate_duplicates through nested stamp merges

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -100,7 +100,7 @@ def _merge_dictionaries(d1, d2, aggregate_duplicates=True):
     for key, value in d1.items():
         if key in d2:
             if isinstance(value, dict):
-                _merge_dictionaries(d1[key], d2[key])
+                _merge_dictionaries(d1[key], d2[key], aggregate_duplicates)
             else:
                 if isinstance(value, (int, float, str)):
                     d1[key] = [value] if aggregate_duplicates else value

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -2320,3 +2320,31 @@ class test_merge_dictionaries(CanvasCase):
     def test_none_values(self, d1, d2, expected_result):
         _merge_dictionaries(d1, d2)
         assert d1 == expected_result
+
+    @pytest.mark.parametrize('aggregate_duplicates,expected_result', [
+        (
+            True,
+            {'nested': {'shared': [1, 2], 'only_d1': 1, 'only_d2': 2}}
+        ),
+        (
+            False,
+            {'nested': {'shared': 1, 'only_d1': 1, 'only_d2': 2}}
+        ),
+    ])
+    def test_nested_dictionaries_honor_aggregate_duplicates(self, aggregate_duplicates, expected_result):
+        """aggregate_duplicates must be propagated into nested dictionaries."""
+        d1 = {'nested': {'shared': 1, 'only_d1': 1}}
+        d2 = {'nested': {'shared': 2, 'only_d2': 2}}
+        _merge_dictionaries(d1, d2, aggregate_duplicates=aggregate_duplicates)
+        assert d1 == expected_result
+
+    @pytest.mark.parametrize('aggregate_duplicates,expected_value', [
+        (True, [1, 2]),
+        (False, 1),
+    ])
+    def test_deeply_nested_dictionaries_honor_aggregate_duplicates(self, aggregate_duplicates, expected_value):
+        """aggregate_duplicates must survive more than one level of recursion."""
+        d1 = {'level1': {'level2': {'level3': {'shared': 1}}}}
+        d2 = {'level1': {'level2': {'level3': {'shared': 2}}}}
+        _merge_dictionaries(d1, d2, aggregate_duplicates=aggregate_duplicates)
+        assert d1 == {'level1': {'level2': {'level3': {'shared': expected_value}}}}

--- a/t/unit/tasks/test_stamping.py
+++ b/t/unit/tasks/test_stamping.py
@@ -1313,3 +1313,33 @@ class test_stamping_mechanism(CanvasCase):
             canvas = chain(tasks())
             canvas.link_error(s("chain_link_error"))
             canvas.stamp(CustomStampingVisitor())
+
+    def test_nested_dict_stamp_respects_append_stamps(self, subtests):
+        """Nested dict stamps must honor append_stamps, like flat stamps do.
+
+        Regression test: the recursive _merge_dictionaries() call dropped its
+        aggregate_duplicates argument, so a stamp whose value is a dict was
+        always aggregated into a list, even when append_stamps=False.
+        """
+
+        class NestedStampVisitor(StampingVisitor):
+            def on_signature(self, sig: Signature, **headers) -> dict:
+                return {"nested_stamp": {"shared": 2}}
+
+        with subtests.test("append_stamps=False does not aggregate nested values"):
+            sig = self.add.s(1, 1)
+            sig.stamp(
+                NestedStampVisitor(),
+                append_stamps=False,
+                nested_stamp={"shared": 1, "only_sig": 1},
+            )
+            assert sig.options["nested_stamp"] == {"shared": 1, "only_sig": 1}
+
+        with subtests.test("append_stamps=True aggregates nested values"):
+            sig = self.add.s(1, 1)
+            sig.stamp(
+                NestedStampVisitor(),
+                append_stamps=True,
+                nested_stamp={"shared": 1, "only_sig": 1},
+            )
+            assert sig.options["nested_stamp"] == {"shared": [1, 2], "only_sig": 1}


### PR DESCRIPTION
Takes over #10588 (per @auvipy's request there), with the unit tests that PR was missing.

## Problem

`_merge_dictionaries()` recursed into nested dictionaries without passing `aggregate_duplicates` along:

```python
if isinstance(value, dict):
    _merge_dictionaries(d1[key], d2[key])   # <- argument dropped
