### PR TITLE
Fix empty group/chain handling in chains and group headers (#9772)

### DIFF
--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1102,7 +1102,12 @@ class _chain(Signature):
             self.app, _id, group_id, chord, clone=False,
             group_index=group_index,
         )
-        return results[0] if results else None
+        if results:
+            return results[0]
+        # All steps were empty groups (no-ops); return a minimal
+        # AsyncResult so callers can safely access .id / .parent.
+        # (Issue #9772)
+        return self.app.AsyncResult(_id or uuid())
 
     def stamp(self, visitor=None, append_stamps=False, **headers):
         visitor_headers = None

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1796,6 +1796,9 @@ class group(Signature):
                     task.tasks, partial_args, group_id, root_id, app,
                 )
                 yield from unroll
+            elif isinstance(task, _chain) and not task.tasks:
+                # Skip empty chains -- they are no-ops.  (Issue #9772)
+                continue
             else:
                 if partial_args and not task.immutable:
                     task.args = tuple(partial_args) + tuple(task.args)
@@ -1979,6 +1982,10 @@ class group(Signature):
             # if this is a group, flatten it by adding all of the group's tasks to the stack
             if isinstance(task, group):
                 stack.extendleft(task.tasks)
+            elif isinstance(task, _chain) and not task.tasks:
+                # Skip empty chains -- they are no-ops and would produce
+                # fabricated results that never complete.  (Issue #9772)
+                continue
             else:
                 new_tasks.append(task)
                 yield task.freeze(group_id=group_id,

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1095,12 +1095,13 @@ class _chain(Signature):
     # TODO figure out why we are always cloning before freeze
     def freeze(self, _id=None, group_id=None, chord=None,
                root_id=None, parent_id=None, group_index=None):
-        """Freeze the chain, returning an AsyncResult for the first step.
+        """Freeze the chain, returning an AsyncResult for the chain's final result.
 
         If the chain contains only empty groups (no-ops), all steps are
         discarded and a minimal AsyncResult is returned so that callers
-        can safely access .id and .parent without a
-        NoneType error.  (Issue #9772)
+        can safely access .id and .parent without a NoneType error.
+        This placeholder result is not backed by any task execution and
+        will never complete.  (Issue #9772)
         """
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1198,11 +1198,16 @@ class _chain(Signature):
         # passed as the ``chain`` message field.
         # As it's reversed the worker can just do ``chain.pop()`` to
         # get the next task in the chain.
+        # Whether partial args have been applied to the logically first
+        # task.  With empty-group skipping and chain-splicing the simple
+        # ``not steps`` heuristic can misfire, so we defer args
+        # application when needed and track it with this flag.
+        # (Issue #9772)
+        applied_first_args = False
+
         while steps:
             task = steps_pop()
-            # if steps is not empty, this is the first task - reverse order
-            # if i = 0, this is the last task - again, because we're reversed
-            is_first_task, is_last_task = not steps, not i
+            is_last_task = not i
 
             if not isinstance(task, abstract.CallableSignature):
                 task = from_dict(task, app=app)
@@ -1221,14 +1226,18 @@ class _chain(Signature):
                 steps_extend(task.tasks)
                 continue
 
+            is_first_task = not steps
+
             # first task gets partial args from chain
             if clone:
                 if is_first_task:
                     task = task.clone(args, kwargs)
+                    applied_first_args = True
                 else:
                     task = task.clone()
             elif is_first_task:
                 task.args = tuple(args) + tuple(task.args)
+                applied_first_args = True
 
             # TODO why isn't this asserting is_last_task == False?
             if isinstance(task, group) and prev_task:
@@ -1303,6 +1312,18 @@ class _chain(Signature):
                     while node.parent:
                         node = node.parent
                     prev_res = node
+        # If partial args were not applied during the loop (e.g. because
+        # chain-splicing or empty-group skipping meant ``not steps``
+        # was never True for the first real task), apply them now to
+        # the logically first task -- the last element of ``tasks``
+        # (which is in reverse order).
+        if not applied_first_args and tasks and (args or kwargs):
+            first_task = tasks[-1]
+            if clone:
+                tasks[-1] = first_task.clone(args, kwargs)
+            else:
+                first_task.args = tuple(args) + tuple(first_task.args)
+
         self.id = last_task_id
         return tasks, results
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1165,6 +1165,26 @@ class _chain(Signature):
             use_link = True
         steps = deque(tasks)
 
+        # Strip leading empty groups from the chain so that
+        # is_first_task (not steps) is correct after popping all items.
+        # Empty groups anywhere in the chain are no-ops and should be
+        # skipped (Issue #9772), but leading ones must be removed up
+        # front because the reverse-iteration loop relies on `not steps`
+        # to detect the original chain's first task for applying partial
+        # args/kwargs.
+        while steps:
+            head = steps[0]
+            if not isinstance(head, abstract.CallableSignature):
+                head = from_dict(head, app=app)
+                steps[0] = head
+            if isinstance(head, group):
+                head = maybe_unroll_group(head)
+                steps[0] = head
+            if isinstance(head, group) and not head.tasks:
+                steps.popleft()
+                continue
+            break
+
         # optimization: now the pop func is a local variable
         steps_pop = steps.pop
         steps_extend = steps.extend
@@ -1173,7 +1193,6 @@ class _chain(Signature):
         prev_res = None
         tasks, results = [], []
         i = 0
-        first_task_args_applied = False
         # NOTE: We are doing this in reverse order.
         # The result is a list of tasks in reverse order, that is
         # passed as the ``chain`` message field.
@@ -1202,19 +1221,14 @@ class _chain(Signature):
                 steps_extend(task.tasks)
                 continue
 
-            # The first non-empty step in the chain receives the chain's
-            # partial args/kwargs.  We track this separately from
-            # is_first_task because empty groups that were skipped above
-            # may have already consumed the positional is_first_task flag.
-            should_apply_first_args = not first_task_args_applied
+            # first task gets partial args from chain
             if clone:
-                if should_apply_first_args:
+                if is_first_task:
                     task = task.clone(args, kwargs)
                 else:
                     task = task.clone()
-            elif should_apply_first_args:
+            elif is_first_task:
                 task.args = tuple(args) + tuple(task.args)
-            first_task_args_applied = True
 
             # TODO why isn't this asserting is_last_task == False?
             if isinstance(task, group) and prev_task:

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1095,6 +1095,13 @@ class _chain(Signature):
     # TODO figure out why we are always cloning before freeze
     def freeze(self, _id=None, group_id=None, chord=None,
                root_id=None, parent_id=None, group_index=None):
+        """Freeze the chain, returning an AsyncResult for the first step.
+
+        If the chain contains only empty groups (no-ops), all steps are
+        discarded and a minimal AsyncResult is returned so that callers
+        can safely access .id and .parent without a
+        NoneType error.  (Issue #9772)
+        """
         # pylint: disable=redefined-outer-name
         #   XXX chord is also a class in outer scope.
         _, results = self._frozen = self.prepare_steps(

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1336,6 +1336,7 @@ class _chain(Signature):
                 tasks[-1] = first_task.clone(args, kwargs)
             else:
                 first_task.args = tuple(args) + tuple(first_task.args)
+                first_task.kwargs = dict(kwargs, **first_task.kwargs)
 
         self.id = last_task_id
         return tasks, results

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1522,6 +1522,26 @@ class chunks(Signature):
         return cls(task, it, n, app=app)()
 
 
+def _chain_effectively_empty(task):
+    """Return True if *task* is a chain whose members are all empty groups.
+
+    A chain with no tasks is trivially empty.  A chain whose tasks are
+    all empty groups (after unrolling single-member groups) is
+    *effectively* empty because every step is a no-op.  (Issue #9772)
+    """
+    if not isinstance(task, _chain):
+        return False
+    if not task.tasks:
+        return True
+    for t in task.tasks:
+        if isinstance(t, group):
+            t = maybe_unroll_group(t)
+        if not isinstance(t, group) or t.tasks:
+            return False
+    return True
+
+
+
 def _maybe_group(tasks, app):
     if isinstance(tasks, dict):
         tasks = signature(tasks, app=app)
@@ -1798,8 +1818,8 @@ class group(Signature):
                     task.tasks, partial_args, group_id, root_id, app,
                 )
                 yield from unroll
-            elif isinstance(task, _chain) and not task.tasks:
-                # Skip empty chains -- they are no-ops.  (Issue #9772)
+            elif _chain_effectively_empty(task):
+                # Skip empty/effectively-empty chains -- they are no-ops.  (Issue #9772)
                 continue
             else:
                 if partial_args and not task.immutable:
@@ -1984,7 +2004,7 @@ class group(Signature):
             # if this is a group, flatten it by adding all of the group's tasks to the stack
             if isinstance(task, group):
                 stack.extendleft(task.tasks)
-            elif isinstance(task, _chain) and not task.tasks:
+            elif _chain_effectively_empty(task):
                 # Skip empty chains -- they are no-ops and would produce
                 # fabricated results that never complete.  (Issue #9772)
                 continue

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1102,7 +1102,7 @@ class _chain(Signature):
             self.app, _id, group_id, chord, clone=False,
             group_index=group_index,
         )
-        return results[0]
+        return results[0] if results else None
 
     def stamp(self, visitor=None, append_stamps=False, **headers):
         visitor_headers = None
@@ -1205,6 +1205,11 @@ class _chain(Signature):
                 steps_extend(task.tasks)
                 continue
 
+            if isinstance(task, group) and not task.tasks:
+                # skip empty groups as they are no-ops
+                # Issue #9772
+                continue
+
             # TODO why isn't this asserting is_last_task == False?
             if isinstance(task, group) and prev_task:
                 # automatically upgrade group(...) | s to chord(group, s)
@@ -1273,10 +1278,11 @@ class _chain(Signature):
 
                 # We need to change that so that it points to the
                 # group result object.
-                node = res
-                while node.parent:
-                    node = node.parent
-                prev_res = node
+                if res is not None:
+                    node = res
+                    while node.parent:
+                        node = node.parent
+                    prev_res = node
         self.id = last_task_id
         return tasks, results
 

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1173,6 +1173,7 @@ class _chain(Signature):
         prev_res = None
         tasks, results = [], []
         i = 0
+        first_task_args_applied = False
         # NOTE: We are doing this in reverse order.
         # The result is a list of tasks in reverse order, that is
         # passed as the ``chain`` message field.
@@ -1191,24 +1192,29 @@ class _chain(Signature):
                 # groups should be called in parallel
                 task = maybe_unroll_group(task)
 
-            # first task gets partial args from chain
-            if clone:
-                if is_first_task:
-                    task = task.clone(args, kwargs)
-                else:
-                    task = task.clone()
-            elif is_first_task:
-                task.args = tuple(args) + tuple(task.args)
+            if isinstance(task, group) and not task.tasks:
+                # skip empty groups as they are no-ops
+                # Issue #9772
+                continue
 
             if isinstance(task, _chain):
                 # splice (unroll) the chain
                 steps_extend(task.tasks)
                 continue
 
-            if isinstance(task, group) and not task.tasks:
-                # skip empty groups as they are no-ops
-                # Issue #9772
-                continue
+            # The first non-empty step in the chain receives the chain's
+            # partial args/kwargs.  We track this separately from
+            # is_first_task because empty groups that were skipped above
+            # may have already consumed the positional is_first_task flag.
+            should_apply_first_args = not first_task_args_applied
+            if clone:
+                if should_apply_first_args:
+                    task = task.clone(args, kwargs)
+                else:
+                    task = task.clone()
+            elif should_apply_first_args:
+                task.args = tuple(args) + tuple(task.args)
+            first_task_args_applied = True
 
             # TODO why isn't this asserting is_last_task == False?
             if isinstance(task, group) and prev_task:

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1048,6 +1048,41 @@ class test_chain(CanvasCase):
         assert len(results) == 2
 
 
+    def test_chain_leading_empty_group_as_dict_strip(self):
+        """Leading empty group passed as a serialized dict should be stripped.
+
+        Exercises the from_dict conversion path in the leading empty-group
+        strip loop of prepare_steps().  (Issue #9772)
+        """
+        # Serialize an empty group to a dict so it enters the
+        # ``not isinstance(head, CallableSignature)`` branch.
+        empty_dict = dict(group())
+        c = _chain(app=self.app)
+        c.tasks = [empty_dict, self.add.s(10)]
+        tasks, results = c.prepare_steps((5,), {}, c.tasks)
+        assert len(tasks) == 1
+        first_task = tasks[-1]
+        assert first_task.args == (5, 10), (
+            f"Expected (5, 10), got {first_task.args}"
+        )
+
+    def test_chain_freeze_nested_chain_leading_empty_group_no_clone(self):
+        """freeze() uses clone=False; the applied_first_args fallback must
+        work for nested chains with leading empty groups.
+
+        When the inner chain is spliced, its leading empty group prevents
+        ``is_first_task`` from firing.  The post-loop fallback must apply
+        partial args to the first real task without cloning.
+        (Issue #9772)
+        """
+        inner = _chain(group(), self.add.s(10), app=self.app)
+        outer = _chain(inner, self.add.s(20), app=self.app)
+        outer.args = (5,)
+        res = outer.freeze()
+        # freeze() returns the result for the first step; it must not crash.
+        assert res is not None
+
+
 class test_group(CanvasCase):
     def test_repr(self):
         x = group([self.add.s(2, 2), self.add.s(4, 4)])
@@ -1473,6 +1508,24 @@ class test_group(CanvasCase):
         sig = self.replace_with_group.s(1, 2)
         res = self.helper_test_get_delay(sig.delay())
         assert res == [3, 2]
+
+
+    def test_group_prepared_skips_empty_chain(self):
+        """_prepared() must skip empty chains that appear as group members.
+
+        An empty chain (``chain()``) in a group is a no-op and should be
+        silently dropped so it does not produce a fabricated result.
+        (Issue #9772)
+        """
+        empty_chain = _chain(app=self.app)  # chain with no tasks
+        real_task = self.add.s(1, 2)
+        g = group(empty_chain, real_task)
+        _, group_id, root_id = g._freeze_gid({})
+        prepared = list(g._prepared(g.tasks, [], group_id, root_id, self.app))
+        # Only the real task should appear; the empty chain is skipped.
+        assert len(prepared) == 1
+        task, result, gid = prepared[0]
+        assert task.args == (1, 2)
 
 
 class test_chord(CanvasCase):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -860,6 +860,21 @@ class test_chain(CanvasCase):
         assert isinstance(final_task.tasks[0].body, chord)
         assert final_task.tasks[0].body.body == chain1
 
+    def test_chain_with_empty_group_does_not_crash(self):
+        """Test that chaining empty groups does not raise AttributeError.
+
+        Regression test for https://github.com/celery/celery/issues/9772
+        """
+        # chain(group([task1, task2]), group(), group()) should not raise
+        g1 = group([self.add.s(2, 2), self.add.s(4, 4)])
+        c = chain(g1, group(), group())
+        c.freeze()  # should not raise AttributeError
+
+    def test_chain_empty_group_between_tasks(self):
+        """An empty group between tasks in a chain should be skipped."""
+        c = chain(self.add.s(2, 2), group(), self.add.s(4, 4))
+        c.freeze()  # should not raise
+
 
 class test_group(CanvasCase):
     def test_repr(self):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1370,10 +1370,20 @@ class test_group(CanvasCase):
         child_count = 24
         child_chord = chord((gchild_sig,), self.add.si(0, 0))
         group_sig = group((child_chord,) * child_count)
-        # Previously this raised IndexError.  After fixing #9772 the empty
-        # chains are stripped from the chord header, so the header is empty
-        # and the chord body is executed immediately (no pending result).
-        group_sig.apply_async()
+        with patch(
+            "celery.canvas.Signature.apply_async",
+        ) as mock_apply_async:
+            # Previously this raised IndexError.  After fixing #9772 the
+            # empty chains are stripped from the chord header, so apply_async
+            # should not be called for any header tasks (they are all no-ops).
+            group_sig.apply_async()
+        # No header tasks should be applied -- every chain is empty.
+        # The child_count calls we see are the chord bodies being applied
+        # (each chord's body is self.add.si(0, 0)).
+        assert mock_apply_async.call_count == child_count, (
+            f"Expected {child_count} apply_async calls (one per chord body), "
+            f"got {mock_apply_async.call_count}"
+        )
 
     def test_apply_contains_chords_containing_chain_with_empty_tail(self):
         ggchild_count = 42
@@ -1525,6 +1535,25 @@ class test_group(CanvasCase):
         task, result, gid = prepared[0]
         assert task.args == (1, 2)
 
+
+
+    def test_group_prepared_skips_effectively_empty_chain(self):
+        """_prepared() must skip chains whose tasks are all empty groups.
+
+        A chain like _chain(group(), group()) has a non-empty .tasks list,
+        but every member is a no-op.  Such chains must be detected and
+        skipped to avoid producing fabricated results that never complete.
+        (Issue #9772)
+        """
+        effectively_empty = _chain(group(), group(), app=self.app)
+        real_task = self.add.s(1, 2)
+        g = group(effectively_empty, real_task)
+        _, group_id, root_id = g._freeze_gid({})
+        prepared = list(g._prepared(g.tasks, [], group_id, root_id, self.app))
+        # Only the real task should appear; the effectively-empty chain is skipped.
+        assert len(prepared) == 1
+        task, result, gid = prepared[0]
+        assert task.args == (1, 2)
 
 class test_chord(CanvasCase):
     def test__get_app_does_not_exhaust_generator(self):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -999,6 +999,54 @@ class test_chain(CanvasCase):
             f"Expected (5, 10) on first task, got {first_task.args}"
         )
 
+    def test_nested_chain_multiple_leading_empty_groups_after_splice(self):
+        """_chain(_chain(group(), group(), add.s(x)), add.s(y)) -- spliced empty groups.
+
+        After the inner chain is spliced into the outer loop, the two
+        leading empty groups must be skipped and partial args must still
+        reach the first real task.
+        Regression test for issue #9772.
+        """
+        inner = _chain(group(), group(), self.add.s(10), app=self.app)
+        outer = _chain(inner, self.add.s(20), app=self.app)
+        tasks, results = outer.prepare_steps((7,), {}, outer.tasks)
+        assert len(tasks) == 2
+        assert len(results) == 2
+        first_task = tasks[-1]
+        assert first_task.args == (7, 10), (
+            f"Expected (7, 10) on first task, got {first_task.args}"
+        )
+
+    def test_nested_chain_only_empty_groups_spliced(self):
+        """_chain(_chain(group(), group()), add.s(x)) -- inner chain is all empty groups.
+
+        After splicing, the inner chain contributes no real tasks.
+        The outer add.s(x) should still receive partial args correctly.
+        Regression test for issue #9772.
+        """
+        inner = _chain(group(), group(), app=self.app)
+        outer = _chain(inner, self.add.s(10), app=self.app)
+        tasks, results = outer.prepare_steps((3,), {}, outer.tasks)
+        assert len(tasks) == 1
+        assert len(results) == 1
+        first_task = tasks[-1]
+        assert first_task.args == (3, 10), (
+            f"Expected (3, 10) on first task, got {first_task.args}"
+        )
+
+    def test_nested_chain_trailing_empty_group_after_splice(self):
+        """_chain(add.s(x), _chain(add.s(y), group())) -- trailing empty in spliced chain.
+
+        The trailing empty group from the inner chain should be silently
+        dropped after splicing.
+        Regression test for issue #9772.
+        """
+        inner = _chain(self.add.s(10), group(), app=self.app)
+        outer = _chain(self.add.s(1, 2), inner, app=self.app)
+        tasks, results = outer.prepare_steps((), {}, outer.tasks)
+        assert len(tasks) == 2
+        assert len(results) == 2
+
 
 class test_group(CanvasCase):
     def test_repr(self):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -968,6 +968,18 @@ class test_chain(CanvasCase):
         assert tasks == []
         assert results == []
 
+    def test_chain_only_empty_groups_freeze_returns_result(self):
+        """chain(group(), group()).freeze() must return an AsyncResult, not None.
+
+        Callers rely on freeze() returning an object with .id and .parent.
+        Regression test for issue #9772.
+        """
+        c = _chain(group(), group(), app=self.app)
+        res = c.freeze()
+        # Must not be None -- callers expect .id / .parent
+        assert res is not None
+        assert res.id is not None
+
     def test_nested_chain_with_leading_empty_group(self):
         """_chain(_chain(group(), add.s(x)), add.s(y)) -- inner empty group stripped.
 
@@ -1265,15 +1277,13 @@ class test_group(CanvasCase):
         # the encapsulated chains - in this case 1 for each child chord
         mock_set_chord_size.assert_has_calls((call(ANY, 1),) * child_count)
 
-    @pytest.mark.xfail(reason="Invalid canvas setup with bad exception")
     def test_apply_contains_chords_containing_empty_chain(self):
         gchild_sig = chain(tuple())
         child_count = 24
         child_chord = chord((gchild_sig,), self.add.si(0, 0))
         group_sig = group((child_chord,) * child_count)
-        # This is an invalid setup because we can't complete a chord header if
-        # there are no actual tasks which will run in it. However, the current
-        # behaviour of an `IndexError` isn't particularly helpful to a user.
+        # Previously this raised IndexError due to empty chain handling.
+        # Fixed by Issue #9772 -- empty chains now resolve gracefully.
         group_sig.apply_async()
 
     def test_apply_contains_chords_containing_chain_with_empty_tail(self):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -987,6 +987,7 @@ class test_chain(CanvasCase):
             f"Expected (5, 10) on first task, got {first_task.args}"
         )
 
+
 class test_group(CanvasCase):
     def test_repr(self):
         x = group([self.add.s(2, 2), self.add.s(4, 4)])

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -879,7 +879,7 @@ class test_chain(CanvasCase):
         """When an empty group precedes a real task, partial args must
         be forwarded to the first non-empty step.
 
-        Regression test for PR #10245 review feedback.
+        Regression test for issue #9772.
         """
         # Use _chain directly to avoid the chain() constructor converting
         # group() | task into a chord.
@@ -893,7 +893,7 @@ class test_chain(CanvasCase):
     def test_chain_empty_group_first_args_go_to_first_real_task(self):
         """chain(group(), add.s(y))(x) -- args pass through to first real task.
 
-        Regression test for issue #9772 / PR #10245.
+        Regression test for issue #9772.
         """
         c = _chain(group(), self.add.s(10), app=self.app)
         tasks, _ = c.prepare_steps((1, 2), {}, c.tasks)
@@ -906,7 +906,7 @@ class test_chain(CanvasCase):
     def test_chain_multiple_leading_empty_groups_args(self):
         """chain(group(), group(), add.s(y))(x) -- multiple leading empty groups.
 
-        Regression test for issue #9772 / PR #10245.
+        Regression test for issue #9772.
         """
         c = _chain(group(), group(), self.add.s(10), app=self.app)
         tasks, _ = c.prepare_steps((3,), {}, c.tasks)
@@ -919,7 +919,7 @@ class test_chain(CanvasCase):
         """chain(add.s(x), group(), add.s(y)) -- empty group in middle.
 
         The empty group should be silently skipped without affecting the chain.
-        Regression test for issue #9772 / PR #10245.
+        Regression test for issue #9772.
         """
         c = _chain(self.add.s(1, 2), group(), self.add.s(10), app=self.app)
         tasks, results = c.prepare_steps((), {}, c.tasks)
@@ -931,7 +931,7 @@ class test_chain(CanvasCase):
         """chain(add.s(x), group()) -- trailing empty group.
 
         The trailing empty group should be silently dropped.
-        Regression test for issue #9772 / PR #10245.
+        Regression test for issue #9772.
         """
         c = _chain(self.add.s(1, 2), group(), app=self.app)
         tasks, results = c.prepare_steps((), {}, c.tasks)
@@ -943,7 +943,7 @@ class test_chain(CanvasCase):
 
         Verifies that partial args are prepended to the chain's *first* real
         task (add.s(x)), not the *last* task (add.s(y)).
-        Regression test for issue #9772 / PR #10245.
+        Regression test for issue #9772.
         """
         c = _chain(group(), self.add.s(100), self.add.s(200), app=self.app)
         tasks, _ = c.prepare_steps((5,), {}, c.tasks)
@@ -961,14 +961,31 @@ class test_chain(CanvasCase):
         """chain(group(), group()) -- chain of only empty groups.
 
         Should produce an empty result without crashing.
-        Regression test for issue #9772 / PR #10245.
+        Regression test for issue #9772.
         """
         c = _chain(group(), group(), app=self.app)
         tasks, results = c.prepare_steps((), {}, c.tasks)
         assert tasks == []
         assert results == []
 
+    def test_nested_chain_with_leading_empty_group(self):
+        """_chain(_chain(group(), add.s(x)), add.s(y)) -- inner empty group stripped.
 
+        When a nested chain contains a leading empty group, the splice
+        (unroll) should expose it to the main loop which skips it.
+        Regression test for issue #9772.
+        """
+        inner = _chain(group(), self.add.s(10), app=self.app)
+        outer = _chain(inner, self.add.s(20), app=self.app)
+        tasks, results = outer.prepare_steps((5,), {}, outer.tasks)
+        # Should produce 2 real tasks: add.s(10) and add.s(20)
+        assert len(tasks) == 2
+        assert len(results) == 2
+        # First logical task (last in reversed list) should get args
+        first_task = tasks[-1]
+        assert first_task.args == (5, 10), (
+            f"Expected (5, 10) on first task, got {first_task.args}"
+        )
 
 class test_group(CanvasCase):
     def test_repr(self):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1326,12 +1326,19 @@ class test_group(CanvasCase):
         mock_set_chord_size.assert_has_calls((call(ANY, 1),) * child_count)
 
     def test_apply_contains_chords_containing_empty_chain(self):
+        """A chord whose header contains only empty chains should not hang.
+
+        Empty chains are no-ops; when every header member is an empty chain
+        the header group is effectively empty and the chord body should be
+        executed immediately.  Regression test for issue #9772.
+        """
         gchild_sig = chain(tuple())
         child_count = 24
         child_chord = chord((gchild_sig,), self.add.si(0, 0))
         group_sig = group((child_chord,) * child_count)
-        # Previously this raised IndexError due to empty chain handling.
-        # Fixed by Issue #9772 -- empty chains now resolve gracefully.
+        # Previously this raised IndexError.  After fixing #9772 the empty
+        # chains are stripped from the chord header, so the header is empty
+        # and the chord body is executed immediately (no pending result).
         group_sig.apply_async()
 
     def test_apply_contains_chords_containing_chain_with_empty_tail(self):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -890,6 +890,85 @@ class test_chain(CanvasCase):
         first_task = tasks[-1]
         assert first_task.args == (2, 2)
 
+    def test_chain_empty_group_first_args_go_to_first_real_task(self):
+        """chain(group(), add.s(y))(x) -- args pass through to first real task.
+
+        Regression test for issue #9772 / PR #10245.
+        """
+        c = _chain(group(), self.add.s(10), app=self.app)
+        tasks, _ = c.prepare_steps((1, 2), {}, c.tasks)
+        # tasks are in reverse order; last element is the first logical task
+        first_task = tasks[-1]
+        assert first_task.args == (1, 2, 10), (
+            f"Expected args (1, 2, 10) on first real task, got {first_task.args}"
+        )
+
+    def test_chain_multiple_leading_empty_groups_args(self):
+        """chain(group(), group(), add.s(y))(x) -- multiple leading empty groups.
+
+        Regression test for issue #9772 / PR #10245.
+        """
+        c = _chain(group(), group(), self.add.s(10), app=self.app)
+        tasks, _ = c.prepare_steps((3,), {}, c.tasks)
+        first_task = tasks[-1]
+        assert first_task.args == (3, 10), (
+            f"Expected args (3, 10) on first real task, got {first_task.args}"
+        )
+
+    def test_chain_empty_group_in_middle(self):
+        """chain(add.s(x), group(), add.s(y)) -- empty group in middle.
+
+        The empty group should be silently skipped without affecting the chain.
+        Regression test for issue #9772 / PR #10245.
+        """
+        c = _chain(self.add.s(1, 2), group(), self.add.s(10), app=self.app)
+        tasks, results = c.prepare_steps((), {}, c.tasks)
+        # Should produce 2 real tasks, not crash
+        assert len(tasks) == 2
+        assert len(results) == 2
+
+    def test_chain_trailing_empty_group(self):
+        """chain(add.s(x), group()) -- trailing empty group.
+
+        The trailing empty group should be silently dropped.
+        Regression test for issue #9772 / PR #10245.
+        """
+        c = _chain(self.add.s(1, 2), group(), app=self.app)
+        tasks, results = c.prepare_steps((), {}, c.tasks)
+        assert len(tasks) == 1
+        assert len(results) == 1
+
+    def test_chain_empty_group_args_reach_correct_task(self):
+        """chain(group(), add.s(x), add.s(y))(z) -- z goes to add.s(x), not add.s(y).
+
+        Verifies that partial args are prepended to the chain's *first* real
+        task (add.s(x)), not the *last* task (add.s(y)).
+        Regression test for issue #9772 / PR #10245.
+        """
+        c = _chain(group(), self.add.s(100), self.add.s(200), app=self.app)
+        tasks, _ = c.prepare_steps((5,), {}, c.tasks)
+        # tasks is in reverse order: [add.s(200), add.s(100)]
+        first_logical_task = tasks[-1]   # add.s(100) with args prepended
+        last_logical_task = tasks[0]     # add.s(200) with NO extra args
+        assert first_logical_task.args == (5, 100), (
+            f"Expected (5, 100) on first task, got {first_logical_task.args}"
+        )
+        assert last_logical_task.args == (200,), (
+            f"Expected (200,) on last task (no extra args), got {last_logical_task.args}"
+        )
+
+    def test_chain_only_empty_groups(self):
+        """chain(group(), group()) -- chain of only empty groups.
+
+        Should produce an empty result without crashing.
+        Regression test for issue #9772 / PR #10245.
+        """
+        c = _chain(group(), group(), app=self.app)
+        tasks, results = c.prepare_steps((), {}, c.tasks)
+        assert tasks == []
+        assert results == []
+
+
 
 class test_group(CanvasCase):
     def test_repr(self):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -875,6 +875,21 @@ class test_chain(CanvasCase):
         c = chain(self.add.s(2, 2), group(), self.add.s(4, 4))
         c.freeze()  # should not raise
 
+    def test_chain_empty_group_first_passes_args(self):
+        """When an empty group precedes a real task, partial args must
+        be forwarded to the first non-empty step.
+
+        Regression test for PR #10245 review feedback.
+        """
+        # Use _chain directly to avoid the chain() constructor converting
+        # group() | task into a chord.
+        c = _chain(group(), self.add.s(), app=self.app)
+        tasks, _ = c.prepare_steps((2, 2), {}, c.tasks)
+        # tasks are returned in reverse order; the first logical task
+        # (add) is last in the list.
+        first_task = tasks[-1]
+        assert first_task.args == (2, 2)
+
 
 class test_group(CanvasCase):
     def test_repr(self):

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1047,7 +1047,6 @@ class test_chain(CanvasCase):
         assert len(tasks) == 2
         assert len(results) == 2
 
-
     def test_chain_leading_empty_group_as_dict_strip(self):
         """Leading empty group passed as a serialized dict should be stripped.
 
@@ -1508,7 +1507,6 @@ class test_group(CanvasCase):
         sig = self.replace_with_group.s(1, 2)
         res = self.helper_test_get_delay(sig.delay())
         assert res == [3, 2]
-
 
     def test_group_prepared_skips_empty_chain(self):
         """_prepared() must skip empty chains that appear as group members.


### PR DESCRIPTION
## Summary

Supersedes #10245 by @kaiisfree, rebased on current `main` and reconciled with #10321 ("Skip empty groups in chains"), which landed after that PR was opened and already fixes the crash reported in #9772 for the common `chain(group([...]), group(), group())` case. The original commits are kept; the final merge commit carries the conflict resolution.

Two problems remained on `main` after #10321:

- **Partial args are silently dropped** when a chain starts with an empty group, an empty chain, or a nested chain that starts with an empty group. `prepare_steps()` detects the chain's first task via `not steps` during its reverse walk, and the in-loop skip from #10321 removes the leading empty group *after* that check, so no task receives the args. `_chain(group(), add.s(10))(1, 2)` ran `add(10)`.
- **Empty chains inside a group or chord header raise `IndexError`** from `_chain.freeze()`, e.g. `group(chain(), add.s(1, 2)).apply_async()` and the previously `xfail`ed `test_apply_contains_chords_containing_empty_chain`.

## Changes (`celery/canvas.py`)

- `_chain.prepare_steps()`: normalise the head of the chain before the reverse walk. Leading empty groups are stripped (same list/tuple predicate as #10321) and a nested chain at the head is spliced in place, so the first real task is the last one popped and receives the partial args. A chain made up of empty groups only keeps a single one, matching #10321's in-loop behaviour, so it still yields an (empty) `GroupResult` rather than a placeholder result that never completes.
- `group._prepared()`, `group._freeze_unroll()`, `group._freeze_tasks()`: skip empty chains so they neither crash `freeze()` nor produce a frozen result with no task behind it. `_chord._descend()` already counted them as 0.

Compared with #10245, the following were dropped because #10321 made them redundant or they conflicted with its semantics: the second in-loop empty-group skip and splice reordering, the `applied_first_args` post-loop fallback, the `res is not None` guard (chord bodies are always frozen now, see `_chord.freeze`), the placeholder `AsyncResult` returned from `_chain.freeze()` for all-empty chains, and the `_chain_effectively_empty()` helper.

## Tests

- All regression tests from #10245 carried over. `test_chain_only_empty_groups*` updated to the reconciled behaviour (one empty group is kept). `test_group_prepared_skips_effectively_empty_chain` removed since that semantic no longer exists.
- New: `test_chain_leading_empty_chain_passes_args`, `test_group_freeze_skips_empty_chain`, `test_group_freeze_skips_empty_chain_in_generator`.
- `test_apply_contains_chords_containing_empty_chain` is no longer `xfail` and asserts the chord bodies are applied immediately.
- `t/unit/tasks/test_canvas.py`: 250 passed, 1 xfailed (pre-existing `test_apply_contains_chords_containing_empty_group`). Full `t/unit`: 3826 passed, 36 skipped.

Fixes #9772

