### PR TITLE
Prevent spawned worker crashes with explicit lazy=True

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -557,7 +557,8 @@ class Celery:
             # the task instance from the current app.
             # Really need a better solution for this :(
             from . import shared_task
-            return shared_task(*args, lazy=False, **opts)
+            opts['lazy'] = False
+            return shared_task(*args, **opts)
 
         def inner_create_task_cls(shared=True, filter=None, lazy=True, **opts):
             _filt = filter

--- a/t/smoke/tasks.py
+++ b/t/smoke/tasks.py
@@ -8,7 +8,7 @@ from signal import SIGKILL
 from time import sleep
 
 import celery.utils
-from celery import Task, shared_task, signature
+from celery import Task, current_app, shared_task, signature
 from celery.canvas import Signature
 from t.integration.tasks import *  # noqa
 from t.integration.tasks import replaced_with_me
@@ -17,6 +17,11 @@ from t.integration.tasks import replaced_with_me
 @shared_task
 def noop(*args, **kwargs) -> None:
     return celery.utils.noop(*args, **kwargs)
+
+
+@current_app.task(lazy=True)
+def add_with_explicit_lazy_option(x, y):
+    return x + y
 
 
 @shared_task

--- a/t/smoke/tests/test_worker.py
+++ b/t/smoke/tests/test_worker.py
@@ -52,6 +52,14 @@ class test_pool_start_method_spawn:
         sig = long_running_task.si(1, verbose=True).set(queue=queue)
         assert sig.delay().get(RESULT_TIMEOUT) is True
 
+    def test_spawn_worker_executes_task_with_explicit_lazy_option(self, celery_setup: CeleryTestSetup):
+        result = celery_setup.app.send_task(
+            "t.smoke.tasks.add_with_explicit_lazy_option",
+            args=(2, 3),
+            queue=celery_setup.worker.worker_queue,
+        )
+        assert result.get(timeout=RESULT_TIMEOUT) == 5
+
 
 @pytest.mark.parametrize("method", list(WorkerRestart.Method))
 class test_worker_restart(SuiteOperations):

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -207,6 +207,17 @@ class test_App:
         assert not _appbase.USING_EXECV
 
     @pytest.mark.usefixtures('depends_on_current_app')
+    def test_task_decorator_accepts_explicit_lazy_in_execv_mode(self):
+        """The execv decorator path must accept an explicit lazy=True option."""
+        with patch.object(_appbase, 'USING_EXECV', True):
+            @self.app.task(lazy=True)
+            def add(x, y):
+                return x + y
+
+            assert add._get_current_object() is self.app.tasks[add.name]
+            assert add(2, 3) == 5
+
+    @pytest.mark.usefixtures('depends_on_current_app')
     def test_task_execv_env_set_after_import(self):
         # a spawned pool child sets the variable from process_initializer()
         with patch.dict(os.environ, {'FORKED_BY_MULTIPROCESSING': '1'}):


### PR DESCRIPTION
## Description

A spawned worker crashes if a task explicitly sets `lazy=True` because 
https://github.com/celery/celery/blob/0c950f6af4f4fd55d409e69077c9b057a51f0c22/celery/app/base.py#L560
passes `lazy=False` alongside `**opts` supplies the keyword twice and raises a TypeError.

This sets `lazy=False` in the options dictionary before forwarding it to shared_task(), ensuring the keyword is passed only once.
