### PR TITLE
docs: fix 'Allows to' grammar in configuration settings

### DIFF
--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -1076,7 +1076,7 @@ Default: Disabled by default.
 
 Path to class that implements backend.
 
-Allows to override backend implementation.
+Allows overriding the backend implementation.
 This can be useful if you need to store additional metadata about executed tasks,
 override retry policies, etc.
 
@@ -2195,7 +2195,7 @@ For example to auto remove results after 24 hours::
 Default: 10.
 
 Threadpool size for GCS operations. Same value defines the connection pool size.
-Allows to control the number of concurrent operations. For example::
+Allows controlling the number of concurrent operations. For example::
 
     gcs_threadpool_maxsize = 20
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Fix grammar in configuration docs:

- `Allows to override backend implementation.` → `Allows overriding the backend implementation.`
- `Allows to control the number of concurrent operations.` → `Allows controlling the number of concurrent operations.`

## Test plan

- [x] Confirmed surrounding sentences still read correctly after the change.