### PR TITLE
Redact SAS tokens and lowercase account keys in AzureBlockBlobBackend.as_uri

### DIFF
--- a/celery/backends/azureblockblob.py
+++ b/celery/backends/azureblockblob.py
@@ -174,13 +174,15 @@ class AzureBlockBlobBackend(KeyValueStoreBackend):
                 f'{self._connection_string}'
             )
 
-        connection_string_parts = self._connection_string.split(';')
-        account_key_prefix = 'AccountKey='
-        redacted_connection_string_parts = [
-            f'{account_key_prefix}**' if part.startswith(account_key_prefix)
-            else part
-            for part in connection_string_parts
-        ]
+        # Azure matches connection string keys case-insensitively, and a
+        # SharedAccessSignature is as much a secret as an AccountKey.
+        secret_keys = {'accountkey', 'sharedaccesssignature'}
+        redacted_connection_string_parts = []
+        for part in self._connection_string.split(';'):
+            key, sep, _ = part.partition('=')
+            if sep and key.strip().lower() in secret_keys:
+                part = f'{key}=**'
+            redacted_connection_string_parts.append(part)
 
         return (
             f'{AZURE_BLOCK_BLOB_CONNECTION_PREFIX}'

--- a/t/unit/backends/test_azureblockblob.py
+++ b/t/unit/backends/test_azureblockblob.py
@@ -226,3 +226,33 @@ class test_as_uri:
             "AccountKey=**;"
             "EndpointSuffix=suffix"
         )
+
+    def test_as_uri_exclude_shared_access_signature(self):
+        backend = AzureBlockBlobBackend(
+            app=self.app,
+            url=(
+                "azureblockblob://"
+                "BlobEndpoint=https://name.blob.core.windows.net/;"
+                "SharedAccessSignature=sv=2022-11-02&sig=signature"
+            )
+        )
+        assert backend.as_uri(include_password=False) == (
+            "azureblockblob://"
+            "BlobEndpoint=https://name.blob.core.windows.net/;"
+            "SharedAccessSignature=**"
+        )
+
+    def test_as_uri_exclude_password_case_insensitive_key(self):
+        backend = AzureBlockBlobBackend(
+            app=self.app,
+            url=(
+                "azureblockblob://"
+                "AccountName=name;"
+                "accountkey=account_key"
+            )
+        )
+        assert backend.as_uri(include_password=False) == (
+            "azureblockblob://"
+            "AccountName=name;"
+            "accountkey=**"
+        )


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

While reading `AzureBlockBlobBackend.as_uri()` I noticed it only masks a connection string part that starts with the exact text `AccountKey=`. The Azure SDK accepts two other forms that carry a secret, and both came out in clear.

The first is a SAS connection string (`BlobEndpoint=...;SharedAccessSignature=sv=...&sig=...`), which `BlobServiceClient.from_connection_string()` accepts as is. The second is the same key in a different case: the SDK upper-cases keys before reading them (`parse_connection_str` in azure-storage-blob 12.30.1), so `accountkey=...` authenticates fine but is not matched by `startswith('AccountKey=')`.

I checked this against azure-storage-blob 12.30.1 with a fake token. On main:

```
>>> AzureBlockBlobBackend(app=app, url="azureblockblob://BlobEndpoint=https://acct.blob.core.windows.net/;SharedAccessSignature=sv=2022-11-02&sig=SECRETSIG%3D").as_uri()
'azureblockblob://BlobEndpoint=https://acct.blob.core.windows.net/;SharedAccessSignature=sv=2022-11-02&sig=SECRETSIG%3D'
>>> AzureBlockBlobBackend(app=app, url="azureblockblob://AccountName=acct;accountkey=c2VjcmV0a2V5").as_uri()
'azureblockblob://AccountName=acct;accountkey=c2VjcmV0a2V5'
```

`as_uri()` is what the worker banner prints on its `results:` line (`celery/apps/worker.py`), so the token ends up in startup logs.

The fix compares each key case-insensitively against `AccountKey` and `SharedAccessSignature` and keeps the key as the user wrote it, so the existing `AccountKey=**` output is unchanged. `include_password=True` still returns the full string.

I added two tests next to the existing `as_uri` ones. Both fail on main with an assertion error and pass with the change, and the whole `t/unit/backends/test_azureblockblob.py` passes (22 tests). flake8 is clean on both files.

AI tools used
