### PR TITLE
Preserve configuration when copying settings

### DIFF
--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -81,6 +81,18 @@ class Settings(ConfigurationView):
 
         self.deprecated_settings = deprecated_settings
 
+    def copy(self):
+        self.finalize()
+        copied = super().copy()
+        if 'deprecated_settings' in self.changes:
+            copied.changes['deprecated_settings'] = (
+                self.changes['deprecated_settings']
+            )
+        else:
+            copied.changes.pop('deprecated_settings', None)
+        return copied
+    __copy__ = copy
+
     @property
     def broker_read_url(self):
         return (

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -373,6 +373,15 @@ class ConfigurationView(ChainMap, AttributeDictMixin):
             _keys=keys,
         )
 
+    def copy(self):
+        # type: () -> 'ConfigurationView'
+        copied = self.__class__(
+            self.changes.copy(), self.defaults, self._keys, self.prefix,
+        )
+        copied.__dict__['key_t'] = self.key_t
+        return copied
+    __copy__ = copy
+
     def _to_keys(self, key):
         # type: (str) -> Sequence[str]
         prefix = self.prefix

--- a/t/unit/app/test_utils.py
+++ b/t/unit/app/test_utils.py
@@ -1,11 +1,54 @@
 from collections.abc import Mapping, MutableMapping
+from copy import copy
 from unittest.mock import Mock
+
+import pytest
 
 from celery.app.defaults import Option
 from celery.app.utils import Settings, bugreport, filter_hidden_settings
 
 
 class test_Settings:
+
+    @pytest.mark.parametrize('copy_fun', [lambda settings: settings.copy(), copy])
+    @pytest.mark.parametrize('configured', [False, True])
+    @pytest.mark.parametrize('namespace, config', [
+        (None, {'task_always_eager': True}),
+        ('CELERY', {'CELERY_TASK_ALWAYS_EAGER': True}),
+        (None, {'CELERY_ALWAYS_EAGER': True}),
+    ])
+    def test_copy_app_settings(self, copy_fun, configured, namespace, config):
+        with self.Celery(set_as_current=False) as app:
+            app.config_from_object(config, namespace=namespace)
+            app.add_defaults(lambda: {'copy_default': 'custom'})
+            if configured:
+                assert app.conf.task_always_eager is True
+            assert app.configured is configured
+
+            copied = copy_fun(app.conf)
+
+            assert copied.task_always_eager is True
+            assert copied.copy_default == 'custom'
+            assert dict(copied) == dict(app.conf)
+            copied.task_always_eager = False
+            assert copied.task_always_eager is False
+            assert app.conf.task_always_eager is True
+
+    @pytest.mark.parametrize('copy_fun', [lambda settings: settings.copy(), copy])
+    @pytest.mark.parametrize('cleared', [False, True])
+    def test_copy_preserves_deprecated_settings(self, copy_fun, cleared):
+        settings = Settings(
+            {'task_always_eager': True},
+            deprecated_settings={'CELERY_ALWAYS_EAGER'},
+        )
+        if cleared:
+            settings.clear()
+
+        copied = copy_fun(settings)
+
+        assert dict(copied) == dict(settings)
+        if not cleared:
+            assert copied.deprecated_settings is settings.deprecated_settings
 
     def test_is_mapping(self):
         """Settings should be a collections.Mapping"""

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -1,5 +1,6 @@
 import pickle
 from collections.abc import Mapping
+from copy import copy
 from itertools import count
 from time import monotonic
 from unittest.mock import Mock
@@ -53,6 +54,73 @@ class test_DictAttribute:
 
 
 class test_ConfigurationView:
