### PR TITLE
Prevent add_defaults() from crashing when config_from_object() fails on an already configured app

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -729,8 +729,8 @@ class Celery:
         self._config_source_silent = silent
         self.namespace = namespace or self.namespace
         if force or self.configured:
-            self._conf = None
             if self.loader.config_from_object(obj, silent=silent):
+                self._conf = None
                 return self.conf
 
     def config_from_envvar(self, variable_name, silent=False, force=False):

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -995,6 +995,16 @@ class test_App:
         self.app.config_from_object('nonexistent.module', silent=True, force=True)
         assert self.app.conf.get('SOME_CONFIG') is None
 
+    def test_config_from_object__can_add_defaults_after_silent_reload_failure(self):
+        self.app.config_from_object({'worker_prefetch_multiplier': 10})
+        assert self.app.conf.worker_prefetch_multiplier == 10
+        assert self.app.configured
+
+        self.app.config_from_object('nonexistent.module', silent=True)
+        self.app.add_defaults({'worker_prefetch_multiplier': 20})
+
+        assert self.app.conf.worker_prefetch_multiplier == 20
+
     def test_config_from_object__silent_survives_v1_pickle(self):
         """The flag must survive the deprecated v1 reduction too.
 


### PR DESCRIPTION
## Description

If `config_from_object(..., silent=True)` fails on an already configured app, `self._conf` has already been cleared, but `configured` is still True. Calling `add_defaults()` then raises an AttributeError.

This PR only clears self._conf after the configuration loads successfully.

```python
def add_defaults(self, fun):
    """Add default configuration from dict ``d``.

    If the argument is a callable function then it will be regarded
    as a promise, and it won't be loaded until the configuration is
    actually needed.

    This method can be compared to:

    .. code-block:: pycon

        >>> celery.conf.update(d)

    with a difference that 1) no copy will be made and 2) the dict will
    not be transferred when the worker spawns child processes, so
    it's important that the same configuration happens at import time
    when pickle restores the object on the other side.
    """
    if not callable(fun):
        d, fun = fun, lambda: d
    if self.configured:
>           return self._conf.add_defaults(fun())
               ^^^^^^^^^^^^^^^^^^^^^^^
E           AttributeError: 'NoneType' object has no attribute 'add_defaults'
```