### PR TITLE
docs: fix awkward 'exception occurred' phrasing in task states

### DIFF
--- a/docs/userguide/tasks.rst
+++ b/docs/userguide/tasks.rst
@@ -1306,7 +1306,7 @@ FAILURE
 
 Task execution resulted in failure.
 
-:meta-data: `result` contains the exception occurred, and `traceback`
+:meta-data: `result` contains the exception that occurred, and `traceback`
             contains the backtrace of the stack at the point when the
             exception was raised.
 :propagates: Yes


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

Clarify awkward phrasing in the FAILURE task state docs:

`contains the exception occurred` → `contains the exception that occurred`.

## Test plan

- [x] Confirmed surrounding sentence still reads correctly after the change.