+
+    @pytest.mark.parametrize('copy_fun', [lambda view: view.copy(), copy])
+    @pytest.mark.parametrize('default_count', [0, 1, 2, 4])
+    def test_copy(self, copy_fun, default_count):
+        nested = []
+        defaults = [{'default': index} for index in range(default_count)]
+        view = ConfigurationView({'changed': 1, 'nested': nested}, defaults)
+
+        copied = copy_fun(view)
+
+        assert dict(copied) == dict(view)
+        assert copied is not view
+        assert copied.changes is not view.changes
+        assert copied.nested is nested
+        assert copied.defaults is not view.defaults
+        for original, duplicate in zip(view.defaults, copied.defaults):
+            assert duplicate is original
+        copied.changed = 2
+        assert view.changed == 1
+        copied.add_defaults({'additional': 3})
+        assert 'additional' not in view
+        if defaults:
+            defaults[0]['default'] = 10
+            assert copied.default == view.default == 10
+
+    @pytest.mark.parametrize('copy_fun', [lambda view: view.copy(), copy])
+    def test_copy_preserves_key_conversions(self, copy_fun):
+        view = ConfigurationView(
+            {'CELERY_ALWAYS_EAGER': True},
+            [{'CELERY_TASK_DEFAULT_QUEUE': 'custom'}],
+            keys=(_old_key_to_new, _new_key_to_old), prefix='CELERY',
+        )
+
+        copied = copy_fun(view)
+
+        assert copied.task_always_eager is True
+        assert copied.task_default_queue == 'custom'
+        copied.task_always_eager = False
+        assert copied.task_always_eager is False
+        assert view.task_always_eager is True
+        assert 'task_default_queue' in copied
+        assert copied.prefix == view.prefix
+        assert copied._keys == view._keys
+
+    @pytest.mark.parametrize('copy_fun', [lambda view: view.copy(), copy])
+    def test_copy_preserves_key_t(self, copy_fun):
+        view = ConfigurationView({'FOO': 1})
+        view.__dict__['key_t'] = str.upper
+
+        copied = copy_fun(view)
+
+        assert copied['foo'] == 1
+        copied['bar'] = 2
+        assert copied.changes['BAR'] == 2
+
+    @pytest.mark.parametrize('copy_fun', [lambda view: view.copy(), copy])
+    def test_copy_does_not_share_observers(self, copy_fun):
+        view = ConfigurationView({'foo': 1})
+        callback = Mock()
+        view.bind_to(callback)
+
+        copied = copy_fun(view)
+        copied.update(foo=2)
+
+        callback.assert_not_called()
+        view.update(foo=3)
+        callback.assert_called_once_with(foo=3)
 
     def setup_method(self):
         self.view = ConfigurationView(


### PR DESCRIPTION
## Description

Copying `app.conf` produces a settings object that cannot be read:

```python
from celery import Celery

app = Celery('example')
app.conf.task_always_eager = True
assert app.conf.task_always_eager is True

copied = app.conf.copy()
assert copied.task_always_eager is True  # TypeError: 'str' object is not callable
```

`copy.copy(app.conf)` fails in the same way. The inherited `ChainMap.copy()` expands the default mappings into positional arguments, but `ConfigurationView` expects a list of defaults followed by key converters and a prefix.

This adds a copy implementation that matches `ConfigurationView`'s constructor and preserves its key conversions. Changes get their own mapping, while default mappings and nested values remain shared. `Settings` also loads pending configuration before copying and preserves the deprecated-settings value without adding it back after `clear()`.

## Validation

- The 30 new cases give **26 failures and 4 passes** on main at `cdd516f71d98121d8a4a659d90d400a78b13dcd3`, and **30 passes** with the fix.
- `pytest -p celery.contrib.pytest t/unit/utils t/unit/app t/unit/test_generics.py`: **1,301 passed, 14 skipped, 1 xfailed**, with 6 subtests passed.
- `pre-commit run --all-files`: passed, including mypy.
- Four memory-broker worker checks using copied settings passed, covering both copy APIs before and after configuration was loaded. Changes to the copy left the original settings unchanged.
- The new copy methods have full line and branch coverage in the focused tests.

These checks used CPython 3.12.13 on macOS. I also ran `apicheck`, `configcheck`, and Bandit; the base and this branch reported the same documentation failures and Bandit findings. The existing `bandit.json` could not be parsed in either tree. I have not run the full upstream platform matrix locally.
